### PR TITLE
fix(resume-browser): resolve session names from conversation index + stable AppImage hook paths

### DIFF
--- a/app/src/main/assets/title-update.sh
+++ b/app/src/main/assets/title-update.sh
@@ -12,7 +12,9 @@ fi
 TOPIC_DIR="$HOME/.claude/topics"
 mkdir -p "$TOPIC_DIR"
 
-# Prune topic files older than 7 days (at most once per day)
+# Prune topic files older than 30 days (matches conversation-index.json
+# retention, so a session's name survives as long as its index entry).
+# Runs at most once per day.
 PRUNE_MARKER="$TOPIC_DIR/.prune-marker"
 NOW=$(date +%s)
 DO_PRUNE=false
@@ -26,8 +28,8 @@ else
     fi
 fi
 if [ "$DO_PRUNE" = true ]; then
-    find "$TOPIC_DIR" -name "topic-*" -mtime +7 -delete 2>/dev/null
-    find "$TOPIC_DIR" -name "marker-*" -mtime +7 -delete 2>/dev/null
+    find "$TOPIC_DIR" -name "topic-*" -mtime +30 -delete 2>/dev/null
+    find "$TOPIC_DIR" -name "marker-*" -mtime +30 -delete 2>/dev/null
     echo "$NOW" > "$PRUNE_MARKER"
 fi
 

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionBrowser.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionBrowser.kt
@@ -62,13 +62,15 @@ object SessionBrowser {
                 val sessionId = jsonlFile.nameWithoutExtension
                 if (sessionId in activeIds) continue
 
-                // Read topic name if available
+                // Read the topic name from the topic file if present.
+                // "New Session" is the placeholder the auto-title hook writes
+                // before the model fills in a real title — normalize it (and a
+                // blank/missing file) to "Untitled" so SessionService can apply
+                // the conversation-index fallback (the topic file is pruned
+                // after 30 days and never syncs across devices).
                 val topicFile = File(topicsDir, "topic-$sessionId")
-                val name = if (topicFile.exists()) {
-                    topicFile.readText().trim().ifBlank { "Untitled" }
-                } else {
-                    "Untitled"
-                }
+                val rawName = if (topicFile.exists()) topicFile.readText().trim() else ""
+                val name = if (rawName.isBlank() || rawName == "New Session") "Untitled" else rawName
 
                 sessions.add(PastSession(
                     sessionId = sessionId,

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -1371,12 +1371,19 @@ class SessionService : Service() {
                 }
                 // Read user-set flag map from the synced conversation-index.json
                 val flagMap = withContext(Dispatchers.IO) { readFlagMap(homeDir) }
+                // Topic files are pruned after 30 days and never sync across
+                // devices; conversation-index.json keeps the name longer and
+                // does sync — fall back to it when the topic-file name is missing.
+                val topicMap = withContext(Dispatchers.IO) { readTopicMap(homeDir) }
                 val arr = org.json.JSONArray()
                 for (s in pastSessions) {
+                    // Prefer the topic-file name; fall back to the index topic.
+                    val indexTopic = topicMap[s.sessionId]
+                    val resolvedName = if (s.name == "Untitled" && !indexTopic.isNullOrBlank()) indexTopic else s.name
                     arr.put(JSONObject().apply {
                         put("sessionId", s.sessionId)
                         put("projectSlug", s.projectSlug)
-                        put("name", s.name)
+                        put("name", resolvedName)
                         put("lastModified", s.lastModified)
                         put("projectPath", s.projectPath)
                         // Fix: React's formatSize(undefined) rendered as "NaNMB".
@@ -3457,6 +3464,34 @@ class SessionService : Service() {
                     row["complete"] = true
                 }
                 if (row.isNotEmpty()) out[sid] = row
+            }
+            out
+        } catch (_: Throwable) { emptyMap() }
+    }
+
+    /**
+     * Read per-session topic names from ~/.claude/conversation-index.json.
+     * Used as a fallback for the Resume Browser when the ephemeral
+     * ~/.claude/topics/topic-<id> file has been pruned (30-day) or was never
+     * synced from another device — the index keeps the name longer and does
+     * sync. Excludes blank / placeholder names. Mirrors the desktop's
+     * readIndexMeta() topic map in session-browser.ts.
+     */
+    private fun readTopicMap(homeDir: File): Map<String, String> {
+        val indexFile = File(homeDir, ".claude/conversation-index.json")
+        if (!indexFile.exists()) return emptyMap()
+        return try {
+            val root = JSONObject(indexFile.readText())
+            val sessions = root.optJSONObject("sessions") ?: return emptyMap()
+            val out = mutableMapOf<String, String>()
+            val keys = sessions.keys()
+            while (keys.hasNext()) {
+                val sid = keys.next()
+                val entry = sessions.optJSONObject(sid) ?: continue
+                val topic = entry.optString("topic", "").trim()
+                if (topic.isNotBlank() && topic != "New Session" && topic != "Untitled") {
+                    out[sid] = topic
+                }
             }
             out
         } catch (_: Throwable) { emptyMap() }

--- a/desktop/hook-scripts/title-update.sh
+++ b/desktop/hook-scripts/title-update.sh
@@ -12,7 +12,9 @@ fi
 TOPIC_DIR="$HOME/.claude/topics"
 mkdir -p "$TOPIC_DIR"
 
-# Prune topic files older than 7 days (at most once per day)
+# Prune topic files older than 30 days (matches conversation-index.json
+# retention, so a session's name survives as long as its index entry).
+# Runs at most once per day.
 PRUNE_MARKER="$TOPIC_DIR/.prune-marker"
 NOW=$(date +%s)
 DO_PRUNE=false
@@ -26,8 +28,8 @@ else
     fi
 fi
 if [ "$DO_PRUNE" = true ]; then
-    find "$TOPIC_DIR" -name "topic-*" -mtime +7 -delete 2>/dev/null
-    find "$TOPIC_DIR" -name "marker-*" -mtime +7 -delete 2>/dev/null
+    find "$TOPIC_DIR" -name "topic-*" -mtime +30 -delete 2>/dev/null
+    find "$TOPIC_DIR" -name "marker-*" -mtime +30 -delete 2>/dev/null
     echo "$NOW" > "$PRUNE_MARKER"
 fi
 

--- a/desktop/scripts/install-hooks.js
+++ b/desktop/scripts/install-hooks.js
@@ -7,33 +7,58 @@ const SETTINGS_PATH = path.join(
   '.claude',
   'settings.json'
 );
-// In packaged builds, __dirname points inside app.asar (which Electron can read),
-// but Claude Code invokes relay.js externally via system node (which can't read asar).
-// Convert to the unpacked path so the hook command works at runtime.
-const rawRelayPath = path.resolve(__dirname, '..', 'hook-scripts', 'relay.js');
-const unpackedRelayPath = rawRelayPath.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
-// Use unpacked path if it exists, otherwise fall back to original
-const RELAY_PATH = fs.existsSync(unpackedRelayPath) ? unpackedRelayPath : rawRelayPath;
+// --- Resolve hook scripts to a STABLE location -----------------------------
+//
+// In packaged builds __dirname is inside app.asar; the hook scripts are
+// extracted to app.asar.unpacked so Claude Code (an external process) can read
+// them. But on Linux YouCoded ships as an AppImage, which mounts at a
+// *different* random /tmp/.mount_XXXXXX path on EVERY launch. Baking that
+// volatile path into ~/.claude/settings.json means every hook (relay,
+// auto-title, statusline) silently breaks the moment the app is closed — and
+// for any `claude` CLI session run outside the app.
+//
+// Fix: copy the bundled hook scripts into a fixed directory under ~/.claude on
+// each launch, and point settings.json at that stable copy instead.
+const rawHookSrcDir = path.resolve(__dirname, '..', 'hook-scripts');
+const HOOK_SRC_DIR = rawHookSrcDir.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
+const STABLE_HOOK_DIR = path.join(require('os').homedir(), '.claude', 'youcoded-hooks');
 
-// Blocking relay for PermissionRequest — holds socket open for bidirectional response
-const rawBlockingRelayPath = path.resolve(__dirname, '..', 'hook-scripts', 'relay-blocking.js');
-const unpackedBlockingRelayPath = rawBlockingRelayPath.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
-const BLOCKING_RELAY_PATH = fs.existsSync(unpackedBlockingRelayPath) ? unpackedBlockingRelayPath : rawBlockingRelayPath;
-
-// Safety: refuse to install hooks whose paths point inside a worktree. The
-// ~/.claude/settings.json file is a shared resource — if we write a worktree
-// path and the worktree is later removed, every hook call fails with ENOENT
-// until the built app is relaunched. This is a belt-and-suspenders backstop
-// for the YOUCODED_PROFILE gate in main.ts; if any future refactor breaks
-// that gate, this guard still prevents corruption.
-if (RELAY_PATH.includes(`${path.sep}.worktrees${path.sep}`)) {
+// Safety: refuse to run when the bundled scripts live inside a dev worktree.
+// settings.json is a shared resource — staging worktree-version scripts into
+// the stable dir would have the installed app run dev code. Belt-and-suspenders
+// backstop for the YOUCODED_PROFILE gate in main.ts.
+if (HOOK_SRC_DIR.includes(`${path.sep}.worktrees${path.sep}`)) {
   console.log(
-    'install-hooks: script path is inside a worktree (' + RELAY_PATH + ') — ' +
-    'refusing to write worktree paths to ~/.claude/settings.json. ' +
+    'install-hooks: hook source is inside a worktree (' + HOOK_SRC_DIR + ') — ' +
+    'refusing to touch ~/.claude/settings.json. ' +
     'If this was unexpected, check that YOUCODED_PROFILE is set when running dev.'
   );
   process.exit(0);
 }
+
+// Copy every bundled hook script into the stable dir (overwrites, so app
+// updates propagate). Returns the directory settings.json should reference:
+// the stable copy, or the bundled dir as a fallback if staging failed.
+function resolveHookDir() {
+  try {
+    fs.mkdirSync(STABLE_HOOK_DIR, { recursive: true });
+    for (const file of fs.readdirSync(HOOK_SRC_DIR)) {
+      // recursive:true so a future lib/ subdir (statusline.sh sources one) copies too.
+      fs.cpSync(path.join(HOOK_SRC_DIR, file), path.join(STABLE_HOOK_DIR, file), { recursive: true });
+      if (file.endsWith('.sh')) fs.chmodSync(path.join(STABLE_HOOK_DIR, file), 0o755);
+    }
+    // Trust the stable dir only if the critical script actually landed.
+    if (fs.existsSync(path.join(STABLE_HOOK_DIR, 'relay.js'))) return STABLE_HOOK_DIR;
+  } catch (e) {
+    console.warn('install-hooks: failed to stage hook scripts to ' + STABLE_HOOK_DIR + ':', e.message);
+  }
+  // Fallback: a volatile path is still better than a missing one.
+  return HOOK_SRC_DIR;
+}
+
+const HOOK_DIR = resolveHookDir();
+const RELAY_PATH = path.join(HOOK_DIR, 'relay.js');
+const BLOCKING_RELAY_PATH = path.join(HOOK_DIR, 'relay-blocking.js');
 
 // Fire-and-forget events use the standard relay
 const FIRE_AND_FORGET_EVENTS = [
@@ -112,10 +137,9 @@ function installHooks() {
   }
 
   // --- Auto-titling hook ---
-  // Always use the app-bundled title-update script (app owns session naming).
-  const rawTitlePath = path.resolve(__dirname, '..', 'hook-scripts', 'title-update.sh');
-  const unpackedTitlePath = rawTitlePath.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
-  const activeTitlePath = fs.existsSync(unpackedTitlePath) ? unpackedTitlePath : rawTitlePath;
+  // Always use the app-bundled title-update script (app owns session naming),
+  // resolved via the stable hook dir so it survives across AppImage launches.
+  const activeTitlePath = path.join(HOOK_DIR, 'title-update.sh');
 
   if (!settings.hooks['PostToolUse']) {
     settings.hooks['PostToolUse'] = [];
@@ -170,9 +194,7 @@ When you see an \`[Auto-Title]\` reminder, **immediately** use Bash to write a 3
   // Always use the app-bundled statusline script (app owns context % display).
   // Only set if unset or pointing to a known youcoded-core/app path — don't overwrite
   // custom user scripts.
-  const rawStatuslinePath = path.resolve(__dirname, '..', 'hook-scripts', 'statusline.sh');
-  const unpackedStatuslinePath = rawStatuslinePath.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
-  const activeStatuslinePath = fs.existsSync(unpackedStatuslinePath) ? unpackedStatuslinePath : rawStatuslinePath;
+  const activeStatuslinePath = path.join(HOOK_DIR, 'statusline.sh');
   const currentStatuslineCmd = settings.statusLine?.command || '';
   const isOurStatusline = !currentStatuslineCmd
     || currentStatuslineCmd.includes('statusline.sh')

--- a/desktop/src/main/session-browser.ts
+++ b/desktop/src/main/session-browser.ts
@@ -8,14 +8,24 @@ const PROJECTS_DIR = path.join(CLAUDE_DIR, 'projects');
 const TOPICS_DIR = path.join(CLAUDE_DIR, 'topics');
 const CONVERSATION_INDEX_PATH = path.join(CLAUDE_DIR, 'conversation-index.json');
 
-/** Read the per-session flag map from conversation-index.json. Also lifts v1
- *  legacy `complete` / `completeUpdatedAt` fields into the new flags shape so
- *  older entries (written before the flags generalization) still show up. */
-function readFlagMap(): Record<string, Record<string, boolean>> {
+/** Read per-session metadata from conversation-index.json: the user-set flag
+ *  map AND the topic (display name). Lifts v1 legacy `complete` into the flags
+ *  shape so older entries still show up.
+ *
+ *  The conversation index is the *durable* name store — it keeps a session's
+ *  topic for 30 days (INDEX_PRUNE_DAYS) and syncs across devices. The
+ *  `topics/topic-<id>` files are the *ephemeral* store — pruned by the
+ *  auto-title hook and never synced. The Resume Browser reads the file first
+ *  and falls back to `topics` here when the file is gone (see readTopic). */
+function readIndexMeta(): {
+  flags: Record<string, Record<string, boolean>>;
+  topics: Record<string, string>;
+} {
+  const flags: Record<string, Record<string, boolean>> = {};
+  const topics: Record<string, string> = {};
   try {
     const raw = fs.readFileSync(CONVERSATION_INDEX_PATH, 'utf8');
     const index = JSON.parse(raw);
-    const out: Record<string, Record<string, boolean>> = {};
     for (const [sid, entry] of Object.entries<any>(index?.sessions || {})) {
       if (!entry) continue;
       const on: Record<string, boolean> = {};
@@ -24,10 +34,13 @@ function readFlagMap(): Record<string, Record<string, boolean>> {
       }
       // v1 legacy — tolerated on read until old devices are upgraded.
       if (!on.complete && entry.complete) on.complete = true;
-      if (Object.keys(on).length > 0) out[sid] = on;
+      if (Object.keys(on).length > 0) flags[sid] = on;
+      if (typeof entry.topic === 'string' && entry.topic.trim()) {
+        topics[sid] = entry.topic.trim();
+      }
     }
-    return out;
-  } catch { return {}; }
+  } catch { /* index missing/corrupt — no flags or topic fallback available */ }
+  return { flags, topics };
 }
 
 const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
@@ -97,13 +110,20 @@ function walkSlugParts(base: string, parts: string[]): string {
   return path.join(base, parts.join('-'));
 }
 
-async function readTopic(sessionId: string): Promise<string> {
+/** Resolve a session's display name. The auto-title hook writes
+ *  `topics/topic-<id>`, but those files are pruned (30-day) and never sync
+ *  across devices — so when the file is missing, or still holds the pre-title
+ *  "New Session" placeholder, fall back to the conversation index, which keeps
+ *  the name longer and is synced. Without this fallback the Resume Browser
+ *  showed "Untitled" for every session whose topic file had been pruned. */
+async function readTopic(sessionId: string, indexTopics: Record<string, string>): Promise<string> {
   try {
-    const content = await fs.promises.readFile(path.join(TOPICS_DIR, `topic-${sessionId}`), 'utf8');
-    return content.trim() || 'Untitled';
-  } catch {
-    return 'Untitled';
-  }
+    const content = (await fs.promises.readFile(path.join(TOPICS_DIR, `topic-${sessionId}`), 'utf8')).trim();
+    if (content && content !== 'New Session') return content;
+  } catch { /* topic file pruned or never written — fall through to the index */ }
+  const indexed = indexTopics[sessionId];
+  if (indexed && indexed !== 'New Session' && indexed !== 'Untitled') return indexed;
+  return 'Untitled';
 }
 
 /**
@@ -130,8 +150,8 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
     return [];
   }
 
-  // Join complete-flag metadata from the synced conversation index
-  const flagMap = readFlagMap();
+  // Join flag + topic metadata from the synced conversation index
+  const indexMeta = readIndexMeta();
 
   const allSessions: PastSession[] = [];
 
@@ -152,9 +172,9 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
       try {
         const stat = await withRetry(() => fs.promises.stat(path.join(slugDir, file)));
         if (stat.size < 500) return null;
-        const name = await readTopic(sessionId);
+        const name = await readTopic(sessionId, indexMeta.topics);
 
-        const joinedFlags = flagMap[sessionId];
+        const joinedFlags = indexMeta.flags[sessionId];
         return {
           sessionId,
           name,


### PR DESCRIPTION
## Problem

On Linux, sessions showed **"Untitled"** in the Resume Browser, and many sessions were **never named at all**. Investigation found three independent bugs.

### Bug 1 — name resolution read only the ephemeral topic file
The Resume Browser (`session-browser.ts` / `SessionBrowser.kt`) resolved each session's name **solely** from `~/.claude/topics/topic-<id>`. But that file is pruned by the auto-title hook, whereas `conversation-index.json` keeps the `topic` for 30 days **and syncs across devices**. Any session whose topic file was pruned (or never synced to a new device) showed "Untitled" despite having a perfectly good name in the index.

**Fix:** fall back to the conversation-index `topic` when the topic file is missing or still holds the `New Session` placeholder. The topic file still wins when present.

### Bug 2 — topic files pruned more aggressively than the index
`title-update.sh` deleted topic files after **7 days**; the index keeps entries for **30 days** (`INDEX_PRUNE_DAYS`). That 7–30 day gap is exactly when Bug 1 bit.

**Fix:** bump the topic-file prune to 30 days so the file survives as long as its index entry.

### Bug 3 — AppImage hook paths were volatile
On Linux YouCoded ships as an AppImage, which mounts at a **different random `/tmp/.mount_XXXXXX` path on every launch**. `install-hooks.js` baked that path straight into `~/.claude/settings.json`, so every hook (relay, auto-title, statusline) silently broke the moment the app closed — and for any `claude` CLI session run outside the app. This is a major cause of sessions never getting named.

**Fix:** `install-hooks.js` now copies the bundled hook scripts into a stable `~/.claude/youcoded-hooks/` directory and points `settings.json` there. Stale `.mount_` paths from prior launches are repaired in place. The worktree-safety guard now checks the script *source* dir.

## Files
- `desktop/src/main/session-browser.ts` — `readFlagMap` → `readIndexMeta` (flags **+ topics**); `readTopic` falls back to the index.
- `desktop/scripts/install-hooks.js` — stage hook scripts to `~/.claude/youcoded-hooks/`.
- `desktop/hook-scripts/title-update.sh` + `app/src/main/assets/title-update.sh` — prune 7 → 30 days.
- `app/.../SessionBrowser.kt` — normalize `New Session`/blank → `Untitled`.
- `app/.../SessionService.kt` — `readTopicMap` + index fallback in the `session:browse` handler.

## Verification
- Desktop `tsc` clean; full test suite passes (the one `update-installer.test.ts` failure is **pre-existing on master**, unrelated).
- `install-hooks.js` exercised against a temp `HOME`: stages all 5 scripts, chmod 755 on `.sh`, writes stable paths, idempotent re-run, and migrates stale `/tmp/.mount_*` paths in place with no duplication.
- End-to-end `listPastSessions`: pruned topic file → falls back to index name; topic file present → file wins; index `topic: "Untitled"` → stays `Untitled`.
- Android: no SDK in the dev environment — Kotlin mirrors the verified desktop logic; CI will compile-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)