### PR TITLE
Collapse completed tool calls into expandable group cards

### DIFF
--- a/app/src/main/kotlin/com/destin/code/ui/ChatScreen.kt
+++ b/app/src/main/kotlin/com/destin/code/ui/ChatScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.destin.code.config.chipsForTier
+import com.destin.code.ui.cards.ToolGroupCard
 import com.destin.code.runtime.BaseTerminalViewClient
 import com.destin.code.runtime.DirectShellBridge
 import com.destin.code.runtime.SessionService
@@ -59,6 +60,44 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 private enum class ScreenMode { Chat, Terminal, Shell }
+
+/** A display item in the chat list — either a single message or a collapsed group of tool calls. */
+private sealed class DisplayItem {
+    data class Single(val message: ChatMessage) : DisplayItem()
+    data class ToolGroup(val messages: List<ChatMessage>, val key: String) : DisplayItem()
+}
+
+/** Returns true if this message is a completed or failed tool call (should be grouped). */
+private fun ChatMessage.isFinishedTool(): Boolean =
+    content is MessageContent.ToolComplete || content is MessageContent.ToolFailed
+
+/**
+ * Groups consecutive finished tool calls into [DisplayItem.ToolGroup]s.
+ * Active tools (Running, AwaitingApproval) and all non-tool messages stay individual.
+ * Only groups runs of 2+ consecutive finished tools; a single finished tool stays individual.
+ */
+private fun groupMessages(messages: List<ChatMessage>): List<DisplayItem> {
+    val result = mutableListOf<DisplayItem>()
+    var i = 0
+    while (i < messages.size) {
+        if (messages[i].isFinishedTool()) {
+            // Collect the consecutive run of finished tools
+            val start = i
+            while (i < messages.size && messages[i].isFinishedTool()) i++
+            val group = messages.subList(start, i)
+            if (group.size >= 2) {
+                // Use first message's id as stable key for the group
+                result.add(DisplayItem.ToolGroup(group, "group_${group.first().id}"))
+            } else {
+                result.add(DisplayItem.Single(group.first()))
+            }
+        } else {
+            result.add(DisplayItem.Single(messages[i]))
+            i++
+        }
+    }
+    return result
+}
 
 /** Apply theme-appropriate foreground/background/cursor colors to a terminal emulator. */
 private fun applyTerminalColors(session: com.termux.terminal.TerminalSession?, isDark: Boolean) {
@@ -142,12 +181,7 @@ fun ChatScreen(service: SessionService) {
     val lastPtyOutput by (bridge?.lastPtyOutputTime?.collectAsState()
         ?: remember { mutableStateOf(0L) })
 
-    // Auto-scroll on new messages
-    LaunchedEffect(chatState.messages.size, "auto_scroll") {
-        if (chatState.messages.isNotEmpty()) {
-            listState.animateScrollToItem(chatState.messages.size - 1)
-        }
-    }
+    // Auto-scroll is handled inside ScreenMode.Chat after displayItems is computed
 
     val isDark = com.destin.code.ui.theme.LocalIsDarkTheme.current
 
@@ -500,39 +534,82 @@ fun ChatScreen(service: SessionService) {
                 HorizontalDivider(color = borderColor, thickness = 0.5.dp)
 
                 // Messages + activity indicator
+                // Group consecutive completed/failed tool calls into collapsible summaries.
+                // Recompute when list size changes OR when any tool state transitions
+                // (e.g. Running→Complete). activeToolName changes on transitions, making
+                // it a lightweight proxy for "some tool card changed state".
+                val displayItems = remember(
+                    chatState.messages.size,
+                    chatState.activeToolName,
+                    chatState.messages.lastOrNull()?.content,
+                ) {
+                    groupMessages(chatState.messages)
+                }
+                // Track which tool groups are expanded
+                val expandedGroups = remember { mutableStateMapOf<String, Boolean>() }
+
+                // Auto-scroll on new messages (uses displayItems count for correct index)
+                LaunchedEffect(chatState.messages.size) {
+                    if (displayItems.isNotEmpty()) {
+                        // +1 for the activity indicator item at the end
+                        listState.animateScrollToItem(displayItems.size)
+                    }
+                }
+
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.weight(1f).fillMaxWidth(),
                     contentPadding = PaddingValues(vertical = 8.dp),
                 ) {
-                    items(chatState.messages, key = { it.id }) { message ->
-                        val toolUseId = (message.content as? MessageContent.ToolAwaitingApproval)?.toolUseId
-                        MessageBubble(
-                            message = message,
-                            expandedCardId = chatState.expandedCardId,
-                            onToggleCard = { chatState.toggleCard(it) },
-                            onAcceptApproval = {
-                                toolUseId?.let { chatState.revertApprovalToRunning(it) }
-                                bridge?.sendApproval(com.destin.code.runtime.PtyBridge.ApprovalOption.Yes)
-                            },
-                            onAcceptAlwaysApproval = {
-                                toolUseId?.let { chatState.revertApprovalToRunning(it) }
-                                bridge?.sendApproval(com.destin.code.runtime.PtyBridge.ApprovalOption.YesAlways)
-                            },
-                            onRejectApproval = {
-                                toolUseId?.let { chatState.revertApprovalToRunning(it) }
-                                bridge?.sendApproval(com.destin.code.runtime.PtyBridge.ApprovalOption.No)
-                            },
-                            onPromptAction = { promptId, input ->
-                                bridge?.writeInput(input)
-                                val prompt = message.content as? MessageContent.InteractivePrompt
-                                val label = prompt?.buttons?.find { it.input == input }?.label ?: ""
-                                chatState.completePrompt(promptId, label)
-                                currentSession?.markPromptCompleted(promptId)
-                            },
-                            session = bridge?.getSession(),
-                            screenVersion = 0,
-                        )
+                    items(displayItems.size, key = { index ->
+                        when (val item = displayItems[index]) {
+                            is DisplayItem.Single -> item.message.id
+                            is DisplayItem.ToolGroup -> item.key
+                        }
+                    }) { index ->
+                        when (val item = displayItems[index]) {
+                            is DisplayItem.ToolGroup -> {
+                                ToolGroupCard(
+                                    messages = item.messages,
+                                    isExpanded = expandedGroups[item.key] == true,
+                                    onToggle = {
+                                        expandedGroups[item.key] = expandedGroups[item.key] != true
+                                    },
+                                    expandedCardId = chatState.expandedCardId,
+                                    onToggleCard = { chatState.toggleCard(it) },
+                                )
+                            }
+                            is DisplayItem.Single -> {
+                                val message = item.message
+                                val toolUseId = (message.content as? MessageContent.ToolAwaitingApproval)?.toolUseId
+                                MessageBubble(
+                                    message = message,
+                                    expandedCardId = chatState.expandedCardId,
+                                    onToggleCard = { chatState.toggleCard(it) },
+                                    onAcceptApproval = {
+                                        toolUseId?.let { chatState.revertApprovalToRunning(it) }
+                                        bridge?.sendApproval(com.destin.code.runtime.PtyBridge.ApprovalOption.Yes)
+                                    },
+                                    onAcceptAlwaysApproval = {
+                                        toolUseId?.let { chatState.revertApprovalToRunning(it) }
+                                        bridge?.sendApproval(com.destin.code.runtime.PtyBridge.ApprovalOption.YesAlways)
+                                    },
+                                    onRejectApproval = {
+                                        toolUseId?.let { chatState.revertApprovalToRunning(it) }
+                                        bridge?.sendApproval(com.destin.code.runtime.PtyBridge.ApprovalOption.No)
+                                    },
+                                    onPromptAction = { promptId, input ->
+                                        bridge?.writeInput(input)
+                                        val prompt = message.content as? MessageContent.InteractivePrompt
+                                        val label = prompt?.buttons?.find { it.input == input }?.label ?: ""
+                                        chatState.completePrompt(promptId, label)
+                                        currentSession?.markPromptCompleted(promptId)
+                                    },
+                                    session = bridge?.getSession(),
+                                    screenVersion = 0,
+                                )
+                            }
+                        }
                     }
                     item {
                         var now by remember { mutableStateOf(System.currentTimeMillis()) }

--- a/app/src/main/kotlin/com/destin/code/ui/cards/ToolGroupCard.kt
+++ b/app/src/main/kotlin/com/destin/code/ui/cards/ToolGroupCard.kt
@@ -1,0 +1,119 @@
+package com.destin.code.ui.cards
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.destin.code.ui.ChatMessage
+import com.destin.code.ui.MessageContent
+import com.destin.code.ui.theme.DestinCodeTheme
+
+/**
+ * Collapsed summary card for a group of completed/failed tool calls.
+ * Shows "▸ N tool calls (X ✓, Y ✗)" collapsed, expands to individual lines on tap.
+ */
+@Composable
+fun ToolGroupCard(
+    messages: List<ChatMessage>,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+    expandedCardId: String? = null,
+    onToggleCard: (String) -> Unit = {},
+) {
+    val successCount = messages.count { it.content is MessageContent.ToolComplete }
+    val failCount = messages.count { it.content is MessageContent.ToolFailed }
+    val borderColor = if (failCount > 0)
+        MaterialTheme.colorScheme.error.copy(alpha = 0.3f)
+    else
+        DestinCodeTheme.extended.surfaceBorder
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .border(0.5.dp, borderColor, RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .clickable { onToggle() }
+            .padding(10.dp)
+    ) {
+        // Summary header
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                if (isExpanded) "▾" else "▸",
+                fontSize = 12.sp,
+                color = DestinCodeTheme.extended.textSecondary,
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                "${messages.size} tool calls",
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                fontSize = 13.sp,
+            )
+            Spacer(Modifier.width(6.dp))
+            val summary = buildString {
+                if (successCount > 0) append("$successCount \u2713")
+                if (successCount > 0 && failCount > 0) append("  ")
+                if (failCount > 0) append("$failCount \u2717")
+            }
+            Text(
+                summary,
+                color = DestinCodeTheme.extended.textSecondary,
+                fontSize = 12.sp,
+            )
+        }
+
+        // Expanded: show individual tool lines (compact, no padding/borders)
+        AnimatedVisibility(visible = isExpanded) {
+            Column(modifier = Modifier.padding(top = 6.dp)) {
+                for (msg in messages) {
+                    val (tool, args, failed) = when (val c = msg.content) {
+                        is MessageContent.ToolComplete -> Triple(c.tool, c.args, false)
+                        is MessageContent.ToolFailed -> Triple(c.tool, c.args, true)
+                        else -> continue
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 1.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            if (failed) "\u2717" else "\u2713",
+                            fontSize = 11.sp,
+                            color = if (failed) MaterialTheme.colorScheme.error
+                                else DestinCodeTheme.extended.textSecondary,
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            tool,
+                            color = if (failed) MaterialTheme.colorScheme.error
+                                else MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 12.sp,
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            args.take(45) + if (args.length > 45) "..." else "",
+                            color = DestinCodeTheme.extended.textSecondary,
+                            fontSize = 11.sp,
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Consecutive completed/failed tool calls collapse into a single `▸ N tool calls (X ✓, Y ✗)` card
- Only active tools (Running, AwaitingApproval) remain as individual cards
- Tapping a group expands to show compact single-line items for each tool
- Groups of 1 stay as regular individual cards (no unnecessary grouping)

Transforms a wall of 18+ tool cards into a single collapsed line with expand-on-tap.

## Changes
- **New:** `ToolGroupCard.kt` — collapsed/expanded group composable
- **Modified:** `ChatScreen.kt` — grouping logic (`DisplayItem` sealed class, `groupMessages()`) and updated LazyColumn rendering

## Test plan
- [ ] Send a message that triggers multiple tool calls — completed tools should collapse into a group
- [ ] Tap the group to expand — individual tool lines should appear
- [ ] Active (running/approval) tools should remain as full individual cards above the group
- [ ] When a running tool completes, it should get absorbed into the collapsed group
- [ ] Single completed tool between text messages should render normally (not grouped)
- [ ] Auto-scroll should still work correctly with grouped items