### PR TITLE
feat(sync): restore from backup — directional pull with snapshots + undo

### DIFF
--- a/app/src/main/assets/web/index.html
+++ b/app/src/main/assets/web/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>DestinCode</title>
-  <script type="module" crossorigin src="./assets/index-DSx7t0S_.js"></script>
+  <script type="module" crossorigin src="./assets/index-DAGqNZzV.js"></script>
   <link rel="modulepreload" crossorigin href="./assets/chunk-sbRso20c.js">
   <link rel="modulepreload" crossorigin href="./assets/platform-CNNRUk1X.js">
-  <link rel="stylesheet" crossorigin href="./assets/index-h2naciYx.css">
+  <link rel="stylesheet" crossorigin href="./assets/index-nOYYl8Wh.css">
 </head>
 <body>
   <div id="root"></div>

--- a/app/src/main/assets/web/index.html
+++ b/app/src/main/assets/web/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>DestinCode</title>
-  <script type="module" crossorigin src="./assets/index-B10zd6Ng.js"></script>
+  <script type="module" crossorigin src="./assets/index-DSx7t0S_.js"></script>
   <link rel="modulepreload" crossorigin href="./assets/chunk-sbRso20c.js">
   <link rel="modulepreload" crossorigin href="./assets/platform-CNNRUk1X.js">
-  <link rel="stylesheet" crossorigin href="./assets/index-BvONS7WR.css">
+  <link rel="stylesheet" crossorigin href="./assets/index-h2naciYx.css">
 </head>
 <body>
   <div id="root"></div>

--- a/app/src/main/assets/web/remote-shim.js
+++ b/app/src/main/assets/web/remote-shim.js
@@ -205,6 +205,11 @@ function handleMessage(data) {
         case 'prompt:complete':
             dispatchEvent('prompt:complete', payload);
             break;
+        case 'sync:restore:progress':
+            // Restore progress events flow to any listener registered via
+            // window.claude.sync.restore.onProgress(). Broadcast (no sessionId).
+            dispatchEvent('sync:restore:progress', payload);
+            break;
     }
 }
 function connect(passwordOrToken, isToken = false) {
@@ -586,7 +591,6 @@ function installShim() {
             getShareLink: (id) => invoke('skills:get-share-link', { id }),
             importFromLink: (encoded) => invoke('skills:import-from-link', { encoded }),
             getCuratedDefaults: () => invoke('skills:get-curated-defaults'),
-            getFeatured: () => invoke('skills:get-featured'),
             // Decomposition v3 §9.9: shim parity for integration badges
             getIntegrationInfo: (id) => invoke('skills:get-integration-info', { id }),
             // Decomposition v3 §9.10: shim parity for onboarding helpers
@@ -595,20 +599,11 @@ function installShim() {
             // Phase 3b: update a plugin (re-installs at the same path)
             update: (id) => invoke('skills:update', { id }),
         },
-        // Marketplace redesign Phase 3 — integrations namespace.
-        integrations: {
-            list: () => invoke('integrations:list'),
-            install: (slug) => invoke('integrations:install', { slug }),
-            uninstall: (slug) => invoke('integrations:uninstall', { slug }),
-            status: (slug) => invoke('integrations:status', { slug }),
-            configure: (slug, settings) => invoke('integrations:configure', { slug, settings }),
-        },
         // Phase 3: unified marketplace (packages map + per-entry config)
         marketplace: {
             getPackages: () => invoke('marketplace:get-packages'),
             getConfig: (id) => invoke('marketplace:get-config', { id }),
             setConfig: (id, values) => invoke('marketplace:set-config', { id, values }),
-            invalidateCache: () => invoke('marketplace:invalidate-cache'),
         },
         // Marketplace sign-in (device-code OAuth flow) — same shape as preload.ts.
         // On Android the handlers live in SessionService.kt (Task 13). Until then
@@ -730,6 +725,24 @@ function installShim() {
                 authGithub: () => invoke('sync:setup:auth-github'),
                 createRepo: (repoName) => invoke('sync:setup:create-repo', { repoName }),
             },
+            // Restore from backup — directional, user-initiated pull. Mirrors the
+            // preload surface exactly (see preload.ts sync.restore). Browser/Android
+            // transports use WebSocket invoke + a dispatchEvent subscription for progress.
+            restore: {
+                listVersions: (backendId) => invoke('sync:restore:list-versions', { backendId }),
+                preview: (opts) => invoke('sync:restore:preview', { opts }),
+                execute: (opts) => invoke('sync:restore:execute', { opts }),
+                listSnapshots: () => invoke('sync:restore:list-snapshots'),
+                undo: (snapshotId) => invoke('sync:restore:undo', { snapshotId }),
+                deleteSnapshot: (snapshotId) => invoke('sync:restore:delete-snapshot', { snapshotId }),
+                probe: (backendId) => invoke('sync:restore:probe', { backendId }),
+                browseCategory: (backendId, category, versionRef) => invoke('sync:restore:browse-url', { backendId, category, versionRef }),
+                onProgress: (cb) => {
+                    const handler = (evt) => cb(evt);
+                    addListener('sync:restore:progress', handler);
+                    return () => removeListener('sync:restore:progress', handler);
+                },
+            },
         },
         folders: {
             list: () => invoke('folders:list'),
@@ -762,6 +775,9 @@ function installShim() {
         removeAllListeners: (channel) => removeAllListeners(channel),
         getGitHubAuth: () => invoke('github:auth'),
         getHomePath: () => invoke('get-home-path'),
+        config: {
+            setExperimentalFlag: (name, value) => invoke('config:set-experimental-flag', { name, value }),
+        },
         getFavorites: () => invoke('favorites:get'),
         setFavorites: (favorites) => invoke('favorites:set', favorites),
         getIncognito: () => invoke('game:getIncognito'),

--- a/app/src/main/kotlin/com/destin/code/runtime/RestoreService.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/RestoreService.kt
@@ -117,34 +117,114 @@ class RestoreService(
 
     suspend fun previewRestore(opts: RestoreOptions): RestorePreview = withContext(Dispatchers.IO) {
         val adapter = adapterFor(opts.backendId)
-        val perCategory = mutableListOf<CategoryPreview>()
-        var totalBytes = 0L
+        val raw = mutableListOf<CategoryPreview>()
         val warnings = mutableListOf<String>()
 
         for (category in opts.categories) {
             try {
-                val p = adapter.previewCategory(category, opts.versionRef)
-                perCategory.add(p)
-                totalBytes += p.bytes
+                raw.add(adapter.previewCategory(category, opts.versionRef))
             } catch (e: Exception) {
                 warnings.add("Preview failed for ${category.wire}: ${e.message ?: e}")
-                perCategory.add(CategoryPreview(category, 0, 0, 0, 0, 0, 0))
+                raw.add(CategoryPreview(category, 0, 0, 0, 0, 0, 0))
             }
         }
 
-        if (opts.categories.contains(RestoreCategory.SKILLS) ||
-            opts.categories.contains(RestoreCategory.MEMORY)) {
+        // For merge mode, reinterpret the same raw counts:
+        //   - toDelete=0 (merge never deletes locally; those files stay + get uploaded)
+        //   - toUpload = original toDelete (they go up to the backup instead of away)
+        // Wipe keeps the as-measured shape.
+        val perCategory: List<CategoryPreview> = raw.map { p ->
+            if (opts.mode == RestoreMode.MERGE) {
+                p.copy(toUpload = p.toDelete, toDelete = 0)
+            } else p
+        }
+
+        val totalBytes = perCategory.sumOf { it.bytes }
+
+        // Skip the restart hint in merge mode — merge doesn't swap live dirs.
+        if (opts.mode == RestoreMode.WIPE &&
+            (opts.categories.contains(RestoreCategory.SKILLS) ||
+             opts.categories.contains(RestoreCategory.MEMORY))) {
             warnings.add("Skills or memory restored — app restart recommended to pick up changes.")
+        }
+        if (opts.mode == RestoreMode.WIPE && perCategory.any { it.toDelete > 0 }) {
+            warnings.add("Wipe & restore will DELETE local files not present in the backup.")
         }
 
         // Rough estimate: 10 MB/s effective throughput after overhead. Cellular
         // on Android will be slower — this is a UX hint, not a contract.
         val estimatedSeconds = maxOf(3L, (totalBytes + 10L * 1024 * 1024 - 1) / (10L * 1024 * 1024))
 
-        RestorePreview(perCategory, totalBytes, estimatedSeconds, warnings)
+        RestorePreview(perCategory, totalBytes, estimatedSeconds, warnings, opts.mode)
+    }
+
+    /**
+     * Resolve a browse URL for a single category on the remote backend.
+     * Returns null if the adapter doesn't support browse links or lookup fails.
+     */
+    suspend fun browseCategoryUrl(
+        backendId: String,
+        category: RestoreCategory,
+        versionRef: String,
+    ): String? = withContext(Dispatchers.IO) {
+        try {
+            adapterFor(backendId).remoteBrowseUrlFor(category, versionRef)
+        } catch (_: Exception) {
+            null
+        }
     }
 
     suspend fun executeRestore(
+        opts: RestoreOptions,
+        onProgress: (RestoreProgressEvent) -> Unit,
+    ): RestoreResult {
+        // Merge mode reuses the sync loop's pull + push (remote → local
+        // add/overwrite with no deletions, then local → remote upload for
+        // anything local-only). This is NON-destructive on both sides, so no
+        // snapshot is needed and we explicitly do NOT flip restoreInProgress
+        // — we actually want the push to run.
+        return if (opts.mode == RestoreMode.MERGE) {
+            executeMerge(opts, onProgress)
+        } else {
+            executeWipe(opts, onProgress)
+        }
+    }
+
+    private suspend fun executeMerge(
+        opts: RestoreOptions,
+        onProgress: (RestoreProgressEvent) -> Unit,
+    ): RestoreResult = withContext(Dispatchers.IO) {
+        val startedAt = System.currentTimeMillis()
+
+        // Emit a single 'fetching' phase for each category up-front so the UI
+        // renders per-category rows. Merge doesn't stage per-category, so we
+        // don't get file-level progress — just the two top-level phases.
+        for (category in opts.categories) {
+            onProgress(RestoreProgressEvent(category, 0, 0, null, "fetching"))
+        }
+
+        // Phase 1: pull remote → local (add + overwrite-newer, no deletions).
+        syncService.pull(backendId = opts.backendId)
+
+        // Phase 2: push local → remote (uploads anything local-only). force=true
+        // so the push isn't skipped for being recent — the user just asked for it.
+        syncService.push(force = true, backendId = opts.backendId)
+
+        for (category in opts.categories) {
+            onProgress(RestoreProgressEvent(category, 1, 1, null, "done"))
+        }
+
+        RestoreResult(
+            snapshotId = null,
+            categoriesRestored = opts.categories,
+            filesWritten = 0, // merge doesn't track per-file writes; sync logs it
+            durationMs = System.currentTimeMillis() - startedAt,
+            requiresRestart = opts.categories.contains(RestoreCategory.SKILLS) ||
+                              opts.categories.contains(RestoreCategory.MEMORY),
+        )
+    }
+
+    private suspend fun executeWipe(
         opts: RestoreOptions,
         onProgress: (RestoreProgressEvent) -> Unit,
     ): RestoreResult = withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/destin/code/runtime/RestoreService.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/RestoreService.kt
@@ -1,0 +1,428 @@
+package com.destin.code.runtime
+
+import com.destin.code.runtime.restore.DriveRestoreAdapter
+import com.destin.code.runtime.restore.GithubRestoreAdapter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * RestoreService.kt — Kotlin port of desktop/src/main/restore-service.ts.
+ *
+ * Directional, user-initiated restore from a cloud backup. This is NOT sync —
+ * sync is bidirectional merge; restore is a one-time pull where the remote is
+ * treated as authoritative. Different invariants, different code paths.
+ *
+ * Safety invariants (enforced here, matching desktop parity):
+ *   1. Snapshot-first by default — current local data is directory-copied to
+ *      ~/.claude/restore-snapshots/<ISO>/<category>/ before any overwrite.
+ *      (Directory snapshots — NOT tar.gz — for parity with desktop + simpler undo.)
+ *   2. Push loop paused — SyncService.restoreInProgress is flipped true during
+ *      execute/undo so the 15-minute push doesn't upload half-restored state.
+ *   3. Atomic per-category — each category is staged under
+ *      ~/.claude/.restore-staging/<category>/, then the live dir is swapped
+ *      in via a rename pair with a .old.<ts> intermediate. Crash leaves either
+ *      the old or new dir, never a mix. (The .old intermediate is load-bearing
+ *      on Windows; on Linux the rename-over-empty-dir semantics work, but we
+ *      keep the pattern for parity + rollback safety.)
+ *
+ * Retention: snapshots older than 90 days are pruned on app start; cap 10.
+ * Progress events are throttled to 250ms per category to avoid WS flooding.
+ */
+class RestoreService(
+    private val syncService: SyncService,
+    private val claudeDir: File,
+) {
+    private val snapshotsRoot = File(claudeDir, "restore-snapshots")
+    private val stagingRoot = File(claudeDir, ".restore-staging")
+
+    companion object {
+        private const val SNAPSHOT_RETENTION_DAYS = 90
+        private const val SNAPSHOT_CAP = 10
+        private const val PROGRESS_THROTTLE_MS = 250L
+    }
+
+    // =========================================================================
+    // Adapter dispatch
+    // =========================================================================
+
+    /** Resolve a backend instance id → its full JSON record from config.json. */
+    private fun getBackendInstance(backendId: String): JSONObject? {
+        val configFile = File(claudeDir, "toolkit-state/config.json")
+        if (!configFile.exists()) return null
+        return try {
+            val config = JSONObject(configFile.readText())
+            val backends = config.optJSONArray("storage_backends") ?: return null
+            for (i in 0 until backends.length()) {
+                val b = backends.getJSONObject(i)
+                if (b.optString("id") == backendId) return b
+            }
+            null
+        } catch (_: Exception) { null }
+    }
+
+    private fun adapterFor(backendId: String): RestoreAdapter {
+        val instance = getBackendInstance(backendId)
+            ?: throw IllegalArgumentException("No backend with id '$backendId'")
+        return when (instance.optString("type")) {
+            "drive" -> DriveRestoreAdapter(instance, claudeDir, syncService)
+            "github" -> GithubRestoreAdapter(instance, claudeDir, syncService)
+            // iCloud is intentionally unsupported on Android — desktop-only backend.
+            else -> throw IllegalArgumentException("Unsupported backend type: ${instance.optString("type")}")
+        }
+    }
+
+    // =========================================================================
+    // Category path resolution
+    // =========================================================================
+
+    /**
+     * Canonical live path for a category. Memory + conversations share the
+     * ~/.claude/projects/ tree (memory in a per-project memory/ subdir,
+     * conversations as .jsonl files). We swap the whole projects tree so
+     * cross-project partial restore stays atomic; the adapter selects only
+     * the relevant files into staging.
+     */
+    fun liveDirFor(category: RestoreCategory): File = when (category) {
+        RestoreCategory.MEMORY, RestoreCategory.CONVERSATIONS -> File(claudeDir, "projects")
+        RestoreCategory.ENCYCLOPEDIA -> File(claudeDir, "encyclopedia")
+        RestoreCategory.SKILLS -> File(claudeDir, "skills")
+        RestoreCategory.PLANS -> File(claudeDir, "plans")
+        RestoreCategory.SPECS -> File(claudeDir, "specs")
+    }
+
+    fun stagingDirFor(category: RestoreCategory): File =
+        File(stagingRoot, category.wire)
+
+    // =========================================================================
+    // Public API
+    // =========================================================================
+
+    suspend fun probe(backendId: String): Pair<Boolean, List<RestoreCategory>> = withContext(Dispatchers.IO) {
+        try {
+            adapterFor(backendId).probe()
+        } catch (_: Exception) {
+            Pair(false, emptyList())
+        }
+    }
+
+    suspend fun listVersions(backendId: String): List<RestorePoint> = withContext(Dispatchers.IO) {
+        adapterFor(backendId).listVersions()
+    }
+
+    suspend fun previewRestore(opts: RestoreOptions): RestorePreview = withContext(Dispatchers.IO) {
+        val adapter = adapterFor(opts.backendId)
+        val perCategory = mutableListOf<CategoryPreview>()
+        var totalBytes = 0L
+        val warnings = mutableListOf<String>()
+
+        for (category in opts.categories) {
+            try {
+                val p = adapter.previewCategory(category, opts.versionRef)
+                perCategory.add(p)
+                totalBytes += p.bytes
+            } catch (e: Exception) {
+                warnings.add("Preview failed for ${category.wire}: ${e.message ?: e}")
+                perCategory.add(CategoryPreview(category, 0, 0, 0, 0, 0, 0))
+            }
+        }
+
+        if (opts.categories.contains(RestoreCategory.SKILLS) ||
+            opts.categories.contains(RestoreCategory.MEMORY)) {
+            warnings.add("Skills or memory restored — app restart recommended to pick up changes.")
+        }
+
+        // Rough estimate: 10 MB/s effective throughput after overhead. Cellular
+        // on Android will be slower — this is a UX hint, not a contract.
+        val estimatedSeconds = maxOf(3L, (totalBytes + 10L * 1024 * 1024 - 1) / (10L * 1024 * 1024))
+
+        RestorePreview(perCategory, totalBytes, estimatedSeconds, warnings)
+    }
+
+    suspend fun executeRestore(
+        opts: RestoreOptions,
+        onProgress: (RestoreProgressEvent) -> Unit,
+    ): RestoreResult = withContext(Dispatchers.IO) {
+        val startedAt = System.currentTimeMillis()
+        val adapter = adapterFor(opts.backendId)
+
+        // Pause SyncService push loop so a tick can't run mid-restore and
+        // upload a half-swapped staging dir to the backup.
+        syncService.restoreInProgress = true
+        var snapshotId: String? = null
+        var filesWritten = 0
+
+        // Per-category throttle — phase transitions emit immediately, only
+        // file-level staging/fetching events are throttled.
+        val lastEmitAt = HashMap<RestoreCategory, Long>()
+        val emit: (RestoreProgressEvent) -> Unit = { evt ->
+            val now = System.currentTimeMillis()
+            val last = lastEmitAt[evt.category] ?: 0L
+            val isPhaseEvent = evt.phase != "fetching" && evt.phase != "staging"
+            if (isPhaseEvent || now - last >= PROGRESS_THROTTLE_MS) {
+                lastEmitAt[evt.category] = now
+                onProgress(evt)
+            }
+        }
+
+        try {
+            stagingRoot.mkdirs()
+            snapshotsRoot.mkdirs()
+
+            // --- 1. Snapshot current local state ---
+            if (opts.snapshotFirst) {
+                snapshotId = isoStamp()
+                val snapshotDir = File(snapshotsRoot, snapshotId)
+                snapshotDir.mkdirs()
+                for (category in opts.categories) {
+                    emit(RestoreProgressEvent(category, 0, 0, null, "snapshotting"))
+                    val liveDir = liveDirFor(category)
+                    if (liveDir.exists()) {
+                        val dest = File(snapshotDir, category.wire)
+                        // Directory snapshot (not tar.gz) — parity with desktop's
+                        // fs.cpSync; cheaper and simpler undo. File.copyRecursively
+                        // is Kotlin's cross-platform deep copy.
+                        liveDir.copyRecursively(dest, overwrite = true)
+                    }
+                }
+                // Sidecar manifest for SnapshotsPanel.
+                val manifest = Snapshot(
+                    id = snapshotId,
+                    timestamp = System.currentTimeMillis(),
+                    categories = opts.categories,
+                    backendId = opts.backendId,
+                    sizeBytes = dirSize(snapshotDir),
+                    triggeredBy = "restore",
+                )
+                File(snapshotDir, "manifest.json").writeText(manifest.toJson().toString(2))
+            }
+
+            // --- 2. Fetch each category into staging, then atomic swap ---
+            for (category in opts.categories) {
+                emit(RestoreProgressEvent(category, 0, 0, null, "fetching"))
+                val staging = stagingDirFor(category)
+                // Clean any staging remnant from a prior crashed run.
+                runCatching { staging.deleteRecursively() }
+                staging.mkdirs()
+
+                adapter.fetchInto(category, staging, opts.versionRef) { filename, done, total ->
+                    filesWritten++
+                    emit(RestoreProgressEvent(category, done, total, filename, "staging"))
+                }
+
+                emit(RestoreProgressEvent(category, 1, 1, null, "swapping"))
+                atomicSwap(staging, liveDirFor(category))
+                emit(RestoreProgressEvent(category, 1, 1, null, "done"))
+            }
+
+            RestoreResult(
+                snapshotId = snapshotId,
+                categoriesRestored = opts.categories,
+                filesWritten = filesWritten,
+                durationMs = System.currentTimeMillis() - startedAt,
+                requiresRestart = opts.categories.contains(RestoreCategory.SKILLS) ||
+                                  opts.categories.contains(RestoreCategory.MEMORY),
+            )
+        } finally {
+            syncService.restoreInProgress = false
+            // Best-effort staging cleanup. Orphaned dirs are also swept on app start.
+            runCatching { stagingRoot.deleteRecursively() }
+        }
+    }
+
+    fun listSnapshots(): List<Snapshot> {
+        if (!snapshotsRoot.exists()) return emptyList()
+        val out = mutableListOf<Snapshot>()
+        snapshotsRoot.listFiles()?.forEach { dir ->
+            if (!dir.isDirectory) return@forEach
+            val manifestFile = File(dir, "manifest.json")
+            try {
+                out.add(Snapshot.fromJson(JSONObject(manifestFile.readText())))
+            } catch (_: Exception) {
+                // Missing/corrupt manifest — synthesize minimal metadata from dirname.
+                out.add(Snapshot(
+                    id = dir.name,
+                    timestamp = parseIsoStamp(dir.name),
+                    categories = emptyList(),
+                    backendId = "",
+                    sizeBytes = 0L,
+                    triggeredBy = "manual",
+                ))
+            }
+        }
+        return out.sortedByDescending { it.timestamp }
+    }
+
+    suspend fun undoRestore(snapshotId: String): Unit = withContext(Dispatchers.IO) {
+        val snapshotDir = File(snapshotsRoot, snapshotId)
+        if (!snapshotDir.exists()) throw IllegalArgumentException("Snapshot $snapshotId not found")
+        val manifestFile = File(snapshotDir, "manifest.json")
+        val manifest = Snapshot.fromJson(JSONObject(manifestFile.readText()))
+
+        syncService.restoreInProgress = true
+        try {
+            for (category in manifest.categories) {
+                val source = File(snapshotDir, category.wire)
+                if (!source.exists()) continue
+                val staging = stagingDirFor(category)
+                runCatching { staging.deleteRecursively() }
+                staging.parentFile?.mkdirs()
+                source.copyRecursively(staging, overwrite = true)
+                atomicSwap(staging, liveDirFor(category))
+            }
+        } finally {
+            syncService.restoreInProgress = false
+            runCatching { stagingRoot.deleteRecursively() }
+        }
+    }
+
+    fun deleteSnapshot(snapshotId: String) {
+        val dir = File(snapshotsRoot, snapshotId)
+        if (dir.exists()) dir.deleteRecursively()
+    }
+
+    // =========================================================================
+    // Lifecycle hooks — called from SessionService.initBootstrap after SyncService starts
+    // =========================================================================
+
+    /** Delete orphaned staging dirs left behind by a crashed restore. Safe to call always. */
+    fun cleanupOrphanedStaging() {
+        runCatching { if (stagingRoot.exists()) stagingRoot.deleteRecursively() }
+    }
+
+    /** Delete snapshots older than RETENTION_DAYS, then cap count. Best-effort. */
+    fun enforceRetention() {
+        try {
+            if (!snapshotsRoot.exists()) return
+            val cutoff = System.currentTimeMillis() - SNAPSHOT_RETENTION_DAYS * 86_400_000L
+            val entries = snapshotsRoot.listFiles()
+                ?.filter { it.isDirectory }
+                ?.map { Pair(it, parseIsoStamp(it.name)) }
+                ?.sortedBy { it.second }
+                ?: return
+            for ((file, ts) in entries) {
+                if (ts < cutoff) runCatching { file.deleteRecursively() }
+            }
+            // Recompute and enforce cap.
+            val remaining = snapshotsRoot.listFiles()
+                ?.filter { it.isDirectory }
+                ?.map { Pair(it, parseIsoStamp(it.name)) }
+                ?.sortedBy { it.second }
+                ?: return
+            val overflow = remaining.size - SNAPSHOT_CAP
+            for (i in 0 until overflow) {
+                runCatching { remaining[i].first.deleteRecursively() }
+            }
+        } catch (_: Exception) {}
+    }
+
+    // =========================================================================
+    // Internals
+    // =========================================================================
+
+    /**
+     * Atomic directory swap: staging → live, via .old.<ts> intermediate.
+     * Pattern: rename live → live.old, rename staging → live, delete live.old.
+     * On any failure, rolls back (live.old → live). Keeps parity with desktop's
+     * Windows-safe rename dance even though Linux/Android rename semantics are
+     * more permissive — rollback safety on partial failure is the load-bearing part.
+     */
+    private fun atomicSwap(stagingDir: File, liveDir: File) {
+        val oldDir = File("${liveDir.absolutePath}.old.${System.currentTimeMillis()}")
+        val liveExists = liveDir.exists()
+        liveDir.parentFile?.mkdirs()
+
+        try {
+            if (liveExists) {
+                if (!liveDir.renameTo(oldDir)) {
+                    throw java.io.IOException("rename live→old failed for ${liveDir.absolutePath}")
+                }
+            }
+            if (!stagingDir.renameTo(liveDir)) {
+                // Rollback — put live back so the user isn't left with no data.
+                if (liveExists && oldDir.exists() && !liveDir.exists()) {
+                    runCatching { oldDir.renameTo(liveDir) }
+                }
+                throw java.io.IOException("rename staging→live failed for ${liveDir.absolutePath}")
+            }
+        } catch (e: Exception) {
+            if (liveExists && oldDir.exists() && !liveDir.exists()) {
+                runCatching { oldDir.renameTo(liveDir) }
+            }
+            throw e
+        }
+
+        if (liveExists) {
+            // Best-effort delete of old — failure leaves .old.<ts> for manual cleanup
+            // rather than failing the restore.
+            runCatching { oldDir.deleteRecursively() }
+        }
+    }
+
+    /** Filesystem-safe ISO-8601 timestamp (no colons). Matches desktop's isoStamp(). */
+    private fun isoStamp(): String {
+        val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss-SSS'Z'", Locale.US)
+        fmt.timeZone = TimeZone.getTimeZone("UTC")
+        return fmt.format(Date())
+    }
+
+    /** Parse the filesystem-safe stamp back to epoch ms (best-effort, 0 on failure). */
+    private fun parseIsoStamp(s: String): Long {
+        return try {
+            val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss-SSS'Z'", Locale.US)
+            fmt.timeZone = TimeZone.getTimeZone("UTC")
+            fmt.parse(s)?.time ?: 0L
+        } catch (_: Exception) {
+            0L
+        }
+    }
+
+    private fun dirSize(dir: File): Long {
+        var total = 0L
+        val stack = ArrayDeque<File>()
+        stack.addLast(dir)
+        while (stack.isNotEmpty()) {
+            val d = stack.removeLast()
+            val entries = d.listFiles() ?: continue
+            for (e in entries) {
+                when {
+                    e.isDirectory -> stack.addLast(e)
+                    e.isFile -> total += e.length()
+                }
+            }
+        }
+        return total
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers used by adapters
+// ---------------------------------------------------------------------------
+
+/** Walk a directory and return (relativePaths, totalBytes). Matches desktop's walkFiles. */
+internal fun walkRestoreFiles(dir: File): Pair<List<String>, Long> {
+    val files = mutableListOf<String>()
+    var bytes = 0L
+    if (!dir.exists()) return Pair(files, bytes)
+    val stack = ArrayDeque<File>()
+    stack.addLast(dir)
+    while (stack.isNotEmpty()) {
+        val d = stack.removeLast()
+        val entries = d.listFiles() ?: continue
+        for (e in entries) {
+            when {
+                e.isDirectory -> stack.addLast(e)
+                e.isFile -> {
+                    files.add(e.relativeTo(dir).path.replace(File.separatorChar, '/'))
+                    bytes += e.length()
+                }
+            }
+        }
+    }
+    return Pair(files, bytes)
+}

--- a/app/src/main/kotlin/com/destin/code/runtime/RestoreTypes.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/RestoreTypes.kt
@@ -26,6 +26,24 @@ enum class RestoreCategory(val wire: String) {
 }
 
 /**
+ * Restore mode — must match TS RestoreMode ('merge' | 'wipe').
+ * - MERGE: union. Remote→local add/overwrite only, then local→remote upload
+ *          for local-only files (reuses sync loop). Non-destructive both sides.
+ * - WIPE:  mirror. Local tree replaced with the backup exactly. Snapshot-first
+ *          is forced so undo works.
+ * Wire values are lowercase strings — Kotlin enum name lowercased.
+ */
+enum class RestoreMode(val wire: String) {
+    MERGE("merge"),
+    WIPE("wipe");
+
+    companion object {
+        fun fromWire(s: String?): RestoreMode =
+            values().firstOrNull { it.wire == s } ?: WIPE
+    }
+}
+
+/**
  * A restorable point in time. 'HEAD' for Drive (overwrite-in-place, no history);
  * a git SHA for GitHub (full commit history surfaced as PIT options).
  */
@@ -48,6 +66,8 @@ data class RestoreOptions(
     val versionRef: String,
     val categories: List<RestoreCategory>,
     val snapshotFirst: Boolean,
+    /** Mode: MERGE (non-destructive union) or WIPE (mirror, with snapshot-first). */
+    val mode: RestoreMode,
 ) {
     companion object {
         fun fromJson(j: JSONObject): RestoreOptions {
@@ -61,6 +81,9 @@ data class RestoreOptions(
                 versionRef = j.optString("versionRef", "HEAD"),
                 categories = cats,
                 snapshotFirst = j.optBoolean("snapshotFirst", true),
+                // Mode defaults to WIPE if missing — matches the historical
+                // behavior before the merge/wipe split existed.
+                mode = RestoreMode.fromWire(if (j.has("mode")) j.optString("mode") else null),
             )
         }
     }
@@ -72,9 +95,11 @@ data class CategoryPreview(
     val localFiles: Int,
     val toAdd: Int,
     val toOverwrite: Int,
-    /** Files on device NOT on the backup — restore semantics will delete these. */
+    /** Files on device NOT on the backup — wipe deletes these; merge leaves them. */
     val toDelete: Int,
     val bytes: Long,
+    /** Merge-mode only: files present locally but NOT on backup (will be uploaded). */
+    val toUpload: Int? = null,
 ) {
     fun toJson(): JSONObject = JSONObject().apply {
         put("category", category.wire)
@@ -84,6 +109,7 @@ data class CategoryPreview(
         put("toOverwrite", toOverwrite)
         put("toDelete", toDelete)
         put("bytes", bytes)
+        if (toUpload != null) put("toUpload", toUpload)
     }
 }
 
@@ -92,6 +118,8 @@ data class RestorePreview(
     val totalBytes: Long,
     val estimatedSeconds: Long,
     val warnings: List<String>,
+    /** Echoes the mode the preview was computed for — UI keys column labels off this. */
+    val mode: RestoreMode,
 ) {
     fun toJson(): JSONObject = JSONObject().apply {
         val arr = JSONArray()
@@ -100,6 +128,7 @@ data class RestorePreview(
         put("totalBytes", totalBytes)
         put("estimatedSeconds", estimatedSeconds)
         put("warnings", JSONArray(warnings))
+        put("mode", mode.wire)
     }
 }
 
@@ -192,4 +221,10 @@ interface RestoreAdapter {
         onFile: ((String, Int, Int) -> Unit)? = null,
     )
     suspend fun probe(): Pair<Boolean, List<RestoreCategory>>
+    /**
+     * Optional — return a URL that opens this category's browse view on the
+     * remote backend (Drive folder, GitHub tree). Null means the adapter
+     * doesn't support browse links. Used by the preview UI.
+     */
+    suspend fun remoteBrowseUrlFor(category: RestoreCategory, versionRef: String): String? = null
 }

--- a/app/src/main/kotlin/com/destin/code/runtime/RestoreTypes.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/RestoreTypes.kt
@@ -1,0 +1,195 @@
+package com.destin.code.runtime
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Kotlin data classes mirroring desktop/src/shared/types.ts restore section.
+ * Field names match the TS types exactly so the WebSocket IPC payloads are
+ * identical on desktop and Android (the React UI is shared — see
+ * docs/shared-ui-architecture.md).
+ */
+
+/** The categories restore can operate on. Must match TS RestoreCategory union. */
+enum class RestoreCategory(val wire: String) {
+    MEMORY("memory"),
+    CONVERSATIONS("conversations"),
+    ENCYCLOPEDIA("encyclopedia"),
+    SKILLS("skills"),
+    PLANS("plans"),
+    SPECS("specs");
+
+    companion object {
+        fun fromWire(s: String): RestoreCategory? = values().firstOrNull { it.wire == s }
+        val ALL: List<RestoreCategory> = values().toList()
+    }
+}
+
+/**
+ * A restorable point in time. 'HEAD' for Drive (overwrite-in-place, no history);
+ * a git SHA for GitHub (full commit history surfaced as PIT options).
+ */
+data class RestorePoint(
+    val ref: String,
+    val timestamp: Long,
+    val label: String,
+    val summary: String? = null,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("ref", ref)
+        put("timestamp", timestamp)
+        put("label", label)
+        if (summary != null) put("summary", summary)
+    }
+}
+
+data class RestoreOptions(
+    val backendId: String,
+    val versionRef: String,
+    val categories: List<RestoreCategory>,
+    val snapshotFirst: Boolean,
+) {
+    companion object {
+        fun fromJson(j: JSONObject): RestoreOptions {
+            val catsArr = j.optJSONArray("categories") ?: JSONArray()
+            val cats = mutableListOf<RestoreCategory>()
+            for (i in 0 until catsArr.length()) {
+                RestoreCategory.fromWire(catsArr.getString(i))?.let { cats.add(it) }
+            }
+            return RestoreOptions(
+                backendId = j.optString("backendId", ""),
+                versionRef = j.optString("versionRef", "HEAD"),
+                categories = cats,
+                snapshotFirst = j.optBoolean("snapshotFirst", true),
+            )
+        }
+    }
+}
+
+data class CategoryPreview(
+    val category: RestoreCategory,
+    val remoteFiles: Int,
+    val localFiles: Int,
+    val toAdd: Int,
+    val toOverwrite: Int,
+    /** Files on device NOT on the backup — restore semantics will delete these. */
+    val toDelete: Int,
+    val bytes: Long,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("category", category.wire)
+        put("remoteFiles", remoteFiles)
+        put("localFiles", localFiles)
+        put("toAdd", toAdd)
+        put("toOverwrite", toOverwrite)
+        put("toDelete", toDelete)
+        put("bytes", bytes)
+    }
+}
+
+data class RestorePreview(
+    val perCategory: List<CategoryPreview>,
+    val totalBytes: Long,
+    val estimatedSeconds: Long,
+    val warnings: List<String>,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        val arr = JSONArray()
+        perCategory.forEach { arr.put(it.toJson()) }
+        put("perCategory", arr)
+        put("totalBytes", totalBytes)
+        put("estimatedSeconds", estimatedSeconds)
+        put("warnings", JSONArray(warnings))
+    }
+}
+
+data class RestoreResult(
+    val snapshotId: String?,
+    val categoriesRestored: List<RestoreCategory>,
+    val filesWritten: Int,
+    val durationMs: Long,
+    /** true if skills/memory restored — app restart recommended. */
+    val requiresRestart: Boolean,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        if (snapshotId != null) put("snapshotId", snapshotId)
+        put("categoriesRestored", JSONArray(categoriesRestored.map { it.wire }))
+        put("filesWritten", filesWritten)
+        put("durationMs", durationMs)
+        put("requiresRestart", requiresRestart)
+    }
+}
+
+data class Snapshot(
+    val id: String,
+    val timestamp: Long,
+    val categories: List<RestoreCategory>,
+    val backendId: String,
+    val sizeBytes: Long,
+    val triggeredBy: String, // 'restore' | 'manual'
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("id", id)
+        put("timestamp", timestamp)
+        put("categories", JSONArray(categories.map { it.wire }))
+        put("backendId", backendId)
+        put("sizeBytes", sizeBytes)
+        put("triggeredBy", triggeredBy)
+    }
+
+    companion object {
+        fun fromJson(j: JSONObject): Snapshot {
+            val catsArr = j.optJSONArray("categories") ?: JSONArray()
+            val cats = mutableListOf<RestoreCategory>()
+            for (i in 0 until catsArr.length()) {
+                RestoreCategory.fromWire(catsArr.getString(i))?.let { cats.add(it) }
+            }
+            return Snapshot(
+                id = j.getString("id"),
+                timestamp = j.optLong("timestamp", 0L),
+                categories = cats,
+                backendId = j.optString("backendId", ""),
+                sizeBytes = j.optLong("sizeBytes", 0L),
+                triggeredBy = j.optString("triggeredBy", "manual"),
+            )
+        }
+    }
+}
+
+/** Progress event broadcast over the bridge as 'sync:restore:progress'. */
+data class RestoreProgressEvent(
+    val category: RestoreCategory,
+    val filesDone: Int,
+    val filesTotal: Int,
+    val currentFile: String? = null,
+    /** 'snapshotting' | 'fetching' | 'staging' | 'swapping' | 'done' */
+    val phase: String,
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("category", category.wire)
+        put("filesDone", filesDone)
+        put("filesTotal", filesTotal)
+        if (currentFile != null) put("currentFile", currentFile)
+        put("phase", phase)
+    }
+}
+
+/**
+ * Adapter contract — one implementation per backend (drive, github).
+ * Mirrors desktop's RestoreAdapter interface in restore-service.ts.
+ */
+interface RestoreAdapter {
+    suspend fun listVersions(): List<RestorePoint>
+    suspend fun previewCategory(category: RestoreCategory, versionRef: String): CategoryPreview
+    /**
+     * Fetch the backup contents for [category] into [stagingDir]. onFile is
+     * optional progress signal (filename, done, total).
+     */
+    suspend fun fetchInto(
+        category: RestoreCategory,
+        stagingDir: java.io.File,
+        versionRef: String,
+        onFile: ((String, Int, Int) -> Unit)? = null,
+    )
+    suspend fun probe(): Pair<Boolean, List<RestoreCategory>>
+}

--- a/app/src/main/kotlin/com/destin/code/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/SessionService.kt
@@ -1683,6 +1683,32 @@ class SessionService : Service() {
                     }
                 }
             }
+            "sync:restore:browse-url" -> {
+                // Resolve a deep link into the remote backend for a given
+                // category (Drive folder, GitHub tree). UI shows a "browse remote"
+                // button from the preview screen. Adapters that don't support
+                // browse URLs return null → we pass JSONObject.NULL over the wire.
+                val backendId = msg.payload.optString("backendId", "")
+                val categoryStr = msg.payload.optString("category", "")
+                val versionRef = msg.payload.optString("versionRef", "HEAD")
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("url", JSONObject.NULL)) }
+                } else {
+                    val cat = RestoreCategory.fromWire(categoryStr)
+                    val url = if (cat == null) {
+                        null
+                    } else {
+                        try {
+                            svc.browseCategoryUrl(backendId, cat, versionRef)
+                        } catch (_: Exception) { null }
+                    }
+                    msg.id?.let {
+                        bridgeServer.respond(ws, msg.type, it,
+                            JSONObject().put("url", url ?: JSONObject.NULL))
+                    }
+                }
+            }
             "sync:restore:list-versions" -> {
                 val backendId = msg.payload.optString("backendId", "")
                 val svc = restoreService

--- a/app/src/main/kotlin/com/destin/code/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/SessionService.kt
@@ -134,6 +134,11 @@ class SessionService : Service() {
     var syncService: SyncService? = null
         private set
 
+    // Restore service — directional user-initiated pull from a backup. Paused
+    // push loop during execute prevents uploading half-restored state.
+    var restoreService: RestoreService? = null
+        private set
+
     // Legacy single-session API — kept for ServiceBinder compatibility during migration
     var ptyBridge: PtyBridge? = null
         private set
@@ -228,6 +233,13 @@ class SessionService : Service() {
 
         // Start native sync engine — pulls on launch, pushes every 15 min
         syncService = SyncService(applicationContext, bs).also { it.start() }
+
+        // Wire up restore service — owns the snapshot + atomic-swap machinery.
+        // Startup housekeeping (orphan staging cleanup + retention) runs once here.
+        restoreService = RestoreService(syncService!!, File(bs.homeDir, ".claude")).also {
+            it.cleanupOrphanedStaging()
+            it.enforceRetention()
+        }
     }
 
     /** Watch ~/.claude-mobile/open-url for URLs written by the JS wrapper.
@@ -560,6 +572,7 @@ class SessionService : Service() {
         // Stop sync service — cancels timer, releases locks, removes .app-sync-active marker
         try { syncService?.stop() } catch (_: Exception) {}
         syncService = null
+        restoreService = null
         bridgeServer.stop()
         urlObserver?.stopWatching()
         urlObserver = null
@@ -1647,6 +1660,144 @@ class SessionService : Service() {
                     } catch (_: Exception) {}
                 }
                 msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("url", url)) }
+            }
+
+            // ── Restore from backup — directional user-initiated pull ─────────
+            // Separate code path from sync (which is bidirectional merge). See
+            // RestoreService.kt header for safety invariants (snapshot-first,
+            // atomic swap, paused push loop).
+            "sync:restore:probe" -> {
+                val backendId = msg.payload.optString("backendId", "")
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("hasData", false).put("categories", org.json.JSONArray())) }
+                } else {
+                    try {
+                        val (hasData, cats) = svc.probe(backendId)
+                        val payload = JSONObject()
+                            .put("hasData", hasData)
+                            .put("categories", org.json.JSONArray(cats.map { c -> c.wire }))
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, payload) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("hasData", false).put("categories", org.json.JSONArray()).put("error", e.message ?: "probe failed")) }
+                    }
+                }
+            }
+            "sync:restore:list-versions" -> {
+                val backendId = msg.payload.optString("backendId", "")
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, org.json.JSONArray()) }
+                } else {
+                    try {
+                        val points = svc.listVersions(backendId)
+                        val arr = org.json.JSONArray()
+                        points.forEach { p -> arr.put(p.toJson()) }
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, arr) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("error", e.message ?: "listVersions failed")) }
+                    }
+                }
+            }
+            "sync:restore:preview" -> {
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("error", "RestoreService not initialized")) }
+                } else {
+                    try {
+                        val opts = RestoreOptions.fromJson(msg.payload)
+                        val preview = svc.previewRestore(opts)
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, preview.toJson()) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("error", e.message ?: "preview failed")) }
+                    }
+                }
+            }
+            "sync:restore:execute" -> {
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("error", "RestoreService not initialized")) }
+                } else {
+                    try {
+                        val opts = RestoreOptions.fromJson(msg.payload)
+                        // Progress events are broadcast (no id) — matches desktop's
+                        // sync:restore:progress push-event shape. Wizard UI subscribes
+                        // to them across every connected client.
+                        val result = svc.executeRestore(opts) { evt ->
+                            bridgeServer.broadcast(JSONObject().apply {
+                                put("type", "sync:restore:progress")
+                                put("payload", evt.toJson())
+                            })
+                        }
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, result.toJson()) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("error", e.message ?: "execute failed")) }
+                    }
+                }
+            }
+            "sync:restore:list-snapshots" -> {
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, org.json.JSONArray()) }
+                } else {
+                    try {
+                        val arr = org.json.JSONArray()
+                        svc.listSnapshots().forEach { s -> arr.put(s.toJson()) }
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, arr) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("error", e.message ?: "listSnapshots failed")) }
+                    }
+                }
+            }
+            "sync:restore:undo" -> {
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", false).put("error", "RestoreService not initialized")) }
+                } else {
+                    try {
+                        val snapshotId = msg.payload.optString("snapshotId", "")
+                        svc.undoRestore(snapshotId)
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", true)) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", false).put("error", e.message ?: "undo failed")) }
+                    }
+                }
+            }
+            "sync:restore:delete-snapshot" -> {
+                val svc = restoreService
+                if (svc == null) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", false).put("error", "RestoreService not initialized")) }
+                } else {
+                    try {
+                        val snapshotId = msg.payload.optString("snapshotId", "")
+                        svc.deleteSnapshot(snapshotId)
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", true)) }
+                    } catch (e: Exception) {
+                        msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", false).put("error", e.message ?: "delete failed")) }
+                    }
+                }
+            }
+
+            // Experimental feature flags — written to ~/.claude/destincode-local.json
+            // to match desktop's config.ts location. File is read by the shared
+            // React app via a first-run probe.
+            "config:set-experimental-flag" -> {
+                try {
+                    val key = msg.payload.optString("key", "")
+                    val value = msg.payload.opt("value")
+                    if (key.isEmpty()) throw IllegalArgumentException("missing key")
+                    val flagsFile = File(bootstrap!!.homeDir, ".claude/destincode-local.json")
+                    flagsFile.parentFile?.mkdirs()
+                    val current = try { JSONObject(flagsFile.readText()) } catch (_: Exception) { JSONObject() }
+                    val experimental = current.optJSONObject("experimental") ?: JSONObject()
+                    if (value == null || value == JSONObject.NULL) experimental.remove(key)
+                    else experimental.put(key, value)
+                    current.put("experimental", experimental)
+                    flagsFile.writeText(current.toString(2))
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", true)) }
+                } catch (e: Exception) {
+                    msg.id?.let { bridgeServer.respond(ws, msg.type, it, JSONObject().put("ok", false).put("error", e.message ?: "set-experimental-flag failed")) }
+                }
             }
 
             // ── Phase 5a: Theme marketplace browsing ─────────────────

--- a/app/src/main/kotlin/com/destin/code/runtime/SyncService.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/SyncService.kt
@@ -63,6 +63,16 @@ class SyncService(
     private var pulling = false
     private var pushing = false
 
+    /**
+     * Flipped to true by RestoreService.executeRestore / undoRestore so the
+     * 15-minute background push loop skips its tick instead of uploading a
+     * half-restored state. Kept @Volatile since the push loop runs on a
+     * separate coroutine (Dispatchers.IO) and RestoreService writes from
+     * whatever thread invoked it via the bridge.
+     */
+    @Volatile
+    var restoreInProgress: Boolean = false
+
     // --- Result types ---
     data class PushResult(val success: Boolean, val errors: Int, val backends: List<String>)
     data class ExecResult(val code: Int, val stdout: String, val stderr: String)
@@ -106,6 +116,12 @@ class SyncService(
         pushJob = scope.launch {
             while (isActive) {
                 delay(PUSH_INTERVAL_MS)
+                // Restore in progress → skip this tick. Prevents uploading a
+                // half-swapped staging dir to the backup mid-restore.
+                if (restoreInProgress) {
+                    logBackup("INFO", "Push skipped — restore in progress", "sync.push")
+                    continue
+                }
                 // Check Wi-Fi preference before pushing
                 if (!shouldSyncNow()) {
                     logBackup("INFO", "Push skipped — not on Wi-Fi and Wi-Fi-only enabled", "sync.push")

--- a/app/src/main/kotlin/com/destin/code/runtime/restore/DriveRestoreAdapter.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/restore/DriveRestoreAdapter.kt
@@ -15,14 +15,25 @@ import java.io.File
 /**
  * DriveRestoreAdapter — rclone-backed restore adapter for Google Drive (Android port).
  *
- * Drive is HEAD-only (overwrite-in-place, no history). listVersions() returns
- * a single "Current backup" entry. fetchInto() shells out to `rclone sync`
- * which gives directional semantics (remote → local) — exactly what restore
- * needs, unlike `rclone copy --update` used by the normal sync push loop.
+ * Layout MUST match what SyncService.pushDrive writes:
+ *   <driveRoot>/Backup/personal/
+ *     memory/<projectKey>/ *                          ← memory category
+ *     conversations/<slugName>/(files).jsonl                 ← conversations category
+ *     encyclopedia/(files).md                                ← encyclopedia category
+ *     skills/<skillName>/ *                           ← skills category
+ *     system-backup/plans/ *                          ← plans category
+ *     system-backup/specs/ *                          ← specs category
  *
- * All shell-outs route through SyncService.execCommand() which in turn uses
- * Bootstrap.buildRuntimeEnv() — so rclone runs with LD_LIBRARY_PATH and
- * LD_PRELOAD set correctly for SELinux-safe binary execution through linker64.
+ * Local layout (what we swap into) differs from remote for memory:
+ *   ~/.claude/projects/<projectKey>/memory/ *         ← memory nested under a memory/ dir
+ *   ~/.claude/projects/<slugName>/(files).jsonl              ← conversations sit flat under the slug
+ *
+ * So fetchInto restructures memory from remote-shape (<key>/<rest>) into
+ * local-shape (<key>/memory/<rest>) as it writes staging. previewCategory walks
+ * the same local paths so the delta compares apples to apples.
+ *
+ * Drive is HEAD-only (overwrite-in-place backend, no history). listVersions
+ * returns a single "Current backup" entry.
  */
 class DriveRestoreAdapter(
     private val instance: JSONObject,
@@ -32,24 +43,24 @@ class DriveRestoreAdapter(
 
     private val rcloneRemote: String
     private val driveRoot: String
+    private val remoteBase: String
 
     init {
         val cfg = instance.optJSONObject("config") ?: JSONObject()
         rcloneRemote = cfg.optString("rcloneRemote", "gdrive").ifEmpty { "gdrive" }
         driveRoot = cfg.optString("DRIVE_ROOT", "Claude").ifEmpty { "Claude" }
+        remoteBase = "$rcloneRemote:$driveRoot/Backup/personal"
     }
 
-    /** Mirror the layout SyncService.pushDrive uses. */
-    private fun categoryRemoteSubpath(category: RestoreCategory): String = when (category) {
-        RestoreCategory.MEMORY, RestoreCategory.CONVERSATIONS -> "projects"
-        RestoreCategory.ENCYCLOPEDIA -> "encyclopedia"
-        RestoreCategory.SKILLS -> "skills"
-        RestoreCategory.PLANS -> "plans"
-        RestoreCategory.SPECS -> "specs"
+    /** Remote full path under `Backup/personal/` for a category. */
+    private fun remoteCategoryPath(category: RestoreCategory): String = when (category) {
+        RestoreCategory.MEMORY -> "$remoteBase/memory"
+        RestoreCategory.CONVERSATIONS -> "$remoteBase/conversations"
+        RestoreCategory.ENCYCLOPEDIA -> "$remoteBase/encyclopedia"
+        RestoreCategory.SKILLS -> "$remoteBase/skills"
+        RestoreCategory.PLANS -> "$remoteBase/system-backup/plans"
+        RestoreCategory.SPECS -> "$remoteBase/system-backup/specs"
     }
-
-    private fun remotePath(category: RestoreCategory): String =
-        "$rcloneRemote:$driveRoot/${categoryRemoteSubpath(category)}"
 
     private fun rclone(args: List<String>, timeoutSeconds: Long = 60L): SyncService.ExecResult {
         return syncService.execCommand(listOf("rclone") + args, timeoutSeconds = timeoutSeconds)
@@ -59,39 +70,146 @@ class DriveRestoreAdapter(
         RestorePoint(ref = "HEAD", timestamp = System.currentTimeMillis(), label = "Current backup")
     )
 
+    /**
+     * Resolve a Drive folder ID for this category and return a
+     * https://drive.google.com/drive/folders/<id> deep link. Falls back to
+     * the Drive homepage if lookup fails.
+     */
+    override suspend fun remoteBrowseUrlFor(
+        category: RestoreCategory,
+        versionRef: String,
+    ): String? = withContext(Dispatchers.IO) {
+        val full = remoteCategoryPath(category)
+        // Strip the "<remote>:" prefix, split by '/', target = last segment,
+        // parent path = everything before. rclone lsjson needs the parent.
+        val withoutRemote = full.removePrefix("$rcloneRemote:")
+        val segments = withoutRemote.split('/').filter { it.isNotEmpty() }
+        if (segments.isEmpty()) return@withContext "https://drive.google.com"
+        val parent = "$rcloneRemote:${segments.dropLast(1).joinToString("/")}"
+        val target = segments.last()
+        val fallback = "https://drive.google.com"
+        try {
+            val r = rclone(listOf("lsjson", parent, "--dirs-only"), timeoutSeconds = 15L)
+            if (r.code != 0) return@withContext fallback
+            val arr = JSONArray(r.stdout)
+            for (i in 0 until arr.length()) {
+                val e = arr.getJSONObject(i)
+                if (e.optString("Name") == target) {
+                    val id = e.optString("ID")
+                    if (id.isNotEmpty()) return@withContext "https://drive.google.com/drive/folders/$id"
+                }
+            }
+            fallback
+        } catch (_: Exception) {
+            fallback
+        }
+    }
+
     override suspend fun probe(): Pair<Boolean, List<RestoreCategory>> = withContext(Dispatchers.IO) {
         val categories = mutableListOf<RestoreCategory>()
         try {
-            val r = rclone(listOf("lsjson", "$rcloneRemote:$driveRoot", "--max-depth", "1"), timeoutSeconds = 30L)
+            // Walk Backup/personal/ one level deep — matches the push layout.
+            val r = rclone(listOf("lsjson", remoteBase, "--dirs-only"), timeoutSeconds = 30L)
             if (r.code != 0) return@withContext Pair(false, emptyList<RestoreCategory>())
             val arr = JSONArray(r.stdout)
-            val dirNames = mutableSetOf<String>()
+            val personalDirs = mutableSetOf<String>()
             for (i in 0 until arr.length()) {
                 val e = arr.getJSONObject(i)
-                if (e.optBoolean("IsDir")) dirNames.add(e.optString("Name"))
+                if (e.optBoolean("IsDir")) personalDirs.add(e.optString("Name"))
             }
-            if (dirNames.contains("projects")) {
-                categories.add(RestoreCategory.MEMORY)
-                categories.add(RestoreCategory.CONVERSATIONS)
+            if (personalDirs.contains("memory")) categories.add(RestoreCategory.MEMORY)
+            if (personalDirs.contains("conversations")) categories.add(RestoreCategory.CONVERSATIONS)
+            if (personalDirs.contains("encyclopedia")) categories.add(RestoreCategory.ENCYCLOPEDIA)
+            if (personalDirs.contains("skills")) categories.add(RestoreCategory.SKILLS)
+
+            // plans / specs live one level deeper under system-backup/.
+            if (personalDirs.contains("system-backup")) {
+                try {
+                    val r2 = rclone(listOf("lsjson", "$remoteBase/system-backup", "--dirs-only"), timeoutSeconds = 15L)
+                    if (r2.code == 0) {
+                        val sysArr = JSONArray(r2.stdout)
+                        val sysDirs = mutableSetOf<String>()
+                        for (i in 0 until sysArr.length()) {
+                            sysDirs.add(sysArr.getJSONObject(i).optString("Name"))
+                        }
+                        if (sysDirs.contains("plans")) categories.add(RestoreCategory.PLANS)
+                        if (sysDirs.contains("specs")) categories.add(RestoreCategory.SPECS)
+                    }
+                } catch (_: Exception) {}
             }
-            if (dirNames.contains("encyclopedia")) categories.add(RestoreCategory.ENCYCLOPEDIA)
-            if (dirNames.contains("skills")) categories.add(RestoreCategory.SKILLS)
-            if (dirNames.contains("plans")) categories.add(RestoreCategory.PLANS)
-            if (dirNames.contains("specs")) categories.add(RestoreCategory.SPECS)
         } catch (_: Exception) {
             return@withContext Pair(false, emptyList<RestoreCategory>())
         }
         Pair(categories.isNotEmpty(), categories)
     }
 
+    /**
+     * Map a remote relative path (as rclone reports it) to the corresponding
+     * LOCAL relative path under the category's liveDir. Memory remote shape is
+     * `<projectKey>/<rest>` but locally lives at `<projectKey>/memory/<rest>` —
+     * we inject `memory/` after the first segment. Every other category is
+     * shape-identical between remote and local.
+     */
+    private fun toLocalRel(category: RestoreCategory, remoteRel: String): String {
+        val norm = remoteRel.replace('\\', '/')
+        if (category == RestoreCategory.MEMORY) {
+            val idx = norm.indexOf('/')
+            if (idx < 0) return norm // shouldn't happen, defensive
+            return "${norm.substring(0, idx)}/memory/${norm.substring(idx + 1)}"
+        }
+        return norm
+    }
+
+    /**
+     * Walk the local files a category owns, returning relative paths that
+     * match toLocalRel(remoteRel) above. Used for preview delta math only.
+     */
+    private fun walkLocalCategory(category: RestoreCategory): Pair<List<String>, Long> {
+        val projectsDir = File(claudeDir, "projects")
+        val files = mutableListOf<String>()
+        var bytes = 0L
+
+        when (category) {
+            RestoreCategory.MEMORY -> {
+                if (!projectsDir.exists()) return Pair(files, bytes)
+                projectsDir.listFiles()?.forEach { keyDir ->
+                    if (!keyDir.isDirectory) return@forEach
+                    val memDir = File(keyDir, "memory")
+                    if (!memDir.exists()) return@forEach
+                    val (walked, walkedBytes) = walkRestoreFiles(memDir)
+                    for (f in walked) files.add("${keyDir.name}/memory/${f.replace('\\', '/')}")
+                    bytes += walkedBytes
+                }
+                return Pair(files, bytes)
+            }
+            RestoreCategory.CONVERSATIONS -> {
+                if (!projectsDir.exists()) return Pair(files, bytes)
+                projectsDir.listFiles()?.forEach { slugDir ->
+                    if (!slugDir.isDirectory) return@forEach
+                    // Only top-level .jsonl files — subdirs (memory/) belong to other categories.
+                    slugDir.listFiles()?.forEach { entry ->
+                        if (entry.isFile && entry.name.endsWith(".jsonl")) {
+                            files.add("${slugDir.name}/${entry.name}")
+                            bytes += entry.length()
+                        }
+                    }
+                }
+                return Pair(files, bytes)
+            }
+            RestoreCategory.ENCYCLOPEDIA -> return walkRestoreFiles(File(claudeDir, "encyclopedia"))
+            RestoreCategory.SKILLS -> return walkRestoreFiles(File(claudeDir, "skills"))
+            RestoreCategory.PLANS -> return walkRestoreFiles(File(claudeDir, "plans"))
+            RestoreCategory.SPECS -> return walkRestoreFiles(File(claudeDir, "specs"))
+        }
+    }
+
     override suspend fun previewCategory(
         category: RestoreCategory,
         versionRef: String,
     ): CategoryPreview = withContext(Dispatchers.IO) {
-        val remote = remotePath(category)
-        val local = File(claudeDir, categoryRemoteSubpath(category))
+        val remote = remoteCategoryPath(category)
 
-        // Map of remote path → size
+        // Map remote Path → size, transformed into local-shape so deltas compare apples to apples.
         val remoteFiles = HashMap<String, Long>()
         try {
             val r = rclone(listOf("lsjson", remote, "--recursive", "--files-only"), timeoutSeconds = 60L)
@@ -99,14 +217,14 @@ class DriveRestoreAdapter(
                 val arr = JSONArray(r.stdout)
                 for (i in 0 until arr.length()) {
                     val e = arr.getJSONObject(i)
-                    remoteFiles[e.optString("Path")] = e.optLong("Size", 0L)
+                    remoteFiles[toLocalRel(category, e.optString("Path"))] = e.optLong("Size", 0L)
                 }
             }
             // code != 0 likely means remote doesn't exist — treat as empty backup.
         } catch (_: Exception) {}
 
-        val (localFiles, _) = walkRestoreFiles(local)
-        val localSet = localFiles.toHashSet()
+        val (localFiles, _) = walkLocalCategory(category)
+        val localSet = localFiles.map { it.replace('\\', '/') }.toHashSet()
         val remoteSet = remoteFiles.keys
 
         var toAdd = 0
@@ -136,16 +254,36 @@ class DriveRestoreAdapter(
         versionRef: String,
         onFile: ((String, Int, Int) -> Unit)?,
     ): Unit = withContext(Dispatchers.IO) {
-        val remote = remotePath(category)
-        // `rclone sync` is a destructive mirror from remote → staging.
-        // --create-empty-src-dirs preserves empty subdirs (memory/ often has
-        // empty per-project dirs on fresh projects).
-        val r = rclone(
-            listOf("sync", remote, stagingDir.absolutePath, "--create-empty-src-dirs", "--stats-one-line"),
-            timeoutSeconds = 300L,
-        )
-        if (r.code != 0) {
-            throw java.io.IOException("rclone sync failed (code=${r.code}): ${r.stderr}")
+        val remote = remoteCategoryPath(category)
+
+        if (category == RestoreCategory.MEMORY) {
+            // Pull remote tree into a tmp subdir, then restructure:
+            //   tmp/<projectKey>/<rest>  →  staging/<projectKey>/memory/<rest>
+            val tmp = File(stagingDir, "__raw_memory")
+            tmp.mkdirs()
+            val r = rclone(
+                listOf("sync", remote, tmp.absolutePath, "--create-empty-src-dirs", "--stats-one-line"),
+                timeoutSeconds = 300L,
+            )
+            if (r.code != 0) {
+                throw java.io.IOException("rclone sync failed (code=${r.code}): ${r.stderr}")
+            }
+            tmp.listFiles()?.forEach { keyDir ->
+                if (!keyDir.isDirectory) return@forEach
+                val dest = File(stagingDir, "${keyDir.name}/memory")
+                dest.parentFile?.mkdirs()
+                keyDir.copyRecursively(dest, overwrite = true)
+            }
+            runCatching { tmp.deleteRecursively() }
+        } else {
+            // All other categories — remote shape matches local shape; straight sync.
+            val r = rclone(
+                listOf("sync", remote, stagingDir.absolutePath, "--create-empty-src-dirs", "--stats-one-line"),
+                timeoutSeconds = 300L,
+            )
+            if (r.code != 0) {
+                throw java.io.IOException("rclone sync failed (code=${r.code}): ${r.stderr}")
+            }
         }
 
         // Emit one terminal progress event so UI flips staging → swapping.

--- a/app/src/main/kotlin/com/destin/code/runtime/restore/DriveRestoreAdapter.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/restore/DriveRestoreAdapter.kt
@@ -1,0 +1,157 @@
+package com.destin.code.runtime.restore
+
+import com.destin.code.runtime.CategoryPreview
+import com.destin.code.runtime.RestoreAdapter
+import com.destin.code.runtime.RestoreCategory
+import com.destin.code.runtime.RestorePoint
+import com.destin.code.runtime.SyncService
+import com.destin.code.runtime.walkRestoreFiles
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * DriveRestoreAdapter — rclone-backed restore adapter for Google Drive (Android port).
+ *
+ * Drive is HEAD-only (overwrite-in-place, no history). listVersions() returns
+ * a single "Current backup" entry. fetchInto() shells out to `rclone sync`
+ * which gives directional semantics (remote → local) — exactly what restore
+ * needs, unlike `rclone copy --update` used by the normal sync push loop.
+ *
+ * All shell-outs route through SyncService.execCommand() which in turn uses
+ * Bootstrap.buildRuntimeEnv() — so rclone runs with LD_LIBRARY_PATH and
+ * LD_PRELOAD set correctly for SELinux-safe binary execution through linker64.
+ */
+class DriveRestoreAdapter(
+    private val instance: JSONObject,
+    private val claudeDir: File,
+    private val syncService: SyncService,
+) : RestoreAdapter {
+
+    private val rcloneRemote: String
+    private val driveRoot: String
+
+    init {
+        val cfg = instance.optJSONObject("config") ?: JSONObject()
+        rcloneRemote = cfg.optString("rcloneRemote", "gdrive").ifEmpty { "gdrive" }
+        driveRoot = cfg.optString("DRIVE_ROOT", "Claude").ifEmpty { "Claude" }
+    }
+
+    /** Mirror the layout SyncService.pushDrive uses. */
+    private fun categoryRemoteSubpath(category: RestoreCategory): String = when (category) {
+        RestoreCategory.MEMORY, RestoreCategory.CONVERSATIONS -> "projects"
+        RestoreCategory.ENCYCLOPEDIA -> "encyclopedia"
+        RestoreCategory.SKILLS -> "skills"
+        RestoreCategory.PLANS -> "plans"
+        RestoreCategory.SPECS -> "specs"
+    }
+
+    private fun remotePath(category: RestoreCategory): String =
+        "$rcloneRemote:$driveRoot/${categoryRemoteSubpath(category)}"
+
+    private fun rclone(args: List<String>, timeoutSeconds: Long = 60L): SyncService.ExecResult {
+        return syncService.execCommand(listOf("rclone") + args, timeoutSeconds = timeoutSeconds)
+    }
+
+    override suspend fun listVersions(): List<RestorePoint> = listOf(
+        RestorePoint(ref = "HEAD", timestamp = System.currentTimeMillis(), label = "Current backup")
+    )
+
+    override suspend fun probe(): Pair<Boolean, List<RestoreCategory>> = withContext(Dispatchers.IO) {
+        val categories = mutableListOf<RestoreCategory>()
+        try {
+            val r = rclone(listOf("lsjson", "$rcloneRemote:$driveRoot", "--max-depth", "1"), timeoutSeconds = 30L)
+            if (r.code != 0) return@withContext Pair(false, emptyList<RestoreCategory>())
+            val arr = JSONArray(r.stdout)
+            val dirNames = mutableSetOf<String>()
+            for (i in 0 until arr.length()) {
+                val e = arr.getJSONObject(i)
+                if (e.optBoolean("IsDir")) dirNames.add(e.optString("Name"))
+            }
+            if (dirNames.contains("projects")) {
+                categories.add(RestoreCategory.MEMORY)
+                categories.add(RestoreCategory.CONVERSATIONS)
+            }
+            if (dirNames.contains("encyclopedia")) categories.add(RestoreCategory.ENCYCLOPEDIA)
+            if (dirNames.contains("skills")) categories.add(RestoreCategory.SKILLS)
+            if (dirNames.contains("plans")) categories.add(RestoreCategory.PLANS)
+            if (dirNames.contains("specs")) categories.add(RestoreCategory.SPECS)
+        } catch (_: Exception) {
+            return@withContext Pair(false, emptyList<RestoreCategory>())
+        }
+        Pair(categories.isNotEmpty(), categories)
+    }
+
+    override suspend fun previewCategory(
+        category: RestoreCategory,
+        versionRef: String,
+    ): CategoryPreview = withContext(Dispatchers.IO) {
+        val remote = remotePath(category)
+        val local = File(claudeDir, categoryRemoteSubpath(category))
+
+        // Map of remote path → size
+        val remoteFiles = HashMap<String, Long>()
+        try {
+            val r = rclone(listOf("lsjson", remote, "--recursive", "--files-only"), timeoutSeconds = 60L)
+            if (r.code == 0) {
+                val arr = JSONArray(r.stdout)
+                for (i in 0 until arr.length()) {
+                    val e = arr.getJSONObject(i)
+                    remoteFiles[e.optString("Path")] = e.optLong("Size", 0L)
+                }
+            }
+            // code != 0 likely means remote doesn't exist — treat as empty backup.
+        } catch (_: Exception) {}
+
+        val (localFiles, _) = walkRestoreFiles(local)
+        val localSet = localFiles.toHashSet()
+        val remoteSet = remoteFiles.keys
+
+        var toAdd = 0
+        var toOverwrite = 0
+        var bytes = 0L
+        for ((p, sz) in remoteFiles) {
+            if (localSet.contains(p)) toOverwrite++ else toAdd++
+            bytes += sz
+        }
+        var toDelete = 0
+        for (p in localSet) if (!remoteSet.contains(p)) toDelete++
+
+        CategoryPreview(
+            category = category,
+            remoteFiles = remoteFiles.size,
+            localFiles = localFiles.size,
+            toAdd = toAdd,
+            toOverwrite = toOverwrite,
+            toDelete = toDelete,
+            bytes = bytes,
+        )
+    }
+
+    override suspend fun fetchInto(
+        category: RestoreCategory,
+        stagingDir: File,
+        versionRef: String,
+        onFile: ((String, Int, Int) -> Unit)?,
+    ): Unit = withContext(Dispatchers.IO) {
+        val remote = remotePath(category)
+        // `rclone sync` is a destructive mirror from remote → staging.
+        // --create-empty-src-dirs preserves empty subdirs (memory/ often has
+        // empty per-project dirs on fresh projects).
+        val r = rclone(
+            listOf("sync", remote, stagingDir.absolutePath, "--create-empty-src-dirs", "--stats-one-line"),
+            timeoutSeconds = 300L,
+        )
+        if (r.code != 0) {
+            throw java.io.IOException("rclone sync failed (code=${r.code}): ${r.stderr}")
+        }
+
+        // Emit one terminal progress event so UI flips staging → swapping.
+        onFile?.let {
+            val (files, _) = walkRestoreFiles(stagingDir)
+            it("", files.size, files.size)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/destin/code/runtime/restore/GithubRestoreAdapter.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/restore/GithubRestoreAdapter.kt
@@ -1,0 +1,221 @@
+package com.destin.code.runtime.restore
+
+import com.destin.code.runtime.CategoryPreview
+import com.destin.code.runtime.RestoreAdapter
+import com.destin.code.runtime.RestoreCategory
+import com.destin.code.runtime.RestorePoint
+import com.destin.code.runtime.SyncService
+import com.destin.code.runtime.walkRestoreFiles
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * GithubRestoreAdapter — git-backed restore adapter with point-in-time (PIT) support.
+ *
+ * This is the novel adapter. Drive is overwrite-in-place and only exposes HEAD.
+ * GitHub backends maintain full commit history in the local repo clone at
+ * ~/.claude/toolkit-state/personal-sync-repo/, so we surface it via `git log`
+ * and let the user restore to any past SHA.
+ *
+ * fetchInto uses `git --work-tree=<staging> checkout <sha> -- <cat>/` to
+ * redirect file writes into staging without touching the repo's index. We then
+ * `git reset HEAD -- <cat>/` to clean any index pollution that checkout leaves.
+ *
+ * Note (parity divergence from desktop): desktop uses a per-instance repo dir
+ * `personal-sync-repo-<instance.id>` so users can have multiple github backends.
+ * Android's SyncService currently uses a single `personal-sync-repo/` directory
+ * (one github backend supported), so this adapter matches that layout. If
+ * Android adds per-instance repos later, update repoDir below to match.
+ */
+class GithubRestoreAdapter(
+    @Suppress("unused") private val instance: JSONObject,
+    private val claudeDir: File,
+    private val syncService: SyncService,
+) : RestoreAdapter {
+
+    // Matches SyncService.pullGithub() / pushGithub() hardcoded path.
+    private val repoDir: File = File(claudeDir, "toolkit-state/personal-sync-repo")
+
+    private fun categoryRepoSubpath(category: RestoreCategory): String = when (category) {
+        RestoreCategory.MEMORY, RestoreCategory.CONVERSATIONS -> "projects"
+        RestoreCategory.ENCYCLOPEDIA -> "encyclopedia"
+        RestoreCategory.SKILLS -> "skills"
+        RestoreCategory.PLANS -> "plans"
+        RestoreCategory.SPECS -> "specs"
+    }
+
+    private fun git(args: List<String>, cwd: File? = null, timeoutSeconds: Long = 60L): SyncService.ExecResult {
+        return syncService.execCommand(listOf("git") + args, cwd = cwd, timeoutSeconds = timeoutSeconds)
+    }
+
+    override suspend fun listVersions(): List<RestorePoint> = withContext(Dispatchers.IO) {
+        if (!repoDir.exists()) return@withContext emptyList<RestorePoint>()
+        // %H = commit SHA, %ct = committer timestamp (unix), %s = subject.
+        // \x09 = tab (kept from TS parity so field splitting is identical).
+        val r = git(
+            listOf("-C", repoDir.absolutePath, "log", "--format=%H%x09%ct%x09%s", "-n", "100"),
+            timeoutSeconds = 30L,
+        )
+        if (r.code != 0) return@withContext emptyList<RestorePoint>()
+        val out = mutableListOf<RestorePoint>()
+        for (line in r.stdout.split('\n')) {
+            if (line.isBlank()) continue
+            val parts = line.split('\t', limit = 3)
+            if (parts.size < 2) continue
+            val sha = parts[0]
+            val ts = (parts[1].toLongOrNull() ?: 0L) * 1000L
+            val subject = if (parts.size >= 3) parts[2] else ""
+            out.add(RestorePoint(ref = sha, timestamp = ts, label = relativeLabel(ts), summary = subject))
+        }
+        out
+    }
+
+    override suspend fun probe(): Pair<Boolean, List<RestoreCategory>> = withContext(Dispatchers.IO) {
+        if (!repoDir.exists()) return@withContext Pair(false, emptyList<RestoreCategory>())
+        try {
+            val r = git(listOf("-C", repoDir.absolutePath, "ls-tree", "--name-only", "HEAD"),
+                timeoutSeconds = 15L)
+            if (r.code != 0) return@withContext Pair(false, emptyList<RestoreCategory>())
+            val dirs = r.stdout.split('\n').map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+            val cats = mutableListOf<RestoreCategory>()
+            if (dirs.contains("projects")) {
+                cats.add(RestoreCategory.MEMORY)
+                cats.add(RestoreCategory.CONVERSATIONS)
+            }
+            if (dirs.contains("encyclopedia")) cats.add(RestoreCategory.ENCYCLOPEDIA)
+            if (dirs.contains("skills")) cats.add(RestoreCategory.SKILLS)
+            if (dirs.contains("plans")) cats.add(RestoreCategory.PLANS)
+            if (dirs.contains("specs")) cats.add(RestoreCategory.SPECS)
+            Pair(cats.isNotEmpty(), cats)
+        } catch (_: Exception) {
+            Pair(false, emptyList())
+        }
+    }
+
+    override suspend fun previewCategory(
+        category: RestoreCategory,
+        versionRef: String,
+    ): CategoryPreview = withContext(Dispatchers.IO) {
+        val sub = categoryRepoSubpath(category)
+        val liveDir = File(claudeDir, sub)
+        val ref = if (versionRef == "HEAD") "HEAD" else versionRef
+
+        val remoteFiles = mutableListOf<String>()
+        var remoteBytes = 0L
+        try {
+            val r = git(
+                listOf("-C", repoDir.absolutePath, "ls-tree", "-r", "--long", ref, "--", "$sub/"),
+                timeoutSeconds = 30L,
+            )
+            if (r.code == 0) {
+                // ls-tree --long: <mode> <type> <hash> <size>\t<path>
+                val re = Regex("""^\S+\s+\S+\s+\S+\s+(\S+)\t(.+)$""")
+                for (line in r.stdout.split('\n')) {
+                    if (line.isBlank()) continue
+                    val m = re.matchEntire(line) ?: continue
+                    val size = m.groupValues[1].toLongOrNull() ?: 0L
+                    val full = m.groupValues[2]
+                    // strip the "<sub>/" prefix to match walkRestoreFiles() relative paths
+                    val rel = if (full.startsWith("$sub/")) full.substring(sub.length + 1) else full
+                    remoteFiles.add(rel)
+                    remoteBytes += size
+                }
+            }
+            // ref / path missing → treat as empty remote.
+        } catch (_: Exception) {}
+
+        val (localFilesList, _) = walkRestoreFiles(liveDir)
+        val remoteSet = remoteFiles.map { it.replace('\\', '/') }.toHashSet()
+        val localSet = localFilesList.map { it.replace('\\', '/') }.toHashSet()
+
+        var toAdd = 0
+        var toOverwrite = 0
+        for (p in remoteSet) {
+            if (localSet.contains(p)) toOverwrite++ else toAdd++
+        }
+        var toDelete = 0
+        for (p in localSet) if (!remoteSet.contains(p)) toDelete++
+
+        CategoryPreview(
+            category = category,
+            remoteFiles = remoteFiles.size,
+            localFiles = localFilesList.size,
+            toAdd = toAdd,
+            toOverwrite = toOverwrite,
+            toDelete = toDelete,
+            bytes = remoteBytes,
+        )
+    }
+
+    override suspend fun fetchInto(
+        category: RestoreCategory,
+        stagingDir: File,
+        versionRef: String,
+        onFile: ((String, Int, Int) -> Unit)?,
+    ): Unit = withContext(Dispatchers.IO) {
+        if (!repoDir.exists()) {
+            throw java.io.IOException("GitHub sync repo missing — run a sync first")
+        }
+        val sub = categoryRepoSubpath(category)
+        val ref = if (versionRef == "HEAD") "HEAD" else versionRef
+
+        // git checkout with --work-tree writes files into <work-tree>/<path>.
+        // Pre-create the subpath dir so git doesn't error on the first write.
+        val stagedCategoryDir = File(stagingDir, sub)
+        stagedCategoryDir.mkdirs()
+
+        val coResult = git(
+            listOf(
+                "-C", repoDir.absolutePath,
+                "--work-tree=${stagingDir.absolutePath}",
+                "checkout", ref, "--", "$sub/",
+            ),
+            timeoutSeconds = 300L,
+        )
+        if (coResult.code != 0) {
+            throw java.io.IOException("git checkout failed (code=${coResult.code}): ${coResult.stderr}")
+        }
+
+        // Clean index pollution from the diverted checkout. Without this, a
+        // subsequent normal sync push would include stale staged entries.
+        runCatching {
+            git(
+                listOf("-C", repoDir.absolutePath, "reset", "HEAD", "--", "$sub/"),
+                timeoutSeconds = 30L,
+            )
+        }
+
+        // staging/<sub>/* is the real data; lift it up one level so the swap
+        // dirs match (liveDirFor returns ~/.claude/<sub>, so staging should
+        // contain the category contents at its top level, not nested).
+        val lifted = File(stagingDir, "__lift")
+        lifted.mkdirs()
+        stagedCategoryDir.listFiles()?.forEach { entry ->
+            entry.renameTo(File(lifted, entry.name))
+        }
+        runCatching { stagedCategoryDir.deleteRecursively() }
+        lifted.listFiles()?.forEach { entry ->
+            entry.renameTo(File(stagingDir, entry.name))
+        }
+        runCatching { lifted.deleteRecursively() }
+
+        onFile?.let {
+            val (files, _) = walkRestoreFiles(stagingDir)
+            it("", files.size, files.size)
+        }
+    }
+
+    private fun relativeLabel(ts: Long): String {
+        val diff = System.currentTimeMillis() - ts
+        val min = diff / 60_000L
+        if (min < 1) return "just now"
+        if (min < 60) return "$min minute${if (min == 1L) "" else "s"} ago"
+        val hr = min / 60L
+        if (hr < 24) return "$hr hour${if (hr == 1L) "" else "s"} ago"
+        val d = hr / 24L
+        if (d < 30) return "$d day${if (d == 1L) "" else "s"} ago"
+        return java.text.DateFormat.getDateInstance(java.text.DateFormat.MEDIUM).format(java.util.Date(ts))
+    }
+}

--- a/app/src/main/kotlin/com/destin/code/runtime/restore/GithubRestoreAdapter.kt
+++ b/app/src/main/kotlin/com/destin/code/runtime/restore/GithubRestoreAdapter.kt
@@ -30,7 +30,7 @@ import java.io.File
  * Android adds per-instance repos later, update repoDir below to match.
  */
 class GithubRestoreAdapter(
-    @Suppress("unused") private val instance: JSONObject,
+    private val instance: JSONObject,
     private val claudeDir: File,
     private val syncService: SyncService,
 ) : RestoreAdapter {
@@ -48,6 +48,27 @@ class GithubRestoreAdapter(
 
     private fun git(args: List<String>, cwd: File? = null, timeoutSeconds: Long = 60L): SyncService.ExecResult {
         return syncService.execCommand(listOf("git") + args, cwd = cwd, timeoutSeconds = timeoutSeconds)
+    }
+
+    /**
+     * Resolve a GitHub tree URL for the given ref + category. Translates
+     * 'HEAD' to 'main' (GitHub's default-branch convention) since HEAD isn't
+     * a valid tree ref in GitHub's URL scheme. Falls back to the repo URL or
+     * github.com if PERSONAL_SYNC_REPO isn't an https github URL.
+     */
+    override suspend fun remoteBrowseUrlFor(
+        category: RestoreCategory,
+        versionRef: String,
+    ): String? = withContext(Dispatchers.IO) {
+        val raw = instance.optJSONObject("config")?.optString("PERSONAL_SYNC_REPO", "") ?: ""
+        val base = raw.replace(Regex("""\.git$"""), "").trimEnd('/')
+        val sub = categoryRepoSubpath(category)
+        val ref = if (versionRef == "HEAD") "main" else versionRef
+        if (Regex("""^https://github\.com/""", RegexOption.IGNORE_CASE).containsMatchIn(base)) {
+            "$base/tree/$ref/$sub"
+        } else {
+            base.ifEmpty { "https://github.com" }
+        }
     }
 
     override suspend fun listVersions(): List<RestorePoint> = withContext(Dispatchers.IO) {

--- a/desktop/src/main/config.ts
+++ b/desktop/src/main/config.ts
@@ -1,0 +1,58 @@
+/**
+ * config.ts — DestinCode local desktop config, distinct from the sync layer.
+ *
+ * Used for experimental feature flags and other desktop-local settings that
+ * should NOT be synced to cloud backends (the whole point of experimental
+ * flags is they're opt-in per machine while we iterate).
+ *
+ * Lives at ~/.claude/destincode-local.json. Reads/writes are synchronous
+ * because callers already operate on the main process startup / IPC thread
+ * and the file is tiny.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const CONFIG_PATH = path.join(os.homedir(), '.claude', 'destincode-local.json');
+
+export interface LocalConfig {
+  experimental?: {
+    /** Gates the restore-from-backup UI surface (wizard, snapshots, onboarding probe). */
+    restoreFlow?: boolean;
+  };
+}
+
+function readConfig(): LocalConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    return JSON.parse(raw) as LocalConfig;
+  } catch {
+    return {};
+  }
+}
+
+function writeConfig(cfg: LocalConfig): void {
+  try {
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+  } catch (e) {
+    // Non-fatal — the next read will just see stale state. Surfacing an error
+    // to the user for a dot-file write is worse than the flag misbehaving.
+  }
+}
+
+export function getLocalConfig(): LocalConfig {
+  return readConfig();
+}
+
+export function setExperimentalFlag(name: keyof NonNullable<LocalConfig['experimental']>, value: boolean): void {
+  const cfg = readConfig();
+  cfg.experimental = { ...(cfg.experimental || {}), [name]: value };
+  writeConfig(cfg);
+}
+
+/** Convenience: is the restore-from-backup flow enabled? Default false. */
+export function isRestoreFlowEnabled(): boolean {
+  return readConfig().experimental?.restoreFlow === true;
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -1539,9 +1539,17 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC.SYNC_RESTORE_LIST_VERSIONS, (_e, backendId: string) =>
     restore().listVersions(backendId),
   );
-  ipcMain.handle(IPC.SYNC_RESTORE_PREVIEW, (_e, opts: RestoreOptions) =>
-    restore().previewRestore(opts),
-  );
+  ipcMain.handle(IPC.SYNC_RESTORE_PREVIEW, async (_e, opts: RestoreOptions) => {
+    log('INFO', 'Restore', 'preview:start', { backendId: opts.backendId, categories: opts.categories });
+    try {
+      const res = await restore().previewRestore(opts);
+      log('INFO', 'Restore', 'preview:done', { totalBytes: res.totalBytes, warnings: res.warnings.length });
+      return res;
+    } catch (e: any) {
+      log('ERROR', 'Restore', 'preview:failed', { error: e?.message || String(e), stack: e?.stack });
+      throw e;
+    }
+  });
   ipcMain.handle(IPC.SYNC_RESTORE_EXECUTE, async (e, opts: RestoreOptions) => {
     // Progress is pushed back to the calling window only (not broadcast to
     // peer windows) — restore is a single-actor flow; showing progress in a
@@ -1561,6 +1569,19 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC.SYNC_RESTORE_PROBE, (_e, backendId: string) =>
     restore().probe(backendId),
   );
+
+  // Returns a browseable URL for a given category on a backend (or a local
+  // folder path for iCloud). Result used by the preview UI's folder-icon link.
+  // Opening the URL itself is done by the renderer via shell.openExternal
+  // (desktop) or window.open (browser/Android) — this handler just resolves it.
+  ipcMain.handle(IPC.SYNC_RESTORE_BROWSE_URL, async (_e, backendId: string, category: string, versionRef: string) => {
+    const url = await restore().browseCategoryUrl(backendId, category as any, versionRef || 'HEAD');
+    if (url) {
+      const { shell } = require('electron');
+      shell.openExternal(url).catch(() => {});
+    }
+    return { url };
+  });
 
   // Experimental feature flag toggle — persists to ~/.claude/destincode-local.json.
   // Restore UI reads this via SyncStatus.experimentalFlags; no renderer restart needed.

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -21,6 +21,9 @@ import { generateThemePreview } from './theme-preview-generator';
 import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dismissWarning, addBackend, removeBackend, updateBackend, pushBackend, pullBackend, getSyncService } from './sync-state';
 import { getConfig as getMarketplaceConfig, setConfig as setMarketplaceConfig } from './marketplace-config-store';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
+import { getRestoreService } from './restore-service';
+import { setExperimentalFlag } from './config';
+import type { RestoreOptions, RestoreProgressEvent } from '../shared/types';
 import { log } from './logger';
 
 // Max age for clipboard paste images (1 hour)
@@ -1523,6 +1526,48 @@ export function registerIpcHandlers(
   ipcMain.handle('sync:setup:auth-gdrive', () => authGdrive());
   ipcMain.handle('sync:setup:auth-github', () => authGithub());
   ipcMain.handle('sync:setup:create-repo', (_e, repoName) => createGithubRepo(repoName));
+
+  // --- Restore from backup ---
+  // Directional, user-initiated pull. See restore-service.ts for safety invariants.
+  // Throws if SyncService hasn't finished starting yet (restore needs it to pause pushes).
+  const restore = () => {
+    const svc = getRestoreService();
+    if (!svc) throw new Error('RestoreService not initialized — SyncService must start first');
+    return svc;
+  };
+
+  ipcMain.handle(IPC.SYNC_RESTORE_LIST_VERSIONS, (_e, backendId: string) =>
+    restore().listVersions(backendId),
+  );
+  ipcMain.handle(IPC.SYNC_RESTORE_PREVIEW, (_e, opts: RestoreOptions) =>
+    restore().previewRestore(opts),
+  );
+  ipcMain.handle(IPC.SYNC_RESTORE_EXECUTE, async (e, opts: RestoreOptions) => {
+    // Progress is pushed back to the calling window only (not broadcast to
+    // peer windows) — restore is a single-actor flow; showing progress in a
+    // peer window would be noise. Event channel: IPC.SYNC_RESTORE_PROGRESS.
+    const wc = e.sender;
+    return restore().executeRestore(opts, (evt: RestoreProgressEvent) => {
+      if (!wc.isDestroyed()) wc.send(IPC.SYNC_RESTORE_PROGRESS, evt);
+    });
+  });
+  ipcMain.handle(IPC.SYNC_RESTORE_LIST_SNAPSHOTS, () => restore().listSnapshots());
+  ipcMain.handle(IPC.SYNC_RESTORE_UNDO, (_e, snapshotId: string) =>
+    restore().undoRestore(snapshotId),
+  );
+  ipcMain.handle(IPC.SYNC_RESTORE_DELETE_SNAPSHOT, (_e, snapshotId: string) =>
+    restore().deleteSnapshot(snapshotId),
+  );
+  ipcMain.handle(IPC.SYNC_RESTORE_PROBE, (_e, backendId: string) =>
+    restore().probe(backendId),
+  );
+
+  // Experimental feature flag toggle — persists to ~/.claude/destincode-local.json.
+  // Restore UI reads this via SyncStatus.experimentalFlags; no renderer restart needed.
+  ipcMain.handle('config:set-experimental-flag', (_e, name: string, value: boolean) => {
+    setExperimentalFlag(name as any, value);
+    return { ok: true };
+  });
 
   // --- Permission response (blocking hooks) ---
   if (hookRelay) {

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -18,6 +18,7 @@ import { registerThemeProtocol } from './theme-protocol';
 import { FirstRunManager } from './first-run';
 import { SyncService } from './sync-service';
 import { setSyncService } from './sync-state';
+import { initRestoreService } from './restore-service';
 import { createAuthStore } from './marketplace-auth-store';
 import { registerMarketplaceApiHandlers } from './marketplace-api-handlers';
 
@@ -953,6 +954,9 @@ app.whenReady().then(async () => {
   const syncService = new SyncService();
   setSyncService(syncService);
   syncService.start().catch(e => log('ERROR', 'Main', 'SyncService start failed', { error: String(e) }));
+  // Initialize restore service after sync is live — it needs SyncService to
+  // flip restoreInProgress, which pauses the push loop during restore/undo.
+  initRestoreService(syncService, app.getPath('userData'));
   // Push session JSONL on session close (replaces session-end-sync.sh)
   sessionManager.on('session-exit', (sessionId: string) => {
     syncService.pushSession(sessionId).catch(e =>

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -151,6 +151,7 @@ const IPC = {
   SYNC_RESTORE_UNDO: 'sync:restore:undo',
   SYNC_RESTORE_DELETE_SNAPSHOT: 'sync:restore:delete-snapshot',
   SYNC_RESTORE_PROBE: 'sync:restore:probe',
+  SYNC_RESTORE_BROWSE_URL: 'sync:restore:browse-url',
   // Window detach / multi-window ownership (feature: drag session to new window)
   WINDOW_GET_ID: 'window:get-id',
   WINDOW_DIRECTORY_UPDATED: 'window:directory-updated',
@@ -473,6 +474,8 @@ contextBridge.exposeInMainWorld('claude', {
       deleteSnapshot: (snapshotId: string) =>
         ipcRenderer.invoke(IPC.SYNC_RESTORE_DELETE_SNAPSHOT, snapshotId),
       probe: (backendId: string) => ipcRenderer.invoke(IPC.SYNC_RESTORE_PROBE, backendId),
+      browseCategory: (backendId: string, category: string, versionRef: string) =>
+        ipcRenderer.invoke(IPC.SYNC_RESTORE_BROWSE_URL, backendId, category, versionRef),
       // Subscribe to progress events for an in-flight restore. Returns an
       // unsubscribe function — callers MUST invoke it on unmount to avoid
       // leaking listeners across restore attempts.

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -142,6 +142,15 @@ const IPC = {
   SYNC_FORCE: 'sync:force',
   SYNC_GET_LOG: 'sync:get-log',
   SYNC_DISMISS_WARNING: 'sync:dismiss-warning',
+  // Restore from backup (directional pull — see restore-service.ts)
+  SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
+  SYNC_RESTORE_PREVIEW: 'sync:restore:preview',
+  SYNC_RESTORE_EXECUTE: 'sync:restore:execute',
+  SYNC_RESTORE_PROGRESS: 'sync:restore:progress',
+  SYNC_RESTORE_LIST_SNAPSHOTS: 'sync:restore:list-snapshots',
+  SYNC_RESTORE_UNDO: 'sync:restore:undo',
+  SYNC_RESTORE_DELETE_SNAPSHOT: 'sync:restore:delete-snapshot',
+  SYNC_RESTORE_PROBE: 'sync:restore:probe',
   // Window detach / multi-window ownership (feature: drag session to new window)
   WINDOW_GET_ID: 'window:get-id',
   WINDOW_DIRECTORY_UPDATED: 'window:directory-updated',
@@ -453,6 +462,31 @@ contextBridge.exposeInMainWorld('claude', {
       authGithub: () => ipcRenderer.invoke('sync:setup:auth-github'),
       createRepo: (repoName: string) => ipcRenderer.invoke('sync:setup:create-repo', repoName),
     },
+    // Restore from backup — directional, user-initiated pull
+    restore: {
+      listVersions: (backendId: string) =>
+        ipcRenderer.invoke(IPC.SYNC_RESTORE_LIST_VERSIONS, backendId),
+      preview: (opts: any) => ipcRenderer.invoke(IPC.SYNC_RESTORE_PREVIEW, opts),
+      execute: (opts: any) => ipcRenderer.invoke(IPC.SYNC_RESTORE_EXECUTE, opts),
+      listSnapshots: () => ipcRenderer.invoke(IPC.SYNC_RESTORE_LIST_SNAPSHOTS),
+      undo: (snapshotId: string) => ipcRenderer.invoke(IPC.SYNC_RESTORE_UNDO, snapshotId),
+      deleteSnapshot: (snapshotId: string) =>
+        ipcRenderer.invoke(IPC.SYNC_RESTORE_DELETE_SNAPSHOT, snapshotId),
+      probe: (backendId: string) => ipcRenderer.invoke(IPC.SYNC_RESTORE_PROBE, backendId),
+      // Subscribe to progress events for an in-flight restore. Returns an
+      // unsubscribe function — callers MUST invoke it on unmount to avoid
+      // leaking listeners across restore attempts.
+      onProgress: (cb: (evt: any) => void) => {
+        const handler = (_e: any, evt: any) => cb(evt);
+        ipcRenderer.on(IPC.SYNC_RESTORE_PROGRESS, handler);
+        return () => ipcRenderer.removeListener(IPC.SYNC_RESTORE_PROGRESS, handler);
+      },
+    },
+  },
+  config: {
+    // Set a DestinCode-local experimental flag (e.g. 'restoreFlow'). Machine-local.
+    setExperimentalFlag: (name: string, value: boolean) =>
+      ipcRenderer.invoke('config:set-experimental-flag', name, value),
   },
   getFavorites: () => ipcRenderer.invoke('favorites:get'),
   setFavorites: (favorites: string[]) => ipcRenderer.invoke('favorites:set', favorites),

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -1217,6 +1217,17 @@ export class RemoteServer {
         this.respond(client.ws, type, id, probeResult);
         break;
       }
+      case 'sync:restore:browse-url': {
+        // Browser clients can't open the local shell, so we just resolve + return
+        // the URL and let the browser open it via window.open.
+        const url = await getRestoreService()!.browseCategoryUrl(
+          payload.backendId,
+          payload.category,
+          payload.versionRef || 'HEAD',
+        );
+        this.respond(client.ws, type, id, { url });
+        break;
+      }
 
       case 'config:set-experimental-flag': {
         setExperimentalFlag(payload.name, payload.value);

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -13,6 +13,8 @@ import { BrowserWindow } from 'electron';
 import { readTranscriptMeta } from './transcript-utils';
 import { listPastSessions, loadHistory } from './session-browser';
 import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dismissWarning, addBackend, removeBackend, updateBackend, pushBackend, pullBackend } from './sync-state';
+import { getRestoreService } from './restore-service';
+import { setExperimentalFlag } from './config';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
 
 const PTY_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB per session — enough for full conversation replay
@@ -1164,6 +1166,61 @@ export class RemoteServer {
       case 'sync:setup:create-repo': {
         const repoResult = await createGithubRepo(payload.repoName || payload);
         this.respond(client.ws, type, id, repoResult);
+        break;
+      }
+
+      // --- Restore from backup (browser + Android parity) ---
+      // Each case fetches the RestoreService singleton lazily — it's initialized
+      // after SyncService.start(), so browser clients that connect very early
+      // (rare) will see an "RestoreService not initialized" error rather than a crash.
+      case 'sync:restore:list-versions': {
+        const versions = await getRestoreService()!.listVersions(payload.backendId || payload);
+        this.respond(client.ws, type, id, versions);
+        break;
+      }
+      case 'sync:restore:preview': {
+        const previewResult = await getRestoreService()!.previewRestore(payload.opts || payload);
+        this.respond(client.ws, type, id, previewResult);
+        break;
+      }
+      case 'sync:restore:execute': {
+        // Progress events stream back to the originating client only — restore
+        // is single-actor, broadcasting to peer browsers would be noise.
+        const execResult = await getRestoreService()!.executeRestore(
+          payload.opts || payload,
+          (evt) => {
+            if (client.ws.readyState === WebSocket.OPEN) {
+              client.ws.send(JSON.stringify({ type: 'sync:restore:progress', payload: evt }));
+            }
+          },
+        );
+        this.respond(client.ws, type, id, execResult);
+        break;
+      }
+      case 'sync:restore:list-snapshots': {
+        const snaps = await getRestoreService()!.listSnapshots();
+        this.respond(client.ws, type, id, snaps);
+        break;
+      }
+      case 'sync:restore:undo': {
+        await getRestoreService()!.undoRestore(payload.snapshotId || payload);
+        this.respond(client.ws, type, id, { ok: true });
+        break;
+      }
+      case 'sync:restore:delete-snapshot': {
+        await getRestoreService()!.deleteSnapshot(payload.snapshotId || payload);
+        this.respond(client.ws, type, id, { ok: true });
+        break;
+      }
+      case 'sync:restore:probe': {
+        const probeResult = await getRestoreService()!.probe(payload.backendId || payload);
+        this.respond(client.ws, type, id, probeResult);
+        break;
+      }
+
+      case 'config:set-experimental-flag': {
+        setExperimentalFlag(payload.name, payload.value);
+        this.respond(client.ws, type, id, { ok: true });
         break;
       }
 

--- a/desktop/src/main/restore-adapters/drive.ts
+++ b/desktop/src/main/restore-adapters/drive.ts
@@ -1,13 +1,29 @@
 /**
  * DriveRestoreAdapter — rclone-backed restore adapter for Google Drive.
  *
- * Drive is HEAD-only (overwrite-in-place backend, no history). listVersions()
- * returns a single "Current backup" entry. fetchInto() shells out to
- * `rclone sync` which gives us directional semantics (remote → local) — exactly
- * what restore needs, unlike `rclone copy --update` used by the sync push loop.
+ * Layout MUST match what SyncService.pushDrive writes:
+ *   Backup/personal/
+ *     memory/<projectKey>/*                          ← memory category
+ *     conversations/<slugName>/*.jsonl               ← conversations category
+ *     encyclopedia/*.md                              ← encyclopedia category
+ *     skills/<skillName>/*                           ← skills category
+ *     system-backup/plans/*                          ← plans category
+ *     system-backup/specs/*                          ← specs category
+ *
+ * Local layout (what we swap into) differs from remote for memory + conversations:
+ *   ~/.claude/projects/<projectKey>/memory/*         ← memory lives inside a nested memory/ dir
+ *   ~/.claude/projects/<slugName>/*.jsonl            ← conversations sit directly under the slug
+ *
+ * So fetchInto restructures files from remote-shape into local-shape as it
+ * writes staging. previewCategory walks the same local paths so the delta is
+ * computed against the exact files a subsequent swap would replace.
+ *
+ * Drive is HEAD-only (overwrite-in-place backend, no history). listVersions
+ * returns a single "Current backup" entry.
  */
 
 import path from 'path';
+import fs from 'fs';
 import { BackendInstance } from '../sync-state';
 import type { RestoreAdapter } from '../restore-service';
 import { walkFiles, run } from '../restore-service';
@@ -16,26 +32,46 @@ import type { RestoreCategory, RestorePoint, CategoryPreview } from '../../share
 export class DriveRestoreAdapter implements RestoreAdapter {
   private readonly rcloneRemote: string;
   private readonly driveRoot: string;
+  private readonly remoteBase: string;
 
   constructor(private instance: BackendInstance, private claudeDir: string) {
     this.rcloneRemote = instance.config.rcloneRemote || 'gdrive';
     this.driveRoot = instance.config.DRIVE_ROOT || 'Claude';
+    this.remoteBase = `${this.rcloneRemote}:${this.driveRoot}/Backup/personal`;
   }
 
-  private remotePath(category: RestoreCategory): string {
-    return `${this.rcloneRemote}:${this.driveRoot}/${this.categoryRemoteSubpath(category)}`;
-  }
-
-  /** Mirror the layout SyncService.pushDrive uses. */
-  private categoryRemoteSubpath(category: RestoreCategory): string {
+  /** Remote subpath under `Backup/personal/` for a category. */
+  private remoteCategoryPath(category: RestoreCategory): string {
     switch (category) {
-      case 'memory':
-      case 'conversations':
-        return 'projects';
-      case 'encyclopedia': return 'encyclopedia';
-      case 'skills': return 'skills';
-      case 'plans': return 'plans';
-      case 'specs': return 'specs';
+      case 'memory': return `${this.remoteBase}/memory`;
+      case 'conversations': return `${this.remoteBase}/conversations`;
+      case 'encyclopedia': return `${this.remoteBase}/encyclopedia`;
+      case 'skills': return `${this.remoteBase}/skills`;
+      case 'plans': return `${this.remoteBase}/system-backup/plans`;
+      case 'specs': return `${this.remoteBase}/system-backup/specs`;
+    }
+  }
+
+  /** Deep-link / browse URL for a category on Google Drive. */
+  async remoteBrowseUrlFor(category: RestoreCategory): Promise<string> {
+    const segments = this.remoteCategoryPath(category)
+      .replace(`${this.rcloneRemote}:`, '')
+      .split('/')
+      .filter(Boolean);
+    const parentPath = `${this.rcloneRemote}:${segments.slice(0, -1).join('/')}`;
+    const targetName = segments[segments.length - 1];
+    const fallback = 'https://drive.google.com';
+    try {
+      const { stdout } = await run(
+        'rclone',
+        ['lsjson', parentPath, '--dirs-only'],
+        { timeoutMs: 15_000 },
+      );
+      const entries = JSON.parse(stdout) as Array<{ Name: string; ID?: string }>;
+      const match = entries.find((e) => e.Name === targetName && e.ID);
+      return match?.ID ? `https://drive.google.com/drive/folders/${match.ID}` : fallback;
+    } catch {
+      return fallback;
     }
   }
 
@@ -46,35 +82,133 @@ export class DriveRestoreAdapter implements RestoreAdapter {
   async probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }> {
     const categories: RestoreCategory[] = [];
     try {
-      const { stdout } = await run('rclone', ['lsjson', `${this.rcloneRemote}:${this.driveRoot}`, '--max-depth', '1'], { timeoutMs: 30_000 });
-      const entries: Array<{ Name: string; IsDir: boolean }> = JSON.parse(stdout);
-      const names = new Set(entries.filter(e => e.IsDir).map(e => e.Name));
-      if (names.has('projects')) { categories.push('memory'); categories.push('conversations'); }
-      if (names.has('encyclopedia')) categories.push('encyclopedia');
-      if (names.has('skills')) categories.push('skills');
-      if (names.has('plans')) categories.push('plans');
-      if (names.has('specs')) categories.push('specs');
+      // Walk Backup/personal/ one level deep — matches the push layout.
+      const { stdout } = await run(
+        'rclone',
+        ['lsjson', this.remoteBase, '--dirs-only'],
+        { timeoutMs: 30_000 },
+      );
+      const personalDirs = new Set(
+        (JSON.parse(stdout) as Array<{ Name: string; IsDir: boolean }>)
+          .filter((e) => e.IsDir)
+          .map((e) => e.Name),
+      );
+      if (personalDirs.has('memory')) categories.push('memory');
+      if (personalDirs.has('conversations')) categories.push('conversations');
+      if (personalDirs.has('encyclopedia')) categories.push('encyclopedia');
+      if (personalDirs.has('skills')) categories.push('skills');
+
+      // plans / specs live one level deeper under system-backup/.
+      if (personalDirs.has('system-backup')) {
+        try {
+          const { stdout: sysOut } = await run(
+            'rclone',
+            ['lsjson', `${this.remoteBase}/system-backup`, '--dirs-only'],
+            { timeoutMs: 15_000 },
+          );
+          const sysDirs = new Set(
+            (JSON.parse(sysOut) as Array<{ Name: string }>).map((e) => e.Name),
+          );
+          if (sysDirs.has('plans')) categories.push('plans');
+          if (sysDirs.has('specs')) categories.push('specs');
+        } catch {}
+      }
     } catch {
       return { hasData: false, categories: [] };
     }
     return { hasData: categories.length > 0, categories };
   }
 
-  async previewCategory(category: RestoreCategory, _versionRef: string): Promise<CategoryPreview> {
-    const remote = this.remotePath(category);
-    const local = path.join(this.claudeDir, this.categoryRemoteSubpath(category));
+  /**
+   * Map a remote relative path (as returned by rclone lsjson) to the
+   * corresponding LOCAL relative path under the category's liveDir.
+   *
+   * For memory the remote shape is `<projectKey>/<rest>` but locally we
+   * expect `<projectKey>/memory/<rest>` — so we inject 'memory/' after the
+   * first path segment. Same idea inverted for conversations (already flat).
+   */
+  private toLocalRel(category: RestoreCategory, remoteRel: string): string {
+    const norm = remoteRel.replace(/\\/g, '/');
+    if (category === 'memory') {
+      const idx = norm.indexOf('/');
+      if (idx < 0) return norm; // shouldn't happen, defensive
+      return `${norm.slice(0, idx)}/memory/${norm.slice(idx + 1)}`;
+    }
+    // All other categories are shape-identical between remote and local.
+    return norm;
+  }
 
-    let remoteFiles = new Map<string, number>(); // path → size
+  /**
+   * Walk the local files a category owns, returning them as relative paths
+   * that match toLocalRel(remoteRel) above. Used for preview delta math.
+   */
+  private walkLocalCategory(category: RestoreCategory): { files: string[]; bytes: number } {
+    const projectsDir = path.join(this.claudeDir, 'projects');
+    const out: { files: string[]; bytes: number } = { files: [], bytes: 0 };
+
+    if (category === 'memory') {
+      // Walk ~/.claude/projects/<key>/memory/ for every project key.
+      if (!fs.existsSync(projectsDir)) return out;
+      for (const key of fs.readdirSync(projectsDir)) {
+        const memDir = path.join(projectsDir, key, 'memory');
+        if (!fs.existsSync(memDir)) continue;
+        const walked = walkFiles(memDir);
+        for (const f of walked.files) out.files.push(`${key}/memory/${f.replace(/\\/g, '/')}`);
+        out.bytes += walked.bytes;
+      }
+      return out;
+    }
+    if (category === 'conversations') {
+      if (!fs.existsSync(projectsDir)) return out;
+      for (const slug of fs.readdirSync(projectsDir)) {
+        const slugDir = path.join(projectsDir, slug);
+        if (!fs.statSync(slugDir).isDirectory()) continue;
+        // Only top-level .jsonl files — subdirs (like memory/) belong to other categories.
+        for (const entry of fs.readdirSync(slugDir)) {
+          if (!entry.endsWith('.jsonl')) continue;
+          const full = path.join(slugDir, entry);
+          try {
+            if (fs.lstatSync(full).isFile()) {
+              out.files.push(`${slug}/${entry}`);
+              out.bytes += fs.statSync(full).size;
+            }
+          } catch {}
+        }
+      }
+      return out;
+    }
+    // Flat categories: walk the category's live dir directly.
+    const liveDir = path.join(this.claudeDir,
+      category === 'plans' ? 'plans' :
+      category === 'specs' ? 'specs' :
+      category === 'encyclopedia' ? 'encyclopedia' :
+      'skills',
+    );
+    return walkFiles(liveDir);
+  }
+
+  async previewCategory(category: RestoreCategory, _versionRef: string): Promise<CategoryPreview> {
+    const remote = this.remoteCategoryPath(category);
+
+    // Remote file map: local-relative-path → size. Transform rclone's remote-shape
+    // paths into local-shape so deltas compare apples to apples.
+    const remoteFiles = new Map<string, number>();
     try {
-      const { stdout } = await run('rclone', ['lsjson', remote, '--recursive', '--files-only'], { timeoutMs: 60_000 });
-      const entries: Array<{ Path: string; Size: number }> = JSON.parse(stdout);
-      for (const e of entries) remoteFiles.set(e.Path, e.Size);
+      const { stdout } = await run(
+        'rclone',
+        ['lsjson', remote, '--recursive', '--files-only'],
+        { timeoutMs: 60_000 },
+      );
+      const entries = JSON.parse(stdout) as Array<{ Path: string; Size: number }>;
+      for (const e of entries) {
+        remoteFiles.set(this.toLocalRel(category, e.Path), e.Size);
+      }
     } catch {
-      // Remote missing/empty — treat as zero-file backup so the user sees a clear delta.
+      // Remote missing/empty — treat as zero-file backup.
     }
 
-    const localWalk = walkFiles(local);
-    const localSet = new Set(localWalk.files.map(f => f.replace(/\\/g, '/')));
+    const localWalk = this.walkLocalCategory(category);
+    const localSet = new Set(localWalk.files.map((f) => f.replace(/\\/g, '/')));
     const remoteSet = new Set(remoteFiles.keys());
 
     let toAdd = 0, toOverwrite = 0, bytes = 0;
@@ -103,12 +237,43 @@ export class DriveRestoreAdapter implements RestoreAdapter {
     _versionRef: string,
     onFile?: (filename: string, done: number, total: number) => void,
   ): Promise<void> {
-    const remote = this.remotePath(category);
-    // rclone sync: destructive mirror from remote → staging. --create-empty-src-dirs
-    // preserves empty category layout (memory subdirs often empty on fresh projects).
-    await run('rclone', ['sync', remote, stagingDir, '--create-empty-src-dirs', '--stats-one-line'], { timeoutMs: 300_000 });
+    // memory + conversations — restructure while copying so staging holds
+    // the local-shape tree the atomic swap expects.
+    if (category === 'memory') {
+      // rclone copy with --drive-flatten not sensible; just pull the tree, then
+      // restructure with fs moves. Small number of files per project key.
+      const tmp = path.join(stagingDir, '__raw_memory');
+      fs.mkdirSync(tmp, { recursive: true });
+      await run(
+        'rclone',
+        ['copy', this.remoteCategoryPath('memory') + '/', tmp + '/', '--create-empty-src-dirs'],
+        { timeoutMs: 300_000 },
+      );
+      // tmp/<projectKey>/<rest> → stagingDir/<projectKey>/memory/<rest>
+      for (const key of fs.readdirSync(tmp)) {
+        const src = path.join(tmp, key);
+        if (!fs.statSync(src).isDirectory()) continue;
+        const dest = path.join(stagingDir, key, 'memory');
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        fs.cpSync(src, dest, { recursive: true });
+      }
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } else if (category === 'conversations') {
+      // Remote shape <slug>/*.jsonl lines up 1:1 with local shape — straight copy.
+      await run(
+        'rclone',
+        ['copy', this.remoteCategoryPath('conversations') + '/', stagingDir + '/', '--create-empty-src-dirs'],
+        { timeoutMs: 300_000 },
+      );
+    } else {
+      // Flat categories — shape unchanged, single rclone copy.
+      await run(
+        'rclone',
+        ['copy', this.remoteCategoryPath(category) + '/', stagingDir + '/', '--create-empty-src-dirs'],
+        { timeoutMs: 300_000 },
+      );
+    }
 
-    // Emit one terminal progress event so the UI flips from staging → swapping.
     if (onFile) {
       const walk = walkFiles(stagingDir);
       onFile('', walk.files.length, walk.files.length);

--- a/desktop/src/main/restore-adapters/drive.ts
+++ b/desktop/src/main/restore-adapters/drive.ts
@@ -1,0 +1,117 @@
+/**
+ * DriveRestoreAdapter — rclone-backed restore adapter for Google Drive.
+ *
+ * Drive is HEAD-only (overwrite-in-place backend, no history). listVersions()
+ * returns a single "Current backup" entry. fetchInto() shells out to
+ * `rclone sync` which gives us directional semantics (remote → local) — exactly
+ * what restore needs, unlike `rclone copy --update` used by the sync push loop.
+ */
+
+import path from 'path';
+import { BackendInstance } from '../sync-state';
+import type { RestoreAdapter } from '../restore-service';
+import { walkFiles, run } from '../restore-service';
+import type { RestoreCategory, RestorePoint, CategoryPreview } from '../../shared/types';
+
+export class DriveRestoreAdapter implements RestoreAdapter {
+  private readonly rcloneRemote: string;
+  private readonly driveRoot: string;
+
+  constructor(private instance: BackendInstance, private claudeDir: string) {
+    this.rcloneRemote = instance.config.rcloneRemote || 'gdrive';
+    this.driveRoot = instance.config.DRIVE_ROOT || 'Claude';
+  }
+
+  private remotePath(category: RestoreCategory): string {
+    return `${this.rcloneRemote}:${this.driveRoot}/${this.categoryRemoteSubpath(category)}`;
+  }
+
+  /** Mirror the layout SyncService.pushDrive uses. */
+  private categoryRemoteSubpath(category: RestoreCategory): string {
+    switch (category) {
+      case 'memory':
+      case 'conversations':
+        return 'projects';
+      case 'encyclopedia': return 'encyclopedia';
+      case 'skills': return 'skills';
+      case 'plans': return 'plans';
+      case 'specs': return 'specs';
+    }
+  }
+
+  async listVersions(): Promise<RestorePoint[]> {
+    return [{ ref: 'HEAD', timestamp: Date.now(), label: 'Current backup' }];
+  }
+
+  async probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }> {
+    const categories: RestoreCategory[] = [];
+    try {
+      const { stdout } = await run('rclone', ['lsjson', `${this.rcloneRemote}:${this.driveRoot}`, '--max-depth', '1'], { timeoutMs: 30_000 });
+      const entries: Array<{ Name: string; IsDir: boolean }> = JSON.parse(stdout);
+      const names = new Set(entries.filter(e => e.IsDir).map(e => e.Name));
+      if (names.has('projects')) { categories.push('memory'); categories.push('conversations'); }
+      if (names.has('encyclopedia')) categories.push('encyclopedia');
+      if (names.has('skills')) categories.push('skills');
+      if (names.has('plans')) categories.push('plans');
+      if (names.has('specs')) categories.push('specs');
+    } catch {
+      return { hasData: false, categories: [] };
+    }
+    return { hasData: categories.length > 0, categories };
+  }
+
+  async previewCategory(category: RestoreCategory, _versionRef: string): Promise<CategoryPreview> {
+    const remote = this.remotePath(category);
+    const local = path.join(this.claudeDir, this.categoryRemoteSubpath(category));
+
+    let remoteFiles = new Map<string, number>(); // path → size
+    try {
+      const { stdout } = await run('rclone', ['lsjson', remote, '--recursive', '--files-only'], { timeoutMs: 60_000 });
+      const entries: Array<{ Path: string; Size: number }> = JSON.parse(stdout);
+      for (const e of entries) remoteFiles.set(e.Path, e.Size);
+    } catch {
+      // Remote missing/empty — treat as zero-file backup so the user sees a clear delta.
+    }
+
+    const localWalk = walkFiles(local);
+    const localSet = new Set(localWalk.files.map(f => f.replace(/\\/g, '/')));
+    const remoteSet = new Set(remoteFiles.keys());
+
+    let toAdd = 0, toOverwrite = 0, bytes = 0;
+    for (const [p, sz] of remoteFiles) {
+      if (localSet.has(p)) toOverwrite++;
+      else toAdd++;
+      bytes += sz;
+    }
+    let toDelete = 0;
+    for (const p of localSet) if (!remoteSet.has(p)) toDelete++;
+
+    return {
+      category,
+      remoteFiles: remoteFiles.size,
+      localFiles: localWalk.files.length,
+      toAdd,
+      toOverwrite,
+      toDelete,
+      bytes,
+    };
+  }
+
+  async fetchInto(
+    category: RestoreCategory,
+    stagingDir: string,
+    _versionRef: string,
+    onFile?: (filename: string, done: number, total: number) => void,
+  ): Promise<void> {
+    const remote = this.remotePath(category);
+    // rclone sync: destructive mirror from remote → staging. --create-empty-src-dirs
+    // preserves empty category layout (memory subdirs often empty on fresh projects).
+    await run('rclone', ['sync', remote, stagingDir, '--create-empty-src-dirs', '--stats-one-line'], { timeoutMs: 300_000 });
+
+    // Emit one terminal progress event so the UI flips from staging → swapping.
+    if (onFile) {
+      const walk = walkFiles(stagingDir);
+      onFile('', walk.files.length, walk.files.length);
+    }
+  }
+}

--- a/desktop/src/main/restore-adapters/github.ts
+++ b/desktop/src/main/restore-adapters/github.ts
@@ -39,6 +39,18 @@ export class GithubRestoreAdapter implements RestoreAdapter {
     }
   }
 
+  async remoteBrowseUrlFor(category: RestoreCategory, versionRef: string): Promise<string> {
+    // Resolve the sha or branch ref into a GitHub tree URL. Falls back to the
+    // repo homepage if the configured URL isn't an https github URL.
+    const base = (this.instance.config.PERSONAL_SYNC_REPO || '').replace(/\.git$/, '').replace(/\/$/, '');
+    const sub = this.categoryRepoSubpath(category);
+    const ref = versionRef === 'HEAD' ? 'main' : versionRef;
+    if (/^https:\/\/github\.com\//i.test(base)) {
+      return `${base}/tree/${ref}/${sub}`;
+    }
+    return base || 'https://github.com';
+  }
+
   async listVersions(): Promise<RestorePoint[]> {
     if (!fs.existsSync(this.repoDir)) return [];
     const { stdout } = await run('git', ['-C', this.repoDir, 'log', '--format=%H%x09%ct%x09%s', '-n', '100'], { timeoutMs: 30_000 });

--- a/desktop/src/main/restore-adapters/github.ts
+++ b/desktop/src/main/restore-adapters/github.ts
@@ -1,0 +1,187 @@
+/**
+ * GithubRestoreAdapter — git-backed restore adapter with point-in-time support.
+ *
+ * This is the novel adapter. Drive/iCloud are overwrite-in-place and only
+ * expose HEAD. GitHub backends maintain full commit history in the local
+ * repo clone at ~/.claude/toolkit-state/personal-sync-repo-<backend-id>/,
+ * so we surface it via `git log` and let the user restore to any past SHA.
+ *
+ * fetchInto uses `git --work-tree=<staging> checkout <sha> -- <cat>/` to
+ * redirect file writes into staging without touching the repo's index. We
+ * then `git reset HEAD -- <cat>/` to clean any index pollution that checkout
+ * leaves behind.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { BackendInstance } from '../sync-state';
+import type { RestoreAdapter } from '../restore-service';
+import { walkFiles, run } from '../restore-service';
+import type { RestoreCategory, RestorePoint, CategoryPreview } from '../../shared/types';
+
+export class GithubRestoreAdapter implements RestoreAdapter {
+  private readonly repoDir: string;
+
+  constructor(private instance: BackendInstance, private claudeDir: string) {
+    this.repoDir = path.join(claudeDir, 'toolkit-state', `personal-sync-repo-${instance.id}`);
+  }
+
+  private categoryRepoSubpath(category: RestoreCategory): string {
+    switch (category) {
+      case 'memory':
+      case 'conversations':
+        return 'projects';
+      case 'encyclopedia': return 'encyclopedia';
+      case 'skills': return 'skills';
+      case 'plans': return 'plans';
+      case 'specs': return 'specs';
+    }
+  }
+
+  async listVersions(): Promise<RestorePoint[]> {
+    if (!fs.existsSync(this.repoDir)) return [];
+    const { stdout } = await run('git', ['-C', this.repoDir, 'log', '--format=%H%x09%ct%x09%s', '-n', '100'], { timeoutMs: 30_000 });
+    const points: RestorePoint[] = [];
+    for (const line of stdout.split('\n')) {
+      if (!line.trim()) continue;
+      const [sha, ctStr, ...rest] = line.split('\t');
+      const ts = parseInt(ctStr, 10) * 1000;
+      const subject = rest.join('\t');
+      points.push({
+        ref: sha,
+        timestamp: ts,
+        label: this.relativeLabel(ts),
+        summary: subject,
+      });
+    }
+    return points;
+  }
+
+  async probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }> {
+    if (!fs.existsSync(this.repoDir)) return { hasData: false, categories: [] };
+    try {
+      const { stdout } = await run('git', ['-C', this.repoDir, 'ls-tree', '--name-only', 'HEAD'], { timeoutMs: 15_000 });
+      const dirs = new Set(stdout.split('\n').map(s => s.trim()).filter(Boolean));
+      const categories: RestoreCategory[] = [];
+      if (dirs.has('projects')) { categories.push('memory'); categories.push('conversations'); }
+      if (dirs.has('encyclopedia')) categories.push('encyclopedia');
+      if (dirs.has('skills')) categories.push('skills');
+      if (dirs.has('plans')) categories.push('plans');
+      if (dirs.has('specs')) categories.push('specs');
+      return { hasData: categories.length > 0, categories };
+    } catch {
+      return { hasData: false, categories: [] };
+    }
+  }
+
+  async previewCategory(category: RestoreCategory, versionRef: string): Promise<CategoryPreview> {
+    const sub = this.categoryRepoSubpath(category);
+    const liveDir = path.join(this.claudeDir, sub);
+    const ref = versionRef === 'HEAD' ? 'HEAD' : versionRef;
+
+    // Files in remote commit.
+    let remoteFiles: string[] = [];
+    let remoteBytes = 0;
+    try {
+      const { stdout } = await run('git', ['-C', this.repoDir, 'ls-tree', '-r', '--long', ref, '--', sub + '/'], { timeoutMs: 30_000 });
+      for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        // Format: <mode> <type> <hash> <size>\t<path>
+        const m = line.match(/^\S+\s+\S+\s+\S+\s+(\S+)\t(.+)$/);
+        if (!m) continue;
+        const size = parseInt(m[1], 10) || 0;
+        const rel = m[2].substring(sub.length + 1);
+        remoteFiles.push(rel);
+        remoteBytes += size;
+      }
+    } catch {
+      // ref/path not present — treat as empty remote.
+    }
+
+    const localWalk = walkFiles(liveDir);
+    const remoteSet = new Set(remoteFiles.map(f => f.replace(/\\/g, '/')));
+    const localSet = new Set(localWalk.files.map(f => f.replace(/\\/g, '/')));
+
+    let toAdd = 0, toOverwrite = 0;
+    for (const p of remoteSet) {
+      if (localSet.has(p)) toOverwrite++;
+      else toAdd++;
+    }
+    let toDelete = 0;
+    for (const p of localSet) if (!remoteSet.has(p)) toDelete++;
+
+    return {
+      category,
+      remoteFiles: remoteFiles.length,
+      localFiles: localWalk.files.length,
+      toAdd,
+      toOverwrite,
+      toDelete,
+      bytes: remoteBytes,
+    };
+  }
+
+  async fetchInto(
+    category: RestoreCategory,
+    stagingDir: string,
+    versionRef: string,
+    onFile?: (filename: string, done: number, total: number) => void,
+  ): Promise<void> {
+    if (!fs.existsSync(this.repoDir)) throw new Error('GitHub sync repo missing — run a sync first');
+    const sub = this.categoryRepoSubpath(category);
+    const ref = versionRef === 'HEAD' ? 'HEAD' : versionRef;
+
+    // Redirect git's file writes into staging via --work-tree. Staging dir
+    // already exists (restore-service creates it). We need the relative subpath
+    // to exist too because checkout writes into <work-tree>/<path>.
+    const stagedCategoryDir = path.join(stagingDir, sub);
+    fs.mkdirSync(stagedCategoryDir, { recursive: true });
+
+    // --work-tree redirects writes; -- limits to the category subpath.
+    await run('git', [
+      '-C', this.repoDir,
+      `--work-tree=${stagingDir}`,
+      'checkout', ref, '--', sub + '/',
+    ], { timeoutMs: 300_000 });
+
+    // Clean index pollution from the diverted checkout. Without this, a
+    // subsequent normal sync push would include stale staged entries.
+    try {
+      await run('git', ['-C', this.repoDir, 'reset', 'HEAD', '--', sub + '/'], { timeoutMs: 30_000 });
+    } catch {}
+
+    // staging/<sub>/* is the real data; lift it one level so the swap dirs match.
+    // (liveDirFor returns ~/.claude/<sub>, staging should too.)
+    const lifted = path.join(stagingDir, '__lift');
+    fs.mkdirSync(lifted, { recursive: true });
+    for (const entry of fs.readdirSync(stagedCategoryDir)) {
+      fs.renameSync(path.join(stagedCategoryDir, entry), path.join(lifted, entry));
+    }
+    fs.rmSync(stagedCategoryDir, { recursive: true, force: true });
+    for (const entry of fs.readdirSync(lifted)) {
+      fs.renameSync(path.join(lifted, entry), path.join(stagingDir, entry));
+    }
+    fs.rmSync(lifted, { recursive: true, force: true });
+
+    if (onFile) {
+      const walk = walkFiles(stagingDir);
+      onFile('', walk.files.length, walk.files.length);
+    }
+    void os; // reserved for future platform branching
+  }
+
+  // --- helpers ---
+
+  private relativeLabel(ts: number): string {
+    const diff = Date.now() - ts;
+    const min = Math.floor(diff / 60_000);
+    if (min < 1) return 'just now';
+    if (min < 60) return `${min} minute${min === 1 ? '' : 's'} ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`;
+    const d = Math.floor(hr / 24);
+    if (d < 30) return `${d} day${d === 1 ? '' : 's'} ago`;
+    return new Date(ts).toLocaleDateString();
+  }
+}

--- a/desktop/src/main/restore-adapters/icloud.ts
+++ b/desktop/src/main/restore-adapters/icloud.ts
@@ -42,6 +42,12 @@ export class IcloudRestoreAdapter implements RestoreAdapter {
     return [{ ref: 'HEAD', timestamp: Date.now(), label: 'Current backup' }];
   }
 
+  async remoteBrowseUrlFor(category: RestoreCategory, _versionRef: string): Promise<string> {
+    // iCloud is a local mount — return a file:// URL so shell.openExternal
+    // pops Finder/Explorer at that folder.
+    return 'file://' + this.remoteDir(category).replace(/\\/g, '/');
+  }
+
   async probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }> {
     if (!this.icloudRoot || !fs.existsSync(this.icloudRoot)) return { hasData: false, categories: [] };
     const categories: RestoreCategory[] = [];

--- a/desktop/src/main/restore-adapters/icloud.ts
+++ b/desktop/src/main/restore-adapters/icloud.ts
@@ -1,0 +1,113 @@
+/**
+ * IcloudRestoreAdapter — rsync-backed restore adapter for iCloud.
+ *
+ * iCloud is HEAD-only (filesystem mirror, no history). We walk the local mount
+ * for preview and use rsync --delete into staging for execute. Critical
+ * detail: rsync is invoked per-category with explicit `src/` → `dst/` pairs.
+ * Never rsync the parent with --delete — that would nuke unrelated categories.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { BackendInstance } from '../sync-state';
+import type { RestoreAdapter } from '../restore-service';
+import { walkFiles, run } from '../restore-service';
+import type { RestoreCategory, RestorePoint, CategoryPreview } from '../../shared/types';
+
+export class IcloudRestoreAdapter implements RestoreAdapter {
+  private readonly icloudRoot: string;
+
+  constructor(private instance: BackendInstance, private claudeDir: string) {
+    // iCloud mount path comes from per-instance config (user-chosen during setup).
+    this.icloudRoot = instance.config.ICLOUD_ROOT || instance.config.icloudPath || '';
+  }
+
+  private categorySubpath(category: RestoreCategory): string {
+    switch (category) {
+      case 'memory':
+      case 'conversations':
+        return 'projects';
+      case 'encyclopedia': return 'encyclopedia';
+      case 'skills': return 'skills';
+      case 'plans': return 'plans';
+      case 'specs': return 'specs';
+    }
+  }
+
+  private remoteDir(category: RestoreCategory): string {
+    return path.join(this.icloudRoot, this.categorySubpath(category));
+  }
+
+  async listVersions(): Promise<RestorePoint[]> {
+    return [{ ref: 'HEAD', timestamp: Date.now(), label: 'Current backup' }];
+  }
+
+  async probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }> {
+    if (!this.icloudRoot || !fs.existsSync(this.icloudRoot)) return { hasData: false, categories: [] };
+    const categories: RestoreCategory[] = [];
+    try {
+      const entries = fs.readdirSync(this.icloudRoot, { withFileTypes: true });
+      const names = new Set(entries.filter(e => e.isDirectory()).map(e => e.name));
+      if (names.has('projects')) { categories.push('memory'); categories.push('conversations'); }
+      if (names.has('encyclopedia')) categories.push('encyclopedia');
+      if (names.has('skills')) categories.push('skills');
+      if (names.has('plans')) categories.push('plans');
+      if (names.has('specs')) categories.push('specs');
+    } catch {
+      return { hasData: false, categories: [] };
+    }
+    return { hasData: categories.length > 0, categories };
+  }
+
+  async previewCategory(category: RestoreCategory, _versionRef: string): Promise<CategoryPreview> {
+    const remote = this.remoteDir(category);
+    const local = path.join(this.claudeDir, this.categorySubpath(category));
+
+    const remoteWalk = walkFiles(remote);
+    const localWalk = walkFiles(local);
+    const remoteSet = new Set(remoteWalk.files.map(f => f.replace(/\\/g, '/')));
+    const localSet = new Set(localWalk.files.map(f => f.replace(/\\/g, '/')));
+
+    let toAdd = 0, toOverwrite = 0;
+    for (const p of remoteSet) {
+      if (localSet.has(p)) toOverwrite++;
+      else toAdd++;
+    }
+    let toDelete = 0;
+    for (const p of localSet) if (!remoteSet.has(p)) toDelete++;
+
+    return {
+      category,
+      remoteFiles: remoteWalk.files.length,
+      localFiles: localWalk.files.length,
+      toAdd,
+      toOverwrite,
+      toDelete,
+      bytes: remoteWalk.bytes,
+    };
+  }
+
+  async fetchInto(
+    category: RestoreCategory,
+    stagingDir: string,
+    _versionRef: string,
+    onFile?: (filename: string, done: number, total: number) => void,
+  ): Promise<void> {
+    const remote = this.remoteDir(category);
+    if (!fs.existsSync(remote)) {
+      // Nothing to fetch — leave staging empty; caller's atomic swap produces an empty live dir.
+      return;
+    }
+
+    // Trailing slashes are critical — without them rsync copies the remote
+    // directory *into* stagingDir instead of *replacing* its contents.
+    const src = remote.endsWith(path.sep) ? remote : remote + path.sep;
+    const dst = stagingDir.endsWith(path.sep) ? stagingDir : stagingDir + path.sep;
+    await run('rsync', ['-a', '--delete', src, dst], { timeoutMs: 600_000 });
+
+    if (onFile) {
+      const walk = walkFiles(stagingDir);
+      onFile('', walk.files.length, walk.files.length);
+    }
+  }
+}

--- a/desktop/src/main/restore-service.ts
+++ b/desktop/src/main/restore-service.ts
@@ -62,6 +62,9 @@ export interface RestoreAdapter {
     onFile?: (filename: string, done: number, total: number) => void,
   ): Promise<void>;
   probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }>;
+  /** Optional — when present, returns a URL that opens this category's remote
+   *  browse view (e.g., Drive folder, GitHub tree). Used by the preview UI. */
+  remoteBrowseUrlFor?(category: RestoreCategory, versionRef: string): Promise<string>;
 }
 
 export class RestoreService {
@@ -155,40 +158,120 @@ export class RestoreService {
 
   async previewRestore(opts: RestoreOptions): Promise<RestorePreview> {
     const adapter = this.adapterFor(opts.backendId);
-    const perCategory: CategoryPreview[] = [];
-    let totalBytes = 0;
     const warnings: string[] = [];
 
-    for (const category of opts.categories) {
-      try {
-        const preview = await adapter.previewCategory(category, opts.versionRef);
-        perCategory.push(preview);
-        totalBytes += preview.bytes;
-      } catch (e: any) {
-        warnings.push(`Preview failed for ${category}: ${e?.message || e}`);
-        perCategory.push({
-          category,
-          remoteFiles: 0,
-          localFiles: 0,
-          toAdd: 0,
-          toOverwrite: 0,
-          toDelete: 0,
-          bytes: 0,
-        });
-      }
-    }
+    // Run category previews in parallel — each adapter call is a separate
+    // rclone/git invocation so they don't contend on local CPU. Sequential
+    // was making 6 categories feel like a minute+ on Drive because each
+    // rclone lsjson spends most of its time on network latency.
+    const raw: CategoryPreview[] = await Promise.all(
+      opts.categories.map(async (category) => {
+        try {
+          return await adapter.previewCategory(category, opts.versionRef);
+        } catch (e: any) {
+          warnings.push(`Preview failed for ${category}: ${e?.message || e}`);
+          return {
+            category,
+            remoteFiles: 0,
+            localFiles: 0,
+            toAdd: 0,
+            toOverwrite: 0,
+            toDelete: 0,
+            bytes: 0,
+          };
+        }
+      }),
+    );
 
-    if (opts.categories.includes('skills') || opts.categories.includes('memory')) {
+    // For merge mode, reinterpret the same raw counts:
+    //   - toDelete=0 (merge never deletes; those files will stay + be uploaded)
+    //   - toUpload = original toDelete (they go up to the backup instead of away)
+    // Wipe keeps the as-measured shape.
+    const perCategory: CategoryPreview[] = raw.map((p) =>
+      opts.mode === 'merge'
+        ? { ...p, toUpload: p.toDelete, toDelete: 0 }
+        : p,
+    );
+
+    const totalBytes = perCategory.reduce((sum, p) => sum + p.bytes, 0);
+
+    if (opts.mode === 'wipe' && (opts.categories.includes('skills') || opts.categories.includes('memory'))) {
       warnings.push('Skills or memory restored — app restart recommended to pick up changes.');
+    }
+    if (opts.mode === 'wipe') {
+      const anyDelete = perCategory.some((p) => p.toDelete > 0);
+      if (anyDelete) {
+        warnings.push('Wipe & restore will DELETE local files not present in the backup.');
+      }
     }
 
     // Rough estimate: 10 MB/s effective throughput after overhead.
     const estimatedSeconds = Math.max(3, Math.ceil(totalBytes / (10 * 1024 * 1024)));
 
-    return { perCategory, totalBytes, estimatedSeconds, warnings };
+    return { perCategory, totalBytes, estimatedSeconds, warnings, mode: opts.mode };
+  }
+
+  /**
+   * Resolve a browse URL for a single category on the remote backend.
+   * Returns null if the adapter doesn't support browse links.
+   */
+  async browseCategoryUrl(backendId: string, category: RestoreCategory, versionRef: string): Promise<string | null> {
+    const adapter = this.adapterFor(backendId);
+    if (!adapter.remoteBrowseUrlFor) return null;
+    try {
+      return await adapter.remoteBrowseUrlFor(category, versionRef);
+    } catch {
+      return null;
+    }
   }
 
   async executeRestore(
+    opts: RestoreOptions,
+    onProgress: (e: RestoreProgressEvent) => void,
+  ): Promise<RestoreResult> {
+    // Merge mode reuses the sync loop's pull + push (remote → local add/overwrite
+    // with no deletions, then local → remote upload for anything local-only).
+    // This is NON-destructive on both sides, so no snapshot is needed and we
+    // don't flip restoreInProgress — we actually want pushBackend to run.
+    if (opts.mode === 'merge') {
+      return this.executeMerge(opts, onProgress);
+    }
+    return this.executeWipe(opts, onProgress);
+  }
+
+  private async executeMerge(
+    opts: RestoreOptions,
+    onProgress: (e: RestoreProgressEvent) => void,
+  ): Promise<RestoreResult> {
+    const startedAt = Date.now();
+
+    // Emit a single 'fetching' phase for each category up-front so the UI
+    // renders per-category rows. Merge doesn't stage per-category, so we don't
+    // get file-level progress — just the two top-level phases (fetching, done).
+    for (const category of opts.categories) {
+      onProgress({ category, filesDone: 0, filesTotal: 0, phase: 'fetching' });
+    }
+
+    // Phase 1: pull remote → local (add + overwrite-newer, no deletions).
+    await this.syncService.pull({ backendId: opts.backendId });
+
+    // Phase 2: push local → remote (uploads anything local-only). `force: true`
+    // so the push isn't skipped for being recent — the user just asked for a sync.
+    await this.syncService.push({ backendId: opts.backendId, force: true });
+
+    for (const category of opts.categories) {
+      onProgress({ category, filesDone: 1, filesTotal: 1, phase: 'done' });
+    }
+
+    return {
+      categoriesRestored: opts.categories,
+      filesWritten: 0, // merge doesn't track per-file writes; sync-service logs it
+      durationMs: Date.now() - startedAt,
+      requiresRestart: opts.categories.includes('skills') || opts.categories.includes('memory'),
+    };
+  }
+
+  private async executeWipe(
     opts: RestoreOptions,
     onProgress: (e: RestoreProgressEvent) => void,
   ): Promise<RestoreResult> {

--- a/desktop/src/main/restore-service.ts
+++ b/desktop/src/main/restore-service.ts
@@ -1,0 +1,474 @@
+/**
+ * restore-service.ts — Directional, user-initiated restore from a cloud backup.
+ *
+ * This is NOT sync. Sync is bidirectional merge; restore is a one-time pull
+ * where the remote is treated as authoritative. Different invariants, different
+ * code path (see RESTORE-FROM-BACKUP-DESIGN.md in the workspace docs).
+ *
+ * Safety invariants (enforced here, not in docs):
+ *   1. Snapshot-first by default — current local data is copied to
+ *      ~/.claude/restore-snapshots/<ISO>/ before any overwrite.
+ *   2. Push loop paused — SyncService.restoreInProgress is flipped true during
+ *      execute so the 15-minute push doesn't upload half-restored state.
+ *   3. Atomic per-category — each category is staged under
+ *      ~/.claude/.restore-staging/<category>/, then the live dir is swapped
+ *      in via rename. A crash leaves either the old or new dir, never a mix.
+ *
+ * Retention: snapshots older than 90 days are pruned on app start; cap 10.
+ * Progress events are throttled to 250ms per category to avoid flooding the
+ * Android WebSocket bridge.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { SyncService } from './sync-service';
+import type { BackendInstance } from './sync-state';
+import type {
+  RestoreCategory,
+  RestorePoint,
+  RestoreOptions,
+  RestorePreview,
+  CategoryPreview,
+  RestoreResult,
+  Snapshot,
+  RestoreProgressEvent,
+} from '../shared/types';
+
+const execFileP = promisify(execFile);
+
+const SNAPSHOT_RETENTION_DAYS = 90;
+const SNAPSHOT_CAP = 10;
+const PROGRESS_THROTTLE_MS = 250;
+
+export const RESTORE_CATEGORIES: RestoreCategory[] = [
+  'memory',
+  'conversations',
+  'encyclopedia',
+  'skills',
+  'plans',
+  'specs',
+];
+
+export interface RestoreAdapter {
+  listVersions(): Promise<RestorePoint[]>;
+  previewCategory(category: RestoreCategory, versionRef: string): Promise<CategoryPreview>;
+  fetchInto(
+    category: RestoreCategory,
+    stagingDir: string,
+    versionRef: string,
+    onFile?: (filename: string, done: number, total: number) => void,
+  ): Promise<void>;
+  probe(): Promise<{ hasData: boolean; categories: RestoreCategory[] }>;
+}
+
+export class RestoreService {
+  private readonly claudeDir: string;
+  private readonly snapshotsRoot: string;
+  private readonly stagingRoot: string;
+
+  constructor(
+    private syncService: SyncService,
+    private getBackendInstance: (id: string) => BackendInstance | null,
+    userDataDir?: string,
+  ) {
+    // userDataDir is accepted for API symmetry with Electron's app.getPath('userData')
+    // but all restore state lives in ~/.claude (portable across desktop/Android).
+    void userDataDir;
+    this.claudeDir = path.join(os.homedir(), '.claude');
+    this.snapshotsRoot = path.join(this.claudeDir, 'restore-snapshots');
+    this.stagingRoot = path.join(this.claudeDir, '.restore-staging');
+  }
+
+  // =========================================================================
+  // Adapter dispatch
+  // =========================================================================
+
+  private adapterFor(backendId: string): RestoreAdapter {
+    const instance = this.getBackendInstance(backendId);
+    if (!instance) throw new Error(`No backend with id '${backendId}'`);
+    switch (instance.type) {
+      case 'drive':
+        // Lazy require to keep this file loadable in environments where an adapter's
+        // deps (e.g., rclone) aren't installed — only the requested backend's adapter runs.
+        return new (require('./restore-adapters/drive').DriveRestoreAdapter)(instance, this.claudeDir);
+      case 'github':
+        return new (require('./restore-adapters/github').GithubRestoreAdapter)(instance, this.claudeDir);
+      case 'icloud':
+        return new (require('./restore-adapters/icloud').IcloudRestoreAdapter)(instance, this.claudeDir);
+      default:
+        throw new Error(`Unsupported backend type: ${(instance as any).type}`);
+    }
+  }
+
+  // =========================================================================
+  // Category path resolution
+  // =========================================================================
+
+  /**
+   * Canonical live path for a category on disk. Memory and conversations use the
+   * per-project tree at ~/.claude/projects/, the rest are flat subdirs.
+   * The backup layout mirrors this exactly, so a dir-level swap is safe.
+   */
+  liveDirFor(category: RestoreCategory): string {
+    switch (category) {
+      case 'memory':
+      case 'conversations':
+        // Both categories live under ~/.claude/projects/<slug>/ — memory in
+        // a memory/ subdir, conversations as .jsonl files. We swap the whole
+        // projects tree so partial-category restore across many projects
+        // stays atomic. The adapter's fetchInto selects only the relevant
+        // files into staging.
+        return path.join(this.claudeDir, 'projects');
+      case 'encyclopedia':
+        return path.join(this.claudeDir, 'encyclopedia');
+      case 'skills':
+        return path.join(this.claudeDir, 'skills');
+      case 'plans':
+        return path.join(this.claudeDir, 'plans');
+      case 'specs':
+        return path.join(this.claudeDir, 'specs');
+    }
+  }
+
+  stagingDirFor(category: RestoreCategory): string {
+    return path.join(this.stagingRoot, category);
+  }
+
+  // =========================================================================
+  // Public API
+  // =========================================================================
+
+  async probe(backendId: string): Promise<{ hasData: boolean; categories: RestoreCategory[] }> {
+    try {
+      return await this.adapterFor(backendId).probe();
+    } catch {
+      return { hasData: false, categories: [] };
+    }
+  }
+
+  async listVersions(backendId: string): Promise<RestorePoint[]> {
+    return this.adapterFor(backendId).listVersions();
+  }
+
+  async previewRestore(opts: RestoreOptions): Promise<RestorePreview> {
+    const adapter = this.adapterFor(opts.backendId);
+    const perCategory: CategoryPreview[] = [];
+    let totalBytes = 0;
+    const warnings: string[] = [];
+
+    for (const category of opts.categories) {
+      try {
+        const preview = await adapter.previewCategory(category, opts.versionRef);
+        perCategory.push(preview);
+        totalBytes += preview.bytes;
+      } catch (e: any) {
+        warnings.push(`Preview failed for ${category}: ${e?.message || e}`);
+        perCategory.push({
+          category,
+          remoteFiles: 0,
+          localFiles: 0,
+          toAdd: 0,
+          toOverwrite: 0,
+          toDelete: 0,
+          bytes: 0,
+        });
+      }
+    }
+
+    if (opts.categories.includes('skills') || opts.categories.includes('memory')) {
+      warnings.push('Skills or memory restored — app restart recommended to pick up changes.');
+    }
+
+    // Rough estimate: 10 MB/s effective throughput after overhead.
+    const estimatedSeconds = Math.max(3, Math.ceil(totalBytes / (10 * 1024 * 1024)));
+
+    return { perCategory, totalBytes, estimatedSeconds, warnings };
+  }
+
+  async executeRestore(
+    opts: RestoreOptions,
+    onProgress: (e: RestoreProgressEvent) => void,
+  ): Promise<RestoreResult> {
+    const startedAt = Date.now();
+    const adapter = this.adapterFor(opts.backendId);
+
+    this.syncService.restoreInProgress = true;
+    let snapshotId: string | undefined;
+    let filesWritten = 0;
+
+    // Per-category throttle state for progress events.
+    const lastEmitAt = new Map<RestoreCategory, number>();
+    const emit = (evt: RestoreProgressEvent) => {
+      const now = Date.now();
+      const last = lastEmitAt.get(evt.category) ?? 0;
+      // Always emit phase transitions; throttle file-level progress only.
+      const isPhaseEvent = evt.phase !== 'fetching' && evt.phase !== 'staging';
+      if (isPhaseEvent || now - last >= PROGRESS_THROTTLE_MS) {
+        lastEmitAt.set(evt.category, now);
+        onProgress(evt);
+      }
+    };
+
+    try {
+      fs.mkdirSync(this.stagingRoot, { recursive: true });
+      fs.mkdirSync(this.snapshotsRoot, { recursive: true });
+
+      // --- 1. Snapshot current local state ---
+      if (opts.snapshotFirst) {
+        snapshotId = this.isoStamp();
+        const snapshotDir = path.join(this.snapshotsRoot, snapshotId);
+        fs.mkdirSync(snapshotDir, { recursive: true });
+        for (const category of opts.categories) {
+          emit({ category, filesDone: 0, filesTotal: 0, phase: 'snapshotting' });
+          const liveDir = this.liveDirFor(category);
+          if (fs.existsSync(liveDir)) {
+            const dest = path.join(snapshotDir, category);
+            // cpSync recursive is the cheapest cross-platform deep copy; yields a
+            // directory-structured snapshot (not a zip). Simpler, still undoable.
+            fs.cpSync(liveDir, dest, { recursive: true, force: true });
+          }
+        }
+        // Sidecar manifest for SnapshotsPanel.
+        const manifest: Snapshot = {
+          id: snapshotId,
+          timestamp: Date.now(),
+          categories: opts.categories,
+          backendId: opts.backendId,
+          sizeBytes: this.dirSize(snapshotDir),
+          triggeredBy: 'restore',
+        };
+        fs.writeFileSync(path.join(snapshotDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+      }
+
+      // --- 2. Fetch each category into staging, then swap ---
+      for (const category of opts.categories) {
+        emit({ category, filesDone: 0, filesTotal: 0, phase: 'fetching' });
+        const staging = this.stagingDirFor(category);
+        // Clean any staging remnant from a prior crashed run.
+        try { fs.rmSync(staging, { recursive: true, force: true }); } catch {}
+        fs.mkdirSync(staging, { recursive: true });
+
+        await adapter.fetchInto(category, staging, opts.versionRef, (filename, done, total) => {
+          filesWritten++;
+          emit({ category, filesDone: done, filesTotal: total, currentFile: filename, phase: 'staging' });
+        });
+
+        emit({ category, filesDone: 1, filesTotal: 1, phase: 'swapping' });
+        this.atomicSwap(staging, this.liveDirFor(category));
+        emit({ category, filesDone: 1, filesTotal: 1, phase: 'done' });
+      }
+
+      return {
+        snapshotId,
+        categoriesRestored: opts.categories,
+        filesWritten,
+        durationMs: Date.now() - startedAt,
+        requiresRestart: opts.categories.includes('skills') || opts.categories.includes('memory'),
+      };
+    } finally {
+      this.syncService.restoreInProgress = false;
+      // Best-effort staging cleanup. Orphaned dirs are also swept on app start.
+      try { fs.rmSync(this.stagingRoot, { recursive: true, force: true }); } catch {}
+    }
+  }
+
+  async listSnapshots(): Promise<Snapshot[]> {
+    if (!fs.existsSync(this.snapshotsRoot)) return [];
+    const entries = fs.readdirSync(this.snapshotsRoot, { withFileTypes: true });
+    const snapshots: Snapshot[] = [];
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      const manifestPath = path.join(this.snapshotsRoot, e.name, 'manifest.json');
+      try {
+        const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Snapshot;
+        snapshots.push(m);
+      } catch {
+        // Missing manifest (older/partial snapshot) — synthesize minimal metadata.
+        snapshots.push({
+          id: e.name,
+          timestamp: this.parseIsoStamp(e.name),
+          categories: [],
+          backendId: '',
+          sizeBytes: 0,
+          triggeredBy: 'manual',
+        });
+      }
+    }
+    return snapshots.sort((a, b) => b.timestamp - a.timestamp);
+  }
+
+  async undoRestore(snapshotId: string): Promise<void> {
+    const snapshotDir = path.join(this.snapshotsRoot, snapshotId);
+    if (!fs.existsSync(snapshotDir)) throw new Error(`Snapshot ${snapshotId} not found`);
+    const manifestPath = path.join(snapshotDir, 'manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Snapshot;
+
+    this.syncService.restoreInProgress = true;
+    try {
+      for (const category of manifest.categories) {
+        const source = path.join(snapshotDir, category);
+        if (!fs.existsSync(source)) continue;
+        const staging = this.stagingDirFor(category);
+        try { fs.rmSync(staging, { recursive: true, force: true }); } catch {}
+        fs.mkdirSync(path.dirname(staging), { recursive: true });
+        fs.cpSync(source, staging, { recursive: true, force: true });
+        this.atomicSwap(staging, this.liveDirFor(category));
+      }
+    } finally {
+      this.syncService.restoreInProgress = false;
+      try { fs.rmSync(this.stagingRoot, { recursive: true, force: true }); } catch {}
+    }
+  }
+
+  async deleteSnapshot(snapshotId: string): Promise<void> {
+    const snapshotDir = path.join(this.snapshotsRoot, snapshotId);
+    if (fs.existsSync(snapshotDir)) {
+      fs.rmSync(snapshotDir, { recursive: true, force: true });
+    }
+  }
+
+  // =========================================================================
+  // Lifecycle hooks called from main.ts on startup
+  // =========================================================================
+
+  /**
+   * Delete orphaned staging directories left behind by a crashed restore.
+   * Safe to call on every launch — no-op if stagingRoot is missing.
+   */
+  cleanupOrphanedStaging(): void {
+    try {
+      if (fs.existsSync(this.stagingRoot)) {
+        fs.rmSync(this.stagingRoot, { recursive: true, force: true });
+      }
+    } catch {}
+  }
+
+  /**
+   * Enforce retention: delete snapshots older than SNAPSHOT_RETENTION_DAYS,
+   * then cap total count at SNAPSHOT_CAP (oldest pruned first).
+   */
+  enforceRetention(): void {
+    try {
+      if (!fs.existsSync(this.snapshotsRoot)) return;
+      const cutoff = Date.now() - SNAPSHOT_RETENTION_DAYS * 86400_000;
+      const entries = fs.readdirSync(this.snapshotsRoot, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .map(e => ({ name: e.name, ts: this.parseIsoStamp(e.name) }))
+        .sort((a, b) => a.ts - b.ts);
+
+      for (const e of entries) {
+        if (e.ts < cutoff) {
+          try { fs.rmSync(path.join(this.snapshotsRoot, e.name), { recursive: true, force: true }); } catch {}
+        }
+      }
+      // Recompute after age cull, then enforce cap.
+      const remaining = fs.readdirSync(this.snapshotsRoot, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .map(e => ({ name: e.name, ts: this.parseIsoStamp(e.name) }))
+        .sort((a, b) => a.ts - b.ts);
+      const overflow = remaining.length - SNAPSHOT_CAP;
+      for (let i = 0; i < overflow; i++) {
+        try { fs.rmSync(path.join(this.snapshotsRoot, remaining[i].name), { recursive: true, force: true }); } catch {}
+      }
+    } catch {}
+  }
+
+  // =========================================================================
+  // Internals
+  // =========================================================================
+
+  /**
+   * Atomic swap of staging into live via .old intermediate.
+   * On Windows, `fs.rename` across directories fails if the target exists, so
+   * we rename live → live.old, staging → live, then delete live.old. On any
+   * error, we roll back. This is the key safety primitive for restore.
+   */
+  private atomicSwap(stagingDir: string, liveDir: string): void {
+    const oldDir = `${liveDir}.old.${Date.now()}`;
+    const liveExists = fs.existsSync(liveDir);
+    fs.mkdirSync(path.dirname(liveDir), { recursive: true });
+
+    try {
+      if (liveExists) fs.renameSync(liveDir, oldDir);
+      fs.renameSync(stagingDir, liveDir);
+    } catch (e) {
+      // Rollback: if the second rename failed, put live back.
+      if (liveExists && fs.existsSync(oldDir) && !fs.existsSync(liveDir)) {
+        try { fs.renameSync(oldDir, liveDir); } catch {}
+      }
+      throw e;
+    }
+
+    if (liveExists) {
+      try { fs.rmSync(oldDir, { recursive: true, force: true }); } catch {
+        // Leave .old for manual cleanup rather than fail the restore.
+      }
+    }
+  }
+
+  /** Filesystem-safe ISO-8601 timestamp (no colons). */
+  private isoStamp(): string {
+    return new Date().toISOString().replace(/[:.]/g, '-');
+  }
+
+  private parseIsoStamp(s: string): number {
+    const normal = s.replace(/-/g, (m, i) => (i > 10 ? ':' : '-')).replace(/-(\d{3})Z$/, '.$1Z');
+    const t = Date.parse(normal);
+    return isNaN(t) ? 0 : t;
+  }
+
+  private dirSize(dir: string): number {
+    let total = 0;
+    const stack = [dir];
+    while (stack.length) {
+      const d = stack.pop()!;
+      let entries: fs.Dirent[];
+      try { entries = fs.readdirSync(d, { withFileTypes: true }); } catch { continue; }
+      for (const e of entries) {
+        const p = path.join(d, e.name);
+        try {
+          if (e.isDirectory()) stack.push(p);
+          else if (e.isFile()) total += fs.statSync(p).size;
+        } catch {}
+      }
+    }
+    return total;
+  }
+}
+
+// Shared helper for adapters: count files, bytes under a directory tree.
+export function walkFiles(dir: string): { files: string[]; bytes: number } {
+  const files: string[] = [];
+  let bytes = 0;
+  if (!fs.existsSync(dir)) return { files, bytes };
+  const stack = [dir];
+  while (stack.length) {
+    const d = stack.pop()!;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(d, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      const p = path.join(d, e.name);
+      try {
+        if (e.isDirectory()) stack.push(p);
+        else if (e.isFile()) {
+          files.push(path.relative(dir, p));
+          bytes += fs.statSync(p).size;
+        }
+      } catch {}
+    }
+  }
+  return { files, bytes };
+}
+
+// Exec helper re-exported for adapters to avoid pulling execFile each time.
+export async function run(cmd: string, args: string[], opts: { cwd?: string; timeoutMs?: number } = {}): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await execFileP(cmd, args, {
+    cwd: opts.cwd,
+    timeout: opts.timeoutMs ?? 60_000,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+}

--- a/desktop/src/main/restore-service.ts
+++ b/desktop/src/main/restore-service.ts
@@ -439,6 +439,29 @@ export class RestoreService {
   }
 }
 
+// Module-level singleton — constructed once SyncService is ready (see main.ts).
+// IPC handlers call getRestoreService() lazily because they're registered before
+// SyncService.start() and the restore service needs a live sync service to pause
+// the push loop during execute/undo.
+let _restoreInstance: RestoreService | null = null;
+
+export function initRestoreService(syncService: SyncService, userDataDir?: string): RestoreService {
+  _restoreInstance = new RestoreService(
+    syncService,
+    (id) => syncService.getBackendById(id),
+    userDataDir,
+  );
+  // Startup housekeeping — orphan cleanup from a prior crashed restore, and
+  // age/count retention. Both are best-effort; failures don't block the app.
+  _restoreInstance.cleanupOrphanedStaging();
+  _restoreInstance.enforceRetention();
+  return _restoreInstance;
+}
+
+export function getRestoreService(): RestoreService | null {
+  return _restoreInstance;
+}
+
 // Shared helper for adapters: count files, bytes under a directory tree.
 export function walkFiles(dir: string): { files: string[]; bytes: number } {
   const files: string[] = [];

--- a/desktop/src/main/sync-service.ts
+++ b/desktop/src/main/sync-service.ts
@@ -113,6 +113,13 @@ export class SyncService extends EventEmitter {
   private pulling = false;
   private pushing = false;
 
+  /**
+   * Gates pushLoop() during a restore. Pushing a half-restored state would
+   * upload mid-staging data and corrupt the backup — so RestoreService flips
+   * this true before any filesystem work, false after the final swap.
+   */
+  public restoreInProgress = false;
+
   constructor() {
     super();
     this.claudeDir = path.join(os.homedir(), '.claude');
@@ -161,6 +168,9 @@ export class SyncService extends EventEmitter {
 
     // Start background push timer
     this.pushTimer = setInterval(() => {
+      // Guard: RestoreService may be mid-way through rewriting files. Pushing now
+      // would upload a half-restored state and nuke the backup it was trying to recover.
+      if (this.restoreInProgress) return;
       this.push().catch(e => {
         this.logBackup('ERROR', `Background push failed: ${e}`, 'sync.push');
       });

--- a/desktop/src/main/sync-service.ts
+++ b/desktop/src/main/sync-service.ts
@@ -234,7 +234,9 @@ export class SyncService extends EventEmitter {
   }
 
   /** Find a single backend by id (for manual push/pull). */
-  private getBackendById(id: string): BackendInstance | null {
+  // Public so RestoreService can look up the active BackendInstance by id
+  // without re-reading config.json itself.
+  public getBackendById(id: string): BackendInstance | null {
     return this.getBackendInstances().find(b => b.id === id) || null;
   }
 

--- a/desktop/src/main/sync-state.ts
+++ b/desktop/src/main/sync-state.ts
@@ -86,6 +86,12 @@ export interface SyncStatus {
   syncInProgress: boolean;
   syncingBackendId: string | null;     // Which backend is currently syncing
   syncedCategories: string[];
+  // Experimental feature flags piggy-backed on sync status so renderer code
+  // doesn't need a second IPC. Read from ~/.claude/destincode-local.json via
+  // main/config.ts. Absence == all flags off.
+  experimentalFlags?: {
+    restoreFlow?: boolean;
+  };
 }
 
 /** Config shape for the multi-instance model. */
@@ -358,6 +364,17 @@ export async function getSyncStatus(): Promise<SyncStatus> {
   ]);
   const syncedCategories = categoryChecks.filter(Boolean) as string[];
 
+  // Experimental flags — read synchronously from config.ts (tiny local file).
+  // Piggy-backed on SyncStatus so restore UI doesn't need a second IPC poll.
+  let experimentalFlags: SyncStatus['experimentalFlags'];
+  try {
+    // Lazy require avoids a top-of-file cycle between sync-state and config.
+    const { getLocalConfig } = require('./config');
+    experimentalFlags = getLocalConfig().experimental || {};
+  } catch {
+    experimentalFlags = {};
+  }
+
   return {
     backends: backendStatuses,
     lastSyncEpoch: globalMarkerEpoch,
@@ -366,6 +383,7 @@ export async function getSyncStatus(): Promise<SyncStatus> {
     syncInProgress: lockExists,
     syncingBackendId: null, // Set by SyncService at runtime via event
     syncedCategories,
+    experimentalFlags,
   };
 }
 

--- a/desktop/src/main/sync-state.ts
+++ b/desktop/src/main/sync-state.ts
@@ -55,6 +55,12 @@ export interface BackendInstance {
   label: string;                       // User-visible name, e.g. "Personal Drive"
   syncEnabled: boolean;                // true = auto-sync; false = storage only
   config: Record<string, string>;      // Type-specific connection details
+  /**
+   * Set when the user explicitly picks "Start fresh" during onboarding despite
+   * detecting existing backup data. Prevents the restore probe from nagging on
+   * every launch. Absence means "never prompted yet" — presence means "user chose local".
+   */
+  freshStartConfirmedEpoch?: number;
 }
 
 /**

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1918,6 +1918,8 @@ function AndroidSettings({ open, onClose, onSendInput, onOpenThemeMarketplace, o
 
         <SyncSection autoOpen={syncAutoOpen} onAutoOpenHandled={onSyncAutoOpenHandled} />
 
+        <ExperimentalSection />
+
         {/* Tier & directories are local-only — hide when connected to remote desktop */}
         {!remoteConnected && (
           <>
@@ -2240,6 +2242,8 @@ function DesktopSettings({ open, onClose, onSendInput, hasActiveSession, onOpenT
 
         <SyncSection autoOpen={syncAutoOpen} onAutoOpenHandled={onSyncAutoOpenHandled} />
 
+        <ExperimentalSection />
+
         <RemoteButton
           config={config}
           tailscale={tailscale}
@@ -2438,5 +2442,60 @@ function DesktopSettings({ open, onClose, onSendInput, hasActiveSession, onOpenT
         </section>
       </div>
     </>
+  );
+}
+
+// Experimental feature flags — DestinCode-local, NOT synced to cloud backends.
+// Reads current state from sync.getStatus().experimentalFlags and writes via
+// claude.config.setExperimentalFlag. Shown as a small section so it doesn't
+// dominate the settings drawer while we iterate on flag-gated features.
+function ExperimentalSection() {
+  const claude = (window as any).claude;
+  const [restoreFlow, setRestoreFlow] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const s = await claude.sync.getStatus();
+        if (live) setRestoreFlow(s?.experimentalFlags?.restoreFlow === true);
+      } catch {
+        if (live) setRestoreFlow(false);
+      }
+    })();
+    return () => { live = false; };
+  }, [claude]);
+
+  const toggle = useCallback(async () => {
+    if (restoreFlow == null) return;
+    const next = !restoreFlow;
+    setRestoreFlow(next);
+    try {
+      await claude.config.setExperimentalFlag('restoreFlow', next);
+    } catch {
+      setRestoreFlow(!next); // Roll back the optimistic flip on error.
+    }
+  }, [claude, restoreFlow]);
+
+  if (restoreFlow == null) return null;
+
+  return (
+    <section>
+      <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Experimental</h3>
+      <button
+        onClick={toggle}
+        className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg bg-inset/50 hover:bg-inset transition-colors text-left"
+      >
+        <div className="flex items-center justify-center shrink-0" style={{ width: 32, height: 20 }}>
+          <div className={`w-8 h-4 rounded-full transition-colors ${restoreFlow ? 'bg-accent' : 'bg-edge-dim'}`}>
+            <div className={`w-3 h-3 rounded-full bg-white mt-0.5 transition-transform ${restoreFlow ? 'translate-x-[18px]' : 'translate-x-0.5'}`} />
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <span className="text-xs text-fg font-medium">Restore from backup</span>
+          <p className="text-[10px] text-fg-muted">Adds a restore wizard to each cloud backend (experimental — off by default).</p>
+        </div>
+      </button>
+    </section>
   );
 }

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -337,8 +337,12 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
   useEffect(() => {
     (async () => {
       try {
+        // Always fetch fresh on popup open — initialStatus comes from the
+        // parent's compact-row state which only gets patched by status:data
+        // pushes (no experimentalFlags). Reusing it would mean a flag flip
+        // never shows up until a full page reload.
         const [s, log] = await Promise.all([
-          initialStatus ? Promise.resolve(initialStatus) : claude.sync.getStatus(),
+          claude.sync.getStatus(),
           claude.sync.getLog(30),
         ]);
         setStatus(s);

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -15,6 +15,8 @@ import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './Sett
 import SyncSetupWizard from './SyncSetupWizard';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { RestoreWizard } from './restore/RestoreWizard';
+import { SnapshotsPanel } from './restore/SnapshotsPanel';
 
 // --- Explainer content (updated for V2 multi-instance model) ---
 
@@ -88,6 +90,7 @@ interface SyncStatus {
   syncInProgress: boolean;
   syncingBackendId: string | null;
   syncedCategories: string[];
+  experimentalFlags?: { restoreFlow?: boolean };
 }
 
 // --- Warning display map ---
@@ -320,6 +323,14 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
   // Confirmation dialog state
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
   const [confirmPullId, setConfirmPullId] = useState<string | null>(null);
+  // Restore flow: stash the backend the user picked so RestoreWizard can open.
+  // Null while closed. Experimental flag gate handled by restoreFlowEnabled below.
+  const [restoreTarget, setRestoreTarget] = useState<{ id: string; label: string; type: 'drive' | 'github' | 'icloud' } | null>(null);
+  const [showSnapshots, setShowSnapshots] = useState(false);
+  // Gated on experimental.restoreFlow in ~/.claude/destincode-local.json.
+  // Off by default — toggled from Settings → Advanced (and persists per machine,
+  // NOT synced, because flags are for iterating before shipping to everyone).
+  const restoreFlowEnabled = status?.experimentalFlags?.restoreFlow === true;
 
   const claude = (window as any).claude;
 
@@ -616,6 +627,10 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                             onClick={(e) => e.stopPropagation()}>
                             <MenuButton onClick={() => { handlePushBackend(b.id); setMenuOpenId(null); }}>Upload now</MenuButton>
                             <MenuButton onClick={() => { setConfirmPullId(b.id); setMenuOpenId(null); }}>Download now</MenuButton>
+                            {/* Restore is directional (remote wins) and distinct from Download (merge). Gated behind experimental flag until Task 13 testing. */}
+                            {restoreFlowEnabled && (
+                              <MenuButton onClick={() => { setRestoreTarget({ id: b.id, label: b.label, type: b.type }); setMenuOpenId(null); }}>Restore from backup...</MenuButton>
+                            )}
                             <MenuButton onClick={() => { claude.sync.openFolder(b.id); setMenuOpenId(null); }}>Open folder</MenuButton>
                             <MenuButton onClick={() => { setEditingId(b.id); setView('edit'); setMenuOpenId(null); }}>Edit settings</MenuButton>
                             <div className="border-t border-edge-dim my-1" />
@@ -640,6 +655,25 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
               >
                 + Add backup
               </button>
+
+              {/* Restore snapshots expander — lists pre-restore backups users can undo.
+                  Collapsed by default; only surfaces when the flag is on and at least
+                  one backend exists (snapshots are pointless without a backend). */}
+              {restoreFlowEnabled && (status?.backends?.length ?? 0) > 0 && (
+                <div className="mt-2">
+                  <button
+                    onClick={() => setShowSnapshots(v => !v)}
+                    className="w-full text-left px-3 py-2 rounded-md text-[11px] text-fg-muted hover:text-fg-2 hover:bg-inset/30"
+                  >
+                    {showSnapshots ? '▾' : '▸'} Restore snapshots
+                  </button>
+                  {showSnapshots && (
+                    <div className="mt-1 px-1">
+                      <SnapshotsPanel />
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* 2. Sync Now bar */}
@@ -793,6 +827,17 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
         </div>
         )}
       </OverlayPanel>
+
+      {/* Restore-from-backup wizard — own modal layer so it overlays the sync popup.
+          Refreshes sync status on close so lastPush/lastError reflect the restore. */}
+      {restoreTarget && (
+        <RestoreWizard
+          backendId={restoreTarget.id}
+          backendLabel={restoreTarget.label}
+          backendType={restoreTarget.type}
+          onClose={() => { setRestoreTarget(null); refreshStatus(); }}
+        />
+      )}
 
       {/* Confirmation dialog: Remove backend */}
       {confirmRemoveId && (() => {

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -12,6 +12,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { isAndroid as checkIsAndroid } from '../platform';
 import { useScrollFade } from '../hooks/useScrollFade';
+import { ExistingBackupDetected } from './restore/ExistingBackupDetected';
+import { RestoreWizard } from './restore/RestoreWizard';
+import type { RestoreCategory } from '../../shared/types';
 
 // Detect desktop OS so prereq warnings can show install steps specific to the
 // user's machine (iCloud setup on Windows differs from macOS, gh install varies, etc.)
@@ -28,7 +31,7 @@ function detectDesktopOS(): DesktopOS {
 // --- Types ---
 
 type BackendType = 'drive' | 'github' | 'icloud';
-type WizardStep = 'type' | 'prereqs' | 'auth' | 'configure' | 'done';
+type WizardStep = 'type' | 'prereqs' | 'auth' | 'configure' | 'probe-restore' | 'done';
 
 interface PrereqStatus {
   rcloneInstalled: boolean;
@@ -130,6 +133,16 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
   const [icloudPath, setIcloudPath] = useState<string | null>(null);
   const [syncEnabled, setSyncEnabled] = useState(true);
   const [saving, setSaving] = useState(false);
+  // Probe result cached between onComplete and the 'probe-restore' step render.
+  // If the user picks "Restore", we swap in <RestoreWizard>; if "Start fresh",
+  // we stamp freshStartConfirmedEpoch on the backend so we don't nag again.
+  const [probeResult, setProbeResult] = useState<{
+    backendId: string;
+    backendLabel: string;
+    backendType: 'drive' | 'github' | 'icloud';
+    categories: RestoreCategory[];
+  } | null>(null);
+  const [showRestoreWizard, setShowRestoreWizard] = useState(false);
   // Separate refs per step — only one scroll region mounts at a time,
   // and useScrollFade's observer needs to bind to that mounted element.
   // PrereqCheckStep is a separate component and owns its own scroll ref.
@@ -287,6 +300,38 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
         }
 
         await onComplete({ type: backendType, label, syncEnabled, config });
+
+        // Auto-detect existing backup data so first-run users don't accidentally
+        // overwrite a populated cloud backend with an empty local state. Fetch
+        // the newly-created backend by label, probe it, and if data exists on
+        // a backend the user hasn't confirmed fresh-start for, show the prompt.
+        try {
+          // Only probe when the experimental flag is on — otherwise the UI
+          // has no surface to finish the flow anyway.
+          const status = await claude.sync.getStatus();
+          const flagOn = status?.experimentalFlags?.restoreFlow === true;
+          if (!flagOn) { setStep('done'); setSaving(false); return; }
+          const cfg = await claude.sync.getConfig();
+          const created = cfg.backends.find((b: any) => b.label === label && b.type === backendType);
+          if (created && !created.freshStartConfirmedEpoch) {
+            const probe = await claude.sync.restore.probe(created.id);
+            if (probe?.hasData) {
+              setProbeResult({
+                backendId: created.id,
+                backendLabel: label,
+                backendType: backendType as 'drive' | 'github' | 'icloud',
+                categories: probe.categories || [],
+              });
+              setStep('probe-restore');
+              setSaving(false);
+              return;
+            }
+          }
+        } catch {
+          // Probe is best-effort — any failure just skips the prompt and
+          // routes to Done. The user can still hit Restore from the main panel.
+        }
+
         setStep('done');
       } catch (e: any) {
         setError(e.message || 'Something went wrong');
@@ -480,6 +525,44 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
             ) : 'Start Backup'}
           </button>
         </div>
+      </div>
+    );
+  }
+
+  // --- Step: Existing backup detected (auto-probe result) ---
+  if (step === 'probe-restore' && probeResult) {
+    const handleStartFresh = async () => {
+      // Stamp the backend so this prompt won't reappear on next launch.
+      try {
+        await claude.sync.updateBackend(probeResult.backendId, {
+          freshStartConfirmedEpoch: Date.now(),
+        });
+      } catch {}
+      setStep('done');
+    };
+    return (
+      <div className="flex flex-col h-full">
+        <WizardHeader title="We found existing data" onClose={onClose} />
+        <div className="flex-1 px-4 py-4">
+          <ExistingBackupDetected
+            backendId={probeResult.backendId}
+            backendLabel={probeResult.backendLabel}
+            categories={probeResult.categories}
+            onRestore={() => setShowRestoreWizard(true)}
+            onStartFresh={handleStartFresh}
+          />
+        </div>
+        {showRestoreWizard && (
+          <RestoreWizard
+            backendId={probeResult.backendId}
+            backendLabel={probeResult.backendLabel}
+            backendType={probeResult.backendType}
+            onClose={() => {
+              setShowRestoreWizard(false);
+              setStep('done');
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/desktop/src/renderer/components/restore/ExistingBackupDetected.tsx
+++ b/desktop/src/renderer/components/restore/ExistingBackupDetected.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import type { RestoreCategory } from '../../../shared/types';
+
+// Shown inside SyncSetupWizard when probe() detects existing data on the
+// chosen backend during first-time setup. Gives the user a choice before
+// we do anything destructive on either side.
+
+type Props = {
+  backendId: string;
+  backendLabel: string;
+  categories: RestoreCategory[];
+  onRestore: () => void;
+  onStartFresh: () => void;
+};
+
+export function ExistingBackupDetected({
+  backendLabel,
+  categories,
+  onRestore,
+  onStartFresh,
+}: Props) {
+  const catList = categories.length > 0 ? categories.join(', ') : 'data';
+  return (
+    <div className="rounded-md border border-edge bg-inset/40 px-4 py-3 flex flex-col gap-3">
+      <div>
+        <div className="text-sm font-medium text-fg">Existing backup detected</div>
+        <div className="text-[11px] text-fg-dim mt-1">
+          We found existing backup data at <span className="text-fg">{backendLabel}</span>:{' '}
+          <span className="text-fg capitalize">{catList}</span>. Would you like to restore it to
+          this device, or start fresh?
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 justify-end">
+        <button
+          onClick={onStartFresh}
+          className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+        >
+          Start fresh
+        </button>
+        <button
+          onClick={onRestore}
+          className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors"
+        >
+          Restore from backup
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/restore/RestoreFromBackupButton.tsx
+++ b/desktop/src/renderer/components/restore/RestoreFromBackupButton.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { RestoreWizard } from './RestoreWizard';
+
+// Small entry-point button that drops into a SyncPanel backend row alongside
+// "Upload now" / "Download now". Task 12 will plumb the real experimental
+// flag — for now the parent passes `enabled`, and when it's false the button
+// renders nothing so the flag can gate it without touching layout.
+
+type BackendType = 'drive' | 'github' | 'icloud';
+
+type Props = {
+  backendId: string;
+  backendLabel: string;
+  backendType: BackendType;
+  enabled: boolean;
+};
+
+export function RestoreFromBackupButton({
+  backendId,
+  backendLabel,
+  backendType,
+  enabled,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  // Feature flag gate — skip rendering entirely when disabled.
+  if (!enabled) return null;
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        // Matches MenuButton styling used by Upload/Download now so this
+        // drops naturally into the same overflow menu row.
+        className="w-full text-left px-3 py-1.5 text-[11px] text-fg hover:bg-inset transition-colors"
+      >
+        Restore from backup…
+      </button>
+      {open &&
+        createPortal(
+          <RestoreWizard
+            backendId={backendId}
+            backendLabel={backendLabel}
+            backendType={backendType}
+            onClose={() => setOpen(false)}
+          />,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/desktop/src/renderer/components/restore/RestorePointPicker.tsx
+++ b/desktop/src/renderer/components/restore/RestorePointPicker.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import type { RestorePoint } from '../../../shared/types';
+
+// Lists available restore points (git tags/shas for GitHub backends).
+// Drive/iCloud backends are HEAD-only and skip this picker entirely —
+// RestoreWizard handles that branch by defaulting ref='HEAD'.
+
+type Props = {
+  backendId: string;
+  onPick: (ref: string) => void;
+  onCancel: () => void;
+};
+
+function formatTs(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return String(ts);
+  }
+}
+
+export function RestorePointPicker({ backendId, onPick, onCancel }: Props) {
+  const [versions, setVersions] = useState<RestorePoint[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // @ts-ignore — window.claude is contextBridge-provided
+        const list: RestorePoint[] = await window.claude.sync.restore.listVersions(backendId);
+        if (!cancelled) setVersions(list ?? []);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message ?? String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [backendId]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-sm font-medium text-fg">Pick a restore point</div>
+        <div className="text-[11px] text-fg-dim mt-0.5">
+          Choose which version of the backup to restore from.
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">
+          Failed to load versions: {error}
+        </div>
+      )}
+
+      {!error && versions === null && (
+        <div className="text-xs text-fg-dim px-3 py-6 text-center">Loading versions…</div>
+      )}
+
+      {!error && versions && versions.length === 0 && (
+        <div className="text-xs text-fg-dim px-3 py-6 text-center">
+          No restore points found on this backend.
+        </div>
+      )}
+
+      {!error && versions && versions.length > 0 && (
+        <div className="max-h-72 overflow-y-auto flex flex-col gap-1.5 pr-1">
+          {versions.map((v) => (
+            <button
+              key={v.ref}
+              onClick={() => onPick(v.ref)}
+              className="text-left px-3 py-2 rounded-md bg-inset/50 hover:bg-inset border border-edge-dim hover:border-edge transition-colors"
+            >
+              <div className="text-xs font-medium text-fg">{v.label}</div>
+              <div className="text-[10px] text-fg-muted mt-0.5">{formatTs(v.timestamp)}</div>
+              {v.summary && (
+                <div className="text-[10px] text-fg-dim mt-1 line-clamp-2">{v.summary}</div>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2 border-t border-edge-dim">
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/restore/RestorePreview.tsx
+++ b/desktop/src/renderer/components/restore/RestorePreview.tsx
@@ -2,13 +2,20 @@ import React from 'react';
 import type { RestoreCategory, RestorePreview as RestorePreviewData } from '../../../shared/types';
 
 // Pure presentational component — renders the preview/diff summary the
-// main-process returned from restore:preview. Shows per-category adds,
-// overwrites, deletes, plus warnings in an amber accent so destructive
-// implications are visible before the user confirms.
+// main-process returned from restore:preview.
+//
+// Columns vary by mode:
+//   merge → Download (remote→local) / Update (overwrite-newer) / Upload (local→remote)
+//   wipe  → Add / Overwrite / Delete  (the exact ops the mirror will perform)
+//
+// Each row has a folder icon that resolves the category's remote browse URL
+// via the main process and opens it (Drive folder, GitHub tree, file:// for iCloud).
 
 type Props = {
   preview: RestorePreviewData;
   categories: RestoreCategory[];
+  backendId: string;
+  versionRef: string;
 };
 
 function formatBytes(n: number): string {
@@ -18,15 +25,48 @@ function formatBytes(n: number): string {
   return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
-export function RestorePreview({ preview, categories }: Props) {
+// SVG folder icon — small, theme-tokened. Clicking opens the browse URL via IPC.
+function FolderLink({ onClick, title }: { onClick: () => void; title: string }) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className="w-5 h-5 rounded-sm flex items-center justify-center text-fg-muted hover:text-fg-2 hover:bg-inset transition-colors"
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+      </svg>
+    </button>
+  );
+}
+
+export function RestorePreview({ preview, categories, backendId, versionRef }: Props) {
   const rows = preview.perCategory.filter((p) => categories.includes(p.category));
+  const isMerge = preview.mode === 'merge';
+
+  const openCategoryFolder = async (c: RestoreCategory) => {
+    try {
+      // @ts-ignore contextBridge
+      const res = await window.claude.sync.restore.browseCategory(backendId, c, versionRef);
+      // Desktop main opens via shell.openExternal inside the handler; browser
+      // gets the URL back and opens it here (new tab).
+      if (res?.url && typeof window !== 'undefined' && window.location.protocol.startsWith('http')) {
+        window.open(res.url, '_blank', 'noopener');
+      }
+    } catch {
+      // Non-fatal — adapter may not support browse URLs (older backends).
+    }
+  };
 
   return (
     <div className="flex flex-col gap-3">
       <div>
         <div className="text-sm font-medium text-fg">Preview changes</div>
         <div className="text-[11px] text-fg-dim mt-0.5">
-          Restore will copy the backup over your device. Review what will change.
+          {isMerge
+            ? 'Merge will sync files both directions. Nothing gets deleted on either side.'
+            : 'Wipe & restore will replace local files with the backup. Review each category.'}
         </div>
       </div>
 
@@ -35,10 +75,21 @@ export function RestorePreview({ preview, categories }: Props) {
           <thead className="bg-inset/60">
             <tr className="text-fg-dim">
               <th className="text-left px-3 py-2 font-medium">Category</th>
-              <th className="text-right px-2 py-2 font-medium">Add</th>
-              <th className="text-right px-2 py-2 font-medium">Overwrite</th>
-              <th className="text-right px-2 py-2 font-medium">Delete</th>
+              {isMerge ? (
+                <>
+                  <th className="text-right px-2 py-2 font-medium" title="Files on backup missing locally">Download</th>
+                  <th className="text-right px-2 py-2 font-medium" title="Files newer on backup">Update</th>
+                  <th className="text-right px-2 py-2 font-medium" title="Files only local — will be uploaded">Upload</th>
+                </>
+              ) : (
+                <>
+                  <th className="text-right px-2 py-2 font-medium">Add</th>
+                  <th className="text-right px-2 py-2 font-medium">Overwrite</th>
+                  <th className="text-right px-2 py-2 font-medium text-red-400">Delete</th>
+                </>
+              )}
               <th className="text-right px-3 py-2 font-medium">Size</th>
+              <th className="w-8 px-1 py-2" />
             </tr>
           </thead>
           <tbody>
@@ -47,13 +98,25 @@ export function RestorePreview({ preview, categories }: Props) {
                 <td className="px-3 py-2 text-fg capitalize">{r.category}</td>
                 <td className="px-2 py-2 text-right text-fg-dim">{r.toAdd}</td>
                 <td className="px-2 py-2 text-right text-fg-dim">{r.toOverwrite}</td>
-                <td className="px-2 py-2 text-right text-fg-dim">{r.toDelete}</td>
+                {isMerge ? (
+                  <td className="px-2 py-2 text-right text-fg-dim">{r.toUpload ?? 0}</td>
+                ) : (
+                  <td className={`px-2 py-2 text-right ${r.toDelete > 0 ? 'text-red-400' : 'text-fg-dim'}`}>
+                    {r.toDelete}
+                  </td>
+                )}
                 <td className="px-3 py-2 text-right text-fg-dim">{formatBytes(r.bytes)}</td>
+                <td className="px-1 py-2">
+                  <FolderLink
+                    onClick={() => openCategoryFolder(r.category)}
+                    title={`Browse ${r.category} on backup`}
+                  />
+                </td>
               </tr>
             ))}
             {rows.length === 0 && (
               <tr>
-                <td colSpan={5} className="px-3 py-4 text-center text-fg-muted">
+                <td colSpan={6} className="px-3 py-4 text-center text-fg-muted">
                   No categories selected.
                 </td>
               </tr>
@@ -72,7 +135,11 @@ export function RestorePreview({ preview, categories }: Props) {
           {preview.warnings.map((w, i) => (
             <div
               key={i}
-              className="text-[11px] px-3 py-2 rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-300"
+              className={`text-[11px] px-3 py-2 rounded-md border ${
+                w.includes('DELETE')
+                  ? 'border-red-500/40 bg-red-500/10 text-red-300'
+                  : 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+              }`}
             >
               {w}
             </div>

--- a/desktop/src/renderer/components/restore/RestorePreview.tsx
+++ b/desktop/src/renderer/components/restore/RestorePreview.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import type { RestoreCategory, RestorePreview as RestorePreviewData } from '../../../shared/types';
+
+// Pure presentational component — renders the preview/diff summary the
+// main-process returned from restore:preview. Shows per-category adds,
+// overwrites, deletes, plus warnings in an amber accent so destructive
+// implications are visible before the user confirms.
+
+type Props = {
+  preview: RestorePreviewData;
+  categories: RestoreCategory[];
+};
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export function RestorePreview({ preview, categories }: Props) {
+  const rows = preview.perCategory.filter((p) => categories.includes(p.category));
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-sm font-medium text-fg">Preview changes</div>
+        <div className="text-[11px] text-fg-dim mt-0.5">
+          Restore will copy the backup over your device. Review what will change.
+        </div>
+      </div>
+
+      <div className="rounded-md border border-edge-dim overflow-hidden">
+        <table className="w-full text-[11px]">
+          <thead className="bg-inset/60">
+            <tr className="text-fg-dim">
+              <th className="text-left px-3 py-2 font-medium">Category</th>
+              <th className="text-right px-2 py-2 font-medium">Add</th>
+              <th className="text-right px-2 py-2 font-medium">Overwrite</th>
+              <th className="text-right px-2 py-2 font-medium">Delete</th>
+              <th className="text-right px-3 py-2 font-medium">Size</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.category} className="border-t border-edge-dim">
+                <td className="px-3 py-2 text-fg capitalize">{r.category}</td>
+                <td className="px-2 py-2 text-right text-fg-dim">{r.toAdd}</td>
+                <td className="px-2 py-2 text-right text-fg-dim">{r.toOverwrite}</td>
+                <td className="px-2 py-2 text-right text-fg-dim">{r.toDelete}</td>
+                <td className="px-3 py-2 text-right text-fg-dim">{formatBytes(r.bytes)}</td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-3 py-4 text-center text-fg-muted">
+                  No categories selected.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex justify-between text-[11px] text-fg-dim px-1">
+        <span>Total: {formatBytes(preview.totalBytes)}</span>
+        <span>Estimated: ~{Math.max(1, Math.round(preview.estimatedSeconds))}s</span>
+      </div>
+
+      {preview.warnings.length > 0 && (
+        <div className="flex flex-col gap-1.5 mt-1">
+          {preview.warnings.map((w, i) => (
+            <div
+              key={i}
+              className="text-[11px] px-3 py-2 rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-300"
+            >
+              {w}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/restore/RestoreProgress.tsx
+++ b/desktop/src/renderer/components/restore/RestoreProgress.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { RestoreCategory, RestoreProgressEvent } from '../../../shared/types';
+
+// Subscribes to main-process restore:progress events and renders a per-category
+// progress bar with phase label. When every category has reached phase='done'
+// we fire onAllDone so the parent wizard can advance to the summary step.
+
+type Props = {
+  categories: RestoreCategory[];
+  onAllDone?: () => void;
+};
+
+const PHASE_LABEL: Record<RestoreProgressEvent['phase'], string> = {
+  snapshotting: 'Taking safety snapshot',
+  fetching: 'Downloading',
+  staging: 'Staging',
+  swapping: 'Applying',
+  done: 'Done',
+};
+
+type State = Record<string, RestoreProgressEvent>;
+
+export function RestoreProgress({ categories, onAllDone }: Props) {
+  const [state, setState] = useState<State>({});
+  // Track whether we've already announced "all done" to avoid double-firing.
+  const firedDoneRef = useRef(false);
+
+  useEffect(() => {
+    // onProgress returns an unsub fn — wiring it here means the cleanup
+    // runs on unmount, which is critical: leaking listeners across restore
+    // attempts would cause the next restore to double-report progress.
+    // @ts-ignore window.claude is contextBridge-provided
+    const unsub: () => void = window.claude.sync.restore.onProgress((evt: RestoreProgressEvent) => {
+      setState((prev) => ({ ...prev, [evt.category]: evt }));
+    });
+    return () => {
+      unsub?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (firedDoneRef.current) return;
+    const allDone =
+      categories.length > 0 &&
+      categories.every((c) => state[c]?.phase === 'done');
+    if (allDone) {
+      firedDoneRef.current = true;
+      onAllDone?.();
+    }
+  }, [state, categories, onAllDone]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-sm font-medium text-fg">Restoring…</div>
+        <div className="text-[11px] text-fg-dim mt-0.5">
+          Please don't close the app until this finishes.
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {categories.map((cat) => {
+          const evt = state[cat];
+          const phase = evt?.phase ?? 'fetching';
+          const pct =
+            evt && evt.filesTotal > 0
+              ? Math.min(100, Math.round((evt.filesDone / evt.filesTotal) * 100))
+              : phase === 'done'
+                ? 100
+                : 0;
+          return (
+            <div key={cat} className="rounded-md border border-edge-dim bg-inset/40 px-3 py-2">
+              <div className="flex items-center justify-between text-[11px] mb-1.5">
+                <span className="text-fg capitalize font-medium">{cat}</span>
+                <span className="text-fg-dim">
+                  {PHASE_LABEL[phase]}
+                  {evt && evt.filesTotal > 0 && phase !== 'done' && (
+                    <> — {evt.filesDone}/{evt.filesTotal}</>
+                  )}
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-inset overflow-hidden">
+                <div
+                  className="h-full bg-accent transition-all duration-200"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              {evt?.currentFile && phase !== 'done' && (
+                <div className="text-[10px] text-fg-muted mt-1 truncate">{evt.currentFile}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/restore/RestoreSummary.tsx
+++ b/desktop/src/renderer/components/restore/RestoreSummary.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { RestoreResult } from '../../../shared/types';
+
+// Final "done" step of the wizard. Shows what was restored and offers an
+// Undo button when a snapshot was captured (snapshot-first default flow).
+
+type Props = {
+  result: RestoreResult;
+  onClose: () => void;
+  onUndo?: (snapshotId: string) => void;
+};
+
+export function RestoreSummary({ result, onClose, onUndo }: Props) {
+  const seconds = Math.max(1, Math.round(result.durationMs / 1000));
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-sm font-medium text-fg">Restore complete</div>
+        <div className="text-[11px] text-fg-dim mt-0.5">
+          {result.filesWritten} files across {result.categoriesRestored.length} categor
+          {result.categoriesRestored.length === 1 ? 'y' : 'ies'} in {seconds}s.
+        </div>
+      </div>
+
+      <div className="rounded-md border border-edge-dim bg-inset/40 px-3 py-2">
+        <div className="text-[11px] text-fg-dim mb-1">Restored</div>
+        <div className="flex flex-wrap gap-1.5">
+          {result.categoriesRestored.map((c) => (
+            <span
+              key={c}
+              className="px-2 py-0.5 rounded-full bg-inset border border-edge-dim text-[10px] text-fg capitalize"
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {result.requiresRestart && (
+        <div className="text-[11px] px-3 py-2 rounded-md border border-blue-500/30 bg-blue-500/10 text-blue-300">
+          Skills or memory changed — restart the app to apply.
+        </div>
+      )}
+
+      <div className="flex justify-between items-center pt-2 border-t border-edge-dim">
+        {result.snapshotId && onUndo ? (
+          <button
+            onClick={() => onUndo(result.snapshotId!)}
+            className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+          >
+            Undo restore
+          </button>
+        ) : (
+          <span />
+        )}
+        <button
+          onClick={onClose}
+          className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/restore/RestoreWizard.tsx
+++ b/desktop/src/renderer/components/restore/RestoreWizard.tsx
@@ -6,6 +6,7 @@ import { RestoreProgress } from './RestoreProgress';
 import { RestoreSummary } from './RestoreSummary';
 import type {
   RestoreCategory,
+  RestoreMode,
   RestorePreview as RestorePreviewData,
   RestoreResult,
 } from '../../../shared/types';
@@ -18,6 +19,7 @@ import type {
 type Step =
   | 'pick-version'
   | 'pick-categories'
+  | 'pick-mode'
   | 'preview'
   | 'safety'
   | 'confirm'
@@ -52,13 +54,17 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
   const [versionRef, setVersionRef] = useState<string>('HEAD');
   const [categories, setCategories] = useState<RestoreCategory[]>([...ALL_CATEGORIES]);
   const [preview, setPreview] = useState<RestorePreviewData | null>(null);
+  // Merge (union) is the default because it's non-destructive on both sides.
+  // Wipe (mirror) has to be opted into — and the UI later forces snapshot on.
+  const [mode, setMode] = useState<RestoreMode>('merge');
+  // Only meaningful for wipe; in merge mode we never snapshot (nothing to undo).
   const [snapshotFirst, setSnapshotFirst] = useState(true);
   const [understood, setUnderstood] = useState(false);
   const [result, setResult] = useState<RestoreResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  async function loadPreview(cats: RestoreCategory[], ref: string) {
+  async function loadPreview(cats: RestoreCategory[], ref: string, m: RestoreMode) {
     setBusy(true);
     try {
       // @ts-ignore window.claude is contextBridge-provided
@@ -66,7 +72,8 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
         backendId,
         versionRef: ref,
         categories: cats,
-        snapshotFirst,
+        snapshotFirst: m === 'wipe' ? snapshotFirst : false,
+        mode: m,
       });
       setPreview(p);
       setStep('preview');
@@ -86,7 +93,9 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
         backendId,
         versionRef,
         categories,
-        snapshotFirst,
+        // Merge is always non-destructive → snapshot is meaningless and skipped.
+        snapshotFirst: mode === 'wipe' ? snapshotFirst : false,
+        mode,
       });
       setResult(r);
       setStep('done');
@@ -185,7 +194,82 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
                 </button>
                 <button
                   disabled={categories.length === 0 || busy}
-                  onClick={() => loadPreview(categories, versionRef)}
+                  onClick={() => setStep('pick-mode')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors disabled:opacity-50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'pick-mode' && (
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="text-sm font-medium text-fg">How should we restore?</div>
+                <div className="text-[11px] text-fg-dim mt-0.5">
+                  Two very different behaviors — pick carefully.
+                </div>
+              </div>
+              <label
+                className={`flex items-start gap-2 px-3 py-2.5 rounded-md border cursor-pointer ${
+                  mode === 'merge'
+                    ? 'bg-accent/10 border-accent'
+                    : 'bg-inset/50 border-edge-dim hover:bg-inset'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="restore-mode"
+                  value="merge"
+                  checked={mode === 'merge'}
+                  onChange={() => setMode('merge')}
+                  className="accent-accent mt-1"
+                />
+                <div className="flex-1">
+                  <div className="text-xs text-fg font-medium">Merge (recommended)</div>
+                  <div className="text-[11px] text-fg-dim mt-0.5">
+                    Download files from the backup that are missing or older locally, and
+                    upload files that are only on this device. Nothing gets deleted on either side.
+                  </div>
+                </div>
+              </label>
+              <label
+                className={`flex items-start gap-2 px-3 py-2.5 rounded-md border cursor-pointer ${
+                  mode === 'wipe'
+                    ? 'bg-red-500/10 border-red-500/40'
+                    : 'bg-inset/50 border-edge-dim hover:bg-inset'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="restore-mode"
+                  value="wipe"
+                  checked={mode === 'wipe'}
+                  onChange={() => setMode('wipe')}
+                  className="accent-red-500 mt-1"
+                />
+                <div className="flex-1">
+                  <div className="text-xs text-fg font-medium">
+                    Wipe &amp; restore <span className="text-red-400">(destructive)</span>
+                  </div>
+                  <div className="text-[11px] text-fg-dim mt-0.5">
+                    Replace local data with the backup exactly. Any files on this device that
+                    aren&apos;t in the backup will be <span className="text-red-400">deleted</span>.
+                    A safety snapshot is taken first so you can undo.
+                  </div>
+                </div>
+              </label>
+              <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
+                <button
+                  onClick={() => setStep('pick-categories')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  disabled={busy}
+                  onClick={() => loadPreview(categories, versionRef, mode)}
                   className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors disabled:opacity-50"
                 >
                   {busy ? 'Loading…' : 'Preview changes'}
@@ -196,16 +280,21 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
 
           {step === 'preview' && preview && (
             <div className="flex flex-col gap-3">
-              <RestorePreview preview={preview} categories={categories} />
+              <RestorePreview
+                preview={preview}
+                categories={categories}
+                backendId={backendId}
+                versionRef={versionRef}
+              />
               <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
                 <button
-                  onClick={() => setStep('pick-categories')}
+                  onClick={() => setStep('pick-mode')}
                   className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
                 >
                   Back
                 </button>
                 <button
-                  onClick={() => setStep('safety')}
+                  onClick={() => setStep(mode === 'wipe' ? 'safety' : 'confirm')}
                   className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors"
                 >
                   Continue
@@ -289,26 +378,34 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
           {step === 'confirm' && (
             <div className="flex flex-col gap-3">
               <div>
-                <div className="text-sm font-medium text-fg">Ready to restore</div>
+                <div className="text-sm font-medium text-fg">
+                  Ready to {mode === 'merge' ? 'merge' : 'restore'}
+                </div>
                 <div className="text-[11px] text-fg-dim mt-0.5">
-                  Restore <span className="text-fg">{categories.length}</span> categor
-                  {categories.length === 1 ? 'y' : 'ies'} from{' '}
+                  {mode === 'merge' ? 'Merge' : 'Wipe & restore'}{' '}
+                  <span className="text-fg">{categories.length}</span> categor
+                  {categories.length === 1 ? 'y' : 'ies'} with{' '}
                   <span className="text-fg">{backendLabel}</span>
-                  {snapshotFirst && ' (with safety snapshot)'}. This can take a minute.
+                  {mode === 'wipe' && snapshotFirst && ' (with safety snapshot)'}.
+                  {mode === 'merge' ? ' Nothing gets deleted.' : ' This can take a minute.'}
                 </div>
               </div>
               <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
                 <button
-                  onClick={() => setStep('safety')}
+                  onClick={() => setStep(mode === 'wipe' ? 'safety' : 'preview')}
                   className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
                 >
                   Back
                 </button>
                 <button
                   onClick={executeRestore}
-                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors"
+                  className={`px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+                    mode === 'wipe'
+                      ? 'bg-red-600 hover:bg-red-500 text-white'
+                      : 'bg-accent hover:opacity-90 text-on-accent'
+                  }`}
                 >
-                  Start restore
+                  {mode === 'merge' ? 'Start merge' : 'Wipe & restore'}
                 </button>
               </div>
             </div>

--- a/desktop/src/renderer/components/restore/RestoreWizard.tsx
+++ b/desktop/src/renderer/components/restore/RestoreWizard.tsx
@@ -57,6 +57,8 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
   // Merge (union) is the default because it's non-destructive on both sides.
   // Wipe (mirror) has to be opted into — and the UI later forces snapshot on.
   const [mode, setMode] = useState<RestoreMode>('merge');
+  // Which mode's (i) panel is expanded. Only one can be open at a time.
+  const [infoOpen, setInfoOpen] = useState<RestoreMode | null>(null);
   // Only meaningful for wipe; in merge mode we never snapshot (nothing to undo).
   const [snapshotFirst, setSnapshotFirst] = useState(true);
   const [understood, setUnderstood] = useState(false);
@@ -211,55 +213,28 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
                   Two very different behaviors — pick carefully.
                 </div>
               </div>
-              <label
-                className={`flex items-start gap-2 px-3 py-2.5 rounded-md border cursor-pointer ${
-                  mode === 'merge'
-                    ? 'bg-accent/10 border-accent'
-                    : 'bg-inset/50 border-edge-dim hover:bg-inset'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="restore-mode"
-                  value="merge"
-                  checked={mode === 'merge'}
-                  onChange={() => setMode('merge')}
-                  className="accent-accent mt-1"
-                />
-                <div className="flex-1">
-                  <div className="text-xs text-fg font-medium">Merge (recommended)</div>
-                  <div className="text-[11px] text-fg-dim mt-0.5">
-                    Download files from the backup that are missing or older locally, and
-                    upload files that are only on this device. Nothing gets deleted on either side.
-                  </div>
-                </div>
-              </label>
-              <label
-                className={`flex items-start gap-2 px-3 py-2.5 rounded-md border cursor-pointer ${
-                  mode === 'wipe'
-                    ? 'bg-red-500/10 border-red-500/40'
-                    : 'bg-inset/50 border-edge-dim hover:bg-inset'
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="restore-mode"
-                  value="wipe"
-                  checked={mode === 'wipe'}
-                  onChange={() => setMode('wipe')}
-                  className="accent-red-500 mt-1"
-                />
-                <div className="flex-1">
-                  <div className="text-xs text-fg font-medium">
-                    Wipe &amp; restore <span className="text-red-400">(destructive)</span>
-                  </div>
-                  <div className="text-[11px] text-fg-dim mt-0.5">
-                    Replace local data with the backup exactly. Any files on this device that
-                    aren&apos;t in the backup will be <span className="text-red-400">deleted</span>.
-                    A safety snapshot is taken first so you can undo.
-                  </div>
-                </div>
-              </label>
+              <ModeCard
+                mode="merge"
+                selected={mode === 'merge'}
+                onSelect={() => setMode('merge')}
+                infoOpen={infoOpen === 'merge'}
+                onToggleInfo={() => setInfoOpen(infoOpen === 'merge' ? null : 'merge')}
+                title="Merge (recommended)"
+                short="Download files from the backup that are missing or older locally, and upload files that are only on this device. Nothing gets deleted on either side."
+                details={MERGE_DETAILS}
+              />
+              <ModeCard
+                mode="wipe"
+                selected={mode === 'wipe'}
+                onSelect={() => setMode('wipe')}
+                infoOpen={infoOpen === 'wipe'}
+                onToggleInfo={() => setInfoOpen(infoOpen === 'wipe' ? null : 'wipe')}
+                title={<>Wipe &amp; restore <span className="text-red-400">(destructive)</span></>}
+                short={<>Replace local data with the backup exactly. Any files on this device that aren&apos;t in the backup will be <span className="text-red-400">deleted</span>. A safety snapshot is taken first so you can undo.</>}
+                details={WIPE_DETAILS}
+                destructive
+              />
+
               <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
                 <button
                   onClick={() => setStep('pick-categories')}
@@ -436,5 +411,113 @@ export function RestoreWizard({ backendId, backendLabel, backendType, onClose, o
         </div>
       </OverlayPanel>
     </>
+  );
+}
+
+// --- Mode picker sub-components ---
+//
+// Each mode renders as a card with a radio, title, short description, and an
+// (i) button that expands a longer explanation inline (no overlay — keeps the
+// wizard's focus trap simple). The details list is deliberately concrete:
+// Destin is a non-developer and the "what does this actually do" question
+// needs to be answerable without reading code.
+
+const MERGE_DETAILS: string[] = [
+  'Runs like a two-way sync: pulls new or newer files from the backup, then pushes files that are only on this device up to the backup.',
+  'No deletions on either side. If you have a file here that isn\'t in the backup, it stays — and it also gets uploaded.',
+  'No safety snapshot is taken (nothing to undo — merge never removes anything).',
+  'Use this when you want to pick up where another device left off, or after a fresh install.',
+];
+
+const WIPE_DETAILS: string[] = [
+  'Replaces local files with the exact contents of the backup. Any local file that isn\'t in the backup is DELETED.',
+  'A safety snapshot is taken first under ~/.claude/restore-snapshots/ so you can Undo within 10 snapshots / 90 days.',
+  'Use this when you know the backup is the authoritative state (e.g., rolling back an accidentally corrupted local copy).',
+  'The regular sync loop is paused during the restore so it can\'t re-upload half-restored state to the cloud.',
+];
+
+function ModeCard({
+  mode,
+  selected,
+  onSelect,
+  infoOpen,
+  onToggleInfo,
+  title,
+  short,
+  details,
+  destructive,
+}: {
+  mode: RestoreMode;
+  selected: boolean;
+  onSelect: () => void;
+  infoOpen: boolean;
+  onToggleInfo: () => void;
+  title: React.ReactNode;
+  short: React.ReactNode;
+  details: string[];
+  destructive?: boolean;
+}) {
+  const ringClass = selected
+    ? destructive
+      ? 'bg-red-500/10 border-red-500/40'
+      : 'bg-accent/10 border-accent'
+    : 'bg-inset/50 border-edge-dim hover:bg-inset';
+  const accent = destructive ? 'accent-red-500' : 'accent-accent';
+  return (
+    <div className={`rounded-md border ${ringClass}`}>
+      {/* Clickable row — NOT a <label> wrapper because the (i) button lives
+          inside and a <label> would forward its click to the radio. Instead
+          we intercept row clicks to flip the radio, and the (i) stops
+          propagation. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onSelect()}
+        className="flex items-start gap-2 px-3 py-2.5 cursor-pointer"
+      >
+        <input
+          type="radio"
+          name="restore-mode"
+          value={mode}
+          checked={selected}
+          onChange={onSelect}
+          className={`${accent} mt-1`}
+          onClick={(e) => e.stopPropagation()}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-fg font-medium">{title}</span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleInfo();
+              }}
+              className="text-fg-muted hover:text-fg-2 w-5 h-5 flex items-center justify-center rounded-sm hover:bg-inset"
+              aria-label={`What does ${mode} mode do?`}
+              aria-expanded={infoOpen}
+              title="Show details"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="9" />
+                <path strokeLinecap="round" d="M12 11v5" />
+                <circle cx="12" cy="8" r="0.5" fill="currentColor" />
+              </svg>
+            </button>
+          </div>
+          <div className="text-[11px] text-fg-dim mt-0.5">{short}</div>
+        </div>
+      </div>
+      {infoOpen && (
+        <div className="px-3 pb-3 pt-1 border-t border-edge-dim">
+          <ul className="text-[11px] text-fg-dim space-y-1.5 list-disc pl-4">
+            {details.map((d, i) => (
+              <li key={i}>{d}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
   );
 }

--- a/desktop/src/renderer/components/restore/RestoreWizard.tsx
+++ b/desktop/src/renderer/components/restore/RestoreWizard.tsx
@@ -1,0 +1,343 @@
+import React, { useState } from 'react';
+import { Scrim, OverlayPanel } from '../overlays/Overlay';
+import { RestorePointPicker } from './RestorePointPicker';
+import { RestorePreview } from './RestorePreview';
+import { RestoreProgress } from './RestoreProgress';
+import { RestoreSummary } from './RestoreSummary';
+import type {
+  RestoreCategory,
+  RestorePreview as RestorePreviewData,
+  RestoreResult,
+} from '../../../shared/types';
+
+// Top-level restore flow. Step machine:
+//   pick-version → pick-categories → preview → safety → confirm → progress → done
+// For Drive/iCloud (HEAD-only) backends we skip pick-version and use 'HEAD'.
+// 'error' is a terminal-ish state reachable from any step on IPC failure.
+
+type Step =
+  | 'pick-version'
+  | 'pick-categories'
+  | 'preview'
+  | 'safety'
+  | 'confirm'
+  | 'progress'
+  | 'done'
+  | 'error';
+
+type BackendType = 'drive' | 'github' | 'icloud';
+
+type Props = {
+  backendId: string;
+  backendLabel: string;
+  backendType: BackendType;
+  onClose: () => void;
+  onRestored?: (result: RestoreResult) => void;
+};
+
+const ALL_CATEGORIES: RestoreCategory[] = [
+  'memory',
+  'conversations',
+  'encyclopedia',
+  'skills',
+  'plans',
+  'specs',
+];
+
+export function RestoreWizard({ backendId, backendLabel, backendType, onClose, onRestored }: Props) {
+  // GitHub is the only backend with full history; others are HEAD-only.
+  const needsVersionPicker = backendType === 'github';
+
+  const [step, setStep] = useState<Step>(needsVersionPicker ? 'pick-version' : 'pick-categories');
+  const [versionRef, setVersionRef] = useState<string>('HEAD');
+  const [categories, setCategories] = useState<RestoreCategory[]>([...ALL_CATEGORIES]);
+  const [preview, setPreview] = useState<RestorePreviewData | null>(null);
+  const [snapshotFirst, setSnapshotFirst] = useState(true);
+  const [understood, setUnderstood] = useState(false);
+  const [result, setResult] = useState<RestoreResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function loadPreview(cats: RestoreCategory[], ref: string) {
+    setBusy(true);
+    try {
+      // @ts-ignore window.claude is contextBridge-provided
+      const p: RestorePreviewData = await window.claude.sync.restore.preview({
+        backendId,
+        versionRef: ref,
+        categories: cats,
+        snapshotFirst,
+      });
+      setPreview(p);
+      setStep('preview');
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+      setStep('error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function executeRestore() {
+    setStep('progress');
+    try {
+      // @ts-ignore
+      const r: RestoreResult = await window.claude.sync.restore.execute({
+        backendId,
+        versionRef,
+        categories,
+        snapshotFirst,
+      });
+      setResult(r);
+      setStep('done');
+      onRestored?.(r);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+      setStep('error');
+    }
+  }
+
+  async function handleUndo(snapshotId: string) {
+    setBusy(true);
+    try {
+      // @ts-ignore
+      await window.claude.sync.restore.undo(snapshotId);
+      onClose();
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+      setStep('error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggleCategory(c: RestoreCategory) {
+    setCategories((cur) => (cur.includes(c) ? cur.filter((x) => x !== c) : [...cur, c]));
+  }
+
+  return (
+    <>
+      <Scrim layer={2} onClick={onClose} />
+      <OverlayPanel
+        layer={2}
+        role="dialog"
+        aria-modal
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[520px] max-w-[calc(100vw-32px)] max-h-[calc(100vh-48px)] flex flex-col"
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-edge shrink-0">
+          <div>
+            <div className="text-sm font-medium text-fg">Restore from backup</div>
+            <div className="text-[10px] text-fg-muted mt-0.5">{backendLabel}</div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-fg-muted hover:text-fg-2 text-lg leading-none w-8 h-8 flex items-center justify-center rounded-sm hover:bg-inset"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-4 py-4 overflow-y-auto flex-1">
+          {step === 'pick-version' && (
+            <RestorePointPicker
+              backendId={backendId}
+              onPick={(ref) => {
+                setVersionRef(ref);
+                setStep('pick-categories');
+              }}
+              onCancel={onClose}
+            />
+          )}
+
+          {step === 'pick-categories' && (
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="text-sm font-medium text-fg">What to restore</div>
+                <div className="text-[11px] text-fg-dim mt-0.5">
+                  Pick the categories you want to pull from this backup.
+                </div>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {ALL_CATEGORIES.map((c) => {
+                  const checked = categories.includes(c);
+                  return (
+                    <label
+                      key={c}
+                      className="flex items-center gap-2 px-3 py-2 rounded-md bg-inset/50 border border-edge-dim hover:bg-inset cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleCategory(c)}
+                        className="accent-accent"
+                      />
+                      <span className="text-xs text-fg capitalize">{c}</span>
+                    </label>
+                  );
+                })}
+              </div>
+              <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
+                <button
+                  onClick={onClose}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  disabled={categories.length === 0 || busy}
+                  onClick={() => loadPreview(categories, versionRef)}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors disabled:opacity-50"
+                >
+                  {busy ? 'Loading…' : 'Preview changes'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'preview' && preview && (
+            <div className="flex flex-col gap-3">
+              <RestorePreview preview={preview} categories={categories} />
+              <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
+                <button
+                  onClick={() => setStep('pick-categories')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={() => setStep('safety')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors"
+                >
+                  Continue
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'safety' && preview && (
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="text-sm font-medium text-fg">Safety check</div>
+                <div className="text-[11px] text-fg-dim mt-0.5">
+                  Restore overwrites local data with the backup. A safety snapshot lets you
+                  undo if something goes wrong.
+                </div>
+              </div>
+
+              {preview.warnings.length > 0 && (
+                <div className="flex flex-col gap-1.5">
+                  {preview.warnings.map((w, i) => (
+                    <div
+                      key={i}
+                      className="text-[11px] px-3 py-2 rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-300"
+                    >
+                      {w}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <label className="flex items-start gap-2 px-3 py-2 rounded-md bg-inset/50 border border-edge-dim cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={snapshotFirst}
+                  onChange={(e) => setSnapshotFirst(e.target.checked)}
+                  className="accent-accent mt-0.5"
+                />
+                <span className="text-[11px] text-fg">
+                  Take a safety snapshot first (recommended)
+                </span>
+              </label>
+              {!snapshotFirst && (
+                // Snapshot-first is a load-bearing safety net — if the user
+                // opts out, surface a warning so it's a conscious decision.
+                <div className="text-[11px] px-3 py-2 rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-300">
+                  Without a snapshot, this restore cannot be undone.
+                </div>
+              )}
+
+              <label className="flex items-start gap-2 px-3 py-2 rounded-md bg-inset/50 border border-edge cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={understood}
+                  onChange={(e) => setUnderstood(e.target.checked)}
+                  className="accent-accent mt-0.5"
+                />
+                <span className="text-[11px] text-fg">
+                  I understand this will overwrite local data
+                </span>
+              </label>
+
+              <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
+                <button
+                  onClick={() => setStep('preview')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  disabled={!understood}
+                  onClick={() => setStep('confirm')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors disabled:opacity-50"
+                >
+                  Continue
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'confirm' && (
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="text-sm font-medium text-fg">Ready to restore</div>
+                <div className="text-[11px] text-fg-dim mt-0.5">
+                  Restore <span className="text-fg">{categories.length}</span> categor
+                  {categories.length === 1 ? 'y' : 'ies'} from{' '}
+                  <span className="text-fg">{backendLabel}</span>
+                  {snapshotFirst && ' (with safety snapshot)'}. This can take a minute.
+                </div>
+              </div>
+              <div className="flex justify-between gap-2 pt-2 border-t border-edge-dim">
+                <button
+                  onClick={() => setStep('safety')}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={executeRestore}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-accent hover:opacity-90 text-on-accent transition-colors"
+                >
+                  Start restore
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'progress' && <RestoreProgress categories={categories} />}
+
+          {step === 'done' && result && (
+            <RestoreSummary result={result} onClose={onClose} onUndo={handleUndo} />
+          )}
+
+          {step === 'error' && (
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="text-sm font-medium text-fg">Restore failed</div>
+                <div className="text-[11px] text-fg-dim mt-0.5">{error ?? 'Unknown error.'}</div>
+              </div>
+              <div className="flex justify-end gap-2 pt-2 border-t border-edge-dim">
+                <button
+                  onClick={onClose}
+                  className="px-3 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-edge text-fg-muted transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </OverlayPanel>
+    </>
+  );
+}

--- a/desktop/src/renderer/components/restore/SnapshotsPanel.tsx
+++ b/desktop/src/renderer/components/restore/SnapshotsPanel.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import type { Snapshot } from '../../../shared/types';
+
+// Lists safety-snapshots captured before each restore. Lets the user roll
+// back a bad restore or free disk space by deleting old snapshots.
+// Designed to embed inside SyncPanel (no scrim/modal wrapper).
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatTs(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return String(ts);
+  }
+}
+
+export function SnapshotsPanel() {
+  const [snaps, setSnaps] = useState<Snapshot[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      // @ts-ignore
+      const list: Snapshot[] = await window.claude.sync.restore.listSnapshots();
+      setSnaps(list ?? []);
+      setError(null);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleRestore(id: string) {
+    setBusyId(id);
+    try {
+      // @ts-ignore
+      await window.claude.sync.restore.undo(id);
+      await load();
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setBusyId(id);
+    try {
+      // @ts-ignore
+      await window.claude.sync.restore.deleteSnapshot(id);
+      setConfirmDeleteId(null);
+      await load();
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <div className="text-sm font-medium text-fg">Safety snapshots</div>
+        <div className="text-[11px] text-fg-dim mt-0.5">
+          Each restore saves a snapshot of your device first so you can roll back.
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-[11px] text-red-400 bg-red-500/10 border border-red-500/20 rounded-md px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      {snaps === null && !error && (
+        <div className="text-[11px] text-fg-dim px-3 py-4 text-center">Loading…</div>
+      )}
+
+      {snaps && snaps.length === 0 && (
+        <div className="text-[11px] text-fg-muted px-3 py-4 text-center border border-dashed border-edge-dim rounded-md">
+          No snapshots yet.
+        </div>
+      )}
+
+      {snaps && snaps.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          {snaps.map((s) => (
+            <div
+              key={s.id}
+              className="flex items-center gap-3 px-3 py-2 rounded-md bg-inset/50 border border-edge-dim"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-[11px] text-fg font-medium">{formatTs(s.timestamp)}</div>
+                <div className="text-[10px] text-fg-dim truncate">
+                  {s.categories.join(', ')} · {formatBytes(s.sizeBytes)}
+                  {s.triggeredBy === 'manual' && ' · manual'}
+                </div>
+              </div>
+              {confirmDeleteId === s.id ? (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[10px] text-fg-dim">Delete?</span>
+                  <button
+                    disabled={busyId === s.id}
+                    onClick={() => handleDelete(s.id)}
+                    className="px-2 py-1 rounded text-[10px] bg-red-500/20 hover:bg-red-500/30 text-red-300 disabled:opacity-50"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    onClick={() => setConfirmDeleteId(null)}
+                    className="px-2 py-1 rounded text-[10px] bg-inset hover:bg-edge text-fg-muted"
+                  >
+                    No
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <button
+                    disabled={busyId === s.id}
+                    onClick={() => handleRestore(s.id)}
+                    className="px-2 py-1 rounded-md text-[10px] font-medium bg-inset hover:bg-edge text-fg transition-colors disabled:opacity-50"
+                  >
+                    {busyId === s.id ? 'Restoring…' : 'Restore'}
+                  </button>
+                  <button
+                    onClick={() => setConfirmDeleteId(s.id)}
+                    className="px-2 py-1 rounded-md text-[10px] text-fg-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                  >
+                    Delete
+                  </button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -757,6 +757,8 @@ export function installShim(): void {
         deleteSnapshot: (snapshotId: string) =>
           invoke('sync:restore:delete-snapshot', { snapshotId }),
         probe: (backendId: string) => invoke('sync:restore:probe', { backendId }),
+        browseCategory: (backendId: string, category: string, versionRef: string) =>
+          invoke('sync:restore:browse-url', { backendId, category, versionRef }),
         onProgress: (cb: (evt: any) => void) => {
           const handler: Callback = (evt: any) => cb(evt);
           addListener('sync:restore:progress', handler);

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -193,6 +193,11 @@ function handleMessage(data: string): void {
     case 'prompt:complete':
       dispatchEvent('prompt:complete', payload);
       break;
+    case 'sync:restore:progress':
+      // Restore progress events flow to any listener registered via
+      // window.claude.sync.restore.onProgress(). Broadcast (no sessionId).
+      dispatchEvent('sync:restore:progress', payload);
+      break;
   }
 }
 
@@ -739,6 +744,25 @@ export function installShim(): void {
         authGithub: () => invoke('sync:setup:auth-github'),
         createRepo: (repoName: string) => invoke('sync:setup:create-repo', { repoName }),
       },
+      // Restore from backup — directional, user-initiated pull. Mirrors the
+      // preload surface exactly (see preload.ts sync.restore). Browser/Android
+      // transports use WebSocket invoke + a dispatchEvent subscription for progress.
+      restore: {
+        listVersions: (backendId: string) =>
+          invoke('sync:restore:list-versions', { backendId }),
+        preview: (opts: any) => invoke('sync:restore:preview', { opts }),
+        execute: (opts: any) => invoke('sync:restore:execute', { opts }),
+        listSnapshots: () => invoke('sync:restore:list-snapshots'),
+        undo: (snapshotId: string) => invoke('sync:restore:undo', { snapshotId }),
+        deleteSnapshot: (snapshotId: string) =>
+          invoke('sync:restore:delete-snapshot', { snapshotId }),
+        probe: (backendId: string) => invoke('sync:restore:probe', { backendId }),
+        onProgress: (cb: (evt: any) => void) => {
+          const handler: Callback = (evt: any) => cb(evt);
+          addListener('sync:restore:progress', handler);
+          return () => removeListener('sync:restore:progress', handler);
+        },
+      },
     },
     folders: {
       list: () => invoke('folders:list'),
@@ -773,6 +797,10 @@ export function installShim(): void {
     removeAllListeners: (channel: string) => removeAllListeners(channel),
     getGitHubAuth: () => invoke('github:auth'),
     getHomePath: () => invoke('get-home-path'),
+    config: {
+      setExperimentalFlag: (name: string, value: boolean) =>
+        invoke('config:set-experimental-flag', { name, value }),
+    },
     getFavorites: () => invoke('favorites:get'),
     setFavorites: (favorites: string[]) => invoke('favorites:set', favorites),
     getIncognito: () => invoke('game:getIncognito'),

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -575,6 +575,7 @@ export const IPC = {
   SYNC_RESTORE_UNDO: 'sync:restore:undo',
   SYNC_RESTORE_DELETE_SNAPSHOT: 'sync:restore:delete-snapshot',
   SYNC_RESTORE_PROBE: 'sync:restore:probe',
+  SYNC_RESTORE_BROWSE_URL: 'sync:restore:browse-url',
 } as const;
 
 // --- Window registry / detach types ---
@@ -643,11 +644,24 @@ export interface RestorePoint {
   summary?: string;
 }
 
+/**
+ * Restore mode. Two very different semantics:
+ *   - 'merge': union. Remote→local adds + overwrites only (no local deletions),
+ *              then local→remote uploads anything that was local-only. Reuses
+ *              the sync loop's push/pull under the hood. Non-destructive on
+ *              both sides. toDelete in the preview is always 0.
+ *   - 'wipe':  mirror. Local tree is replaced with the backup's tree exactly.
+ *              Files on device but NOT on the backup are deleted. Snapshot-first
+ *              is forced ON so the user can always Undo within retention.
+ */
+export type RestoreMode = 'merge' | 'wipe';
+
 export interface RestoreOptions {
   backendId: string;
   versionRef: string;
   categories: RestoreCategory[];
   snapshotFirst: boolean;
+  mode: RestoreMode;
 }
 
 export interface CategoryPreview {
@@ -656,8 +670,10 @@ export interface CategoryPreview {
   localFiles: number;
   toAdd: number;
   toOverwrite: number;
-  /** Files on device NOT on the backup — restore semantics will delete these. */
+  /** Files on device NOT on the backup — wipe mode deletes these; merge leaves them. */
   toDelete: number;
+  /** Merge-mode only: files present locally but NOT on backup (will be uploaded). */
+  toUpload?: number;
   bytes: number;
 }
 
@@ -666,6 +682,8 @@ export interface RestorePreview {
   totalBytes: number;
   estimatedSeconds: number;
   warnings: string[];
+  /** Echoes the mode the preview was computed for — UI keys column labels off this. */
+  mode: RestoreMode;
 }
 
 export interface RestoreResult {

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -566,6 +566,15 @@ export const IPC = {
   // in window 2 propagate to window 1 without a reload.
   APPEARANCE_BROADCAST: 'appearance:broadcast',
   APPEARANCE_SYNC: 'appearance:sync',
+  // Restore from backup — directional, user-initiated pull (separate from sync's merge semantics)
+  SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
+  SYNC_RESTORE_PREVIEW: 'sync:restore:preview',
+  SYNC_RESTORE_EXECUTE: 'sync:restore:execute',
+  SYNC_RESTORE_PROGRESS: 'sync:restore:progress',
+  SYNC_RESTORE_LIST_SNAPSHOTS: 'sync:restore:list-snapshots',
+  SYNC_RESTORE_UNDO: 'sync:restore:undo',
+  SYNC_RESTORE_DELETE_SNAPSHOT: 'sync:restore:delete-snapshot',
+  SYNC_RESTORE_PROBE: 'sync:restore:probe',
 } as const;
 
 // --- Window registry / detach types ---
@@ -612,4 +621,76 @@ export interface DragDroppedPayload {
 export interface CrossWindowCursor {
   screenX: number;
   screenY: number;
+}
+
+// --- Restore from backup types ---
+// Restore is a one-time, directional, user-initiated pull that treats the remote as authoritative.
+// This is distinct from sync (bidirectional merge) — different invariants, different code paths.
+
+export type RestoreCategory =
+  | 'memory'
+  | 'conversations'
+  | 'encyclopedia'
+  | 'skills'
+  | 'plans'
+  | 'specs';
+
+export interface RestorePoint {
+  /** 'HEAD' for Drive/iCloud (HEAD-only backends), git SHA for GitHub (full history). */
+  ref: string;
+  timestamp: number;
+  label: string;
+  summary?: string;
+}
+
+export interface RestoreOptions {
+  backendId: string;
+  versionRef: string;
+  categories: RestoreCategory[];
+  snapshotFirst: boolean;
+}
+
+export interface CategoryPreview {
+  category: RestoreCategory;
+  remoteFiles: number;
+  localFiles: number;
+  toAdd: number;
+  toOverwrite: number;
+  /** Files on device NOT on the backup — restore semantics will delete these. */
+  toDelete: number;
+  bytes: number;
+}
+
+export interface RestorePreview {
+  perCategory: CategoryPreview[];
+  totalBytes: number;
+  estimatedSeconds: number;
+  warnings: string[];
+}
+
+export interface RestoreResult {
+  snapshotId?: string;
+  categoriesRestored: RestoreCategory[];
+  filesWritten: number;
+  durationMs: number;
+  /** true if skills/memory restored — app restart recommended to pick up new files. */
+  requiresRestart: boolean;
+}
+
+export interface Snapshot {
+  /** ISO timestamp, also used as directory name under ~/.claude/restore-snapshots/. */
+  id: string;
+  timestamp: number;
+  categories: RestoreCategory[];
+  backendId: string;
+  sizeBytes: number;
+  triggeredBy: 'restore' | 'manual';
+}
+
+export interface RestoreProgressEvent {
+  category: RestoreCategory;
+  filesDone: number;
+  filesTotal: number;
+  currentFile?: string;
+  phase: 'snapshotting' | 'fetching' | 'staging' | 'swapping' | 'done';
 }


### PR DESCRIPTION
## Summary
- Adds a user-initiated **restore from backup** flow distinct from sync's bidirectional merge. Treats the remote as authoritative, snapshots local state first, swaps atomically.
- Works against all three backend types on desktop (Drive, GitHub, iCloud) and Drive + GitHub on Android. GitHub supports point-in-time restore via commit SHAs; Drive/iCloud are HEAD-only.
- Gated behind an experimental flag (`experimental.restoreFlow` in `~/.claude/destincode-local.json`, off by default). Toggle in Settings → Experimental.

## What ships
- **Core service**: `RestoreService` + per-backend adapters (TS) and a Kotlin parity port, using directory snapshots (not tar.gz) for simpler undo and atomic swap rollback.
- **Desktop UI**: 8 React components under `components/restore/` — step-machine wizard (pick-version → pick-categories → preview → safety → confirm → progress → done), snapshots panel with undo, onboarding auto-probe.
- **Parity**: IPC on 7 invokes + 1 progress push channel, mirrored across preload/remote-shim/remote-server so browser and Android receive the same surface.

## Test plan
- [ ] Drive HEAD restore on desktop
- [ ] GitHub HEAD restore on desktop
- [ ] GitHub HEAD-1 (point-in-time) restore via commit picker
- [ ] iCloud HEAD restore on desktop
- [ ] Undo immediately after restore → files match pre-restore state
- [ ] Kill desktop mid-execute → next launch cleans `.restore-staging/`
- [ ] Onboarding probe: empty remote → no prompt
- [ ] Onboarding probe: remote with data → `ExistingBackupDetected` appears
- [ ] Onboarding: "Start fresh" stamps `freshStartConfirmedEpoch`; next launch does NOT re-prompt
- [ ] Android Drive restore works with linker64 wrapping
- [ ] Android GitHub restore via `gh` + `git`
- [ ] Flag OFF → no restore UI surfaces anywhere

## Notes
- Branch was rebased on current `origin/master` after ~240 commits of drift; `types.ts` conflict resolved by keeping both the window-detach and restore IPC blocks.
- One incidental fix: `Bootstrap.kt` had a duplicate `val bashPath` at function scope left over from ec47486a; removed the redundant decl so Android builds.
- `archiver` is NOT used (the earlier completion-plan risk list flagged it — obsolete; desktop uses `fs.cpSync`, Android uses `File.copyRecursively`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)