### PR TITLE
fix: close three Linux platform-parity gaps

### DIFF
--- a/desktop/node_modules
+++ b/desktop/node_modules
@@ -1,0 +1,1 @@
+/home/destin/youcoded-dev/.wt-linux-node/desktop/node_modules

--- a/desktop/src/main/prerequisite-installer.ts
+++ b/desktop/src/main/prerequisite-installer.ts
@@ -423,8 +423,23 @@ export async function installGit(): Promise<{ success: boolean; error?: string }
       }
       log('INFO', 'prereq', `Git installed: ${check.version}`);
       return { success: true };
+    } else if (process.platform === 'linux') {
+      // No portable Git tarball exists, and a real install needs root +
+      // distro detection (apt/dnf/pacman) — not something to do silently.
+      // Git ships preinstalled on most Linux distros, and installMissing()
+      // re-detects before calling this, so reaching here means Git is
+      // genuinely absent. Surface actionable per-distro guidance instead of
+      // a dead-end "unsupported platform" error.
+      return {
+        success: false,
+        error:
+          'Install Git with your distribution\'s package manager, then click Try Again:\n' +
+          '  Debian / Ubuntu:  sudo apt install git\n' +
+          '  Fedora / RHEL:    sudo dnf install git\n' +
+          '  Arch:             sudo pacman -S git',
+      };
     } else {
-      return { success: false, error: 'Unsupported platform for Git install' };
+      return { success: false, error: `Unsupported platform for Git install: ${process.platform}` };
     }
 
     refreshPath();

--- a/desktop/src/main/remote-config.ts
+++ b/desktop/src/main/remote-config.ts
@@ -146,7 +146,10 @@ export class RemoteConfig {
         ? ['C:\\Program Files\\Tailscale\\tailscale.exe', `${process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)'}\\Tailscale\\tailscale.exe`]
         : process.platform === 'darwin'
           ? ['/Applications/Tailscale.app/Contents/MacOS/Tailscale', '/usr/local/bin/tailscale', '/opt/homebrew/bin/tailscale']
-          : ['/usr/bin/tailscale', '/usr/local/bin/tailscale'];
+          // Linux: `which` above already covers anything on PATH. These are
+          // common install locations that a GUI-launched app's stripped PATH
+          // often misses — notably /snap/bin (snap) and linuxbrew.
+          : ['/usr/bin/tailscale', '/usr/local/bin/tailscale', '/snap/bin/tailscale', '/home/linuxbrew/.linuxbrew/bin/tailscale'];
       for (const p of candidates) {
         try { fs.accessSync(p); tsPath = p; break; } catch {}
       }

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -188,8 +188,13 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
     const types: { type: BackendType; desc: string }[] = [
       { type: 'drive', desc: 'Stores your data in a Google Drive folder. Works on any device.' },
       { type: 'github', desc: 'Stores your data in a private GitHub repository. Includes full version history.' },
-      // iCloud not available on Android — no iCloud Drive support
-      ...(!checkIsAndroid() ? [{ type: 'icloud' as BackendType, desc: 'Stores your data in iCloud Drive. Best for Mac and iPhone users.' }] : []),
+      // iCloud only where an iCloud Drive client exists: macOS, and
+      // iCloud-for-Windows on Windows. Linux has no iCloud client at all and
+      // Android has no iCloud Drive support — offering it there gave users a
+      // dead option that silently failed prereq detection.
+      ...(!checkIsAndroid() && detectDesktopOS() !== 'linux'
+        ? [{ type: 'icloud' as BackendType, desc: 'Stores your data in iCloud Drive. Best for Mac and iPhone users.' }]
+        : []),
     ];
 
     return (


### PR DESCRIPTION
Follow-up to the Linux window-controls fix (#94) — a sweep for the same bug class (a `win32`/`darwin` branch with no real Linux path) turned up three more spots.

## 1. `installGit()` — actionable message instead of a dead end

`prerequisite-installer.ts` `installGit()` had Windows (`winget`) and macOS (`xcode-select`) branches; Linux fell through to `'Unsupported platform for Git install'`. There is no portable Git tarball and a genuine install needs root + distro detection, so this is **not** auto-installed. Instead the Linux branch now returns actionable per-distro guidance:

```
Install Git with your distribution's package manager, then click Try Again:
  Debian / Ubuntu:  sudo apt install git
  Fedora / RHEL:    sudo dnf install git
  Arch:             sudo pacman -S git
```

Git is preinstalled on most distros, and `installMissing()` re-detects before calling this (see #93), so this path is rare — but when hit it's now a clear instruction rather than a dead end.

## 2. iCloud backend hidden on Linux

`SyncSetupWizard.tsx` offered the iCloud sync backend on every desktop OS. Linux has **no iCloud Drive client at all**, so picking it always failed prereq detection silently (no path found → looks "not configured"). It's now hidden on Linux, using the existing `detectDesktopOS()` helper — still shown on macOS and on Windows (iCloud for Windows creates `~/iCloudDrive`), still hidden on Android.

## 3. Tailscale path detection — more Linux fallback locations

`resolveTailscalePath()`'s Linux fallback list was only `/usr/bin/tailscale` + `/usr/local/bin/tailscale`. Added `/snap/bin/tailscale` and `/home/linuxbrew/.linuxbrew/bin/tailscale` — common install locations a GUI-launched app's stripped PATH misses. (The `which` lookup that runs first already covers anything genuinely on PATH; this only widens the not-on-PATH fallback.)

## Testing

- `tsc --noEmit` passes.
- Full desktop test suite passes (941 tests). One unrelated pre-existing failure (`sync-service-tags.test.ts`) also fails on clean `origin/master`.

## Related

- #93 — Node.js auto-install on Linux
- #94 — window caption buttons on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)