### PR TITLE
fix(chat): subagent end_turn no longer pollutes parent model pill

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -755,6 +755,12 @@ function AppInner() {
             model: event.data.model ?? null,
             anthropicRequestId: event.data.anthropicRequestId ?? null,
             usage: event.data.usage ?? null,
+            // Forward the subagent stamp so the reducer can drop a sub-agent's
+            // end_turn instead of overwriting parent turn.model and tearing down
+            // the parent's in-flight state via endTurn(). Mirrors assistant-text /
+            // tool-use / tool-result dispatches above.
+            parentAgentToolUseId: event.data.parentAgentToolUseId,
+            agentId: event.data.agentId,
           });
           break;
         case 'assistant-thinking':

--- a/desktop/src/renderer/components/buddy/BubbleFeed.tsx
+++ b/desktop/src/renderer/components/buddy/BubbleFeed.tsx
@@ -169,6 +169,10 @@ export function BubbleFeed({ sessionId }: Props) {
             model: event.data.model ?? null,
             anthropicRequestId: event.data.anthropicRequestId ?? null,
             usage: event.data.usage ?? null,
+            // Forward the subagent stamp so the reducer can drop a sub-agent's
+            // end_turn instead of polluting parent turn.model — see App.tsx mirror.
+            parentAgentToolUseId: event.data.parentAgentToolUseId,
+            agentId: event.data.agentId,
           });
           break;
         case 'assistant-thinking':

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -657,6 +657,18 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     }
 
     case 'TRANSCRIPT_TURN_COMPLETE': {
+      // A sub-agent's end_turn must NOT reach into parent state. Without
+      // this guard the parent turn's `model` gets overwritten with the
+      // sub-agent's model (the status-bar pill silently flips, and the
+      // drift-reconciliation effect in App.tsx persists it via
+      // setPreference), and endTurn() prematurely tears down the parent's
+      // in-flight turn — flagging the still-running Task tool as failed
+      // and tripping the attention banner. Mirrors the same guard on
+      // TRANSCRIPT_ASSISTANT_TEXT / TOOL_USE / TOOL_RESULT above. We don't
+      // delegate to applySubagentEvent here because a sub-agent's end_turn
+      // produces no visible nested segment — the parent's own tool-result
+      // for the Task tool is what completes the agent in the UI.
+      if (action.parentAgentToolUseId) return state;
       const session = next.get(action.sessionId);
       if (!session) return state;
 

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -289,6 +289,11 @@ export type ChatAction =
       model: string | null;
       anthropicRequestId: string | null;
       usage: TurnUsage | null;
+      // Stamped by SubagentWatcher onto turn-complete events that originate
+      // in a sub-agent JSONL. Reducer must drop these so a sub-agent's
+      // end_turn doesn't pollute parent state — see chat-reducer.ts.
+      parentAgentToolUseId?: string;
+      agentId?: string;
     }
   // Dispatched when the transcript watcher detects Claude Code's
   // user-interrupt markers ("[Request interrupted by user]" / "...for tool

--- a/desktop/tests/transcript-reducer.test.ts
+++ b/desktop/tests/transcript-reducer.test.ts
@@ -621,4 +621,64 @@ describe('Subagent threading', () => {
     const parent = session.toolCalls.get('toolu_parent')!;
     expect(parent.subagentSegments!.length).toBe(1);
   });
+
+  // Regression: a sub-agent's end_turn was reaching into parent state because
+  // TRANSCRIPT_TURN_COMPLETE lacked the parentAgentToolUseId guard that the
+  // other three transcript handlers have. The visible symptom was the
+  // status-bar model pill flipping to the sub-agent's model mid-turn (and the
+  // drift-reconciliation effect persisting it via setPreference).
+  it('subagent TRANSCRIPT_TURN_COMPLETE does not pollute parent turn.model or call endTurn', () => {
+    // User sent a prompt — isThinking flips to true.
+    state = chatReducer(state, {
+      type: 'TRANSCRIPT_USER_MESSAGE',
+      sessionId: SESSION,
+      uuid: 'uuid-user',
+      text: 'Run an agent for me',
+      timestamp: 999,
+    });
+    // Parent emits assistant text on its own turn so turn.model is set to the
+    // parent's model (opus), then dispatches the Agent tool_use.
+    state = chatReducer(state, {
+      type: 'TRANSCRIPT_ASSISTANT_TEXT',
+      sessionId: SESSION,
+      uuid: 'uuid-parent-text',
+      text: 'Dispatching an agent…',
+      timestamp: 1000,
+      model: 'claude-opus-4-7',
+    });
+    state = emitParentAgentToolUse();
+
+    const parentTurnId = state.get(SESSION)!.currentTurnId!;
+    expect(parentTurnId).not.toBeNull();
+    expect(state.get(SESSION)!.assistantTurns.get(parentTurnId)!.model).toBe('claude-opus-4-7');
+    expect(state.get(SESSION)!.isThinking).toBe(true);
+
+    // Sub-agent's final assistant message: parseTranscriptLine emits a
+    // turn-complete event, SubagentWatcher stamps it with parentAgentToolUseId.
+    state = chatReducer(state, {
+      type: 'TRANSCRIPT_TURN_COMPLETE',
+      sessionId: SESSION,
+      uuid: 'uuid-subagent-done',
+      timestamp: 2000,
+      stopReason: 'end_turn',
+      model: 'claude-haiku-4-5-20251001',
+      anthropicRequestId: 'req_subagent',
+      usage: null,
+      parentAgentToolUseId: 'toolu_parent',
+      agentId: 'abc',
+    });
+
+    const session = state.get(SESSION)!;
+    // Parent turn.model must remain the parent's model — the drift-reconciliation
+    // effect in App.tsx walks back to find this value and would silently flip
+    // (and persist) the status-bar pill if the sub-agent's model leaked through.
+    expect(session.assistantTurns.get(parentTurnId)!.model).toBe('claude-opus-4-7');
+    expect(session.assistantTurns.get(parentTurnId)!.stopReason).toBeNull();
+    expect(session.assistantTurns.get(parentTurnId)!.anthropicRequestId).toBeNull();
+    // endTurn() must NOT have run — parent is still in-flight running the agent.
+    expect(session.currentTurnId).toBe(parentTurnId);
+    expect(session.isThinking).toBe(true);
+    // The parent's Task tool must not have been flipped to 'failed: Turn ended'.
+    expect(session.toolCalls.get('toolu_parent')!.status).not.toBe('failed');
+  });
 });


### PR DESCRIPTION
## Summary
- A sub-agent's `TRANSCRIPT_TURN_COMPLETE` was reaching into parent session state because the action lacked the `parentAgentToolUseId` guard that the three sibling transcript handlers (`ASSISTANT_TEXT` / `TOOL_USE` / `TOOL_RESULT`) all have.
- Visible symptom: when an agent runs with a different model (e.g. Haiku via Task tool while the main session is on Opus), the status-bar model pill silently flips to the sub-agent's model and is even persisted via `setPreference` by the drift-reconciliation effect.
- Hidden side effects: the in-flight Task tool briefly flashes `failed: Turn ended` (because `endTurn()` flips `activeTurnToolIds` to failed), `isThinking` clears mid-turn, and the attention banner can trip.

## Fix (5 files, +87 lines)
- `chat-types.ts` — add optional `parentAgentToolUseId` / `agentId` to the `TRANSCRIPT_TURN_COMPLETE` action shape.
- `App.tsx` + `BubbleFeed.tsx` — forward both fields in the `turn-complete` dispatchers (mirror of `assistant-text` / `tool-use` / `tool-result`).
- `chat-reducer.ts` — early-return at the top of the `TRANSCRIPT_TURN_COMPLETE` case when `parentAgentToolUseId` is set. We drop the event rather than routing through `applySubagentEvent` because a sub-agent's `end_turn` produces no visible nested segment — the parent's own `tool-result` for the Task tool is what completes the agent in the UI.
- `transcript-reducer.test.ts` — regression test that fails without the guard with `expected 'claude-haiku-4-5-...' to be 'claude-opus-4-7'`.

## Test plan
- [x] `npm test` — 889 passing (was 888 baseline + 1 new regression test), 0 regressions.
- [x] `tsc --noEmit` — clean.
- [x] Bug-pinning confirmed: temporarily reverted the guard line and the new test failed with exactly the expected drift; restored.
- [ ] Manual smoke: dispatch a Task agent that uses a different model from the main session and confirm the status-bar pill stays on the main session's model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)