### PR TITLE
fix: detect Tailscale as installed when VPN is off

### DIFF
--- a/desktop/src/main/remote-config.ts
+++ b/desktop/src/main/remote-config.ts
@@ -2,6 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import bcrypt from 'bcryptjs';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
 
 const CONFIG_PATH = () => path.join(os.homedir(), '.claude', 'destincode-remote.json');
 const BCRYPT_ROUNDS = 10;
@@ -136,30 +140,65 @@ export class RemoteConfig {
     return tsPath;
   }
 
-  /** Detect Tailscale installation and connection status. */
+  /**
+   * Detect Tailscale installation and connection status.
+   *
+   * Fix: previously this ran `tailscale ip -4` first and used its success as the
+   * installation signal. That command fails when the VPN is disconnected (or the
+   * daemon is stopped), so the UI showed Tailscale as "uninstalled" any time the
+   * VPN was off. We now probe installation independently of the daemon — by
+   * verifying the binary on disk (or via `tailscale version`, which doesn't need
+   * the local API) — and only then probe connection state.
+   */
   static async detectTailscale(port: number): Promise<{ installed: boolean; connected: boolean; ip: string | null; hostname: string | null; url: string | null }> {
-    try {
-      const { execFile } = require('child_process');
-      const { promisify } = require('util');
-      const execFileAsync = promisify(execFile);
-      const tsPath = RemoteConfig.resolveTailscalePath();
+    const notInstalled = { installed: false, connected: false, ip: null, hostname: null, url: null };
 
-      const { stdout: ip } = await execFileAsync(tsPath, ['ip', '-4']);
-      const tailscaleIp = ip.trim();
+    const tsPath = RemoteConfig.resolveTailscalePath();
 
-      let hostname = '';
-      let connected = false;
-      try {
-        const { stdout: statusJson } = await execFileAsync(tsPath, ['status', '--json']);
-        const status = JSON.parse(statusJson);
-        hostname = status.Self?.HostName || '';
-        connected = status.BackendState === 'Running';
-      } catch {}
-
-      return { installed: true, connected, ip: tailscaleIp, hostname, url: `http://${tailscaleIp}:${port}` };
-    } catch {
-      return { installed: false, connected: false, ip: null, hostname: null, url: null };
+    // Step 1: confirm the binary exists, independent of daemon state.
+    // resolveTailscalePath() returns a verified absolute path on success, or
+    // the literal 'tailscale' as a fallback. For the fallback, run
+    // `tailscale version` (does not require the daemon) to check PATH.
+    let installed = false;
+    if (tsPath !== 'tailscale') {
+      try { fs.accessSync(tsPath); installed = true; } catch {}
+    } else {
+      try { await execFileAsync(tsPath, ['version']); installed = true; } catch {}
     }
+    if (!installed) return notInstalled;
+
+    // Step 2: probe daemon for connection state. Tolerate failure — when the
+    // Tailscale service is fully stopped, `status --json` errors out, but
+    // Tailscale is still installed (just not running).
+    let connected = false;
+    let hostname: string | null = null;
+    let tailscaleIp: string | null = null;
+    try {
+      const { stdout: statusJson } = await execFileAsync(tsPath, ['status', '--json']);
+      const status = JSON.parse(statusJson);
+      hostname = status.Self?.HostName || null;
+      connected = status.BackendState === 'Running';
+      if (connected) {
+        // Prefer the IP from status JSON (one fewer subprocess). Fall back to
+        // `tailscale ip -4` only if status JSON didn't include one.
+        const ips: string[] = status.Self?.TailscaleIPs ?? [];
+        tailscaleIp = ips.find((ip) => ip.includes('.')) ?? null;
+        if (!tailscaleIp) {
+          try {
+            const { stdout: ipOut } = await execFileAsync(tsPath, ['ip', '-4']);
+            tailscaleIp = ipOut.trim() || null;
+          } catch {}
+        }
+      }
+    } catch {}
+
+    return {
+      installed: true,
+      connected,
+      ip: tailscaleIp,
+      hostname,
+      url: tailscaleIp ? `http://${tailscaleIp}:${port}` : null,
+    };
   }
 
   /** Install Tailscale silently. Windows: winget, macOS: brew, Linux: manual. */

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -731,8 +731,8 @@ function RemoteButton({
                       </div>
                     </section>
 
-                    {/* Add Device — always visible when remote is configured */}
-                    {tailscale?.installed && config?.hasPassword && (
+                    {/* Add Device — requires Tailscale running, otherwise tailscale.url is null */}
+                    {tailscale?.installed && tailscale?.connected && tailscale?.url && config?.hasPassword && (
                       <button
                         onClick={() => onSetShowAddDevice(!showAddDevice)}
                         className="w-full px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/25 text-xs text-blue-400 font-medium hover:bg-blue-500/20 transition-colors flex items-center justify-center gap-1.5"
@@ -801,16 +801,22 @@ function RemoteButton({
 
                       {tailscale?.installed ? (
                         <>
+                          {/* Distinguish "installed and connected" from "installed but VPN off" —
+                              previously detection conflated the two and forced the not-installed branch. */}
                           <div className="py-2 flex items-center justify-between">
                             <span className="text-xs text-fg-2">Status</span>
-                            <span className="text-[10px] text-green-400">
-                              Connected{tailscale.hostname ? ` · ${tailscale.hostname}` : ''}
-                            </span>
+                            {tailscale.connected ? (
+                              <span className="text-[10px] text-green-400">
+                                Connected{tailscale.hostname ? ` · ${tailscale.hostname}` : ''}
+                              </span>
+                            ) : (
+                              <span className="text-[10px] text-fg-muted">VPN not active</span>
+                            )}
                           </div>
 
                           <div className="py-2 flex items-center justify-between">
                             <span className="text-xs text-fg-2">IP</span>
-                            <span className="text-xs text-fg-dim font-mono">{tailscale.ip}</span>
+                            <span className="text-xs text-fg-dim font-mono">{tailscale.ip ?? '—'}</span>
                           </div>
 
                           <label className="flex items-center justify-between py-2 cursor-pointer">

--- a/desktop/tests/remote-config.test.ts
+++ b/desktop/tests/remote-config.test.ts
@@ -7,6 +7,30 @@ import os from 'os';
 vi.mock('fs');
 vi.mock('os');
 
+// child_process.execFile is required() inside detectTailscale. We intercept
+// it so each test can deterministically simulate the tailscale CLI's behavior.
+// vi.hoisted is required because vi.mock factories run before normal `const`
+// declarations are initialized — without hoisting, the closure would capture
+// an undefined execFileMock and the real binary would run.
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+vi.mock('child_process', () => ({
+  execFile: (file: string, args: string[], cb: (err: Error | null, result?: { stdout: string; stderr: string }) => void) => {
+    try {
+      const stdout = execFileMock(file, args);
+      cb(null, { stdout, stderr: '' });
+    } catch (err) {
+      cb(err as Error);
+    }
+  },
+}));
+
+// `which` is also require()'d inside resolveTailscalePath. Force it to throw
+// so the candidate-path fallback runs (and uses our mocked fs.accessSync).
+vi.mock('which', () => ({
+  default: { sync: () => { throw new Error('not found'); } },
+  sync: () => { throw new Error('not found'); },
+}));
+
 describe('RemoteConfig', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -94,5 +118,105 @@ describe('RemoteConfig', () => {
     // IPv6-mapped IPv4
     expect(config.isTailscaleIp('::ffff:100.64.1.1')).toBe(true);
     expect(config.isTailscaleIp('::ffff:192.168.1.1')).toBe(false);
+  });
+
+  describe('detectTailscale', () => {
+    beforeEach(() => {
+      execFileMock.mockReset();
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+    });
+
+    it('returns installed:false when binary is missing', async () => {
+      // No candidate path exists on disk and `tailscale version` is never reached
+      // because resolveTailscalePath falls through to the literal 'tailscale',
+      // which then fails the version probe.
+      vi.mocked(fs.accessSync).mockImplementation(() => { throw new Error('ENOENT'); });
+      execFileMock.mockImplementation(() => { throw new Error('ENOENT'); });
+
+      const { RemoteConfig } = await import('../src/main/remote-config');
+      const result = await RemoteConfig.detectTailscale(9900);
+
+      expect(result).toEqual({
+        installed: false,
+        connected: false,
+        ip: null,
+        hostname: null,
+        url: null,
+      });
+    });
+
+    it('returns installed:true, connected:false when VPN is stopped (regression test)', async () => {
+      // Binary exists at a candidate path on disk...
+      vi.mocked(fs.accessSync).mockImplementation(() => {});
+      // ...but `tailscale status --json` fails because the daemon is stopped.
+      // Previously this also tried `tailscale ip -4` first and the failure
+      // caused the function to return installed:false. Regression guard.
+      execFileMock.mockImplementation((_file: string, args: string[]) => {
+        if (args[0] === 'status') throw new Error('failed to connect to local Tailscale daemon');
+        if (args[0] === 'ip') throw new Error('Tailscale is stopped');
+        return '';
+      });
+
+      const { RemoteConfig } = await import('../src/main/remote-config');
+      const result = await RemoteConfig.detectTailscale(9900);
+
+      expect(result.installed).toBe(true);
+      expect(result.connected).toBe(false);
+      expect(result.ip).toBeNull();
+      expect(result.url).toBeNull();
+    });
+
+    it('returns installed:true, connected:false when daemon reports BackendState !== Running', async () => {
+      vi.mocked(fs.accessSync).mockImplementation(() => {});
+      execFileMock.mockImplementation((_file: string, args: string[]) => {
+        if (args[0] === 'status') return JSON.stringify({ BackendState: 'Stopped', Self: { HostName: 'mybox' } });
+        return '';
+      });
+
+      const { RemoteConfig } = await import('../src/main/remote-config');
+      const result = await RemoteConfig.detectTailscale(9900);
+
+      expect(result.installed).toBe(true);
+      expect(result.connected).toBe(false);
+      expect(result.hostname).toBe('mybox');
+      expect(result.ip).toBeNull();
+      expect(result.url).toBeNull();
+    });
+
+    it('returns installed:true, connected:true with IP from status JSON when running', async () => {
+      vi.mocked(fs.accessSync).mockImplementation(() => {});
+      execFileMock.mockImplementation((_file: string, args: string[]) => {
+        if (args[0] === 'status') return JSON.stringify({
+          BackendState: 'Running',
+          Self: { HostName: 'mybox', TailscaleIPs: ['100.64.1.5', 'fd7a:115c::1'] },
+        });
+        return '';
+      });
+
+      const { RemoteConfig } = await import('../src/main/remote-config');
+      const result = await RemoteConfig.detectTailscale(9900);
+
+      expect(result.installed).toBe(true);
+      expect(result.connected).toBe(true);
+      expect(result.hostname).toBe('mybox');
+      expect(result.ip).toBe('100.64.1.5');
+      expect(result.url).toBe('http://100.64.1.5:9900');
+    });
+
+    it('falls back to `tailscale ip -4` when status JSON has no TailscaleIPs', async () => {
+      vi.mocked(fs.accessSync).mockImplementation(() => {});
+      execFileMock.mockImplementation((_file: string, args: string[]) => {
+        if (args[0] === 'status') return JSON.stringify({ BackendState: 'Running', Self: { HostName: 'mybox' } });
+        if (args[0] === 'ip') return '100.64.1.5\n';
+        return '';
+      });
+
+      const { RemoteConfig } = await import('../src/main/remote-config');
+      const result = await RemoteConfig.detectTailscale(9900);
+
+      expect(result.connected).toBe(true);
+      expect(result.ip).toBe('100.64.1.5');
+      expect(result.url).toBe('http://100.64.1.5:9900');
+    });
   });
 });


### PR DESCRIPTION
Detection ran `tailscale ip -4` first and used its success as the installation signal, so disconnecting the VPN (or stopping the daemon) made the UI show Tailscale as uninstalled and prompt to reinstall it.

Now probe installation independently of the daemon — verify the binary on disk, or run `tailscale version` which doesn't require the local API — then probe `status --json` separately for connection state. The UI gains a "VPN not active" state for the installed-but-disconnected case (the existing top-level status branch was already there but unreachable).