### PR TITLE
fix(android): four parity / lifecycle fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,10 +22,18 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar">
 
+        <!-- configChanges: keep this list maximal. Without it, every soft-keyboard
+             show/hide, rotation, dark-mode toggle, or multi-window resize destroys
+             MainActivity, which destroys the WebView (wiping React chat state and
+             active-session tracking) and re-runs initBootstrap (which re-installs
+             bundled plugins → /reload-plugins gets typed into the live session).
+             Process death from memory reclaim still recreates the Activity and is
+             handled separately by a state-rehydration path. -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustNothing">
+            android:windowSoftInputMode="adjustNothing"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboard|keyboardHidden|navigation|uiMode|locale|fontScale|density">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/kotlin/com/youcoded/app/runtime/ManagedSession.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/ManagedSession.kt
@@ -89,8 +89,12 @@ class ManagedSession(
     var bridgeServer: LocalBridgeServer? = null
 
     /** Current Claude Code permission mode, detected from terminal status bar.
-     *  Values match React's PermissionMode type: "normal" | "auto-accept" | "plan" | "bypass". */
-    var permissionMode: String = "normal"
+     *  Values match React's PermissionMode type: "normal" | "auto-accept" | "plan" | "bypass".
+     *  Fix: initialize to "bypass" when dangerousMode (parity with desktop session-manager.ts:93).
+     *  Without this, SessionStrip's danger indicator never lit up because it reads
+     *  permissionMode === "bypass", not the dangerousMode flag. The user can still cycle
+     *  modes with Shift+Tab during the session — the cycle handler updates this field. */
+    var permissionMode: String = if (dangerousMode) "bypass" else "normal"
 
     /** Draft text in the input bar — shared across Chat/Terminal/Shell modes */
     var inputDraft by mutableStateOf(TextFieldValue())

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -709,7 +709,12 @@ class SessionService : Service() {
                 val info = MessageRouter.buildSessionInfo(
                     id = session.id, name = session.name.value,
                     cwd = cwd, status = "active",
-                    permissionMode = "normal", skipPermissions = dangerous,
+                    // Fix: derive permissionMode from the dangerous flag (parity with
+                    // desktop session-manager.ts). Hardcoding "normal" here meant the
+                    // initial session:created broadcast told React permissionMode=normal
+                    // even when dangerous=true, so SessionStrip's danger indicator missed
+                    // until the next cycle of session:list. Now correct from message #1.
+                    permissionMode = if (dangerous) "bypass" else "normal", skipPermissions = dangerous,
                     createdAt = session.createdAt,
                     // Pass the resolved model (payload > model-preference.json > "sonnet")
                     // so React's status-bar switcher shows the right alias immediately,

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SyncService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SyncService.kt
@@ -108,7 +108,14 @@ class SyncService(
                 val stalePid = appSyncMarkerPath.readText().trim().toIntOrNull() ?: 0
                 val myPid = android.os.Process.myPid()
                 if (stalePid > 0 && stalePid != myPid && !isPidAlive(stalePid)) {
-                    logBackup("WARN", "Cleaned stale .app-sync-active marker (PID $stalePid is dead — previous crash?)", "sync.lifecycle")
+                    // Fix: log at INFO (was WARN). The cleanup is a benign self-heal —
+                    // the foreground service's PID dies any time the system reclaims it
+                    // for memory (frequent on aggressive vendors), so this fires on most
+                    // restarts. The SyncPanel's log viewer renders the last 30 backup.log
+                    // lines and styles WARN entries prominently, making routine recovery
+                    // look like a persistent error. INFO keeps the diagnostic trail without
+                    // crying wolf. Mirror in desktop/src/main/sync-service.ts.
+                    logBackup("INFO", "Cleaned stale .app-sync-active marker (PID $stalePid is dead — previous crash?)", "sync.lifecycle")
                 }
             }
         } catch (_: Exception) {}

--- a/app/src/main/kotlin/com/youcoded/app/skills/PluginInstaller.kt
+++ b/app/src/main/kotlin/com/youcoded/app/skills/PluginInstaller.kt
@@ -97,8 +97,17 @@ class PluginInstaller(
             }
 
             // Guard: already installed via YouCoded
+            // Fix: accept the manifest at either ".claude-plugin/plugin.json" OR root
+            // "plugin.json". Some plugins (incl. our bundled wecoded-themes-plugin and
+            // wecoded-marketplace-publisher) ship the manifest at the root, and
+            // ensurePluginJson() does NOT normalize when a root manifest exists ("Claude
+            // Code will find it at root"). Without this dual-path check, every launch
+            // missed the guard, re-ran installFromLocal, returned Success, fired
+            // onPluginsChanged, and typed /reload-plugins into the active session.
             val targetDir = File(pluginsDir, id)
-            if (targetDir.exists() && File(targetDir, ".claude-plugin/plugin.json").exists()) {
+            val hasManifest = File(targetDir, ".claude-plugin/plugin.json").exists() ||
+                File(targetDir, "plugin.json").exists()
+            if (targetDir.exists() && hasManifest) {
                 return@withContext InstallResult.AlreadyInstalled("YouCoded")
             }
 

--- a/desktop/src/main/sync-service.ts
+++ b/desktop/src/main/sync-service.ts
@@ -181,7 +181,10 @@ export class SyncService extends EventEmitter {
       if (this.fileExists(this.appSyncMarkerPath)) {
         const stalePid = parseInt(fs.readFileSync(this.appSyncMarkerPath, 'utf8').trim(), 10);
         if (stalePid > 0 && stalePid !== process.pid && !this.isPidAlive(stalePid)) {
-          this.logBackup('WARN', `Cleaned stale .app-sync-active marker (PID ${stalePid} is dead — previous crash?)`, 'sync.lifecycle');
+          // Fix: log at INFO (was WARN). Mirrors Android — see app/.../SyncService.kt.
+          // The SyncPanel log viewer renders WARN entries prominently, making this
+          // benign self-heal look like a persistent error after any system kill.
+          this.logBackup('INFO', `Cleaned stale .app-sync-active marker (PID ${stalePid} is dead — previous crash?)`, 'sync.lifecycle');
         }
       }
     } catch {}


### PR DESCRIPTION
## Summary

Four small fixes that close Android↔Desktop parity gaps and stop the WebView from recreating on routine UI events. Diagnosed via adb against a live debug build (`R5CY72QFCZB`); `dumpsys activity` had already accumulated three `MainActivity` history records in a single task before the manifest fix landed.

- **`/reload-plugins` on every relaunch** (`PluginInstaller.kt`) — bundled-plugin idempotency guard now accepts `plugin.json` at the package root, not just under `.claude-plugin/`. Bundled plugins (`wecoded-themes-plugin`, `wecoded-marketplace-publisher`) ship at root, and `ensurePluginJson` deliberately skips creating the dotted form when a root manifest exists, so the guard missed every launch and re-fired `installFromLocal` → `onPluginsChanged` → `/reload-plugins\r` typed into the live session.
- **Danger indicator missing on skip-permissions sessions** (`ManagedSession.kt` + `SessionService.kt`) — derive `permissionMode` from `dangerousMode` at construction *and* in the `session:create` response, mirroring desktop `session-manager.ts`. SessionStrip reads `permissionMode === "bypass"`; the field was hardcoded `"normal"` everywhere on Android.
- **Stale "Cleaned stale .app-sync-active marker" warning in sync menu** (`SyncService.kt` + desktop `sync-service.ts`) — demote benign self-heal log from `WARN` to `INFO`. The SyncPanel log viewer renders the last 30 backup.log lines and styles WARN entries prominently, so routine recovery looked like a persistent error.
- **MainActivity recreates on every soft-keyboard / rotation / dark-mode toggle** (`AndroidManifest.xml`) — declare `configChanges` so the Activity handles these in-process. Recreation destroys the WebView (wiping React chat state and active-session tracking) and re-runs `initBootstrap` (re-installing bundled plugins → `/reload-plugins`). Process-death rehydration is out of scope and tracked separately.

## Test plan

- [ ] **App: leave + re-enter** — `/reload-plugins` does NOT appear in the chat
- [ ] **App: launch with `--dangerously-skip-permissions`** — danger indicator on session pill from the first message
- [ ] **App: Settings → Sync → log viewer** — no persistent WARN about stale marker
- [ ] **App: rotate device / toggle dark mode / show+hide soft keyboard** — chat history persists; terminal stays attached to the right session
- [ ] **Desktop: backup.log** shows INFO (not WARN) for any stale-marker self-heal

🤖 Generated with [Claude Code](https://claude.com/claude-code)