### PR TITLE
feat(drawer): favorites-only view + persistent Add Skills tile

### DIFF
--- a/desktop/src/renderer/components/CommandDrawer.tsx
+++ b/desktop/src/renderer/components/CommandDrawer.tsx
@@ -141,46 +141,62 @@ export default function CommandDrawer({ open, searchMode, externalFilter, onSele
           </div>
         </div>
 
-        {/* Scrollable content */}
+        {/* Scrollable content.
+             "Add Skills +" is always the last box in the drawer (even when the
+             user has favorites) so the marketplace is always one click away.
+             When a search has zero matches, it stands alone as the empty-state
+             affordance. */}
         <div ref={scrollRef} className="scroll-fade px-4 pb-4" style={{ maxHeight: 'calc(45vh - 80px)' }}>
-          {filtered.length === 0 ? (
-            <div className="text-center py-6">
-              <p className="text-sm text-fg-muted">No matching skills</p>
-              <button
-                onClick={() => { onClose(); onOpenMarketplace(); }}
-                className="mt-2 text-sm text-accent hover:underline"
-              >
-                Browse Marketplace
-              </button>
-            </div>
-          ) : grouped ? (
-            // Categorized view
-            categoryOrder.map((cat) => {
-              const items = grouped.get(cat);
-              if (!items || items.length === 0) return null;
-              return (
-                <div key={cat} className="mb-4">
-                  <h3 className="text-[10px] font-medium text-fg-muted tracking-wider mb-2">
-                    {categoryLabels[cat]}
-                  </h3>
-                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    {items.map((skill) => (
-                      <SkillCard key={skill.id} skill={skill} onClick={onSelect} />
-                    ))}
+          {grouped ? (
+            // Categorized view (browse mode)
+            <>
+              {categoryOrder.map((cat) => {
+                const items = grouped.get(cat);
+                if (!items || items.length === 0) return null;
+                return (
+                  <div key={cat} className="mb-4">
+                    <h3 className="text-[10px] font-medium text-fg-muted tracking-wider mb-2">
+                      {categoryLabels[cat]}
+                    </h3>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                      {items.map((skill) => (
+                        <SkillCard key={skill.id} skill={skill} onClick={onSelect} />
+                      ))}
+                    </div>
                   </div>
-                </div>
-              );
-            })
+                );
+              })}
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                <AddSkillsCard onClick={() => { onClose(); onOpenMarketplace(); }} />
+              </div>
+            </>
           ) : (
-            // Flat search results
+            // Flat search results — "Add Skills +" trails the matches
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
               {filtered.map((skill) => (
                 <SkillCard key={skill.id} skill={skill} onClick={onSelect} />
               ))}
+              <AddSkillsCard onClick={() => { onClose(); onOpenMarketplace(); }} />
             </div>
           )}
         </div>
       </div>
     </>
+  );
+}
+
+// Persistent "Add Skills +" tile — matches SkillCard's drawer dimensions so it
+// sits naturally at the end of the grid. Uses dashed border + accent color to
+// read as an action, not a skill.
+function AddSkillsCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="bg-panel/40 border border-dashed border-edge rounded-lg p-3 text-left hover:bg-inset hover:border-accent transition-colors flex flex-col items-center justify-center text-accent"
+    >
+      <span className="text-lg font-medium leading-none">+</span>
+      <span className="text-sm font-medium mt-1">Add Skills</span>
+      <span className="text-[11px] text-fg-muted mt-1">Browse marketplace</span>
+    </button>
   );
 }

--- a/desktop/src/renderer/state/skill-context.tsx
+++ b/desktop/src/renderer/state/skill-context.tsx
@@ -27,9 +27,16 @@ interface SkillActions {
 }
 
 interface SkillContextValue extends SkillState, SkillActions {
-  /** Skills filtered for the CommandDrawer: favorites ∪ curated defaults */
+  /** Skills filtered for the CommandDrawer: user favorites only. Curated defaults
+   *  seed the favorites list on first encounter (see SEEDED_KEY below), not at read time. */
   drawerSkills: SkillEntry[];
 }
+
+// localStorage key tracking which curated-default skill ids have already been
+// one-time seeded into favorites. Once an id is in this list we never re-seed it,
+// so unfavoriting it sticks. Adding NEW curated defaults later still seeds them
+// the next time the app loads.
+const SEEDED_KEY = 'destincode-seeded-favorites';
 
 const SkillContext = createContext<SkillContextValue | null>(null);
 
@@ -47,11 +54,31 @@ export function SkillProvider({ children }: { children: ReactNode }) {
       window.claude.skills.getFavorites(),
       window.claude.skills.getChips(),
       window.claude.skills.getCuratedDefaults(),
-    ]).then(([inst, favs, ch, defaults]) => {
+    ]).then(async ([inst, favs, ch, defaults]) => {
       setInstalled(inst ?? []);
-      setFavorites(favs ?? []);
       setChipsState(ch ?? []);
       setCuratedDefaults(defaults ?? []); // Guard: IPC may return undefined if registry key mismatches
+
+      // First-run seeding: for each curated default we haven't seeded before,
+      // persist it as a favorite so the drawer is non-empty out of the box.
+      // We track seeded ids separately so unfavoriting sticks permanently.
+      const curated = defaults ?? [];
+      const currentFavs = favs ?? [];
+      let seeded: string[] = [];
+      try { seeded = JSON.parse(localStorage.getItem(SEEDED_KEY) ?? '[]'); } catch {}
+      const toSeed = curated.filter(id => !seeded.includes(id));
+      if (toSeed.length > 0) {
+        const favSet = new Set(currentFavs);
+        for (const id of toSeed) {
+          if (!favSet.has(id)) {
+            try { await window.claude.skills.setFavorite(id, true); favSet.add(id); } catch {}
+          }
+        }
+        localStorage.setItem(SEEDED_KEY, JSON.stringify([...new Set([...seeded, ...toSeed])]));
+        setFavorites(Array.from(favSet));
+      } else {
+        setFavorites(currentFavs);
+      }
       setLoading(false);
     }).catch((err) => {
       console.error('[SkillContext] Failed to load:', err);
@@ -102,18 +129,12 @@ export function SkillProvider({ children }: { children: ReactNode }) {
     await refreshInstalled();
   }, [refreshInstalled]);
 
-  // Compute drawer skills: favorites ∪ curated defaults, favorites sorted first
+  // Drawer shows only user favorites. Curated defaults seed favorites on first run
+  // (see initial-load effect); after that the user fully controls what's in the drawer.
   const drawerSkills = useMemo(() => {
     const favSet = new Set(favorites);
-    const ids = new Set([...favorites, ...curatedDefaults]);
-    return installed
-      .filter(s => ids.has(s.id))
-      .sort((a, b) => {
-        const aFav = favSet.has(a.id) ? 0 : 1;
-        const bFav = favSet.has(b.id) ? 0 : 1;
-        return aFav - bFav;
-      });
-  }, [installed, favorites, curatedDefaults]);
+    return installed.filter(s => favSet.has(s.id));
+  }, [installed, favorites]);
 
   // Stable references for pass-through IPC methods (no state dependencies)
   const listMarketplace = useCallback((filters?: SkillFilters) => window.claude.skills.listMarketplace(filters), []);


### PR DESCRIPTION
## Summary
- Command Drawer now shows **only user favorites** (previously: favorites ∪ curated defaults on every render).
- Curated defaults seed the favorites list **once per id** via a new \`destincode-seeded-favorites\` localStorage marker. Unfavoriting a seeded skill sticks permanently; adding new curated ids later still seeds them.
- The last box in the drawer is always an **"Add Skills +"** tile that opens the marketplace — present even when the user has favorites, and also shown when a search has zero matches.

## Why
Users couldn't actually hide curated skills from the drawer — the union with \`curatedDefaults\` on every read resurrected them. Moving to favorites-only gives full user control while preserving a populated out-of-the-box experience via one-time seeding.

## Coordination
Pairs with destincode-marketplace#5 which narrows \`curated-defaults.json\` to \`theme-builder\` only. Merge order: marketplace PR first (or concurrent) — otherwise existing users on next launch would auto-favorite all 8 pre-existing curated ids.

## Test plan
- [ ] Fresh profile (no \`destincode-skills.json\`, no \`destincode-seeded-favorites\` in localStorage) → theme-builder auto-appears in drawer.
- [ ] Unfavorite theme-builder from Skill Manager → does not re-appear on reload.
- [ ] Existing users with pre-existing favorites → favorites preserved, theme-builder added once.
- [ ] "Add Skills +" tile opens the marketplace.
- [ ] Drawer search with zero matches shows only the Add Skills tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)