### PR TITLE
Add monochrome icon for Android 13+ themed icons

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+  <!-- Scale content to sit within the 66% safe zone (roughly 18-90) -->
+  <group
+      android:translateX="24"
+      android:translateY="24"
+      android:scaleX="1.5"
+      android:scaleY="1.5">
+
+  <!-- Rounded terminal window -->
+  <path
+      android:pathData="M8,1 L32,1 A7,7,0,0,1,39,8 L39,32 A7,7,0,0,1,32,39 L8,39 A7,7,0,0,1,1,32 L1,8 A7,7,0,0,1,8,1 Z"
+      android:fillColor="#FFFFFF"
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="1.5"/>
+
+  <!-- Top bar line -->
+  <path
+      android:pathData="M6,6.5 L34,6.5"
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="1"
+      android:strokeLineCap="round"/>
+
+  <!-- Bottom bar line -->
+  <path
+      android:pathData="M6,33.5 L34,33.5"
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="1"
+      android:strokeLineCap="round"/>
+
+  <!-- Chevron prompt -->
+  <path
+      android:pathData="M5.2,17.2 L7.4,17.2 L10.2,20.5 L7.4,23.8 L5.2,23.8 L8,20.5 Z"
+      android:fillColor="#FFFFFF"/>
+
+  <!-- D letter (traced glyph) -->
+  <group
+      android:translateX="12.8"
+      android:translateY="24.0"
+      android:scaleX="0.00550"
+      android:scaleY="-0.00550"
+      android:pivotX="0"
+      android:pivotY="0">
+    <path
+        android:pathData="M1073,670 Q1073,518 1035.5,394 Q998,270 918.5,182.5 Q839,95 715,47.5 Q591,0 418,0 L86,0 L86,1307 L473,1307 Q623,1307 735.5,1269.5 Q848,1232 923,1154 Q998,1076 1035.5,956 Q1073,836 1073,670 Z M809,654 Q809,760 792,843 Q775,926 734.5,983.5 Q694,1041 626,1071 Q558,1101 457,1101 L332,1101 L332,206 L440,206 Q621,206 715,314 Q809,422 809,654 Z"
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="25"
+        android:strokeLineJoin="round"/>
+  </group>
+
+  <!-- C letter (traced glyph) -->
+  <group
+      android:translateX="19.6"
+      android:translateY="24.0"
+      android:scaleX="0.00550"
+      android:scaleY="-0.00550"
+      android:pivotX="0"
+      android:pivotY="0">
+    <path
+        android:pathData="M1004,51 Q917,16 835.5,-1 Q754,-18 666,-18 Q525,-18 416.5,23.5 Q308,65 233.5,147 Q159,229 120.5,350.5 Q82,472 82,633 Q82,798 124,926.5 Q166,1055 244,1143.5 Q322,1232 433.5,1278.5 Q545,1325 684,1325 Q729,1325 768.5,1323 Q808,1321 846,1315.5 Q884,1310 923,1301 Q962,1292 1004,1278 L1004,1034 Q919,1074 842,1091 Q765,1108 702,1108 Q609,1108 543,1074.5 Q477,1041 434.5,980.5 Q392,920 372,836.5 Q352,753 352,653 Q352,547 372.5,463.5 Q393,380 436,322 Q479,264 546,233.5 Q613,203 705,203 Q738,203 776.5,209.5 Q815,216 854.5,226.5 Q894,237 932.5,251.5 Q971,266 1004,281 Z"
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="25"
+        android:strokeLineJoin="round"/>
+  </group>
+
+  <!-- Cursor block -->
+  <path
+      android:pathData="M30,15 L35,15 A0.5,0.5,0,0,1,35.5,15.5 L35.5,25.5 A0.5,0.5,0,0,1,35,26 L30,26 A0.5,0.5,0,0,1,29.5,25.5 L29.5,15.5 A0.5,0.5,0,0,1,30,15 Z"
+      android:fillColor="#FFFFFF"/>
+
+  </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
## Summary
- Adds `ic_launcher_monochrome.xml` derived from the foreground drawable with all fill/stroke colors set to solid white and alpha attributes removed
- Adds `<monochrome>` layer to both `ic_launcher.xml` and `ic_launcher_round.xml` adaptive icon definitions
- Enables wallpaper-tinted themed icons on Android 13+ (Pixel, Samsung, and other launchers that support Material You theming)

Closes #17

## Test plan
- [ ] Build the app and install on an Android 13+ device or emulator
- [ ] Enable themed icons in launcher settings (Settings > Wallpaper & style > Themed icons)
- [ ] Verify the DestinCode icon renders as a single-tone icon matching the wallpaper accent color
- [ ] Verify the icon shape (terminal window, DC letters, chevron, cursor) is clearly visible in monochrome
- [ ] Verify the standard (non-themed) icon is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)