### PR TITLE
build(linux): add deb, rpm, and pacman package targets

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -58,15 +58,18 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build
-        run: npm run build
-
       - name: Install Linux build deps
         if: runner.os == 'Linux'
-        # xvfb: headless display for the smoke test.
-        # rpm: required by electron-builder's rpm target (not on the runner by default).
-        run: sudo apt-get install -y xvfb rpm
+        # Must run BEFORE the build — electron-builder's deb/rpm/pacman
+        # packagers run inside `npm run build`:
+        #   libarchive-tools -> provides bsdtar, required by the pacman target
+        #   rpm              -> required by the rpm target
+        #   xvfb             -> headless display for the smoke test below
+        run: sudo apt-get install -y xvfb rpm libarchive-tools
         working-directory: .
+
+      - name: Build
+        run: npm run build
 
       - name: Smoke test
         # Launch the production build briefly and verify no renderer crash.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -21,7 +21,11 @@ jobs:
             artifact: desktop/release/*.dmg
             name: macos
           - os: ubuntu-latest
-            artifact: desktop/release/*.AppImage
+            artifact: |
+              desktop/release/*.AppImage
+              desktop/release/*.deb
+              desktop/release/*.rpm
+              desktop/release/*.pacman
             name: linux
 
     runs-on: ${{ matrix.os }}
@@ -57,9 +61,11 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Install xvfb (Linux)
+      - name: Install Linux build deps
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y xvfb
+        # xvfb: headless display for the smoke test.
+        # rpm: required by electron-builder's rpm target (not on the runner by default).
+        run: sudo apt-get install -y xvfb rpm
         working-directory: .
 
       - name: Smoke test

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,7 +1,5 @@
 appId: com.youcoded.desktop
 productName: YouCoded
-# homepage is required metadata for the deb/rpm packagers.
-homepage: https://github.com/itsdestin/youcoded
 directories:
   output: release
   buildResources: assets

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,5 +1,7 @@
 appId: com.youcoded.desktop
 productName: YouCoded
+# homepage is required metadata for the deb/rpm packagers.
+homepage: https://github.com/itsdestin/youcoded
 directories:
   output: release
   buildResources: assets

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -13,8 +13,19 @@ mac:
         - arm64
   category: public.app-category.developer-tools
 linux:
-  target: AppImage
+  # AppImage runs on any distro but stays a loose file. deb / rpm / pacman are
+  # real installers (Debian-Ubuntu / Fedora / Arch) that install to a fixed
+  # path and register a menu entry + icon, so YouCoded pins to the taskbar and
+  # behaves like a native app.
+  target:
+    - AppImage
+    - deb
+    - rpm
+    - pacman
   category: Development
+  # maintainer is required by the deb/rpm packagers.
+  maintainer: itsdestin <itsdestin@users.noreply.github.com>
+  synopsis: Desktop GUI for Claude Code with the YouCoded toolkit
 npmRebuild: false
 asarUnpack:
   - dist/main/pty-worker.js

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -26,6 +26,17 @@ linux:
   # maintainer is required by the deb/rpm packagers.
   maintainer: itsdestin <itsdestin@users.noreply.github.com>
   synopsis: Desktop GUI for Claude Code with the YouCoded toolkit
+pacman:
+  # electron-builder auto-generates Debian-style dependency names for the
+  # pacman target, and `libappindicator-gtk3` is AUR-only — not in Arch's
+  # official repos — so a stock `pacman -U` of the package fails to resolve
+  # it. Pin the real Arch runtime deps instead (all in core/extra).
+  depends:
+    - gtk3
+    - nss
+    - libxss
+    - libnotify
+    - alsa-lib
 npmRebuild: false
 asarUnpack:
   - dist/main/pty-worker.js

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,6 +2,7 @@
   "name": "youcoded",
   "version": "1.2.4",
   "description": "Desktop GUI for Claude Code with the YouCoded toolkit",
+  "homepage": "https://github.com/itsdestin/youcoded",
   "main": "dist/main/main.js",
   "scripts": {
     "dev": "node scripts/run-dev.js",


### PR DESCRIPTION
## Why

The Linux build produced **only an AppImage** — a loose file the system doesn't know about. It can't be pinned to the taskbar, doesn't show in the app menu, and runs from a volatile `/tmp/.mount_XXXX` path that changes every launch (the root cause of the hook-path bug in #97).

## Change

`electron-builder` (already producing the AppImage) now also emits real installers from the same build:

- **`electron-builder.yml`** — `linux.target` builds `AppImage` + `deb` + `rpm` + `pacman`. Added `maintainer` + `synopsis` (required by the deb/rpm packagers). Each installer registers a `.desktop` entry + icon, so YouCoded installs to a fixed path and pins like a native app.
- **`desktop-release.yml`** — the Linux job now collects all four artifact types, and installs `rpm` on the runner (electron-builder's rpm target needs the `rpm` binary, not present on `ubuntu-latest` by default).

AppImage stays as the no-install / any-distro option.

| Format | For |
|--------|-----|
| `.AppImage` | Any distro, no install |
| `.deb` | Debian / Ubuntu / Mint |
| `.rpm` | Fedora / RHEL / openSUSE |
| `.pacman` | Arch / CachyOS / Manjaro |

## Verification

Triggered a `workflow_dispatch` run on this branch (builds all targets, skips the release upload since it's not a tag) — see the linked run. **Do not merge until the Linux job is green**, confirming all four targets build on the CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)