### PR TITLE
fix(theme-effects): mask chrome regions out of particle canvas

### DIFF
--- a/desktop/src/renderer/components/ThemeEffects.tsx
+++ b/desktop/src/renderer/components/ThemeEffects.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTheme } from '../state/theme-context';
 import { useChromeGeometry } from '../hooks/useChromeGeometry';
 import {
@@ -143,16 +143,6 @@ export default function ThemeEffects() {
     chromeRectsRef.current = chromeRects;
   }, [chromeRects]);
 
-  const [viewport, setViewport] = useState(() => ({
-    width: typeof window !== 'undefined' ? window.innerWidth : 1280,
-    height: typeof window !== 'undefined' ? window.innerHeight : 720,
-  }));
-  useEffect(() => {
-    const onResize = () => setViewport({ width: window.innerWidth, height: window.innerHeight });
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
-
   const effects = activeTheme?.effects;
   const preset = effects?.particles ?? 'none';
   const accent = activeTheme?.tokens?.accent ?? '#888888';
@@ -265,6 +255,17 @@ export default function ThemeEffects() {
 
   if (preset === 'none' || reducedEffects) return null;
 
+  // Build the clip-path once per render (mask the chrome panels out of the
+  // canvas). Read window dimensions inline — useChromeGeometry's resize
+  // listener already triggers a re-render whenever chrome geometry changes.
+  const chromeMaskPath = buildChromeClipPath(
+    {
+      width: typeof window !== 'undefined' ? window.innerWidth : 1280,
+      height: typeof window !== 'undefined' ? window.innerHeight : 720,
+    },
+    chromeRects,
+  );
+
   return (
     <canvas
       ref={canvasRef}
@@ -280,8 +281,8 @@ export default function ThemeEffects() {
         // Mask out glassmorphism chrome regions so their backdrop-filter
         // sees a static gradient (cached blur) instead of a per-frame
         // canvas update (forced re-blur). See theme-effects-mask.ts.
-        clipPath: buildChromeClipPath(viewport, chromeRects),
-        WebkitClipPath: buildChromeClipPath(viewport, chromeRects),
+        clipPath: chromeMaskPath,
+        WebkitClipPath: chromeMaskPath,
       }}
       aria-hidden="true"
     />

--- a/desktop/src/renderer/components/ThemeEffects.tsx
+++ b/desktop/src/renderer/components/ThemeEffects.tsx
@@ -1,16 +1,28 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from '../state/theme-context';
+import { useChromeGeometry } from '../hooks/useChromeGeometry';
+import {
+  buildChromeClipPath,
+  chromeEdgeFalloff,
+  type ChromeRect,
+} from './theme-effects-mask';
 
 interface Particle {
   x: number; y: number; speed: number; opacity: number; length: number; size: number;
 }
 
-function drawRain(ctx: CanvasRenderingContext2D, particles: Particle[], w: number, h: number, rainColor: string) {
+function drawRain(
+  ctx: CanvasRenderingContext2D,
+  particles: Particle[],
+  w: number, h: number,
+  rainColor: string,
+  getMul: (p: Particle) => number,
+) {
   ctx.clearRect(0, 0, w, h);
   ctx.strokeStyle = rainColor;
   ctx.lineWidth = 1;
   for (const p of particles) {
-    ctx.globalAlpha = p.opacity;
+    ctx.globalAlpha = p.opacity * getMul(p);
     ctx.beginPath();
     ctx.moveTo(p.x, p.y);
     ctx.lineTo(p.x - 1, p.y + p.length);
@@ -21,10 +33,16 @@ function drawRain(ctx: CanvasRenderingContext2D, particles: Particle[], w: numbe
   ctx.globalAlpha = 1;
 }
 
-function drawDust(ctx: CanvasRenderingContext2D, particles: Particle[], w: number, h: number, accent: string) {
+function drawDust(
+  ctx: CanvasRenderingContext2D,
+  particles: Particle[],
+  w: number, h: number,
+  accent: string,
+  getMul: (p: Particle) => number,
+) {
   ctx.clearRect(0, 0, w, h);
   for (const p of particles) {
-    ctx.globalAlpha = p.opacity;
+    ctx.globalAlpha = p.opacity * getMul(p);
     ctx.fillStyle = accent;
     ctx.beginPath();
     ctx.arc(p.x, p.y, 1, 0, Math.PI * 2);
@@ -36,11 +54,17 @@ function drawDust(ctx: CanvasRenderingContext2D, particles: Particle[], w: numbe
   ctx.globalAlpha = 1;
 }
 
-function drawEmber(ctx: CanvasRenderingContext2D, particles: Particle[], w: number, h: number, accent: string) {
+function drawEmber(
+  ctx: CanvasRenderingContext2D,
+  particles: Particle[],
+  w: number, h: number,
+  accent: string,
+  getMul: (p: Particle) => number,
+) {
   ctx.clearRect(0, 0, w, h);
   const t = Date.now() * 0.001;
   for (const p of particles) {
-    ctx.globalAlpha = p.opacity * 0.8;
+    ctx.globalAlpha = p.opacity * 0.8 * getMul(p);
     ctx.fillStyle = accent;
     ctx.beginPath();
     ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2);
@@ -56,11 +80,17 @@ function drawEmber(ctx: CanvasRenderingContext2D, particles: Particle[], w: numb
   ctx.globalAlpha = 1;
 }
 
-function drawSnow(ctx: CanvasRenderingContext2D, particles: Particle[], w: number, h: number, accent: string) {
+function drawSnow(
+  ctx: CanvasRenderingContext2D,
+  particles: Particle[],
+  w: number, h: number,
+  accent: string,
+  getMul: (p: Particle) => number,
+) {
   ctx.clearRect(0, 0, w, h);
   const t = Date.now() * 0.0005;
   for (const p of particles) {
-    ctx.globalAlpha = p.opacity;
+    ctx.globalAlpha = p.opacity * getMul(p);
     ctx.fillStyle = accent;
     ctx.beginPath();
     ctx.arc(p.x, p.y, p.length * 0.15 + 1, 0, Math.PI * 2);
@@ -78,11 +108,12 @@ function drawCustom(
   w: number, h: number,
   img: HTMLImageElement,
   drift: number,
+  getMul: (p: Particle) => number,
 ) {
   ctx.clearRect(0, 0, w, h);
   const t = Date.now() * 0.001;
   for (const p of particles) {
-    ctx.globalAlpha = p.opacity;
+    ctx.globalAlpha = p.opacity * getMul(p);
     ctx.drawImage(img, p.x - p.size / 2, p.y - p.size / 2, p.size, p.size);
     p.y -= p.speed * 0.5;
     p.x += Math.sin(t + p.length) * drift;
@@ -102,6 +133,25 @@ export default function ThemeEffects() {
   const animRef = useRef<number>(0);
   const particlesRef = useRef<Particle[]>([]);
   const imgRef = useRef<HTMLImageElement | null>(null);
+
+  const chromeRects = useChromeGeometry();
+  // Mirror the latest rects into a ref so the rAF closure (which is set
+  // up once per [preset, ...] change) can read fresh values without
+  // re-creating the animation loop on every chrome resize.
+  const chromeRectsRef = useRef<ChromeRect[]>([]);
+  useEffect(() => {
+    chromeRectsRef.current = chromeRects;
+  }, [chromeRects]);
+
+  const [viewport, setViewport] = useState(() => ({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1280,
+    height: typeof window !== 'undefined' ? window.innerHeight : 720,
+  }));
+  useEffect(() => {
+    const onResize = () => setViewport({ width: window.innerWidth, height: window.innerHeight });
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   const effects = activeTheme?.effects;
   const preset = effects?.particles ?? 'none';
@@ -159,6 +209,7 @@ export default function ThemeEffects() {
     }));
 
     const rainColor = accent + '40';
+    const FADE_DISTANCE = 24; // px — soft falloff band around every chrome rect
     let lastFrame = 0;
     let running = false;
     const draw = (now: number) => {
@@ -168,12 +219,14 @@ export default function ThemeEffects() {
       lastFrame = now;
       const w = canvas.width;
       const h = canvas.height;
-      if (preset === 'rain') drawRain(ctx, particlesRef.current, w, h, rainColor);
-      else if (preset === 'dust') drawDust(ctx, particlesRef.current, w, h, accent);
-      else if (preset === 'ember') drawEmber(ctx, particlesRef.current, w, h, accent);
-      else if (preset === 'snow') drawSnow(ctx, particlesRef.current, w, h, accent);
+      const rects = chromeRectsRef.current;
+      const getMul = (p: Particle) => chromeEdgeFalloff(p.x, p.y, rects, FADE_DISTANCE);
+      if (preset === 'rain') drawRain(ctx, particlesRef.current, w, h, rainColor, getMul);
+      else if (preset === 'dust') drawDust(ctx, particlesRef.current, w, h, accent, getMul);
+      else if (preset === 'ember') drawEmber(ctx, particlesRef.current, w, h, accent, getMul);
+      else if (preset === 'snow') drawSnow(ctx, particlesRef.current, w, h, accent, getMul);
       else if (preset === 'custom' && imgRef.current) {
-        drawCustom(ctx, particlesRef.current, w, h, imgRef.current, particleDrift);
+        drawCustom(ctx, particlesRef.current, w, h, imgRef.current, particleDrift, getMul);
       }
     };
     const startAnim = () => {
@@ -224,6 +277,11 @@ export default function ThemeEffects() {
         zIndex: -1,
         pointerEvents: 'none',
         opacity: 0.6,
+        // Mask out glassmorphism chrome regions so their backdrop-filter
+        // sees a static gradient (cached blur) instead of a per-frame
+        // canvas update (forced re-blur). See theme-effects-mask.ts.
+        clipPath: buildChromeClipPath(viewport, chromeRects),
+        WebkitClipPath: buildChromeClipPath(viewport, chromeRects),
       }}
       aria-hidden="true"
     />

--- a/desktop/src/renderer/components/theme-effects-mask.ts
+++ b/desktop/src/renderer/components/theme-effects-mask.ts
@@ -1,0 +1,61 @@
+// Pure helpers used by ThemeEffects to mask the particle canvas around
+// glassmorphism chrome panels (header bar, status bar, input bar). Kept
+// pure + free of React/DOM imports so the unit tests can run under jsdom
+// without any browser stubs.
+
+export interface ChromeRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** Builds a CSS `clip-path: path(evenodd, ...)` value that includes the
+ *  whole viewport with rectangular holes punched out for each chrome rect.
+ *  Even-odd fill rule means the inner subpaths subtract from the outer. */
+export function buildChromeClipPath(
+  viewport: { width: number; height: number },
+  rects: ChromeRect[],
+): string {
+  if (rects.length === 0) return 'none';
+  const outer = `M 0 0 H ${viewport.width} V ${viewport.height} H 0 Z`;
+  const holes = rects
+    .map(
+      (r) =>
+        `M ${r.left} ${r.top} H ${r.left + r.width} V ${r.top + r.height} H ${r.left} Z`,
+    )
+    .join(' ');
+  return `path(evenodd, '${outer} ${holes}')`;
+}
+
+/** Returns an opacity multiplier in [0, 1] for a particle at (x, y) based
+ *  on its distance to the nearest chrome rect.
+ *  - 1.0 when the particle is at least `fadeDistance` pixels away from every rect
+ *  - 0.0 when the particle is strictly inside any rect
+ *  - linear ramp in the fade band between
+ *  Used to soften the edge of the canvas clip so particles don't pop at
+ *  the masked-rect boundary. */
+export function chromeEdgeFalloff(
+  x: number,
+  y: number,
+  rects: ChromeRect[],
+  fadeDistance: number,
+): number {
+  if (rects.length === 0) return 1;
+  let minMultiplier = 1;
+  for (const r of rects) {
+    const right = r.left + r.width;
+    const bottom = r.top + r.height;
+    // Component distances from the point to the rect — 0 if the point is
+    // inside the corresponding axis range, positive if outside.
+    const dx = Math.max(r.left - x, 0, x - right);
+    const dy = Math.max(r.top - y, 0, y - bottom);
+    const outside = Math.sqrt(dx * dx + dy * dy);
+    if (outside === 0) return 0; // inside this rect
+    if (outside < fadeDistance) {
+      const m = outside / fadeDistance;
+      if (m < minMultiplier) minMultiplier = m;
+    }
+  }
+  return minMultiplier;
+}

--- a/desktop/src/renderer/components/theme-effects-mask.ts
+++ b/desktop/src/renderer/components/theme-effects-mask.ts
@@ -31,8 +31,8 @@ export function buildChromeClipPath(
 /** Returns an opacity multiplier in [0, 1] for a particle at (x, y) based
  *  on its distance to the nearest chrome rect.
  *  - 1.0 when the particle is at least `fadeDistance` pixels away from every rect
- *  - 0.0 when the particle is strictly inside any rect
- *  - linear ramp in the fade band between
+ *  - 0.0 when the particle is on or inside any rect
+ *  - linear ramp between 0 and 1 inside the fade band
  *  Used to soften the edge of the canvas clip so particles don't pop at
  *  the masked-rect boundary. */
 export function chromeEdgeFalloff(

--- a/desktop/src/renderer/hooks/useChromeGeometry.ts
+++ b/desktop/src/renderer/hooks/useChromeGeometry.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ChromeRect } from '../components/theme-effects-mask';
+
+// CSS classes of the always-on glassmorphism chrome panels. These are the
+// elements whose backdrop-filter cost we want to make static. Dynamic
+// overlays (.settings-drawer, .layer-surface popups) are intentionally
+// excluded — masking them would require tracking show/hide/animate state
+// and is not worth the complexity. Cost while a popup is open is a
+// known, accepted trade-off documented in the plan.
+const CHROME_SELECTORS = ['.header-bar', '.status-bar', '.input-bar-container'];
+
+export function useChromeGeometry(): ChromeRect[] {
+  // rectsRef holds the live data; we mutate its items in-place so callers
+  // that hold a reference (e.g. test code reading result.current after a
+  // ResizeObserver trigger without wrapping in act()) always see fresh values.
+  const rectsRef = useRef<ChromeRect[]>([]);
+  const [, setVersion] = useState(0);
+
+  useEffect(() => {
+    const elements = CHROME_SELECTORS
+      .map((sel) => document.querySelector(sel))
+      .filter((el): el is Element => el !== null);
+
+    if (elements.length === 0) {
+      rectsRef.current = [];
+      return;
+    }
+
+    const measure = () => {
+      elements.forEach((el, i) => {
+        const r = el.getBoundingClientRect();
+        const next = { left: r.left, top: r.top, width: r.width, height: r.height };
+        if (i < rectsRef.current.length) {
+          // Mutate in-place so any held reference reflects the new value
+          // immediately — even before React flushes the re-render triggered
+          // by setVersion below.
+          Object.assign(rectsRef.current[i], next);
+        } else {
+          rectsRef.current.push(next);
+        }
+      });
+      // Trim if elements were removed.
+      rectsRef.current.length = elements.length;
+      // Trigger a re-render so React picks up the latest ref values.
+      setVersion((v) => v + 1);
+    };
+
+    // Synchronous initial measurement avoids a frame where the canvas is
+    // unmasked while React is still scheduling the first observer callback.
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    elements.forEach((el) => observer.observe(el));
+    window.addEventListener('resize', measure);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
+  return rectsRef.current;
+}

--- a/desktop/src/renderer/hooks/useChromeGeometry.ts
+++ b/desktop/src/renderer/hooks/useChromeGeometry.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ChromeRect } from '../components/theme-effects-mask';
 
 // CSS classes of the always-on glassmorphism chrome panels. These are the
@@ -10,11 +10,7 @@ import type { ChromeRect } from '../components/theme-effects-mask';
 const CHROME_SELECTORS = ['.header-bar', '.status-bar', '.input-bar-container'];
 
 export function useChromeGeometry(): ChromeRect[] {
-  // rectsRef holds the live data; we mutate its items in-place so callers
-  // that hold a reference (e.g. test code reading result.current after a
-  // ResizeObserver trigger without wrapping in act()) always see fresh values.
-  const rectsRef = useRef<ChromeRect[]>([]);
-  const [, setVersion] = useState(0);
+  const [rects, setRects] = useState<ChromeRect[]>([]);
 
   useEffect(() => {
     const elements = CHROME_SELECTORS
@@ -22,27 +18,16 @@ export function useChromeGeometry(): ChromeRect[] {
       .filter((el): el is Element => el !== null);
 
     if (elements.length === 0) {
-      rectsRef.current = [];
+      setRects([]);
       return;
     }
 
     const measure = () => {
-      elements.forEach((el, i) => {
+      const next = elements.map((el) => {
         const r = el.getBoundingClientRect();
-        const next = { left: r.left, top: r.top, width: r.width, height: r.height };
-        if (i < rectsRef.current.length) {
-          // Mutate in-place so any held reference reflects the new value
-          // immediately — even before React flushes the re-render triggered
-          // by setVersion below.
-          Object.assign(rectsRef.current[i], next);
-        } else {
-          rectsRef.current.push(next);
-        }
+        return { left: r.left, top: r.top, width: r.width, height: r.height };
       });
-      // Trim if elements were removed.
-      rectsRef.current.length = elements.length;
-      // Trigger a re-render so React picks up the latest ref values.
-      setVersion((v) => v + 1);
+      setRects(next);
     };
 
     // Synchronous initial measurement avoids a frame where the canvas is
@@ -59,5 +44,5 @@ export function useChromeGeometry(): ChromeRect[] {
     };
   }, []);
 
-  return rectsRef.current;
+  return rects;
 }

--- a/desktop/tests/theme-effects-mask.test.ts
+++ b/desktop/tests/theme-effects-mask.test.ts
@@ -44,7 +44,7 @@ describe('chromeEdgeFalloff', () => {
     expect(chromeEdgeFalloff(50, 50, [rect], FADE)).toBe(1);
   });
 
-  it('returns 0 for a particle strictly inside a rect', () => {
+  it('returns 0 for a particle inside or on the boundary of a rect', () => {
     expect(chromeEdgeFalloff(150, 120, [rect], FADE)).toBe(0);
   });
 

--- a/desktop/tests/theme-effects-mask.test.ts
+++ b/desktop/tests/theme-effects-mask.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildChromeClipPath,
+  chromeEdgeFalloff,
+  type ChromeRect,
+} from '../src/renderer/components/theme-effects-mask';
+
+describe('buildChromeClipPath', () => {
+  const viewport = { width: 1280, height: 720 };
+
+  it('returns "none" when there are no rects (no clip applied)', () => {
+    expect(buildChromeClipPath(viewport, [])).toBe('none');
+  });
+
+  it('produces an SVG path with the viewport outer rect plus one hole', () => {
+    const rects: ChromeRect[] = [{ left: 0, top: 0, width: 1280, height: 40 }];
+    const result = buildChromeClipPath(viewport, rects);
+    expect(result.startsWith("path(evenodd, '")).toBe(true);
+    expect(result).toContain('M 0 0 H 1280 V 720 H 0 Z');
+    expect(result).toContain('M 0 0 H 1280 V 40 H 0 Z');
+    expect(result.endsWith("')")).toBe(true);
+  });
+
+  it('emits a hole subpath for every rect, separated by spaces', () => {
+    const rects: ChromeRect[] = [
+      { left: 0, top: 0, width: 1280, height: 40 },
+      { left: 0, top: 680, width: 1280, height: 40 },
+    ];
+    const result = buildChromeClipPath(viewport, rects);
+    expect(result).toContain('M 0 0 H 1280 V 40 H 0 Z');
+    expect(result).toContain('M 0 680 H 1280 V 720 H 0 Z');
+  });
+});
+
+describe('chromeEdgeFalloff', () => {
+  const FADE = 24;
+  const rect: ChromeRect = { left: 100, top: 100, width: 200, height: 50 };
+
+  it('returns 1 when there are no rects', () => {
+    expect(chromeEdgeFalloff(50, 50, [], FADE)).toBe(1);
+  });
+
+  it('returns 1 for a particle far outside every rect', () => {
+    expect(chromeEdgeFalloff(50, 50, [rect], FADE)).toBe(1);
+  });
+
+  it('returns 0 for a particle strictly inside a rect', () => {
+    expect(chromeEdgeFalloff(150, 120, [rect], FADE)).toBe(0);
+  });
+
+  it('returns a smooth fraction within the fade band outside the rect', () => {
+    // Particle 12px above the rect's top edge (rect top = 100, so y = 88 is 12px above)
+    const m = chromeEdgeFalloff(150, 88, [rect], FADE);
+    expect(m).toBeGreaterThan(0);
+    expect(m).toBeLessThan(1);
+    // 12 / 24 = 0.5
+    expect(m).toBeCloseTo(0.5, 2);
+  });
+
+  it('uses the minimum (closest) rect when several rects are nearby', () => {
+    const rectA: ChromeRect = { left: 100, top: 100, width: 100, height: 50 };
+    const rectB: ChromeRect = { left: 100, top: 200, width: 100, height: 50 };
+    // Particle at (150, 180) — 30px below A (well outside fade), 20px above B (inside fade band)
+    const m = chromeEdgeFalloff(150, 180, [rectA, rectB], FADE);
+    expect(m).toBeCloseTo(20 / 24, 2);
+  });
+});

--- a/desktop/tests/use-chrome-geometry.test.ts
+++ b/desktop/tests/use-chrome-geometry.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useChromeGeometry } from '../src/renderer/hooks/useChromeGeometry';
 
 // Minimal ResizeObserver stub — captures observed elements and exposes a
@@ -78,7 +78,9 @@ describe('useChromeGeometry', () => {
         left: 0, top: 0, width: 1280, height: 60,
         right: 1280, bottom: 60, x: 0, y: 0, toJSON: () => ({}),
       }) as DOMRect;
-    StubResizeObserver.instances[0].trigger();
+    act(() => {
+      StubResizeObserver.instances[0].trigger();
+    });
 
     expect(result.current[0].height).toBe(60);
   });

--- a/desktop/tests/use-chrome-geometry.test.ts
+++ b/desktop/tests/use-chrome-geometry.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useChromeGeometry } from '../src/renderer/hooks/useChromeGeometry';
+
+// Minimal ResizeObserver stub — captures observed elements and exposes a
+// `trigger()` so tests can simulate a resize event on demand.
+class StubResizeObserver {
+  static instances: StubResizeObserver[] = [];
+  cb: ResizeObserverCallback;
+  observed = new Set<Element>();
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+    StubResizeObserver.instances.push(this);
+  }
+  observe(el: Element) { this.observed.add(el); }
+  unobserve(el: Element) { this.observed.delete(el); }
+  disconnect() { this.observed.clear(); }
+  trigger() { this.cb([], this); }
+}
+
+describe('useChromeGeometry', () => {
+  let originalRO: typeof ResizeObserver;
+
+  beforeEach(() => {
+    originalRO = (globalThis as any).ResizeObserver;
+    (globalThis as any).ResizeObserver = StubResizeObserver;
+    StubResizeObserver.instances = [];
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    (globalThis as any).ResizeObserver = originalRO;
+  });
+
+  function makeChrome(className: string, rect: { left: number; top: number; width: number; height: number }) {
+    const el = document.createElement('div');
+    el.className = className;
+    el.getBoundingClientRect = () =>
+      ({
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        right: rect.left + rect.width,
+        bottom: rect.top + rect.height,
+        x: rect.left,
+        y: rect.top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    document.body.appendChild(el);
+    return el;
+  }
+
+  it('returns [] when no chrome elements exist', () => {
+    const { result } = renderHook(() => useChromeGeometry());
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns rects for matched chrome elements on first render', () => {
+    makeChrome('header-bar', { left: 0, top: 0, width: 1280, height: 40 });
+    makeChrome('status-bar', { left: 0, top: 680, width: 1280, height: 40 });
+    const { result } = renderHook(() => useChromeGeometry());
+    expect(result.current).toEqual([
+      { left: 0, top: 0, width: 1280, height: 40 },
+      { left: 0, top: 680, width: 1280, height: 40 },
+    ]);
+  });
+
+  it('updates rects when ResizeObserver fires', () => {
+    const header = makeChrome('header-bar', { left: 0, top: 0, width: 1280, height: 40 });
+    const { result } = renderHook(() => useChromeGeometry());
+    expect(result.current[0].height).toBe(40);
+
+    // Simulate the input bar growing — change the rect, then trigger the observer.
+    header.getBoundingClientRect = () =>
+      ({
+        left: 0, top: 0, width: 1280, height: 60,
+        right: 1280, bottom: 60, x: 0, y: 0, toJSON: () => ({}),
+      }) as DOMRect;
+    StubResizeObserver.instances[0].trigger();
+
+    expect(result.current[0].height).toBe(60);
+  });
+
+  it('disconnects the observer on unmount', () => {
+    makeChrome('header-bar', { left: 0, top: 0, width: 1280, height: 40 });
+    const { unmount } = renderHook(() => useChromeGeometry());
+    const obs = StubResizeObserver.instances[0];
+    expect(obs.observed.size).toBe(1);
+    unmount();
+    expect(obs.observed.size).toBe(0);
+  });
+});

--- a/desktop/tests/use-chrome-geometry.test.ts
+++ b/desktop/tests/use-chrome-geometry.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useChromeGeometry } from '../src/renderer/hooks/useChromeGeometry';
 


### PR DESCRIPTION
## Summary

Particle canvas now mounts a CSS `clip-path: path(evenodd, ...)` that punches holes wherever a glassmorphism chrome panel sits (header bar, status bar, input bar). Chrome's `backdrop-filter` no longer sees per-frame canvas updates, so Chromium caches the blur output and stops recomputing it 30 times per second. Per-particle opacity falloff (24px fade band around each chrome rect) keeps particles from popping at the masked edges. Particle simulation is unchanged — same count, same physics, same presets.

## Why

Themes that combine particles with heavy chrome blur (e.g. `halftone-dimension` with `panels-blur: 20px`) pegged the GPU copy engine at ~100% even while the user was actively using the app. Diagnosed in the same investigation that produced #91 (visibility-gate); that PR fixes the idle case but the active-use cost remained intrinsic to the per-frame backdrop-filter recompute.

## Empirical verification

Both apps on `halftone-dimension`, Reduced Effects OFF, dev window visible and maximized:

| Sample | Live (no fix) | Dev (this PR) |
|--------|--------------|---------------|
| 1 | 101% copy | < 0.5% copy |
| 2 | 99.4% copy | < 0.5% copy |
| 3 | 99.4% copy | < 0.5% copy |

Steady-state >200x reduction on the GPU copy engine.

## Trade-offs

- **Particles no longer appear inside chrome panels.** They previously showed as faint blurred halos through the glass (~5% effective opacity after a 20px blur on a 6–14px particle). The diff is small but not zero. The 24px edge-fade keeps the boundary smooth.
- **Open popups / drawers** (SettingsPanel, PreferencesPopup, ResumeBrowser, etc.) still trigger their own backdrop-filter cost while open — they are not in the static-chrome selector list. Acceptable: cost only while user is actively interacting.
- **Chat bubbles with `bubble-blur > 0`** (e.g. strawberry-kitty's 13px) also still re-blur as canvas changes underneath them. Smaller surface area, smaller cost. Out of scope for this PR.

## Architecture

Three-layer split — adding a fourth chrome selector or a sixth particle preset touches exactly one file each.

- `desktop/src/renderer/components/theme-effects-mask.ts` (new) — pure helpers (`buildChromeClipPath`, `chromeEdgeFalloff`, `ChromeRect`)
- `desktop/src/renderer/hooks/useChromeGeometry.ts` (new) — finds glass-chrome elements, tracks via `ResizeObserver`
- `desktop/src/renderer/components/ThemeEffects.tsx` — wires it in: clip-path on canvas, edge-fade in draw functions

The visibility-gate from #91 is preserved unchanged.

## Test plan

- [x] `npx vitest run` — full suite green (933 pass, 34 skip), including 12 new tests for the helpers + hook
- [x] `npx tsc --noEmit -p desktop/tsconfig.json` — no new errors
- [x] `npx vite build` — clean build
- [x] Halftone Dimension: GPU copy engine drops from ~100% to <0.5% in dev; live app on same theme stays at ~100% (control)
- [ ] Solid themes (Light/Dark/Midnight/Crème) — no change (eyes-on)
- [ ] Other particle themes (Strawberry Kitty, Kuromi Dreamer, Golden Sunbreak, Devils Garden) — no visual regression (eyes-on)
- [ ] Reduced Effects toggle ON → particles disappear; OFF → particles return masked (eyes-on)
- [ ] Multi-line input grows input bar → mask tracks the new height with no flicker (eyes-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)