### PR TITLE
test(sync): fix time-bomb date in sync-service-tags.test.ts

### DIFF
--- a/desktop/tests/sync-service-tags.test.ts
+++ b/desktop/tests/sync-service-tags.test.ts
@@ -74,8 +74,13 @@ describe('updateConversationIndex — interaction with epoch-seeded entries', ()
     svc.setSessionFlag('sess-c', 'helpful', true);
     expect(new Date(readIndex().sessions['sess-c'].lastActive).getTime()).toBe(0);
 
-    // Topic file appears later (user sent first message)
-    writeTopicFile('sess-c', 'Topic written later', new Date('2026-04-12T08:00:00Z'));
+    // Topic file appears later (user sent first message). The mtime must be
+    // RECENT relative to now: updateConversationIndex() prunes any entry whose
+    // lastActive is older than INDEX_PRUNE_DAYS (30). A hardcoded past date
+    // here is a time bomb — it upserts fine, then gets pruned in the same call
+    // once that date ages past the 30-day window. (This test failed exactly
+    // that way after 2026-05-12.)
+    writeTopicFile('sess-c', 'Topic written later', new Date(Date.now() - 60_000));
 
     svc.updateConversationIndex();
 


### PR DESCRIPTION
## Problem

`desktop/tests/sync-service-tags.test.ts` failed on `master` — the test `updateConversationIndex — interaction with epoch-seeded entries > overwrites an epoch-seeded entry when the topic file shows up` threw `TypeError: Cannot read properties of undefined (reading 'topic')` at line 83. This made the CI `build` job red on **every** PR (`1 failed | 941 passed`), masking real regressions.

## Root cause — a time-bomb test, not a code bug

The test wrote its topic file with a **hardcoded mtime of `2026-04-12T08:00:00Z`**:

```ts
writeTopicFile('sess-c', 'Topic written later', new Date('2026-04-12T08:00:00Z'));
```

`updateConversationIndex()` upserts an index entry from each topic file, then — in the **same call** — prunes any entry whose `lastActive` is older than `INDEX_PRUNE_DAYS` (30). The entry's `lastActive` is the topic file's mtime.

While "now" was inside 30 days of 2026-04-12 the test passed; once the clock moved past **2026-05-12**, the freshly-upserted `sess-c` entry was immediately pruned in the same `updateConversationIndex()` call → `readIndex().sessions['sess-c']` came back `undefined` → line 83 threw.

`updateConversationIndex()`'s prune behaviour is **correct** — genuinely old sessions shouldn't stay in the recent index. The bug was the test pinning a fixed calendar date.

## Fix

The topic file models "user sent their first message just now", so its mtime should be **recent relative to `Date.now()`**, not a fixed date:

```ts
writeTopicFile('sess-c', 'Topic written later', new Date(Date.now() - 60_000));
```

No production code change. (The other hardcoded date in the file, line 43, is a pure `lastActive === mtime` equality check with no pruning involved — deterministic and not a time bomb, left as-is.)

## Testing

- `sync-service-tags.test.ts` — all 10 tests pass.
- Full desktop suite: **`942 passed`** (was `941 passed | 1 failed`). CI `build` job is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)