### PR TITLE
fix(first-run): support Node.js auto-install on Linux

### DIFF
--- a/desktop/src/main/first-run.ts
+++ b/desktop/src/main/first-run.ts
@@ -223,6 +223,20 @@ export class FirstRunManager extends EventEmitter {
       const prereq = this.state.prerequisites.find((p) => p.name === name);
       if (prereq?.status === 'installed') continue;
 
+      // Re-detect before installing. The prerequisite may have appeared on
+      // disk since detectAll() ran — the user installed it manually, or a
+      // previous attempt partially succeeded. Without this, a retry blindly
+      // re-runs install() and can fail again even though the tool is now
+      // present. (This is exactly how a Linux user got permanently stuck on
+      // the setup screen: installNode() had no Linux branch, so every retry
+      // re-failed even after Node was installed out-of-band.)
+      const preCheck = await detect();
+      if (preCheck.installed) {
+        this.updatePrereq(name, { status: 'installed', version: preCheck.version });
+        log('INFO', 'first-run', `${label} already present — skipping install`);
+        continue;
+      }
+
       this.updatePrereq(name, { status: 'installing' });
       this.updateState({
         statusMessage: `Installing ${label}...`,

--- a/desktop/src/main/prerequisite-installer.ts
+++ b/desktop/src/main/prerequisite-installer.ts
@@ -70,19 +70,21 @@ export interface DetectionResult {
 }
 
 // ---------------------------------------------------------------------------
-// User-local install layout (macOS)
+// User-local install layout (macOS + Linux)
 //
-// Node's official .pkg requires admin (sudo) and does not honor
+// Node's official macOS .pkg requires admin (sudo) and does not honor
 // `-target CurrentUserHomeDirectory` — the pkg isn't authored for per-user
-// install, so `installer` exits non-zero for a normal user. We sidestep by
-// extracting the official tarball to a user-writable dir and persisting it
-// to PATH ourselves, so no admin prompt is ever needed.
+// install, so `installer` exits non-zero for a normal user. On Linux, a
+// distro-package-manager install (apt/dnf/pacman) would each need sudo plus
+// distro detection. We sidestep both by extracting the official prebuilt
+// tarball to a user-writable dir and persisting it to PATH ourselves, so no
+// admin prompt and no package manager is ever needed.
 // ---------------------------------------------------------------------------
 
 const NODE_VERSION = 'v20.19.0';
 const PATH_MARKER = '# Added by YouCoded first-run installer';
 
-/** Root dir for YouCoded-managed user-local tools (macOS). */
+/** Root dir for YouCoded-managed user-local tools (macOS: ~/Library/..., Linux: ~/.youcoded). */
 function youcodedDataDir(): string {
   if (process.platform === 'darwin') {
     return path.join(os.homedir(), 'Library', 'Application Support', 'YouCoded');
@@ -90,7 +92,7 @@ function youcodedDataDir(): string {
   return path.join(os.homedir(), '.youcoded');
 }
 
-/** Where we extract Node's tarball on macOS. */
+/** Where we extract Node's tarball (macOS + Linux). */
 export function userLocalNodeDir(): string {
   return path.join(youcodedDataDir(), 'node');
 }
@@ -338,12 +340,17 @@ export async function installNode(): Promise<{ success: boolean; error?: string 
         ],
         { timeout: 300000 },
       );
-    } else if (process.platform === 'darwin') {
-      // User-local tarball install — no sudo, no admin prompt.
-      // Node's .pkg is system-wide only; previous `installer -target
-      // CurrentUserHomeDirectory` was rejected by the pkg metadata.
+    } else if (process.platform === 'darwin' || process.platform === 'linux') {
+      // User-local tarball install — no sudo, no admin prompt, no distro
+      // package manager. macOS: Node's .pkg is system-wide only (previous
+      // `installer -target CurrentUserHomeDirectory` was rejected by the pkg
+      // metadata). Linux: apt/dnf/pacman would each need sudo + distro
+      // detection. The official prebuilt tarball sidesteps both.
+      //
+      // `process.platform` ('darwin' | 'linux') is also the exact token Node
+      // uses in its dist tarball names, so we interpolate it directly.
       const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
-      const tarName = `node-${NODE_VERSION}-darwin-${arch}.tar.gz`;
+      const tarName = `node-${NODE_VERSION}-${process.platform}-${arch}.tar.gz`;
       const tmpTar = path.join(os.tmpdir(), tarName);
       await downloadFile(
         `https://nodejs.org/dist/${NODE_VERSION}/${tarName}`,
@@ -352,7 +359,7 @@ export async function installNode(): Promise<{ success: boolean; error?: string 
 
       const installDir = userLocalNodeDir();
       fs.mkdirSync(installDir, { recursive: true });
-      // --strip-components=1 peels the top-level `node-vX.Y.Z-darwin-<arch>/`
+      // --strip-components=1 peels the top-level `node-vX.Y.Z-<plat>-<arch>/`
       // directory so bin/ lib/ include/ share/ land directly under installDir.
       await runCommand('tar', [
         '-xzf', tmpTar,
@@ -365,7 +372,7 @@ export async function installNode(): Promise<{ success: boolean; error?: string 
       prependToProcessPath(userLocalNodeBinDir());
       persistPathToShellProfiles(userLocalNodeBinDir());
     } else {
-      return { success: false, error: 'Unsupported platform for Node.js install' };
+      return { success: false, error: `Unsupported platform for Node.js install: ${process.platform}` };
     }
 
     refreshPath();


### PR DESCRIPTION
## Problem

A Linux user installing YouCoded via AppImage was **permanently stuck on the first-run setup screen**. The setup flow tries to auto-install Node.js, but `installNode()` in `prerequisite-installer.ts` only had branches for Windows (`winget`) and macOS (user-local tarball) — Linux fell straight through to:

```ts
return { success: false, error: 'Unsupported platform for Node.js install' };
```

It got worse on retry: `installMissing()` in `first-run.ts` only re-detects a prerequisite *after* a successful install, never *before*. So even though Node `26.1.0` landed on the user's system mid-session, every "retry" just re-ran the broken `installNode()` instead of noticing Node was now present — the failure was unrecoverable from the UI.

Log evidence from the affected machine:

```
INFO   prereq      Installing Node.js...
ERROR  first-run   Node.js installation failed   error: "Unsupported platform for Node.js install"
```

...repeated on every launch, including launches *after* Node was already on disk.

## Fix

**1. `installNode()` — add Linux support.** Linux now reuses the macOS user-local tarball path. `process.platform` (`'darwin' | 'linux'`) is the exact token Node uses in its dist tarball names, so the two branches merge cleanly. No sudo, no distro package manager (`apt`/`dnf`/`pacman` would each need root + distro detection) — the official prebuilt tarball is extracted to `~/.youcoded/node` and that bin dir is persisted to PATH (`prependToProcessPath` + `persistPathToShellProfiles`, both already Linux-safe).

**2. `installMissing()` — re-detect before installing.** Each prerequisite is now detected *before* `install()` is called. If it is already present (manual install, or a partial prior run), it is marked installed and the install is skipped. This makes the flow self-heal and also avoids a redundant download.

## Testing

- `tsc --noEmit` passes.
- Full desktop test suite passes (941 tests). One unrelated pre-existing failure — `sync-service-tags.test.ts` — was verified to also fail on clean `origin/master`; not touched by this change.
- No new test added: the installer code has no existing unit coverage, and exercising `installNode()` requires real network + `tar` I/O. The change mirrors the already-proven macOS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)