### PR TITLE
fix(theme): derive inline-code color from theme tokens

### DIFF
--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -25,7 +25,7 @@
   --edge-dim: #DCDCDC80;
   --scrollbar-thumb: #C0C0C0;
   --scrollbar-hover: #999999;
-  --code: #8B6914;
+  /* --code is computed per-theme by theme-engine.ts from --accent / --fg-2 so community themes get a palette-matched inline-code color instead of inheriting a hardcoded yellow from :root. */
   --link: #2563EB;
   --link-hover: #1D4ED8;
   --hl-theme: light;
@@ -57,7 +57,6 @@
   --edge-dim: #37373780;
   --scrollbar-thumb: #333333;
   --scrollbar-hover: #555555;
-  --code: #D4A843;
   --link: #66AAFF;
   --link-hover: #88CCFF;
   --hl-theme: dark;
@@ -89,7 +88,6 @@
   --edge-dim: #30363D80;
   --scrollbar-thumb: #30363D;
   --scrollbar-hover: #484F58;
-  --code: #C9A84C;
   --link: #58A6FF;
   --link-hover: #79C0FF;
   --hl-theme: dark;
@@ -121,7 +119,6 @@
   --edge-dim: #D4C8B580;
   --scrollbar-thumb: #CBBFB0;
   --scrollbar-hover: #A89A8A;
-  --code: #7A5D2E;
   --link: #5B4A1E;
   --link-hover: #3D3219;
   --hl-theme: light;

--- a/desktop/src/renderer/themes/theme-engine.ts
+++ b/desktop/src/renderer/themes/theme-engine.ts
@@ -195,12 +195,25 @@ export function computeOverlayTokens(
   // dark themes rely more on borders so shadows can be subtle.
   const shadowStrength = overlay?.['shadow-strength'] ?? (lum > 0.2 ? 0.2 : 0.1);
 
+  // Inline-code color — prefer the theme's accent so code picks up palette
+  // character, but fall back to fg-2 when accent is too close to fg (some
+  // themes use accent == fg for high-contrast buttons, which would make code
+  // invisible against prose). Previously this was a hardcoded yellow/gold in
+  // globals.css that community themes silently inherited from :root.
+  const [fgR, fgG, fgB] = parseHex(tokens.fg);
+  const [accR, accG, accB] = parseHex(tokens.accent);
+  const accentFgDistance = Math.sqrt(
+    (accR - fgR) ** 2 + (accG - fgG) ** 2 + (accB - fgB) ** 2,
+  );
+  const code = accentFgDistance > 40 ? tokens.accent : tokens['fg-2'];
+
   const result: Record<string, string> = {
     '--scrim': overlay?.scrim ?? `rgba(${scrimR}, ${scrimG}, ${scrimB}, 0.5)`,
     '--scrim-heavy': overlay?.['scrim-heavy'] ?? `rgba(${scrimR}, ${scrimG}, ${scrimB}, 0.7)`,
     '--shadow-strength': String(shadowStrength),
     '--destructive': overlay?.destructive ?? '#DD4444',
     '--destructive-dim': `rgba(${parseHex(overlay?.destructive ?? '#DD4444').join(', ')}, 0.15)`,
+    '--code': code,
   };
 
   return result;


### PR DESCRIPTION
## Summary
- Replaces the hardcoded inline-code color in `globals.css` with a value derived from the active theme's tokens in `theme-engine.ts`.
- Inline `<code>` elements now respect the user's theme instead of clashing on dark/colored themes.

## Test plan
- [ ] Switch through several themes and confirm inline code in chat messages picks up a readable, theme-appropriate color.
- [ ] Verify reduced-effects mode still renders inline code legibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)