### PR TITLE
fix(header): show window caption buttons on Linux

### DIFF
--- a/desktop/src/renderer/components/HeaderBar.tsx
+++ b/desktop/src/renderer/components/HeaderBar.tsx
@@ -5,11 +5,20 @@ import type { SessionStatusColor } from './StatusDot';
 import type { PermissionMode } from '../../shared/types';
 import { isAndroid, isRemoteMode } from '../platform';
 
-/** Custom window caption buttons for Windows/Linux (macOS uses native traffic lights). */
-const showCaptionButtons = typeof navigator !== 'undefined'
-  && navigator.platform === 'Win32';
-
 const isMac = typeof navigator !== 'undefined' && navigator.platform.startsWith('Mac');
+
+/** Custom window caption buttons for Windows + Linux desktop. The Electron
+ *  BrowserWindow is frameless (`frame: false`) on BOTH — so without these the
+ *  window has no minimize/maximize/close at all. macOS uses native traffic
+ *  lights, Android has no OS window chrome, remote runs in a browser tab.
+ *
+ *  Fix: this was gated to `navigator.platform === 'Win32'`, which left Linux
+ *  (`navigator.platform` is e.g. `Linux x86_64`) with zero window controls on
+ *  a frameless window. Gate on "desktop and not macOS" instead. */
+const showCaptionButtons = typeof navigator !== 'undefined'
+  && !isMac
+  && !isAndroid()
+  && !isRemoteMode();
 
 /** Toggle sits on the opposite side of the OS window-control buttons
  *  so the header is balanced. macOS traffic lights live on the left,


### PR DESCRIPTION
## Problem

YouCoded's window on **Linux had no minimize / maximize / close buttons**.

The Electron `BrowserWindow` is created frameless (`frame: false`, `titleBarStyle: 'hidden'`) on both Windows and Linux — only macOS gets native chrome (traffic lights). The custom caption buttons that replace the OS chrome are rendered by `HeaderBar.tsx`, gated on:

```ts
const showCaptionButtons = typeof navigator !== 'undefined'
  && navigator.platform === 'Win32';
```

On Linux `navigator.platform` is `Linux x86_64` (etc.), so `showCaptionButtons` was always `false` — a frameless window with zero window controls. The constant's own doc comment already said "Windows/Linux"; only the condition was wrong.

## Fix

Re-gate the constant as **"desktop, and not macOS"**:

```ts
const showCaptionButtons = typeof navigator !== 'undefined'
  && !isMac
  && !isAndroid()
  && !isRemoteMode();
```

- macOS → native traffic lights (`<MacTrafficLights>`), no custom buttons — unchanged.
- Android → no OS window chrome (fullscreen WebView).
- Remote → runs in a browser tab, no Electron window controls.
- Windows **and Linux** → custom `<CaptionButtons>`.

`isMac` is moved a few lines up so the new constant can reuse it. No other logic changes — `toggleOnLeft` already correctly treated Linux like Windows.

## Testing

- `tsc --noEmit` passes.
- Full desktop test suite passes (941 tests). One unrelated pre-existing failure (`sync-service-tags.test.ts`) also fails on clean `origin/master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)