### PR TITLE
fix(theme-engine): restore gradient background (halftone-dimension)

### DIFF
--- a/desktop/src/renderer/themes/theme-engine.ts
+++ b/desktop/src/renderer/themes/theme-engine.ts
@@ -270,8 +270,16 @@ export function applyThemeToDom(theme: ThemeDefinition, reducedEffects = false):
   //    Also expose as --wallpaper-url so portaled glass overlays can render
   //    a blurred copy via ::before (backdrop-filter doesn't work on body children)
   const bg = theme.background;
-  if (bg?.type === 'image' && bg.value) {
+  // Fix: gradient backgrounds also need the app-shell transparency + glass treatment
+  // gated on [data-wallpaper]. Without this, the bg-canvas app-shell paints over the
+  // #theme-bg gradient layer and the gradient appears as a flat canvas-colored screen.
+  const hasBackgroundLayer = (bg?.type === 'image' || bg?.type === 'gradient') && !!bg.value;
+  if (hasBackgroundLayer) {
     root.setAttribute('data-wallpaper', '');
+  } else {
+    root.removeAttribute('data-wallpaper');
+  }
+  if (bg?.type === 'image' && bg.value) {
     body.style.backgroundImage = `url("${bg.value}")`;
     body.style.backgroundSize = 'cover';
     body.style.backgroundPosition = 'center';
@@ -281,7 +289,6 @@ export function applyThemeToDom(theme: ThemeDefinition, reducedEffects = false):
       // The slight dimming is handled by the vignette/overlay in custom_css if needed
     }
   } else {
-    root.removeAttribute('data-wallpaper');
     body.style.backgroundImage = '';
     body.style.backgroundSize = '';
     body.style.backgroundPosition = '';


### PR DESCRIPTION
## Summary

- `applyTheme()` only set `data-wallpaper` on `<html>` for `type: 'image'` backgrounds
- Gradient backgrounds (`type: 'gradient'`) never got the attribute, so `[data-wallpaper] .app-shell { background-color: transparent }` in `globals.css` never fired
- The `.app-shell` kept its `bg-canvas` Tailwind class (`#08060e`), painting over the `#theme-bg` gradient layer — producing a blank black screen
- Fix: broaden the `data-wallpaper` condition to include `type: 'gradient'`; body-level image wallpaper logic is unchanged

## Root cause

Regression introduced by `destinclaude-themes` commit `fcddd65` which stripped halftone-dimension's custom_css rule `[data-panels-blur] .app-shell { background-color: transparent }`, on the assumption the engine covered it. The engine only covered image wallpapers.

## Test plan

- [ ] Apply halftone-dimension theme — deep purple gradient should be visible behind panels
- [ ] Apply an image-wallpaper theme (e.g. golden-sunbreak) — still works normally
- [ ] Apply a solid theme (e.g. Dark) — no `data-wallpaper` attribute, no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)