### PR TITLE
Stop losing conversation tags on reinstall/sync

### DIFF
--- a/desktop/src/main/restore-service.ts
+++ b/desktop/src/main/restore-service.ts
@@ -344,6 +344,20 @@ export class RestoreService {
         emit({ category, filesDone: 1, filesTotal: 1, phase: 'done' });
       }
 
+      // --- 3. Pull conversation-index.json (conversation tags) ---
+      // Tags (complete/priority/helpful flags) live in system-backup, not any
+      // restore category. Merge-mode gets them via syncService.pull(); wipe-
+      // mode has to fetch explicitly because we can't run the full pull here
+      // (it would overwrite the categories we just atomically swapped in).
+      // Non-fatal — the core restore already succeeded.
+      if (opts.categories.includes('conversations')) {
+        try {
+          await this.syncService.pullConversationIndexOnly(opts.backendId);
+        } catch (e) {
+          // swallow: tags are an enrichment, not a hard requirement
+        }
+      }
+
       return {
         snapshotId,
         categoriesRestored: opts.categories,

--- a/desktop/src/main/sync-service.ts
+++ b/desktop/src/main/sync-service.ts
@@ -91,6 +91,11 @@ const PUSH_INTERVAL_MS = 15 * 60 * 1000;   // 15 minutes
 const PUSH_DEBOUNCE_MIN = 15;
 const PULL_DEBOUNCE_MIN = 10;
 const INDEX_PRUNE_DAYS = 30;
+// Tags set via setSessionFlag should reach the backend within seconds, not
+// wait for the 15-minute cycle. Debounce coalesces rapid tagging into one
+// upload. A full push in flight preempts the index-only push (it will upload
+// the index anyway), so the net cost is at most one extra small upload.
+const INDEX_PUSH_DEBOUNCE_MS = 30_000;
 const RCLONE_TIMEOUT = 60_000;
 const GIT_TIMEOUT = 60_000;
 const SESSION_PUSH_TIMEOUT = 15_000;
@@ -110,6 +115,7 @@ export class SyncService extends EventEmitter {
   private indexStagingDir: string;
 
   private pushTimer: NodeJS.Timeout | null = null;
+  private indexPushTimer: NodeJS.Timeout | null = null;
   private pulling = false;
   private pushing = false;
 
@@ -1298,9 +1304,14 @@ export class SyncService extends EventEmitter {
       } catch {}
     }
 
-    // Prune old entries
+    // Prune old entries, but skip epoch-sentinel entries. Those are seeded by
+    // setSessionFlag() when a user tags a session before its topic file exists;
+    // epoch is older than any prune threshold, so without this guard the
+    // pending entry (and its flag) would be deleted immediately on next push.
     for (const [sid, entry] of Object.entries(index.sessions)) {
-      if (new Date(entry.lastActive).getTime() < pruneThreshold) {
+      const ts = new Date(entry.lastActive).getTime();
+      if (ts === 0) continue;
+      if (ts < pruneThreshold) {
         delete index.sessions[sid];
       }
     }
@@ -1376,7 +1387,15 @@ export class SyncService extends EventEmitter {
   }
 
   /** Set a named flag on a session. Fresh updatedAt timestamp so cross-device
-   *  merge honors latest-writer-wins per-flag. Creates the entry if missing. */
+   *  merge honors latest-writer-wins per-flag. Creates the entry if missing.
+   *
+   *  Seeding an unknown session is the tricky case: a naive "lastActive: now"
+   *  seed corrupted cross-device merge (local bare stub beat real remote entry
+   *  by mere seconds) and blocked the next topic scan from writing the real
+   *  topic (scan skips when existing.lastActive >= file.mtime). Fix: try the
+   *  topic file first; if absent, seed lastActive=epoch so the next scan wins
+   *  and cross-device merge picks the peer's real entry. Epoch-seeded entries
+   *  are protected from the age-based prune in updateConversationIndex(). */
   setSessionFlag(sessionId: string, flag: string, value: boolean): void {
     const index: ConversationIndex = this.readJson(this.conversationIndexPath) || { version: 1, sessions: {} };
     if (!index.sessions) index.sessions = {};
@@ -1391,17 +1410,144 @@ export class SyncService extends EventEmitter {
       flags[flag] = { value: !!value, updatedAt: now };
       index.sessions[sessionId] = { ...existing, flags };
     } else {
-      // First time seeing this session — seed a minimal entry.
+      // Try to populate from the topic file if it already exists on disk.
+      const topicFilePath = path.join(this.claudeDir, 'topics', `topic-${sessionId}`);
+      let topic = 'Untitled';
+      let lastActive = new Date(0).toISOString();   // epoch = "pending topic scan"
+      let slug = '';
+      try {
+        const stat = fs.statSync(topicFilePath);
+        const content = fs.readFileSync(topicFilePath, 'utf8').trim();
+        if (content && content !== 'New Session') {
+          topic = content;
+          lastActive = stat.mtime.toISOString();
+          slug = this.getCurrentSlug();
+        }
+      } catch {
+        // Topic file doesn't exist yet — stick with the epoch sentinel.
+      }
+
       index.sessions[sessionId] = {
-        topic: 'Untitled',
-        lastActive: now,
-        slug: '',
+        topic,
+        lastActive,
+        slug,
         device: os.hostname(),
         flags: { [flag]: { value: !!value, updatedAt: now } },
       };
     }
 
     this.atomicWrite(this.conversationIndexPath, JSON.stringify(index, null, 2));
+
+    // Tags are high-value metadata with a narrow window — if the user closes
+    // the app before the 15-min push, the tag never reaches the backup and is
+    // lost forever on reinstall. A 30s debounce gets them off-device quickly
+    // without bombarding the backend on every click.
+    this.scheduleIndexPush();
+  }
+
+  /** Schedule a 30s-debounced index-only push. Resets the timer on each call. */
+  private scheduleIndexPush(): void {
+    if (this.indexPushTimer) clearTimeout(this.indexPushTimer);
+    this.indexPushTimer = setTimeout(() => {
+      this.indexPushTimer = null;
+      // A full push in flight will upload the index as part of its run — skip
+      // to avoid redundant writes (and any rclone contention on the same file).
+      if (this.pushing) return;
+      this.pushIndexOnly().catch(e => {
+        this.logBackup('ERROR', `Index-only push failed: ${e}`, 'sync.push.index');
+      });
+    }, INDEX_PUSH_DEBOUNCE_MS);
+  }
+
+  /** Pull just conversation-index.json from a single backend and merge it
+   *  into the local index via mergeConversationIndex(). Used by the restore
+   *  wipe flow, which stages categories atomically and cannot invoke the full
+   *  pull() without clobbering those just-restored dirs. */
+  async pullConversationIndexOnly(backendId: string): Promise<void> {
+    const instance = this.getBackendById(backendId);
+    if (!instance) return;
+    fs.mkdirSync(this.indexStagingDir, { recursive: true });
+    // Clean any stale staged file so a failed fetch doesn't re-merge old data.
+    const stagedIndex = path.join(this.indexStagingDir, 'conversation-index.json');
+    try { fs.unlinkSync(stagedIndex); } catch {}
+
+    try {
+      await this.fetchIndexFromBackend(instance);
+    } catch (e) {
+      this.logBackup('WARN', `Index fetch from ${instance.id} failed: ${e}`, 'sync.pull.index');
+      return;
+    }
+
+    if (this.fileExists(stagedIndex)) {
+      this.mergeConversationIndex(stagedIndex);
+    }
+  }
+
+  /** Per-backend implementation of conversation-index fetch into staging. */
+  private async fetchIndexFromBackend(instance: BackendInstance): Promise<void> {
+    const stagedDir = this.indexStagingDir;
+    switch (instance.type) {
+      case 'drive': {
+        const rcloneRemote = instance.config.rcloneRemote || 'gdrive';
+        const driveRoot = instance.config.DRIVE_ROOT || 'Claude';
+        await this.rclone(['copy', `${rcloneRemote}:${driveRoot}/Backup/system-backup/conversation-index.json`, stagedDir + '/', '--checksum']);
+        break;
+      }
+      case 'github': {
+        const repoDir = path.join(this.claudeDir, 'toolkit-state', `personal-sync-repo-${instance.id}`);
+        if (!this.dirExists(path.join(repoDir, '.git'))) return;
+        await this.gitExec(['pull', 'personal-sync', 'main'], repoDir);
+        const src = path.join(repoDir, 'system-backup', 'conversation-index.json');
+        if (this.fileExists(src)) fs.copyFileSync(src, path.join(stagedDir, 'conversation-index.json'));
+        break;
+      }
+      case 'icloud': {
+        const icloudPath = this.resolveICloudPath(instance);
+        if (!icloudPath) return;
+        const src = path.join(icloudPath, 'system-backup', 'conversation-index.json');
+        if (this.fileExists(src)) fs.copyFileSync(src, path.join(stagedDir, 'conversation-index.json'));
+        break;
+      }
+    }
+  }
+
+  /** Push just conversation-index.json to each sync-enabled backend's
+   *  system-backup/. Narrow counterpart to push() — used by the 30s tag
+   *  debouncer so tags propagate faster than the 15-min full-push cycle. */
+  async pushIndexOnly(): Promise<void> {
+    if (!this.fileExists(this.conversationIndexPath)) return;
+    const instances = this.getSyncEnabledBackends();
+    for (const instance of instances) {
+      try {
+        switch (instance.type) {
+          case 'drive': {
+            const rcloneRemote = instance.config.rcloneRemote || 'gdrive';
+            const driveRoot = instance.config.DRIVE_ROOT || 'Claude';
+            await this.rclone(['copyto', this.conversationIndexPath, `${rcloneRemote}:${driveRoot}/Backup/system-backup/conversation-index.json`, '--checksum']);
+            break;
+          }
+          case 'github': {
+            const repoDir = path.join(this.claudeDir, 'toolkit-state', `personal-sync-repo-${instance.id}`);
+            if (!this.dirExists(path.join(repoDir, '.git'))) break;
+            fs.mkdirSync(path.join(repoDir, 'system-backup'), { recursive: true });
+            fs.copyFileSync(this.conversationIndexPath, path.join(repoDir, 'system-backup', 'conversation-index.json'));
+            await this.gitExec(['add', 'system-backup/conversation-index.json'], repoDir);
+            await this.gitExec(['commit', '-m', 'sync: conversation-index (tags)'], repoDir);
+            await this.gitExec(['push', 'personal-sync', 'main'], repoDir);
+            break;
+          }
+          case 'icloud': {
+            const icloudPath = this.resolveICloudPath(instance);
+            if (!icloudPath) break;
+            fs.mkdirSync(path.join(icloudPath, 'system-backup'), { recursive: true });
+            fs.copyFileSync(this.conversationIndexPath, path.join(icloudPath, 'system-backup', 'conversation-index.json'));
+            break;
+          }
+        }
+      } catch (e) {
+        this.logBackup('WARN', `Index push to ${instance.id} failed: ${e}`, 'sync.push.index');
+      }
+    }
   }
 
   /** Create topic cache files from index for cross-device sessions. */

--- a/desktop/tests/sync-service-tags.test.ts
+++ b/desktop/tests/sync-service-tags.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Stub homedir before importing SyncService, because the constructor
+// captures paths from os.homedir() at instantiation time.
+let tmpHome: string;
+let origHomedir: typeof os.homedir;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'youcoded-sync-tags-'));
+  origHomedir = os.homedir;
+  (os as any).homedir = () => tmpHome;
+  fs.mkdirSync(path.join(tmpHome, '.claude', 'topics'), { recursive: true });
+});
+
+afterEach(() => {
+  (os as any).homedir = origHomedir;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+async function freshService() {
+  // Dynamic import each time so the constructor runs under the stubbed homedir.
+  const mod = await import('../src/main/sync-service');
+  return new mod.SyncService();
+}
+
+function readIndex(): any {
+  const p = path.join(tmpHome, '.claude', 'conversation-index.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function writeTopicFile(sessionId: string, content: string, mtime?: Date): void {
+  const p = path.join(tmpHome, '.claude', 'topics', `topic-${sessionId}`);
+  fs.writeFileSync(p, content);
+  if (mtime) fs.utimesSync(p, mtime, mtime);
+}
+
+describe('setSessionFlag — unknown session with topic file present', () => {
+  it('seeds entry from the topic file (topic + mtime), not a bare "Untitled"', async () => {
+    const svc = await freshService();
+    const mtime = new Date('2026-04-10T12:00:00Z');
+    writeTopicFile('sess-a', 'Real topic about cats', mtime);
+
+    svc.setSessionFlag('sess-a', 'complete', true);
+
+    const idx = readIndex();
+    expect(idx.sessions['sess-a'].topic).toBe('Real topic about cats');
+    expect(new Date(idx.sessions['sess-a'].lastActive).getTime()).toBe(mtime.getTime());
+    expect(idx.sessions['sess-a'].slug).not.toBe('');
+    expect(idx.sessions['sess-a'].flags.complete.value).toBe(true);
+  });
+});
+
+describe('setSessionFlag — unknown session with NO topic file', () => {
+  it('seeds entry with epoch lastActive as a "pending topic scan" sentinel', async () => {
+    const svc = await freshService();
+
+    svc.setSessionFlag('sess-b', 'priority', true);
+
+    const idx = readIndex();
+    expect(idx.sessions['sess-b'].flags.priority.value).toBe(true);
+    // Epoch (1970-01-01) signals that the next topic scan should overwrite us.
+    expect(new Date(idx.sessions['sess-b'].lastActive).getTime()).toBe(0);
+  });
+});
+
+describe('updateConversationIndex — interaction with epoch-seeded entries', () => {
+  it('overwrites an epoch-seeded entry when the topic file shows up', async () => {
+    const svc = await freshService();
+
+    // Flag set before topic file existed — entry seeded with epoch lastActive
+    svc.setSessionFlag('sess-c', 'helpful', true);
+    expect(new Date(readIndex().sessions['sess-c'].lastActive).getTime()).toBe(0);
+
+    // Topic file appears later (user sent first message)
+    writeTopicFile('sess-c', 'Topic written later', new Date('2026-04-12T08:00:00Z'));
+
+    svc.updateConversationIndex();
+
+    const entry = readIndex().sessions['sess-c'];
+    expect(entry.topic).toBe('Topic written later');
+    // Flag survives the topic-scan overwrite
+    expect(entry.flags.helpful.value).toBe(true);
+  });
+
+  it('does NOT prune epoch-seeded entries (they are pending, not old)', async () => {
+    const svc = await freshService();
+
+    // Epoch-seeded pending entry
+    svc.setSessionFlag('sess-d', 'complete', true);
+
+    // Also add a real-old entry that SHOULD be pruned (lastActive 60 days ago)
+    const idxPath = path.join(tmpHome, '.claude', 'conversation-index.json');
+    const current = JSON.parse(fs.readFileSync(idxPath, 'utf8'));
+    current.sessions['sess-old'] = {
+      topic: 'Old session',
+      lastActive: new Date(Date.now() - 60 * 86400_000).toISOString(),
+      slug: 'whatever',
+      device: 'host',
+    };
+    fs.writeFileSync(idxPath, JSON.stringify(current));
+
+    svc.updateConversationIndex();
+
+    const after = readIndex();
+    // Epoch entry survives prune
+    expect(after.sessions['sess-d']).toBeDefined();
+    expect(after.sessions['sess-d'].flags.complete.value).toBe(true);
+    // Real-old entry is pruned as before
+    expect(after.sessions['sess-old']).toBeUndefined();
+  });
+});
+
+describe('setSessionFlag — 30s debounced index-only push', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('schedules a push 30 seconds after setSessionFlag (not sooner)', async () => {
+    const svc = await freshService();
+    const spy = vi.spyOn(svc as any, 'pushIndexOnly').mockResolvedValue(undefined);
+
+    svc.setSessionFlag('x', 'complete', true);
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(29_000);
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2_000);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces: rapid repeated calls coalesce to one push', async () => {
+    const svc = await freshService();
+    const spy = vi.spyOn(svc as any, 'pushIndexOnly').mockResolvedValue(undefined);
+
+    svc.setSessionFlag('x', 'complete', true);
+    vi.advanceTimersByTime(20_000);
+    svc.setSessionFlag('y', 'priority', true);
+    vi.advanceTimersByTime(20_000);
+    svc.setSessionFlag('z', 'helpful', true);
+
+    // 40 seconds since the first call, but each call resets the timer
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(31_000);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips if a full push is in flight when the timer fires', async () => {
+    const svc = await freshService();
+    const spy = vi.spyOn(svc as any, 'pushIndexOnly').mockResolvedValue(undefined);
+
+    svc.setSessionFlag('x', 'complete', true);
+    // Full push starts while we're waiting
+    (svc as any).pushing = true;
+    vi.advanceTimersByTime(31_000);
+
+    // Index push is redundant — full push will upload the index anyway
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('pullConversationIndexOnly — restore-from-backup hook', () => {
+  // Minimal fake backend; we stub the per-backend fetch so the type isn't load-bearing.
+  const fakeBackend = { id: 'b1', type: 'drive', syncEnabled: true, config: {} };
+
+  it('merges a fetched remote index into local (cross-device restore case)', async () => {
+    const svc = await freshService();
+    vi.spyOn(svc, 'getBackendById').mockReturnValue(fakeBackend as any);
+
+    // Local has a tag set from this device
+    svc.setSessionFlag('local-only', 'helpful', true);
+
+    // Simulate the per-backend fetch writing a remote index into staging, as
+    // a real rclone/git pull would. Matches the production contract.
+    const stagingDir = path.join(tmpHome, '.claude', 'toolkit-state', '.index-staging');
+    vi.spyOn(svc as any, 'fetchIndexFromBackend').mockImplementation(async () => {
+      fs.mkdirSync(stagingDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stagingDir, 'conversation-index.json'),
+        JSON.stringify({
+          version: 1,
+          sessions: {
+            'remote-only': {
+              topic: 'From other device',
+              lastActive: new Date().toISOString(),
+              slug: 'other-slug',
+              device: 'other-host',
+              flags: { complete: { value: true, updatedAt: new Date().toISOString() } },
+            },
+          },
+        }),
+      );
+    });
+
+    await svc.pullConversationIndexOnly('b1');
+
+    const after = readIndex();
+    expect(after.sessions['local-only'].flags.helpful.value).toBe(true);
+    expect(after.sessions['remote-only'].flags.complete.value).toBe(true);
+    expect(after.sessions['remote-only'].topic).toBe('From other device');
+  });
+
+  it('is a no-op when the fetch produces no staged file (offline / missing backup)', async () => {
+    const svc = await freshService();
+    vi.spyOn(svc, 'getBackendById').mockReturnValue(fakeBackend as any);
+    svc.setSessionFlag('only-local', 'priority', true);
+
+    // Fetch returns normally but writes nothing — the remote backup is empty
+    vi.spyOn(svc as any, 'fetchIndexFromBackend').mockResolvedValue(undefined);
+
+    await svc.pullConversationIndexOnly('b1');
+
+    // Local entry untouched, no merge attempted
+    const after = readIndex();
+    expect(after.sessions['only-local'].flags.priority.value).toBe(true);
+  });
+
+  it('early-returns silently if the backendId is unknown', async () => {
+    const svc = await freshService();
+    svc.setSessionFlag('only-local', 'complete', true);
+
+    // Default getBackendById returns null — pull should not throw
+    await expect(svc.pullConversationIndexOnly('nope')).resolves.toBeUndefined();
+
+    const after = readIndex();
+    expect(after.sessions['only-local'].flags.complete.value).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Three compounding bugs caused complete/priority/helpful session tags to disappear on every sync cycle and on reinstall. Plus one restore gap. All fixed here.

## The three SyncService bugs

**A. `setSessionFlag()` bare seed corruption.** When tagging an unknown session, the entry was seeded with `lastActive: now`, which blocked the next topic scan from writing the real topic (scan skips when `existing.lastActive >= file.mtime`). Entry stayed as "Untitled" forever, and raced with real entries on cross-device merge.

*Fix:* try the topic file first — it often exists even when the index is behind. If missing, seed with epoch (`new Date(0)`) as a "pending topic scan" sentinel. Epoch always loses to real mtime and to remote entries on merge, so the next scan / next peer's push writes the real base entry. The per-flag merge keeps the flag alive throughout.

**B. Age-based prune nuked the epoch sentinel.** Prune deletes `lastActive < (now - 30 days)`. Epoch is 1970 — way older than 30 days. Without a guard, fix A would be self-defeating.

*Fix:* skip `lastActive === 0` from prune. Real-old entries still prune as before.

**C. 15-minute push window loses tags on close.** Tags only reached the backend on the 15-min push cycle. Users tagging then closing the app within that window never got the tags backed up — uninstall/reinstall silently lost them.

*Fix:* 30-second debounced index-only push (`pushIndexOnly`) triggered from `setSessionFlag`. Coalesces rapid tagging into one small upload. Skipped if a full push is in flight (that push uploads the index anyway).

## Restore fix

Wipe-mode restore never pulled the conversation index because it isn't in any restore category. Merge mode worked (uses `syncService.pull()` which already includes the index), but wipe had to skip `pull()` to protect its atomic per-category swaps.

*Fix:* new `SyncService.pullConversationIndexOnly(backendId)` — narrow pull that only stages `system-backup/conversation-index.json` and merges it. `RestoreService.executeWipe` calls it after categories swap in, guarded by the conversations category being selected.

## Companion PR

Toolkit sync layer deletion: itsdestin/youcoded-core#114 — removes the bash-side sync code that was also racing with the app and stripping the `flags` field on every toolkit sync cycle. That PR lands first; this one survives standalone but the full end-to-end fix requires both.

## Test plan

Automated (`tests/sync-service-tags.test.ts`, 10 tests):
- [x] `setSessionFlag` with topic file present — seeds from topic file, not "Untitled"
- [x] `setSessionFlag` without topic file — seeds with epoch sentinel
- [x] `updateConversationIndex` scan overwrites epoch seed with real topic
- [x] Prune skips epoch-sentinel entries, still prunes real-old ones
- [x] 30s debounce — no push before 30s, push after
- [x] Debounce coalesces repeated calls
- [x] Debounce skips if full push in flight
- [x] `pullConversationIndexOnly` merges fetched remote into local
- [x] No-op when fetch produces no staged file
- [x] Early-returns for unknown backendId

Full suite: 361/362 pass (1 pre-existing flake in `transcript-watcher` unrelated to these changes — passes when run alone).

Manual:
- [ ] Tag a session, close the app within 30s, reopen — tag persists locally
- [ ] Tag a session, wait >30s, check backend has `flags` in conversation-index.json
- [ ] Wipe-restore the conversations category on a fresh install — tags come back
- [ ] Tag a brand-new session before its topic file exists — entry gets correct topic on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)