### PR TITLE
fix(terminal): dedup PTY resize when dimensions unchanged

### DIFF
--- a/desktop/src/renderer/components/TerminalView.tsx
+++ b/desktop/src/renderer/components/TerminalView.tsx
@@ -142,15 +142,27 @@ export default function TerminalView({ sessionId, visible }: Props) {
     // Fit terminal to container and sync dimensions to PTY.
     // Skip when container is collapsed to 0x0 (hidden terminals) to avoid
     // setting a 1-column width on the PTY that causes text bunching.
+    //
+    // Dedup on unchanged dims: Windows ConPTY (used by node-pty on Win) reflows
+    // and re-emits visible buffer contents on every resize call. The
+    // ResizeObserver fires for any layout shift (font load, sibling resize,
+    // 1-pixel container jitter), and fit() can return the same cols/rows
+    // across ticks. Without dedup, each spurious resize re-emits Claude's
+    // Ink-rendered UI (banner + input bar) into xterm scrollback — so
+    // scrolling back looks like the same chunk repeated between every turn.
+    let lastCols = 0;
+    let lastRows = 0;
     const fitAndSync = () => {
       try {
         const el = containerRef.current;
         if (!el || el.clientWidth === 0 || el.clientHeight === 0) return;
         fitAddon.fit();
         const dims = fitAddon.proposeDimensions();
-        if (dims && dims.cols && dims.rows) {
-          window.claude.session.resize(sessionId, dims.cols, dims.rows);
-        }
+        if (!dims || !dims.cols || !dims.rows) return;
+        if (dims.cols === lastCols && dims.rows === lastRows) return;
+        lastCols = dims.cols;
+        lastRows = dims.rows;
+        window.claude.session.resize(sessionId, dims.cols, dims.rows);
       } catch {
         // Ignore fit errors during teardown
       }


### PR DESCRIPTION
## Summary
- ResizeObserver in \`TerminalView\` was triggering a PTY SIGWINCH on every layout tick, even when \`fitAddon.proposeDimensions()\` returned the same cols/rows as the previous call.
- On Windows, that routes through node-pty → ConPTY, which reflows its visible buffer on every resize and re-emits the repainted contents to the terminal. Claude Code's Ink UI (intro banner + input bar) was getting re-emitted into xterm scrollback each time.
- Result: scrolling back through terminal history showed the same banner/UI chunk repeated between every user message.
- Fix: track last sent cols/rows inside \`fitAndSync\` and skip the IPC when dims are unchanged.

## Test plan
- [ ] Fresh session, don't move the window, chat 5+ turns — scrollback should show linear history with **no** repeating banner.
- [ ] Same session but resize the window slightly between turns — still no repeating banner accumulating per resize.
- [ ] Real dimension changes (drag-resize, fullscreen toggle) still propagate to the PTY: Claude's UI reflows correctly on real size changes.
- [ ] Android WebView path unaffected (the resize IPC pipe is the same but Termux's Linux PTY has no reflow behavior to guard against anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)