### PR TITLE
feat(integrations): plugin-backed install + icons + postInstallCommand

### DIFF
--- a/desktop/src/main/integration-installer.ts
+++ b/desktop/src/main/integration-installer.ts
@@ -1,18 +1,20 @@
-// Integration installer — Phase 3 scaffold.
+// Integration installer — plugin-wrapping flow.
 //
-// Today this reads the integrations index from the marketplace registry and
-// returns stub state. The actual install/uninstall/connect work is deferred
-// to a follow-up PR that ships Google Workspace as the first vertical slice.
+// setup.type === 'plugin' routes through the existing PluginInstaller +
+// ClaudeCodeRegistry rather than inventing a parallel install pipeline. After
+// a successful install, the returned state carries an optional
+// `postInstallCommand` so the renderer can spin up a fresh Sonnet session
+// that runs the setup command (e.g. /google-services-setup) without
+// interrupting the user's active session.
 //
-// Why ship a scaffold now:
-//   - Locks down the IPC shape + 4-file parity (no breaking changes later).
-//   - Lets the marketplace UI render an Integrations rail with real cards.
-//   - Makes the follow-up PR a purely "wire up the script runner + OAuth" job.
+// api-key / macos-only / script setup types are still stubs — tracked as
+// follow-ups once OAuth + keyring work lands.
 
 import fs from "fs";
 import path from "path";
 import os from "os";
-import type { IntegrationEntry, IntegrationIndex, IntegrationState } from "../shared/types";
+import type { IntegrationEntry, IntegrationIndex, IntegrationState, SkillEntry } from "../shared/types";
+import { installPlugin, uninstallPlugin } from "./plugin-installer";
 
 const REGISTRY_BASE = `https://raw.githubusercontent.com/itsdestin/wecoded-marketplace/${process.env.YOUCODED_MARKETPLACE_BRANCH || "master"}`;
 
@@ -21,8 +23,32 @@ const INTEGRATIONS_CACHE = path.join(CACHE_DIR, "integrations.json");
 const MANIFEST_PATH = path.join(os.homedir(), ".claude", "integrations.json");
 const CACHE_TTL = 24 * 60 * 60 * 1000;
 
+// Install response = state + optional post-install hint. The renderer consumes
+// `postInstallCommand` to spawn a new Sonnet session and run the command.
+export interface IntegrationInstallResult extends IntegrationState {
+  postInstallCommand?: string;
+}
+
+// The installer looks up plugin entries through a provider-shaped callback so
+// it doesn't have a hard dep on the SkillProvider class (keeps this file
+// unit-testable with a fake).
+export interface IntegrationInstallerDeps {
+  getPluginEntryById?: (id: string) => Promise<SkillEntry | null>;
+}
+
+// Map the current platform to the string the registry uses in `platforms`.
+function currentPlatform(): "darwin" | "linux" | "win32" | "unknown" {
+  if (process.platform === "darwin") return "darwin";
+  if (process.platform === "linux") return "linux";
+  if (process.platform === "win32") return "win32";
+  return "unknown";
+}
+
 export class IntegrationInstaller {
-  constructor() {
+  private deps: IntegrationInstallerDeps;
+
+  constructor(deps: IntegrationInstallerDeps = {}) {
+    this.deps = deps;
     if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
   }
 
@@ -39,6 +65,13 @@ export class IntegrationInstaller {
     } catch {
       return this.readCache(INTEGRATIONS_CACHE, Infinity) ?? empty();
     }
+  }
+
+  // Bust the cache — used after a cross-version schema bump so old cached
+  // entries without the new fields (iconUrl, platforms, plugin setup type)
+  // don't linger for 24h.
+  invalidateCatalogCache(): void {
+    try { fs.rmSync(INTEGRATIONS_CACHE, { force: true }); } catch { /* ignore */ }
   }
 
   // Manifest = ~/.claude/integrations.json. Single source of truth for which
@@ -66,39 +99,114 @@ export class IntegrationInstaller {
     return manifest[slug] ?? { slug, installed: false, connected: false };
   }
 
-  // STUB: installer. Records intent in the manifest and returns needs-auth so
-  // the card can show the right state. The actual OAuth/script execution ships
-  // with the Google Workspace vertical slice.
-  async install(slug: string): Promise<IntegrationState> {
+  async install(slug: string): Promise<IntegrationInstallResult> {
+    const catalog = await this.listCatalog();
+    const entry = (catalog.integrations || []).find((e) => e.slug === slug);
+    if (!entry) return this.recordFailure(slug, `Integration not found: ${slug}`);
+
+    // Refuse to install a planned ("Coming soon") entry even if the UI is
+    // out of sync — avoids a corrupted manifest that claims it's installed.
+    if (entry.status !== "available") {
+      return this.recordFailure(slug, `Integration is not available: status=${entry.status}`);
+    }
+
+    // Platform gate — honour entry.platforms if present.
+    if (entry.platforms && entry.platforms.length > 0) {
+      const cur = currentPlatform();
+      if (cur === "unknown" || !entry.platforms.includes(cur as any)) {
+        return this.recordFailure(slug, `Not supported on this platform (needs ${entry.platforms.join("/")})`);
+      }
+    }
+
+    if (entry.setup.type === "plugin") {
+      return this.installPluginBacked(entry);
+    }
+
+    // Non-plugin setup types — still stubs. Keep the manifest in sync with
+    // the UI so the user sees a clear error rather than a success that silently
+    // does nothing.
+    return this.recordFailure(slug, `setup.type "${entry.setup.type}" not yet implemented`);
+  }
+
+  private async installPluginBacked(entry: IntegrationEntry): Promise<IntegrationInstallResult> {
+    const pluginId = entry.setup.pluginId;
+    if (!pluginId) return this.recordFailure(entry.slug, "setup.pluginId missing");
+    if (!this.deps.getPluginEntryById) {
+      return this.recordFailure(entry.slug, "plugin lookup unavailable");
+    }
+
+    const plugin = await this.deps.getPluginEntryById(pluginId);
+    if (!plugin) return this.recordFailure(entry.slug, `Plugin not found in marketplace: ${pluginId}`);
+
+    // Hand off to the real plugin installer. It wires up all four Claude Code
+    // registries so /reload-plugins picks the plugin up.
+    const result = await installPlugin({
+      id: plugin.id,
+      sourceType: plugin.sourceType || "local",
+      sourceRef: plugin.sourceRef || plugin.id,
+      sourceSubdir: plugin.sourceSubdir,
+      sourceMarketplace: (plugin as any).sourceMarketplace,
+      description: plugin.description,
+      author: plugin.author,
+      version: plugin.version,
+    });
+
+    if (result.status === "failed") {
+      return this.recordFailure(entry.slug, result.error || "Plugin install failed");
+    }
+
     const manifest = this.readManifest();
     const state: IntegrationState = {
-      slug,
+      slug: entry.slug,
       installed: true,
-      connected: false,
-      error: "not-implemented: install flow lands with Google Workspace",
+      // `connected` stays false until the post-install setup actually wires
+      // up credentials. For plugins without a postInstallCommand we flip it
+      // true immediately since there's nothing else to do.
+      connected: !entry.setup.postInstallCommand,
+      lastSync: new Date().toISOString(),
     };
-    manifest[slug] = state;
+    manifest[entry.slug] = state;
     this.writeManifest(manifest);
-    return state;
+
+    return { ...state, postInstallCommand: entry.setup.postInstallCommand };
   }
 
   async uninstall(slug: string): Promise<IntegrationState> {
     const manifest = this.readManifest();
+    // Best-effort plugin removal. If the catalog lookup fails we still clear
+    // the manifest so the UI isn't stuck with an "installed" label.
+    try {
+      const catalog = await this.listCatalog();
+      const entry = (catalog.integrations || []).find((e) => e.slug === slug);
+      if (entry?.setup.type === "plugin" && entry.setup.pluginId) {
+        await uninstallPlugin(entry.setup.pluginId);
+      }
+    } catch { /* ignore — clear state below regardless */ }
+
     delete manifest[slug];
     this.writeManifest(manifest);
     return { slug, installed: false, connected: false };
   }
 
   async configure(slug: string, _settings: Record<string, unknown>): Promise<IntegrationState> {
-    // Deferred; real configure per-integration in the follow-up.
     const manifest = this.readManifest();
     const current = manifest[slug] ?? { slug, installed: false, connected: false };
     return { ...current, error: "not-implemented: configure" };
   }
 
-  // ── cache helpers (duplicated from skill-provider intentionally — keeping
-  // them small + local avoids coupling the two surfaces before we see if they
-  // actually want to share one utility) ──────────────────────────────────────
+  private recordFailure(slug: string, error: string): IntegrationInstallResult {
+    const manifest = this.readManifest();
+    const state: IntegrationState = {
+      slug,
+      installed: manifest[slug]?.installed ?? false,
+      connected: false,
+      error,
+    };
+    manifest[slug] = state;
+    this.writeManifest(manifest);
+    return state;
+  }
+
   private readCache(filePath: string, ttl: number): any {
     try {
       const raw = fs.readFileSync(filePath, "utf8");

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -218,9 +218,22 @@ export function registerIpcHandlers(
   // Phase 3a: pass the shared config store so theme installs also record into
   // the unified youcoded-skills.json packages map used for update tracking.
   const themeMarketplace = new ThemeMarketplaceProvider(skillProvider.configStore);
-  // Phase 3 scaffold — kept inline (not a constructor arg) so this file is
-  // the only thing that changes when the installer grows real OAuth wiring.
-  const integrationInstaller = new IntegrationInstaller();
+  // Phase 4: installer is now plugin-backed. Wire in a plugin lookup so the
+  // installer can resolve an integration's setup.pluginId to the marketplace
+  // entry that installPlugin() needs.
+  const integrationInstaller = new IntegrationInstaller({
+    getPluginEntryById: async (id: string) => {
+      try {
+        const entries = await skillProvider.listMarketplace();
+        return entries.find((e) => e.id === id) ?? null;
+      } catch {
+        return null;
+      }
+    },
+  });
+  // Drop any stale cached integrations index so the new schema fields
+  // (iconUrl, platforms, plugin setup) are picked up on first read.
+  integrationInstaller.invalidateCatalogCache();
 
   ipcMain.handle(IPC.THEME_MARKETPLACE_LIST, async (_event, filters) => {
     return themeMarketplace.listThemes(filters);

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -188,7 +188,7 @@ const IPC = {
 
 contextBridge.exposeInMainWorld('claude', {
   session: {
-    create: (opts: { name: string; cwd: string; skipPermissions: boolean; cols?: number; rows?: number; resumeSessionId?: string; provider?: 'claude' | 'gemini' }) =>
+    create: (opts: { name: string; cwd: string; skipPermissions: boolean; cols?: number; rows?: number; resumeSessionId?: string; provider?: 'claude' | 'gemini'; model?: string }) =>
       ipcRenderer.invoke(IPC.SESSION_CREATE, opts),
     destroy: (sessionId: string) =>
       ipcRenderer.invoke(IPC.SESSION_DESTROY, sessionId),

--- a/desktop/src/renderer/components/marketplace/IntegrationCard.tsx
+++ b/desktop/src/renderer/components/marketplace/IntegrationCard.tsx
@@ -2,10 +2,20 @@
 // on the right. Never mixed into a skill/theme grid (per design doc): only
 // rendered inside the dedicated integrations rail.
 
-import React from "react";
+import React, { useState } from "react";
 import type { IntegrationEntry, IntegrationState } from "../../../shared/types";
 
 export type IntegrationCardItem = IntegrationEntry & { state: IntegrationState };
+
+// Icons live in the marketplace repo at integrations/icons/. We resolve the
+// stored relative path against the same raw.githubusercontent.com base that
+// the rest of the registry fetches from, keeping app + registry in lockstep.
+const MARKETPLACE_BRANCH = "master";
+const ICON_BASE = `https://raw.githubusercontent.com/itsdestin/wecoded-marketplace/${MARKETPLACE_BRANCH}/integrations`;
+function resolveIconUrl(rel?: string): string | null {
+  if (!rel) return null;
+  return `${ICON_BASE}/${rel}`;
+}
 
 interface Props {
   item: IntegrationCardItem;
@@ -33,17 +43,31 @@ const TONE_CLASS: Record<string, string> = {
 export default function IntegrationCard({ item, onPrimary, busy }: Props) {
   const status = statusLabel(item);
   const planned = item.status === "planned";
+  const iconUrl = resolveIconUrl(item.iconUrl);
+  // Fall back to the letter tile if the icon fails to load — keeps the grid
+  // from breaking when a new entry is added without its asset yet.
+  const [iconFailed, setIconFailed] = useState(false);
+  const showIcon = iconUrl && !iconFailed;
   return (
     <div
       className="layer-surface flex items-start gap-4 p-4 min-w-[320px]"
       style={item.accentColor ? { borderColor: item.accentColor } : undefined}
     >
       <div
-        className="w-10 h-10 rounded-md shrink-0 flex items-center justify-center text-on-accent text-sm font-semibold"
-        style={{ background: item.accentColor || "var(--accent)" }}
+        className={`w-10 h-10 rounded-md shrink-0 flex items-center justify-center text-on-accent text-sm font-semibold overflow-hidden ${showIcon ? "bg-inset" : ""}`}
+        style={showIcon ? undefined : { background: item.accentColor || "var(--accent)" }}
         aria-hidden
       >
-        {item.displayName.slice(0, 1)}
+        {showIcon ? (
+          <img
+            src={iconUrl!}
+            alt=""
+            className="w-full h-full object-contain"
+            onError={() => setIconFailed(true)}
+          />
+        ) : (
+          item.displayName.slice(0, 1)
+        )}
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-start justify-between gap-2">

--- a/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
@@ -69,7 +69,30 @@ export default function MarketplaceScreen({
         // safe placeholder so users can recover from a stuck state.
         await (window as any).claude.integrations.uninstall(item.slug);
       } else {
-        await (window as any).claude.integrations.install(item.slug);
+        const result = await (window as any).claude.integrations.install(item.slug);
+        // setup.type === 'plugin' entries can carry a post-install slash
+        // command (e.g. /google-services-setup). Run it in a fresh Sonnet
+        // session so the user's active chat isn't hijacked by a multi-step
+        // OAuth walkthrough.
+        if (result?.postInstallCommand) {
+          const info = await (window as any).claude.session.create({
+            name: `Set up ${item.displayName}`,
+            cwd: "", // main falls back to home dir when blank
+            skipPermissions: false,
+            model: "claude-sonnet-4-6",
+          });
+          if (info?.id) {
+            // Pragmatic fixed delay — the CLI takes ~1–2s to reach the
+            // prompt. Claude Code buffers stdin until ready, so an early
+            // send is tolerated; a late send is the common case.
+            setTimeout(() => {
+              try {
+                (window as any).claude.session.sendInput(info.id, result.postInstallCommand + "\r");
+              } catch { /* user can type the command themselves */ }
+            }, 3000);
+            onExit(); // land on the new session
+          }
+        }
       }
       await refreshIntegrations();
     } finally {

--- a/desktop/src/renderer/state/marketplace-context.tsx
+++ b/desktop/src/renderer/state/marketplace-context.tsx
@@ -159,7 +159,12 @@ export function MarketplaceProvider({ children }: { children: React.ReactNode })
       // upstream plugins that no longer exist (e.g. pre-decomposition
       // journaling-assistant prompt stubs). Metadata is preserved in the
       // registry but shouldn't surface in the install UI.
-      setSkillEntries((marketplaceSkills || []).filter((e: any) => !e.deprecated));
+      // Also filter integrationOnly entries — those plugins (e.g. imessage,
+      // google-services) are surfaced through the Integrations tile instead
+      // and would double-list if shown in the plugins grid too.
+      setSkillEntries(
+        (marketplaceSkills || []).filter((e: any) => !e.deprecated && !e.integrationOnly),
+      );
       setThemeEntries(themes || []);
       setInstalledSkills(installed || []);
       setFavoritesState(favs || []);

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -171,6 +171,11 @@ export interface SkillEntry {
   deprecated?: boolean;
   deprecatedAt?: string;
 
+  // When true, the plugins grid should hide this entry because it is surfaced
+  // through the dedicated Integrations tile instead (e.g. google-services,
+  // imessage). The entry is still installable — just not double-listed.
+  integrationOnly?: boolean;
+
   // Source info from index.json — needed by the in-app file viewer to fetch
   // raw SKILL.md/commands/agents content when the plugin isn't installed.
   // 'local' = subdir in wecoded-marketplace repo (sourceRef is that subdir).
@@ -294,7 +299,9 @@ export interface FeaturedData {
 }
 
 // Marketplace redesign Phase 3 — integrations as a first-class kind.
-export type IntegrationKind = 'mcp' | 'shell' | 'http';
+// 'plugin' kind wraps an existing marketplace plugin + optional post-install
+// slash command, avoiding a second install pipeline.
+export type IntegrationKind = 'mcp' | 'shell' | 'http' | 'plugin';
 export type IntegrationStatusValue =
   | 'not-installed'
   | 'installing'
@@ -303,11 +310,15 @@ export type IntegrationStatusValue =
   | 'error';
 
 export interface IntegrationSetup {
-  type: 'script' | 'api-key' | 'macos-only';
+  type: 'script' | 'api-key' | 'macos-only' | 'plugin';
   path?: string;
   requiresOAuth?: boolean;
   oauthProvider?: string;
   keyName?: string;
+  // setup.type === 'plugin' — the marketplace plugin id to install and an
+  // optional slash command the app runs in a fresh session after install.
+  pluginId?: string;
+  postInstallCommand?: string;
 }
 
 export interface IntegrationEntry {
@@ -320,6 +331,12 @@ export interface IntegrationEntry {
   status: 'available' | 'planned' | 'deprecated';
   accentColor?: string;
   lifeArea?: string[];
+  // Relative path under integrations/icons/ in the marketplace repo; the UI
+  // resolves this against the raw.githubusercontent.com base URL.
+  iconUrl?: string;
+  // Platforms where this integration can run. When present and the current
+  // platform isn't listed, the card shows a "<platform>-only" affordance.
+  platforms?: Array<'darwin' | 'linux' | 'win32'>;
 }
 
 export interface IntegrationIndex {


### PR DESCRIPTION
## Summary

- Makes the marketplace **Integrations** tile actually install things instead of writing "not-implemented" to the manifest (integration-installer.ts:72 scaffold, now real).
- Adds `iconUrl` + `platforms` to `IntegrationEntry` and a new `setup.type: 'plugin'` that wraps an existing marketplace plugin (`pluginId`) plus an optional `postInstallCommand`.
- On install, the renderer spawns a **fresh Claude-Sonnet-4.6 session** and runs the post-install slash command (e.g. `/google-services-setup`) so OAuth walkthroughs don't hijack the user's active chat.
- Plugins grid filters `integrationOnly: true` entries so google-services + imessage stop double-listing once they're surfaced through the tile.

## Why

Pairs with [wecoded-marketplace#7](https://github.com/itsdestin/wecoded-marketplace/pull/7) — that PR shipped the `google-services` plugin but left the integrations tile unchanged. Without these desktop changes, clicking "Install" on the Google Services tile would write a fake state to `~/.claude/integrations.json` and the user would see `not-implemented: install flow lands with Google Workspace` in the card's error pill.

## Changes

- `shared/types.ts`: new fields on `IntegrationEntry` (`iconUrl`, `platforms`, `integrationOnly` on `SkillEntry`), new `'plugin'` variant on `IntegrationSetup` with `pluginId` + `postInstallCommand`.
- `main/integration-installer.ts`: real install for `setup.type === 'plugin'` via `installPlugin()` + `ClaudeCodeRegistry`. Platform gate. Cache invalidation on startup. Constructor takes a `getPluginEntryById` DI callback.
- `main/ipc-handlers.ts`: wires SkillProvider lookup into the installer.
- `main/preload.ts`: `session.create` opts now type-includes `model`.
- `renderer/components/marketplace/IntegrationCard.tsx`: renders `iconUrl` with letter-tile fallback on load error.
- `renderer/components/marketplace/MarketplaceScreen.tsx`: on install response, if `postInstallCommand` is present, creates a fresh Sonnet session and sends the command after a 3s boot delay.
- `renderer/state/marketplace-context.tsx`: filters `integrationOnly: true` from the plugins grid so imessage + google-services aren't double-listed.

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `npm test` — 328 passing, 34 skipped (no regressions)
- [ ] Manual: open Marketplace → Integrations → install Google Services → confirm a new "Set up Google Services" session opens and `/google-services-setup` runs
- [ ] Manual: confirm imessage no longer appears in the plugins grid, only the integrations rail
- [ ] Manual: confirm Windows/macOS Control tiles render with retro icons and "Coming soon" badges

## Follow-ups

- Real **settings panel** for installed integrations (currently re-clicking uninstalls — Phase-3 placeholder).
- `api-key` setup type is still stubbed; Todoist needs to migrate to an MCP install + auth flow.
- `applescript`, `apple-services`, `github`, `canva`, `macos-control`, `windows-control` ship as "Coming soon" tiles — concrete install wiring later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)