### PR TITLE
fix(appearance): glass sliders thumb frozen for built-in/community themes

### DIFF
--- a/desktop/src/renderer/components/ThemeScreen.tsx
+++ b/desktop/src/renderer/components/ThemeScreen.tsx
@@ -64,7 +64,7 @@ const PencilIcon = ({ className = 'w-3 h-3' }: { className?: string }) => (
 );
 
 export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, onPublishTheme }: Props) {
-  const { allThemes, theme: activeSlug, setTheme, reducedEffects, setReducedEffects, showTimestamps, setShowTimestamps, setGlassOverride } = useTheme();
+  const { allThemes, activeTheme, theme: activeSlug, setTheme, reducedEffects, setReducedEffects, showTimestamps, setShowTimestamps, setGlassOverride } = useTheme();
   // Flips the popup body to the plain-language explainer view via the (i) icon.
   const [showInfo, setShowInfo] = useState(false);
   // Slug of the theme currently being edited (pencil opened). Null = main list.
@@ -78,7 +78,15 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
     setEditingSlug(slug);
   };
 
-  const editingTheme = editingSlug ? allThemes.find(t => t.slug === editingSlug) ?? null : null;
+  // Fix: read from activeTheme (which has glassOverrides merged) rather than
+  // raw allThemes, otherwise the Panel/Bubble Blur + Opacity sliders read a
+  // stale base value and the thumb appears frozen while overrides still
+  // persist + apply to the DOM. openEditor() always activates the theme being
+  // edited, so activeSlug === editingSlug here. Fall back to the raw lookup
+  // if they ever diverge (e.g. race with a concurrent setTheme).
+  const editingTheme = editingSlug
+    ? (editingSlug === activeSlug ? activeTheme : allThemes.find(t => t.slug === editingSlug) ?? null)
+    : null;
 
   if (showInfo) {
     return (


### PR DESCRIPTION
## Summary
- Panel/Bubble Blur + Opacity sliders in the per-theme edit view showed a frozen thumb while the underlying glass override *was* persisting and applying to the DOM.
- Root cause: the edit view's \`theme\` prop came from \`allThemes.find(...)\` (raw theme), but for non-user themes overrides live in a separate \`glassOverrides\` map that only merges into \`activeTheme\`. Controlled \`value\` prop never changed → browser snapped thumb back every render.
- Fix: read \`editingTheme\` from \`activeTheme\` when \`editingSlug === activeSlug\` (true ~always — \`openEditor()\` activates the theme being edited). Falls back to raw lookup for the theoretical race.

## Test plan
- [ ] Launch dev build, open Appearance → pencil on a built-in/community wallpaper theme (e.g. strawberry-kitty once it ships, halftone-dimension today)
- [ ] Drag Panel Blur, Panel Opacity, Bubble Blur, Bubble Opacity — thumb should now track the drag
- [ ] Close + reopen the editor — values persist
- [ ] Pencil on a user-authored theme — sliders still work (unchanged path, writes to the theme file)
- [ ] Toggle Reduce Visual Effects — blur sliders greyed, opacity still editable