### PR TITLE
fix(game): surface server trouble instead of silent "Connecting…"

### DIFF
--- a/.github/workflows/partykit-deploy.yml
+++ b/.github/workflows/partykit-deploy.yml
@@ -37,3 +37,31 @@ jobs:
         env:
           PARTYKIT_LOGIN: ${{ secrets.PARTYKIT_LOGIN }}
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+
+      # Health check: `partykit deploy` returns success as soon as the
+      # upload is accepted, even if the deployed code throws on the first
+      # request. Probe the actual lobby room over HTTPS and fail the job
+      # on 5xx so a broken deploy can't silently slip into production
+      # (this is how v2.4.2 ended up with the lobby 500-ing).
+      - name: Verify lobby room responds
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOST="destinclaude-games.itsdestin.partykit.dev"
+          URL="https://$HOST/party/global-lobby"
+          echo "Probing $URL ..."
+          # Give the edge a moment to pick up the new deployment before probing.
+          sleep 5
+          for attempt in 1 2 3 4 5; do
+            CODE=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+            echo "attempt $attempt: HTTP $CODE"
+            # Any non-5xx answer means the room constructed + responded —
+            # PartyKit returns 400/426 for non-WS GETs, which is fine here.
+            if [ "$CODE" != "000" ] && [ "$CODE" -lt 500 ]; then
+              echo "Lobby room is healthy."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Lobby room returned 5xx after deploy — last code: $CODE"
+          exit 1

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -729,12 +729,25 @@ function AppInner() {
     }).catch(() => {});
     if (!det) return;
 
-    const cleanupDir = det.onDirectoryUpdated?.((dir: any) => setWindowDirectory(dir));
+    const cleanupDir = det.onDirectoryUpdated?.((dir: any) => {
+      setWindowDirectory(dir);
+      // The directory snapshot carries leaderWindowId too. Pull it from every
+      // directory push so non-leader windows still learn who the leader is —
+      // main only fires WINDOW_LEADER_CHANGED when the id *changes* from the
+      // previously broadcast value, so window 2+ would otherwise never hear
+      // about the existing leader and stay stuck on "Connecting…" forever.
+      if (typeof dir?.leaderWindowId === 'number') setLeaderWindowId(dir.leaderWindowId);
+    });
     const cleanupLeader = det.onLeaderChanged?.((id: number) => setLeaderWindowId(id));
     // Pull the current directory immediately — the push from main may have
     // fired before this effect ran (on a brand-new window, React mounts after
-    // registerWindow already broadcast, so we'd miss it).
-    det.getDirectory?.().then((dir: any) => { if (dir) setWindowDirectory(dir); }).catch(() => {});
+    // registerWindow already broadcast, so we'd miss it). Same applies to the
+    // leader — hydrate both from this response.
+    det.getDirectory?.().then((dir: any) => {
+      if (!dir) return;
+      setWindowDirectory(dir);
+      if (typeof dir.leaderWindowId === 'number') setLeaderWindowId(dir.leaderWindowId);
+    }).catch(() => {});
 
     const cleanupAcquired = det.onOwnershipAcquired?.((payload: any) => {
       const { sessionId: sid, sessionInfo, freshWindow, refocusOnly } = payload;

--- a/desktop/src/renderer/components/game/GameLobby.tsx
+++ b/desktop/src/renderer/components/game/GameLobby.tsx
@@ -16,29 +16,33 @@ interface Props {
 }
 
 // Classify the lobby error so the hint matches the actual cause.
-// Old version blanket-suggested `gh auth login` for ANY connection error —
-// misleading when the real failure is server-side (PartyKit 5xx) or network.
+// Tone rules for this screen (Destin's direction):
+//  - no jargon, no "error codes" in the user-facing hint
+//  - don't catastrophize — most of these resolve themselves in seconds
+//  - tell the user what *they* can do, not what the code is doing
+// The raw code stays in the headline string (from the reducer) for
+// debugging, but the hint below it is always plain language.
 function classifyPartyError(msg: string | null): {
   hint: string;
   showAuthCmd: boolean;
 } {
   const text = (msg ?? '').toLowerCase();
-  if (text.includes('github') || text.includes('gh auth') || text.includes('auth failed')) {
+  if (text.includes('github') || text.includes('gh auth') || text.includes('auth failed') || text.includes("sign-in") || text.includes("signed in")) {
     return {
-      hint: 'Make sure GitHub CLI is installed and authenticated:',
+      hint: "Games use your GitHub name as your player tag. Sign in to GitHub from a terminal with:",
       showAuthCmd: true,
     };
   }
   if (text.includes('code 1011') || text.includes('code 500') || text.includes('code 1012') || text.includes('code 1013')) {
-    return { hint: 'The game server is having trouble. This usually clears up on its own.', showAuthCmd: false };
+    return { hint: 'The game server is taking a breather. This usually fixes itself in a minute.', showAuthCmd: false };
   }
-  if (text.includes('code 1006') || text.includes('code 1015') || text.includes('lost connection')) {
-    return { hint: 'Network looks down. Check your internet connection.', showAuthCmd: false };
+  if (text.includes('code 1006') || text.includes('code 1015') || text.includes('lost the connection') || text.includes('lost connection')) {
+    return { hint: "Looks like the internet hiccuped. We'll keep trying — you can also hit Retry.", showAuthCmd: false };
   }
   if (text.includes('code 4000')) {
-    return { hint: 'Lobby refused the connection (no username). Try reloading the app.', showAuthCmd: false };
+    return { hint: 'Something got mixed up signing in. Try reloading the app.', showAuthCmd: false };
   }
-  return { hint: 'Reconnecting automatically… if it never recovers, try reloading.', showAuthCmd: false };
+  return { hint: "Hang tight — we'll keep trying in the background.", showAuthCmd: false };
 }
 
 function ErrorScreen({ connection }: { connection: GameConnection }) {
@@ -368,12 +372,31 @@ export default function GameLobby({ connection, incognito, onToggleIncognito }: 
   if (state.partyError && !incognito) return <ErrorScreen connection={connection} />;
   if (state.screen === 'joining') return <JoiningScreen connection={connection} />;
   if (state.screen === 'waiting') return <WaitingScreen connection={connection} />;
-  // Show connecting spinner while waiting for PartyKit (setup screen, not incognito)
+  // Show connecting spinner while waiting for PartyKit (setup screen, not incognito).
+  // After ~10s of no open, `slowConnect` flips and we swap in friendlier copy
+  // plus a Reload button — prevents the infinite-silent-spinner that hid the
+  // "PartyKit crashed, partysocket retrying forever on 5xx" case.
   if (!state.connected && !incognito) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3 px-4 py-8">
+      <div className="flex-1 flex flex-col items-center justify-center gap-4 px-4 py-8">
         <BrailleSpinner size="lg" />
-        <p className="text-sm text-fg-dim">Connecting...</p>
+        <p className="text-sm text-fg-dim">
+          {state.slowConnect ? 'Still trying to connect…' : 'Connecting…'}
+        </p>
+        {state.slowConnect && (
+          <>
+            <p className="text-xs text-fg-muted text-center max-w-xs">
+              {state.slowConnectHint ?? 'Taking a little longer than usual. Hang tight…'}
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="text-xs text-[#66AAFF] hover:text-[#88CCFF] transition-colors"
+              title="Reload the app"
+            >
+              Reload app
+            </button>
+          </>
+        )}
       </div>
     );
   }

--- a/desktop/src/renderer/game/party-client.ts
+++ b/desktop/src/renderer/game/party-client.ts
@@ -25,10 +25,25 @@ export interface PartyClientOptions {
   onOpen?: () => void;
   onClose?: (info: CloseInfo) => void;
   onError?: (error: Event) => void;
+  /** Fires if the socket hasn't opened after `slowConnectMs`. Used so the UI
+   * can swap the bare "Connecting…" spinner for a friendlier "taking longer
+   * than usual" message + probe the server to classify the cause. */
+  onSlowConnect?: () => void;
+  /** Default 10_000 ms. Partysocket's own backoff is opaque to callers, so
+   * we wrap it with a single "is this dragging on?" timer. */
+  slowConnectMs?: number;
 }
+
+const DEFAULT_SLOW_MS = 10_000;
+
+// Standard WebSocket readyState constants — hoisted so this file can be
+// bundled into the Android WebView without depending on `WebSocket` globals
+// at module evaluation time.
+const WS_OPEN = 1;
 
 export class PartyClient {
   private socket: PartySocket;
+  private slowTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: PartyClientOptions) {
     this.socket = new PartySocket({
@@ -47,9 +62,26 @@ export class PartyClient {
       }
     });
 
-    if (options.onOpen) {
-      this.socket.addEventListener("open", options.onOpen);
+    // Start the slow-connect timer. If the socket opens first, clear it;
+    // otherwise fire onSlowConnect so callers can surface a friendlier state
+    // without waiting on partysocket's silent reconnect loop.
+    if (options.onSlowConnect) {
+      const ms = options.slowConnectMs ?? DEFAULT_SLOW_MS;
+      this.slowTimer = setTimeout(() => {
+        this.slowTimer = null;
+        if (this.socket.readyState !== WS_OPEN) {
+          options.onSlowConnect!();
+        }
+      }, ms);
     }
+
+    this.socket.addEventListener("open", () => {
+      if (this.slowTimer) {
+        clearTimeout(this.slowTimer);
+        this.slowTimer = null;
+      }
+      options.onOpen?.();
+    });
     if (options.onClose) {
       // Forward code/reason so the caller can show *why* the socket dropped
       this.socket.addEventListener("close", (event: CloseEvent) => {
@@ -66,6 +98,10 @@ export class PartyClient {
   }
 
   close(): void {
+    if (this.slowTimer) {
+      clearTimeout(this.slowTimer);
+      this.slowTimer = null;
+    }
     this.socket.close();
   }
 

--- a/desktop/src/renderer/hooks/usePartyLobby.ts
+++ b/desktop/src/renderer/hooks/usePartyLobby.ts
@@ -1,8 +1,37 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useGameDispatch } from '../state/game-context';
-import { PartyClient } from '../game/party-client';
+import { PartyClient, PARTYKIT_HOST } from '../game/party-client';
 
 const PING_INTERVAL = 30_000; // 30s — matches server sweep interval
+
+// Called once the socket has been stuck in CONNECTING for ~10s. Runs a
+// plain HTTP GET against the lobby room to classify *why* the socket isn't
+// opening, then returns user-facing copy with no jargon or error codes.
+//
+// Why probe separately: partysocket silently retries forever on 5xx and
+// never surfaces the response code to its consumers. The only way to tell
+// "server is down" from "server is reachable but crashing" from "you're
+// offline" is to ask the HTTPS endpoint directly.
+async function classifySlowConnect(): Promise<string> {
+  try {
+    const res = await fetch(`https://${PARTYKIT_HOST}/party/global-lobby`, {
+      method: 'GET',
+      // Short abort so we don't hang here longer than the user's patience —
+      // friendlier copy beats a second silent wait.
+      signal: AbortSignal.timeout(6_000),
+    });
+    if (res.status >= 500) {
+      return 'The game server is having a rough morning. Give it a minute and try again.';
+    }
+    // 2xx / 3xx / 4xx all mean the server answered — so the WebSocket
+    // handshake is just slow. Network is fine; encourage patience.
+    return 'Taking a little longer than usual. Hang tight…';
+  } catch {
+    // Fetch rejected → DNS failure, offline, or firewall. Avoid "network
+    // error" jargon and just describe what to check.
+    return "Can't reach the game server. Check your internet and try again.";
+  }
+}
 
 // isLeader: true when this renderer is the leader window (multi-window detach
 // feature). Only the leader maintains the lobby socket; non-leader windows
@@ -67,7 +96,7 @@ export function usePartyLobby(isLeader: boolean = true) {
       .then((auth: { username: string } | null) => {
         if (cancelled) return;
         if (!auth) {
-          dispatch({ type: 'PARTY_ERROR', message: 'GitHub CLI not authenticated. Run: gh auth login' });
+          dispatch({ type: 'PARTY_ERROR', message: "You're not signed in to GitHub yet — games use your GitHub name as your player tag." });
           return;
         }
 
@@ -110,6 +139,16 @@ export function usePartyLobby(isLeader: boolean = true) {
           onOpen: () => {
             dispatch({ type: 'PARTY_CONNECTED', username: auth.username });
           },
+          onSlowConnect: () => {
+            // Swap the bare spinner for friendlier copy immediately, then
+            // kick off an HTTP probe to refine the hint. We dispatch twice
+            // so the user sees *something* change right at the 10s mark
+            // without waiting on the probe round-trip.
+            dispatch({ type: 'PARTY_SLOW_CONNECT', hint: 'Taking a little longer than usual. Hang tight…' });
+            classifySlowConnect().then((hint) => {
+              if (!cancelled) dispatch({ type: 'PARTY_SLOW_CONNECT', hint });
+            });
+          },
           onClose: (info) => {
             // Forward the close code so the UI can show *why* (DevTools is
             // unavailable in some environments — this is the only way for
@@ -117,7 +156,7 @@ export function usePartyLobby(isLeader: boolean = true) {
             dispatch({ type: 'PARTY_DISCONNECTED', code: info.code, reason: info.reason });
           },
           onError: () => {
-            dispatch({ type: 'PARTY_ERROR', message: 'Lost connection to game server' });
+            dispatch({ type: 'PARTY_ERROR', message: "Lost the connection to the game server. We'll keep trying." });
           },
         });
 
@@ -135,7 +174,10 @@ export function usePartyLobby(isLeader: boolean = true) {
           // token call failed. The detail makes the lobby ErrorScreen useful.
           const detail = err instanceof Error ? err.message : String(err);
           console.warn('[lobby] getGitHubAuth failed:', err);
-          dispatch({ type: 'PARTY_ERROR', message: `GitHub auth failed: ${detail}` });
+          // Keep the raw detail in the console for debugging, but show the
+          // user a plain-language version. Destin is a non-dev — "GitHub auth
+          // failed: Error: spawn gh ENOENT" is meaningless to a real user.
+          dispatch({ type: 'PARTY_ERROR', message: "Couldn't check your GitHub sign-in. Make sure the GitHub CLI (gh) is installed and you've signed in." });
         }
       });
 

--- a/desktop/src/renderer/state/game-reducer.ts
+++ b/desktop/src/renderer/state/game-reducer.ts
@@ -3,7 +3,17 @@ import { GameState, GameAction, createInitialGameState } from './game-types';
 export function gameReducer(state: GameState, action: GameAction): GameState {
   switch (action.type) {
     case 'PARTY_CONNECTED':
-      return { ...state, connected: true, username: action.username, screen: 'lobby', partyError: null };
+      // Clear both hard errors AND the slow-connect hint — a fresh successful
+      // open means the earlier friendlier copy is no longer relevant.
+      return {
+        ...state,
+        connected: true,
+        username: action.username,
+        screen: 'lobby',
+        partyError: null,
+        slowConnect: false,
+        slowConnectHint: null,
+      };
 
     case 'PARTY_DISCONNECTED': {
       // Keep username — game actions guard on it, and PARTY_CONNECTED refreshes
@@ -20,12 +30,16 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       if (action.code === undefined) {
         return { ...state, connected: false, onlineUsers: [], partyError: null };
       }
+      // Keep the raw code in the message so classifyPartyError() can still
+      // pick a specific hint — but phrase the headline in plain language.
+      // "Lost the connection (code 1006) — trying again…" reads less alarming
+      // than "Disconnected from game server" while preserving the diagnostic.
       const reason = action.reason ? `: ${action.reason}` : '';
       return {
         ...state,
         connected: false,
         onlineUsers: [],
-        partyError: `Disconnected from game server (code ${action.code}${reason}) — reconnecting...`,
+        partyError: `Lost the connection (code ${action.code}${reason}) — trying again…`,
       };
     }
 
@@ -36,7 +50,16 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       // User hit Retry on the ErrorScreen — clear the banner so partysocket's
       // ongoing reconnect attempts can promote to PARTY_CONNECTED, or so the
       // lobby effect re-runs the auth fetch on next dependency change.
-      return { ...state, partyError: null };
+      return { ...state, partyError: null, slowConnect: false, slowConnectHint: null };
+
+    case 'PARTY_SLOW_CONNECT':
+      // Fired by PartyClient's slow-connect timer (10s of CONNECTING with no
+      // open). usePartyLobby may follow up with an HTTP probe to set the hint
+      // based on what the server actually returned.
+      return { ...state, slowConnect: true, slowConnectHint: action.hint ?? state.slowConnectHint };
+
+    case 'PARTY_SLOW_CLEARED':
+      return { ...state, slowConnect: false, slowConnectHint: null };
 
     case 'PRESENCE_UPDATE':
       return { ...state, onlineUsers: action.online };

--- a/desktop/src/renderer/state/game-types.ts
+++ b/desktop/src/renderer/state/game-types.ts
@@ -14,6 +14,14 @@ export interface ChatMessage {
 
 export interface GameState {
   connected: boolean;
+  /** True once we've been spinning on "Connecting…" long enough that the UI
+   * should swap in a friendlier "taking longer than usual" message. Separate
+   * from `partyError` so the spinner path stays distinct from hard failures. */
+  slowConnect: boolean;
+  /** Set by the lightweight HTTP probe in usePartyLobby when slowConnect
+   * fires — gives the spinner screen a plain-language explanation of the
+   * likely cause (offline vs server-napping vs just-slow). */
+  slowConnectHint: string | null;
   partyError: string | null;
   username: string | null;
   onlineUsers: OnlineUser[];
@@ -45,6 +53,8 @@ export type GameAction =
   | { type: 'PARTY_DISCONNECTED'; code?: number; reason?: string }
   | { type: 'PARTY_ERROR'; message: string }
   | { type: 'PARTY_ERROR_CLEARED' }
+  | { type: 'PARTY_SLOW_CONNECT'; hint?: string | null }
+  | { type: 'PARTY_SLOW_CLEARED' }
   | { type: 'PRESENCE_UPDATE'; online: OnlineUser[] }
   | { type: 'USER_JOINED'; username: string; status: string }
   | { type: 'USER_LEFT'; username: string }
@@ -84,6 +94,8 @@ export interface GameConnection {
 export function createInitialGameState(): GameState {
   return {
     connected: false,
+    slowConnect: false,
+    slowConnectHint: null,
     partyError: null,
     username: null,
     onlineUsers: [],


### PR DESCRIPTION
## Summary
- Game panel would spin on "Connecting…" indefinitely when PartyKit returned 5xx (as it did in prod against v2.4.2) because partysocket silently retries on server errors.
- Release verification only checked `partykit deploy` exit code, so a broken room could ship unnoticed.

## What changed
- `party-client.ts`: new `onSlowConnect` callback fires after 10s stuck in CONNECTING.
- `usePartyLobby.ts`: slow-connect triggers an HTTPS probe of `/party/global-lobby` to classify the cause (offline vs server-crashing vs slow handshake) and dispatches plain-language copy.
- `game-reducer.ts` + `game-types.ts`: new `slowConnect` + `slowConnectHint` state fields (cleared on `PARTY_CONNECTED` or `PARTY_ERROR_CLEARED`).
- `GameLobby.tsx`: slow-connect branch renders the hint + a Reload button. Rewrote the existing `classifyPartyError` hints in layman's terms — no raw codes in user-facing copy, no jargon, no catastrophizing.
- `.github/workflows/partykit-deploy.yml`: after `partykit deploy`, curls `/party/global-lobby` up to 5×; any 5xx fails the job. `/release` inherits this because it just watches the workflow.

Cross-platform: all renderer changes ride the shared React UI, so Android (WebView) gets the same behavior for free.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 316 pass, 0 new failures
- [ ] Manual: open game panel with partykit reachable — still shows "Connecting…" briefly then lobby (fast path).
- [ ] Manual: open with partykit returning 500 — spinner swaps to "Still trying to connect… / The game server is having a rough morning…" after 10s, Reload button appears.
- [ ] Manual: open offline — swaps to "Still trying to connect… / Can't reach the game server. Check your internet…"
- [ ] CI: re-trigger partykit-deploy manually to confirm the new health probe passes against the live (once redeployed) endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)