### PR TITLE
feat: surface CLI interactive prompts in chat view

### DIFF
--- a/app/src/main/kotlin/com/destin/code/parser/InkSelectParser.kt
+++ b/app/src/main/kotlin/com/destin/code/parser/InkSelectParser.kt
@@ -8,18 +8,20 @@ data class ParsedMenu(
     val title: String,
     val options: List<String>,
     val selectedIndex: Int,  // which option is currently highlighted by ❯
+    val description: String? = null, // Contextual text above menu (e.g., resume trade-offs)
 )
 
 object InkSelectParser {
 
     // Matches the selected line: optional leading whitespace + ❯, optionally followed by number
-    private val SELECTED_LINE = Regex("""^\s*❯\s*(?:\d+\.\s+)?(.+)$""")
+    // Supports both period ("1. ") and colon ("1: ") numbered formats — resume prompt uses colons
+    private val SELECTED_LINE = Regex("""^\s*❯\s*(?:\d+[.:]\s+)?(.+)$""")
     // Strips ANSI escape sequences from terminal output
     private val ANSI_ESCAPE = Regex("""\u001B\[[0-9;]*[a-zA-Z]""")
     // Matches unselected lines: 2+ leading spaces (no ❯), optionally numbered
-    private val UNSELECTED_LINE = Regex("""^\s{2,}(?:\d+\.\s+)?(.+)$""")
-    // Detects a new option (has a number prefix like "1. " or "2. ")
-    private val NUMBERED_PREFIX = Regex("""^\s*\d+\.\s+""")
+    private val UNSELECTED_LINE = Regex("""^\s{2,}(?:\d+[.:]\s+)?(.+)$""")
+    // Detects a new option (has a number prefix like "1. " or "1: ")
+    private val NUMBERED_PREFIX = Regex("""^\s*\d+[.:]\s+""")
 
     // Title overrides for known prompts — keyed by lowercase keyword found in context
     // Note: bypass permissions prompt is handled by a hardcoded handler in ManagedSession,
@@ -28,6 +30,8 @@ object InkSelectParser {
         "trust" to "Trust This Folder?",
         "dark mode" to "Choose a Theme for the Terminal",
         "login method" to "Select Login Method",
+        // Resume session prompt — shown when resuming a stale/large session
+        "resuming from a summary" to "Resume Session",
     )
 
     /**
@@ -113,7 +117,36 @@ object InkSelectParser {
         val id = "menu_" + options.joinToString("_") { it.take(10) }
             .lowercase().replace(Regex("[^a-z0-9_]"), "")
 
-        return ParsedMenu(id = id, title = title, options = options, selectedIndex = selectedIndex)
+        // Extract contextual description from lines above the menu (e.g., resume
+        // session trade-off text: session age, token count, usage warning)
+        val description = extractDescription(lines, optionIndices.first(), title)
+
+        return ParsedMenu(id = id, title = title, options = options, selectedIndex = selectedIndex, description = description)
+    }
+
+    /**
+     * Extract descriptive text from lines above the menu options, between the
+     * title region and the first option. Used to surface contextual info like
+     * the resume prompt's session-age and usage-limit trade-off explanation.
+     */
+    private fun extractDescription(lines: List<String>, firstOptionLine: Int, title: String): String? {
+        val searchStart = maxOf(0, firstOptionLine - 15)
+        val descLines = mutableListOf<String>()
+        val titleNorm = title.trimEnd(':', '?').trim()
+        val boxDrawing = Regex("""^[─┌┐└┘│╭╮╯╰┬┴├┤┼╔╗╚╝║═━]+$""")
+
+        for (i in searchStart until firstOptionLine) {
+            val clean = stripAnsi(lines[i]).trim()
+            if (clean.isEmpty()) continue
+            if (boxDrawing.matches(clean)) continue
+            // Skip the line that became the title (avoid duplication)
+            if (clean.trimEnd(':', '?').trim() == titleNorm) continue
+            // Skip footer instructions
+            if (clean.contains("enter to confirm", ignoreCase = true)) continue
+            descLines.add(clean)
+        }
+
+        return if (descLines.isEmpty()) null else descLines.joinToString(" ")
     }
 
     /**

--- a/app/src/main/kotlin/com/destin/code/runtime/ManagedSession.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/ManagedSession.kt
@@ -381,6 +381,7 @@ class ManagedSession(
         "Trust This Folder?",
         "Choose a Theme for the Terminal",
         "Select Login Method",
+        "Resume Session", // Stale session resume — lets user choose summary vs full resume
     )
 
     /** Detect permission mode from visible screen only (not raw buffer).
@@ -493,7 +494,7 @@ class ManagedSession(
                 }
                 activePrompts.add(parsed.id)
                 broadcastPrompt(parsed.id, parsed.title,
-                    InkSelectParser.toPromptButtons(parsed))
+                    InkSelectParser.toPromptButtons(parsed), parsed.description)
             }
         } else {
             val staleMenus = activePrompts.filter { it.startsWith("menu_") }
@@ -563,13 +564,15 @@ class ManagedSession(
     }
 
     /** Broadcast a prompt event to the React UI via bridge server. */
-    private fun broadcastPrompt(promptId: String, title: String, buttons: List<PromptButton>) {
+    private fun broadcastPrompt(promptId: String, title: String, buttons: List<PromptButton>, description: String? = null) {
         bridgeServer?.broadcast(JSONObject().apply {
             put("type", "prompt:show")
             put("payload", JSONObject().apply {
                 put("sessionId", id)
                 put("promptId", promptId)
                 put("title", title)
+                // Include description when present (e.g., resume session trade-off text)
+                if (description != null) put("description", description)
                 put("buttons", org.json.JSONArray().also { arr ->
                     buttons.forEach { btn ->
                         arr.put(JSONObject().apply {

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -462,6 +462,7 @@ function AppInner() {
         sessionId: payload.sessionId,
         promptId: payload.promptId,
         title: payload.title,
+        description: payload.description,
         buttons: payload.buttons || [],
       });
     });

--- a/desktop/src/renderer/components/PromptCard.tsx
+++ b/desktop/src/renderer/components/PromptCard.tsx
@@ -52,6 +52,12 @@ export default React.memo(function PromptCard({ prompt, sessionId, onSelect }: P
             <span className="text-fg-faint text-xs select-none">|</span>
             <span className="text-xs font-medium text-fg-2">{prompt.title}</span>
           </div>
+          {/* Description — contextual trade-off explanation (e.g., resume session) */}
+          {prompt.description && (
+            <div className="px-3 py-1.5 text-xs text-fg-dim leading-relaxed border-t border-edge">
+              {prompt.description}
+            </div>
+          )}
           {/* Buttons */}
           <div className="flex items-center gap-2 px-3 py-2 border-t border-edge bg-inset/30">
             {prompt.buttons.map((btn) => (

--- a/desktop/src/renderer/components/ToolCard.tsx
+++ b/desktop/src/renderer/components/ToolCard.tsx
@@ -184,6 +184,10 @@ function friendlyToolDisplay(tool: ToolCallState): { label: string; detail: stri
       return { label: truncate(String(header), 40), detail: '' };
     }
 
+    case 'ExitPlanMode': {
+      return { label: 'Plan ready — would you like to proceed?', detail: '' };
+    }
+
     default: {
       // MCP tools: mcp__{server}__{action}
       if (toolName.startsWith('mcp__')) {
@@ -301,6 +305,63 @@ function PermissionButtons({ requestId, suggestions, onResponded, onFailed }: {
       >
         No
       </button>
+    </div>
+  );
+}
+
+// --- ExitPlanMode UI ---
+// The CLI shows a 4-option Ink menu for plan approval, not a standard Yes/No
+// permission prompt. We render the real options and send PTY input (arrow keys
+// + Enter) to select the chosen option in the Ink menu, then close the hook
+// socket so the relay exits cleanly.
+
+const PLAN_INTENT_STYLES = {
+  accept: 'bg-green-600/60 hover:bg-green-600/80 text-green-100',
+  reject: 'bg-red-600/60 hover:bg-red-600/80 text-red-100',
+  neutral: 'bg-blue-600/60 hover:bg-blue-600/80 text-blue-100',
+};
+
+const PLAN_OPTIONS = [
+  { label: 'Yes, and bypass permissions', intent: 'accept' as const },
+  { label: 'Yes, manually approve edits', intent: 'accept' as const },
+  { label: 'No, refine plan', intent: 'reject' as const },
+  { label: 'Tell Claude what to change', intent: 'neutral' as const },
+];
+
+function PlanApprovalButtons({ requestId, sessionId, onResponded }: {
+  requestId: string;
+  sessionId: string;
+  onResponded?: () => void;
+}) {
+  const [responding, setResponding] = useState(false);
+  const DOWN = '\u001b[B';
+
+  const handleSelect = useCallback((optionIndex: number) => {
+    setResponding(true);
+    // Send arrow-down keys to navigate from option 1 (default) to the target,
+    // then Enter to confirm the selection in the Ink menu
+    const input = DOWN.repeat(optionIndex) + '\r';
+    window.claude.session.sendInput(sessionId, input);
+    // Close the hook socket — the Ink menu handles the decision, so we don't
+    // need to send a hook response. Closing prevents the relay from timing out.
+    (window as any).claude.session.respondToPermission(requestId, { decision: { behavior: 'deny' } }).catch(() => {});
+    if (onResponded) onResponded();
+  }, [requestId, sessionId, onResponded, DOWN]);
+
+  const pad = isAndroid() ? 'py-2' : 'py-1';
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-3 py-2 border-t border-edge bg-inset/30">
+      {PLAN_OPTIONS.map((opt, idx) => (
+        <button
+          key={opt.label}
+          disabled={responding}
+          onClick={() => handleSelect(idx)}
+          className={`px-3 ${pad} text-xs font-medium rounded-sm transition-colors disabled:opacity-50 ${PLAN_INTENT_STYLES[opt.intent]}`}
+        >
+          {opt.label}
+        </button>
+      ))}
     </div>
   );
 }
@@ -545,10 +606,13 @@ export default React.memo(function ToolCard({ tool, sessionId }: Props) {
       </button>
 
 
-      {/* Permission / AskUserQuestion UI */}
+      {/* Permission / AskUserQuestion / ExitPlanMode UI */}
       {tool.status === 'awaiting-approval' && tool.requestId && (() => {
         // AskUserQuestion needs its own UI with option selection instead of Yes/No
         const isAskUser = tool.toolName === 'AskUserQuestion' && isValidQuestions(tool.input);
+        // ExitPlanMode has a 4-option Ink menu in the CLI (bypass/manual/refine/feedback),
+        // not a standard Yes/No permission — render the real options
+        const isPlanApproval = tool.toolName === 'ExitPlanMode';
         const onRespondedCb = () => {
           if (sessionId && tool.requestId) {
             const action = { type: 'PERMISSION_RESPONDED' as const, sessionId, requestId: tool.requestId };
@@ -569,6 +633,12 @@ export default React.memo(function ToolCard({ tool, sessionId }: Props) {
             requestId={tool.requestId}
             onResponded={onRespondedCb}
             onFailed={onFailedCb}
+          />
+        ) : isPlanApproval && sessionId ? (
+          <PlanApprovalButtons
+            requestId={tool.requestId}
+            sessionId={sessionId}
+            onResponded={onRespondedCb}
           />
         ) : (
           <PermissionButtons

--- a/desktop/src/renderer/hooks/usePromptDetector.ts
+++ b/desktop/src/renderer/hooks/usePromptDetector.ts
@@ -18,6 +18,7 @@ const SETUP_PROMPT_TITLES = new Set([
   'Choose a Theme',
   'Select Login Method',
   'Skip Permissions Warning',
+  'Resume Session', // Stale session resume — lets user choose summary vs full resume
 ]);
 
 // After a permission response (PERMISSION_RESPONDED/EXPIRED clears
@@ -138,6 +139,7 @@ export function usePromptDetector() {
               sessionId: sid,
               promptId: menu.id,
               title: menu.title,
+              description: menu.description,
               buttons: buttons.map((b) => ({ label: b.label, input: b.input })),
             });
           }, PROMPT_DEBOUNCE_MS);

--- a/desktop/src/renderer/parser/ink-select-parser.ts
+++ b/desktop/src/renderer/parser/ink-select-parser.ts
@@ -6,6 +6,8 @@ const TITLE_OVERRIDES: Record<string, string> = {
   'login method': 'Select Login Method',
   'dangerously-skip-permissions': 'Skip Permissions Warning',
   'skip all permission': 'Skip Permissions Warning',
+  // Resume session prompt — shown when resuming a stale/large session
+  'resuming from a summary': 'Resume Session',
 };
 
 export interface ParsedMenu {
@@ -13,6 +15,7 @@ export interface ParsedMenu {
   title: string;
   options: string[];
   selectedIndex: number;
+  description?: string; // Contextual text above the menu (e.g., resume trade-off explanation)
 }
 
 export interface PromptButton {
@@ -28,7 +31,8 @@ function stripAnsi(line: string): string {
  * Strip leading numbering ("1. ", "2. ") from an option label if present.
  */
 function stripNumbering(text: string): string {
-  return text.replace(/^\d+\.\s+/, '');
+  // Match both period ("1. ") and colon ("1: ") numbered formats
+  return text.replace(/^\d+[.:]\s+/, '');
 }
 
 /**
@@ -56,7 +60,9 @@ function isOptionLine(line: string, referenceIndent: number): boolean {
   const trimmed = line.trim();
   if (!trimmed) return false;
   if (/^[─┌┐└┘│╭╮╯╰┬┴├┤┼╔╗╚╝║═]+$/.test(trimmed)) return false;
-  if (!/^\d+\.\s+/.test(trimmed)) return false;
+  // Match both period ("1. ") and colon ("1: ") numbered formats — the resume
+  // session prompt uses colon-numbered options while other Ink menus use periods
+  if (!/^\d+[.:]\s+/.test(trimmed)) return false;
   const indent = indentOf(line);
   return Math.abs(indent - referenceIndent) <= 2;
 }
@@ -105,7 +111,7 @@ export function parseInkSelect(screenText: string): ParsedMenu | null {
     if (!trimmed) break;
     if (!isOptionLine(lines[i], referenceIndent)) break;
     // Don't include lines that look like titles (end with ? or :)
-    if (/[?:]$/.test(trimmed) && !/^\d+\.\s+/.test(trimmed)) break;
+    if (/[?:]$/.test(trimmed) && !/^\d+[.:]\s+/.test(trimmed)) break;
     options.unshift(stripNumbering(trimmed));
   }
 
@@ -131,7 +137,11 @@ export function parseInkSelect(screenText: string): ParsedMenu | null {
   const id = 'menu_' + options.map((o) => o.slice(0, 10)).join('_')
     .toLowerCase().replace(/[^a-z0-9_]/g, '');
 
-  return { id, title, options, selectedIndex };
+  // Extract contextual description from lines above the menu (e.g., resume
+  // session trade-off text: session age, token count, usage warning)
+  const description = extractDescription(lines, Math.max(0, firstOptionLine), title);
+
+  return { id, title, options, selectedIndex, description };
 }
 
 /**
@@ -158,6 +168,32 @@ function extractTitle(lines: string[], firstOptionLine: number): string {
   }
 
   return 'Select an Option';
+}
+
+/**
+ * Extract descriptive text from lines above the menu options, between the
+ * title region and the first option. Used to surface contextual info like
+ * the resume prompt's session-age and usage-limit trade-off explanation.
+ * Skips box-drawing, empty lines, and lines that match the extracted title.
+ */
+function extractDescription(lines: string[], firstOptionLine: number, title: string): string | undefined {
+  const searchStart = Math.max(0, firstOptionLine - 15);
+  const descLines: string[] = [];
+
+  for (let i = searchStart; i < firstOptionLine; i++) {
+    const clean = stripAnsi(lines[i]).trim();
+    if (!clean) continue;
+    // Skip box-drawing / decorative lines
+    if (/^[─┌┐└┘│╭╮╯╰┬┴├┤┼╔╗╚╝║═━]+$/.test(clean)) continue;
+    // Skip the line that became the title (avoid duplication)
+    if (clean.replace(/[:?]$/, '').trim() === title.replace(/[:?]$/, '').trim()) continue;
+    // Skip footer instructions (e.g., "Enter to confirm - Esc to cancel")
+    if (/enter to confirm/i.test(clean)) continue;
+    descLines.push(clean);
+  }
+
+  if (descLines.length === 0) return undefined;
+  return descLines.join(' ');
 }
 
 export function menuToButtons(menu: ParsedMenu): PromptButton[] {

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -155,6 +155,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         prompt: {
           promptId: action.promptId,
           title: action.title,
+          description: action.description,
           buttons: action.buttons,
         },
       });

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -3,6 +3,7 @@ import { ChatMessage, ToolCallState, ToolGroupState } from '../../shared/types';
 export interface InteractivePrompt {
   promptId: string;
   title: string;
+  description?: string; // Contextual text explaining the prompt (e.g., resume trade-offs)
   buttons: { label: string; input: string }[];
   completed?: string; // label of the selected option, if completed
 }
@@ -75,6 +76,7 @@ export type ChatAction =
       sessionId: string;
       promptId: string;
       title: string;
+      description?: string;
       buttons: { label: string; input: string }[];
     }
   | {


### PR DESCRIPTION
Resume session prompt and ExitPlanMode were only usable in terminal view. Resume showed 3 options (summary/full/don't ask) that never reached chat. ExitPlanMode showed 4 options (bypass/manual/refine/feedback) but chat rendered generic Yes/No.

Resume fix: broaden Ink parser to match colon-numbered options (1: Foo), add title override and description extraction so the PromptCard shows session age, token count, and usage trade-off text.

ExitPlanMode fix: add PlanApprovalButtons component to ToolCard that renders the 4 real CLI options and sends PTY arrow-key input to navigate the Ink menu, replacing the incorrect binary Yes/No.