### PR TITLE
feat(terminal): pre-blurred wallpaper layer for readability

### DIFF
--- a/desktop/src/renderer/components/TerminalView.tsx
+++ b/desktop/src/renderer/components/TerminalView.tsx
@@ -43,6 +43,16 @@ export default function TerminalView({ sessionId, visible }: Props) {
   const hasBlur = !!(bg?.['panels-blur'] && bg['panels-blur'] > 0 && !reducedEffects);
   // Terminal needs to be see-through when any visual background is active
   const seeThrough = hasWallpaper || hasGradient || hasBlur;
+  // Dedicated background layer for terminal readability (image themes only).
+  // Preferred source: theme author supplies a pre-blurred+darkened
+  // `terminal-value` asset (zero runtime cost). Fallback: use the sharp
+  // wallpaper with a runtime CSS filter — applied once on a static image,
+  // not per-frame like backdrop-filter, so it's cheap. Reduced-effects
+  // skips the runtime fallback entirely.
+  const terminalBgAsset = hasWallpaper ? bg?.['terminal-value'] : undefined;
+  const terminalBgFallback = hasWallpaper && !terminalBgAsset && !reducedEffects ? bg?.value : undefined;
+  const terminalBg = terminalBgAsset ?? terminalBgFallback;
+  const needsRuntimeBlur = !!terminalBgFallback;
 
   // Sync xterm theme when app theme changes. Always keep WebGL for performance.
   useEffect(() => {
@@ -201,9 +211,14 @@ export default function TerminalView({ sessionId, visible }: Props) {
     terminalRef.current?.write(data, () => notifyBufferReady(sessionId));
   });
 
+  // With a blurred terminal wallpaper (pre-baked OR runtime) we can sit xterm
+  // at a gentler 0.92 opacity — the blurred layer handles ambience. Without
+  // one (gradient, glass-only, or reduced-effects themes), fall back to the
+  // old 0.88 container opacity trick so the sharp background peeks through.
+  const xtermOpacity = terminalBg ? 0.92 : (seeThrough ? 0.88 : 1);
+
   return (
     <div
-      ref={containerRef}
       className={visible ? undefined : 'terminal-hidden'}
       style={{
         position: 'absolute',
@@ -213,10 +228,6 @@ export default function TerminalView({ sessionId, visible }: Props) {
         bottom: 0,
         borderRadius: 'var(--radius-md)',
         overflow: 'hidden',
-        // When a wallpaper/gradient is active, reduce terminal opacity so
-        // the background peeks through. WebGL stays loaded (no lag), and
-        // the text remains readable at 88% opacity.
-        opacity: seeThrough ? 0.88 : 1,
         // Use visibility:hidden instead of display:none so xterm.js can
         // measure fonts and maintain its screen buffer while the terminal
         // tab is not active. display:none causes a 0x0 container, which
@@ -228,6 +239,34 @@ export default function TerminalView({ sessionId, visible }: Props) {
         // text selection in the ChatView sitting underneath.
         pointerEvents: visible ? 'auto' : 'none',
       }}
-    />
+    >
+      {terminalBg && (
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: `url("${terminalBg}")`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            // Runtime `filter` on a static image paints once — unlike
+            // backdrop-filter which recomposites every frame. Only applied
+            // when the theme didn't ship a pre-baked terminal asset.
+            filter: needsRuntimeBlur ? 'blur(32px) brightness(0.82)' : undefined,
+            // Blur expands beyond the element's bounds; scale up so the
+            // soft edges don't reveal clipped pixels at the corners.
+            transform: needsRuntimeBlur ? 'scale(1.1)' : undefined,
+          }}
+        />
+      )}
+      <div
+        ref={containerRef}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          opacity: xtermOpacity,
+        }}
+      />
+    </div>
   );
 }

--- a/desktop/src/renderer/themes/theme-asset-resolver.ts
+++ b/desktop/src/renderer/themes/theme-asset-resolver.ts
@@ -34,6 +34,10 @@ export function resolveAllAssetPaths<T extends ThemeDefinition | LoadedTheme>(th
       const r = resolveAssetPath(bg.value, slug);
       if (r) bg.value = r;
     }
+    if (bg['terminal-value']) {
+      const r = resolveAssetPath(bg['terminal-value'], slug);
+      if (r) bg['terminal-value'] = r;
+    }
     if (bg.pattern) {
       const r = resolveAssetPath(bg.pattern, slug);
       if (r) bg.pattern = r;

--- a/desktop/src/renderer/themes/theme-types.ts
+++ b/desktop/src/renderer/themes/theme-types.ts
@@ -36,6 +36,10 @@ export interface ThemeFont {
 export interface ThemeBackground {
   type: 'solid' | 'gradient' | 'image';
   value: string;
+  // Pre-blurred + darkened wallpaper used exclusively in TerminalView so
+  // xterm text stays readable over high-frequency image detail. Optional —
+  // themes without it fall back to the container-opacity wallpaper-peek trick.
+  'terminal-value'?: string;
   opacity?: number;
   'panels-blur'?: number;
   'panels-opacity'?: number;


### PR DESCRIPTION
## Summary
- TerminalView renders a dedicated blurred+darkened background layer behind xterm so text stays readable over high-frequency wallpaper detail (surfaced by Kuromi Dreamer's light-canvas palette).
- New optional manifest field `background.terminal-value` points at a pre-baked asset (zero runtime cost). When absent, TerminalView falls back to a runtime CSS `filter: blur()` on the sharp wallpaper.
- xterm opacity moves from 0.88 → 0.92 when the blurred layer is present — ambience is handled by the layer, not the peek.

## Test plan
- [ ] Load Kuromi Dreamer (local user theme — has `terminal-value` baked): terminal should show a softly blurred lavender haze behind text, clearly more readable than before.
- [ ] Load Halftone Dimension / Golden Sunbreak / Kitty Pink (no `terminal-value` yet): terminal should use the runtime-blur fallback and still look improved.
- [ ] Toggle reduced-effects: image themes should revert to the opaque 0.88 peek trick (no runtime blur).
- [ ] Solid + gradient themes: no layer rendered, behavior identical to before.

## Follow-ups
- Bake `wallpaper-terminal.webp` for shipped themes in `destinclaude-themes` (separate PR).
- Update theme-builder skill to generate the asset by default (separate PR in `destinclaude`).