### PR TITLE
fix(android): restore menu navigation on pre-session prompts

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/PtyBridge.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/PtyBridge.kt
@@ -212,10 +212,23 @@ class PtyBridge(
         // sending `\r`, eliminating the 600 ms timing assumption entirely. Not
         // urgent on Android because Linux PTY scheduling is more predictable
         // than ConPTY, but desirable for parity with desktop's design.
+        //
+        // Special case — payloads containing ESC bytes (0x1b) MUST take the
+        // split path even when short. ManagedSession.detectPrompts and
+        // InkSelectParser.toPromptButtons build menu-navigation payloads of
+        // the form `<UPs><DOWNs>\r` (sign-in, theme, trust-folder, bypass).
+        // These are 13–25 bytes — well under SAFE_ATOMIC_LEN — but writing
+        // arrows + Enter atomically causes Ink's Select component to either
+        // miss the navigation or commit Enter on the wrong row. The 600 ms
+        // gap was the original mechanism (pre-cc007084) that made multi-arrow
+        // nav work; the atomic fast-path silently broke all four pre-session
+        // menus. Splitting only escape-containing payloads preserves the
+        // chat-message fast path while fixing menu navigation.
         val SAFE_ATOMIC_LEN = 56
+        val hasEscape = text.any { it.code == 0x1b }
         when {
             !text.endsWith("\r") -> session?.write(text)
-            text.length <= SAFE_ATOMIC_LEN -> session?.write(text)
+            !hasEscape && text.length <= SAFE_ATOMIC_LEN -> session?.write(text)
             else -> {
                 val preamble = text.dropLast(1)
                 session?.write(preamble)

--- a/desktop/src/renderer/components/marketplace/MarketplaceHero.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceHero.tsx
@@ -32,15 +32,15 @@ export default function MarketplaceHero({ slots, lookup, onOpen }: Props) {
     <section
       role="region"
       aria-label="Featured"
-      className="layer-surface relative overflow-hidden min-h-[180px] p-6 flex flex-col justify-end gap-2"
+      className="layer-surface relative overflow-hidden min-h-[110px] sm:min-h-[180px] p-4 sm:p-6 flex flex-col justify-end gap-2"
       style={slot.accentColor ? { borderColor: slot.accentColor } : undefined}
     >
       <div className="relative z-10">
         <p className="text-xs uppercase tracking-wide text-fg-dim">Featured</p>
-        <h2 className="text-2xl font-semibold text-fg">
+        <h2 className="text-base sm:text-2xl font-semibold text-fg">
           {entry?.displayName || slot.id}
         </h2>
-        <p className="text-sm text-fg-2 max-w-xl mt-1">{slot.blurb}</p>
+        <p className="text-sm text-fg-2 max-w-xl mt-1 line-clamp-1 sm:line-clamp-none">{slot.blurb}</p>
         <button
           type="button"
           onClick={() => onOpen(slot.id)}


### PR DESCRIPTION
## Summary

Commit `cc007084` added an atomic fast-path to `PtyBridge.writeInput` for sends ≤56 bytes ending in `\r` — empirically safe for short typed chat messages, but it silently broke every pre-session prompt menu on Android:

- **Trust This Folder?**
- **Choose a Theme for the Terminal**
- **Select Login Method**
- **Bypass Permissions**

Their button payloads are escape-containing arrow-then-Enter sequences (13–25 bytes — well under the 56-byte threshold) built by `ManagedSession.detectPrompts` and `InkSelectParser.toPromptButtons` of the form `<UPs><DOWNs>\r`. Pre-`cc007084` these always took the split path (body, 600ms gap, then `\r`), which gave Ink's Select component time to settle the cursor before Enter committed. The atomic fast-path collapsed body+Enter into one write — Ink either missed the navigation entirely or committed Enter on the wrong row.

## Fix

Force the split path when the payload contains any ESC byte (`0x1b`). One predicate added; the rest of `writeInput` is unchanged.

```kotlin
val SAFE_ATOMIC_LEN = 56
val hasEscape = text.any { it.code == 0x1b }
when {
    !text.endsWith("\r") -> session?.write(text)
    !hasEscape && text.length <= SAFE_ATOMIC_LEN -> session?.write(text)
    else -> { /* split: body, 600ms gap, then \r */ }
}
```

Preserves the chat-message fast-path (typed text has no escapes) while restoring the pre-regression behavior for the four menus.

## Verification

Verified live on a freshly-cleared install (`adb shell pm clear` + reinstall): trust folder, theme picker, and login method menu taps all land on the chosen option from the first try.

## Follow-up

Desktop `pty-worker.js` has an analogous atomic fast-path landed in the same commit (`cc007084`) and likely shares this regression for any code path that calls `claude.session.sendInput(...)` with escape-containing payloads. Tracking as a separate PR after on-device-equivalent verification on desktop.

## Test plan

- [ ] Clear app data, reinstall, walk through tier picker → bootstrap → Trust This Folder → Choose Theme → Select Login Method
- [ ] Each menu tap commits the option you actually tapped (not the row before/after, not nothing)
- [ ] Launch a session with `--dangerously-skip-permissions` later — Bypass Permissions "Accept the Risks" tap commits cleanly
- [ ] Type a normal chat message ("yes\r") — atomic fast-path still active, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)