### PR TITLE
fix(theme-watcher): replace fs.watch with chokidar for reliable cross-platform hot-reload

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "destincode",
-  "version": "2.1.4",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "destincode",
-      "version": "2.1.4",
+      "version": "2.3.2",
       "hasInstallScript": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "bcryptjs": "^3.0.3",
-        "node-pty": "^1.2.0-beta.12",
+        "chokidar": "^4.0.3",
+        "node-pty": "1.2.0-beta.12",
         "partysocket": "^1.1.16",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
@@ -2815,6 +2816,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chownr": {
@@ -7105,6 +7121,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/rehype-highlight": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -21,6 +21,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "bcryptjs": "^3.0.3",
+    "chokidar": "^4.0.3",
     "node-pty": "1.2.0-beta.12",
     "partysocket": "^1.1.16",
     "qrcode.react": "^4.2.0",

--- a/desktop/src/main/theme-watcher.ts
+++ b/desktop/src/main/theme-watcher.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import chokidar, { type FSWatcher } from 'chokidar';
 import type { BrowserWindow } from 'electron';
 import { migrateBarJsonFiles } from './theme-migration';
 
 const THEMES_DIR = path.join(os.homedir(), '.claude', 'destinclaude-themes');
+const WATCHED_EXTS = new Set(['.json', '.svg', '.png', '.jpg', '.jpeg', '.webp', '.css']);
 
 /** Ensures themes dir exists and migrates any bare JSON files to folder format. */
 function ensureAndMigrate(): void {
@@ -22,36 +24,55 @@ function ensureAndMigrate(): void {
 export function startThemeWatcher(win: BrowserWindow): () => void {
   ensureAndMigrate();
 
-  let watcher: fs.FSWatcher | null = null;
+  // chokidar, not fs.watch — fs.watch misses events for subdirs created after
+  // the watcher starts on Windows, and doesn't support recursive on Linux at all.
+  // The theme-builder's _preview/ folder is created at runtime, so fs.watch broke hot-reload there.
+  let watcher: FSWatcher | null = null;
   const debounceMap = new Map<string, ReturnType<typeof setTimeout>>();
 
+  const fire = (absPath: string) => {
+    const rel = path.relative(THEMES_DIR, absPath).replace(/\\/g, '/');
+    if (!rel || rel.startsWith('..')) return;
+    const slug = rel.split('/')[0];
+    if (!slug) return;
+
+    const ext = path.extname(rel).toLowerCase();
+    if (!WATCHED_EXTS.has(ext)) return;
+
+    const existing = debounceMap.get(slug);
+    if (existing) clearTimeout(existing);
+    debounceMap.set(slug, setTimeout(() => {
+      debounceMap.delete(slug);
+      if (!win.isDestroyed()) {
+        win.webContents.send('theme:reload', slug);
+      }
+    }, 100));
+  };
+
   try {
-    watcher = fs.watch(THEMES_DIR, { recursive: true }, (_eventType, filename) => {
-      if (!filename) return;
-      // Extract slug from path (first path component)
-      const normalized = filename.replace(/\\/g, '/');
-      const slug = normalized.split('/')[0];
-      if (!slug) return;
-
-      // Only reload on relevant file changes
-      const ext = path.extname(normalized).toLowerCase();
-      if (!['.json', '.svg', '.png', '.jpg', '.jpeg', '.webp', '.css'].includes(ext)) return;
-
-      const existing = debounceMap.get(slug);
-      if (existing) clearTimeout(existing);
-      debounceMap.set(slug, setTimeout(() => {
-        debounceMap.delete(slug);
-        if (!win.isDestroyed()) {
-          win.webContents.send('theme:reload', slug);
-        }
-      }, 100));
+    watcher = chokidar.watch(THEMES_DIR, {
+      ignoreInitial: true,
+      // awaitWriteFinish coalesces rapid writes (including atomic rename-over) into a single event.
+      awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 25 },
+    });
+    watcher.on('add', fire);
+    watcher.on('change', fire);
+    watcher.on('unlink', fire);
+    watcher.on('unlinkDir', (absPath) => {
+      // Emit a reload keyed on the removed slug so the renderer can revert active-theme state.
+      const rel = path.relative(THEMES_DIR, absPath).replace(/\\/g, '/');
+      if (!rel || rel.includes('/') || rel.startsWith('..')) return;
+      if (!win.isDestroyed()) win.webContents.send('theme:reload', rel);
+    });
+    watcher.on('error', (err) => {
+      console.warn('[theme-watcher] chokidar error:', err);
     });
   } catch (err) {
-    console.warn('[theme-watcher] fs.watch failed, themes will not hot-reload:', err);
+    console.warn('[theme-watcher] chokidar failed, themes will not hot-reload:', err);
   }
 
   return () => {
-    watcher?.close();
+    void watcher?.close();
     for (const t of debounceMap.values()) clearTimeout(t);
     debounceMap.clear();
   };


### PR DESCRIPTION
## Summary

- `fs.watch(dir, { recursive: true })` is macOS-only in practice: libuv doesn't support recursive on Linux, and Windows drops events for subdirs created *after* the watcher starts.
- The theme-builder's `~/.claude/destinclaude-themes/_preview/` folder is created at runtime — so on Windows, manifest writes inside it fired no events, and on Linux hot-reload never worked at all.
- Swapped to chokidar, which handles both cases. Preserves the `theme:reload` IPC channel + slug payload, so the renderer contract is unchanged.

## Notes

- Pinned chokidar to `^4` — v5 is ESM-only and `desktop/` is CommonJS.
- `awaitWriteFinish: { stabilityThreshold: 100 }` coalesces atomic rename writes; kept the per-slug debounce layer so multi-file writes within a theme still coalesce.
- Added `unlinkDir` handler so deleting a top-level theme folder (including `_preview`) still fires the revert path in `theme-context.tsx`.
- Audited other `fs.watch` callers in `desktop/src/main/`: `transcript-watcher.ts` and `ipc-handlers.ts` both watch individual files (non-recursive) with polling fallbacks — left as-is.

## Test plan

- [ ] New folder hot-reload: `mkdir ~/.claude/destinclaude-themes/test-hot && write manifest.json` → appears in picker without restart
- [ ] Existing folder hot-reload: edit a token in an existing theme manifest → active theme re-renders
- [ ] Folder delete: `rm -rf` a user theme → app reverts, theme removed from picker
- [ ] `_preview` flow: `/theme-builder "test vibe"` → pick concept → quick-apply appears with no workaround
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 140 passed / 34 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)