### PR TITLE
ci: install rpm + libarchive-tools on Linux CI runners (unbreaks #98 regression)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -42,7 +42,10 @@ jobs:
       #   libarchive-tools -> provides bsdtar (pacman target)
       #   rpm              -> rpm target
       - name: Install Linux build deps
-        run: sudo apt-get install -y rpm libarchive-tools
+        # `apt-get update` prefix: the cached package index on ubuntu-latest
+        # often points to .deb versions that have rolled off the mirror, so
+        # a bare install hits HTTP 404 / exit 100. Refresh the index first.
+        run: sudo apt-get update && sudo apt-get install -y rpm libarchive-tools
 
       - name: Run unit tests
         run: ./gradlew test

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # bundleWebUi (a Gradle dep of preBuild) shells out to
+      # scripts/build-web-ui.sh, which runs `npm run build` in desktop/. That
+      # invokes electron-builder for ALL configured Linux targets
+      # (AppImage + deb + rpm + pacman), so the runner needs rpm + bsdtar
+      # even though Android doesn't consume the installers. PR #98 added
+      # pacman+rpm targets without updating this workflow; every Android CI
+      # run since 2026-05-20 has been red on bsdtar exit 127.
+      #   libarchive-tools -> provides bsdtar (pacman target)
+      #   rpm              -> rpm target
+      - name: Install Linux build deps
+        run: sudo apt-get install -y rpm libarchive-tools
+
       - name: Run unit tests
         run: ./gradlew test
 

--- a/.github/workflows/android-test-build.yml
+++ b/.github/workflows/android-test-build.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # build-web-ui.sh runs `npm run build` in desktop/, which invokes
+      # electron-builder for all configured Linux targets. Pacman needs
+      # bsdtar (libarchive-tools); rpm target needs the rpm package. See
+      # android-ci.yml for the full backstory on the PR #98 regression.
+      - name: Install Linux build deps
+        run: sudo apt-get install -y rpm libarchive-tools
+
       # Build the full React UI so the APK has a working WebView.
       # bundleWebUi (Gradle preBuild dep) would do this too, but running
       # it explicitly here keeps this workflow's intent self-documenting.

--- a/.github/workflows/android-test-build.yml
+++ b/.github/workflows/android-test-build.yml
@@ -31,7 +31,10 @@ jobs:
       # bsdtar (libarchive-tools); rpm target needs the rpm package. See
       # android-ci.yml for the full backstory on the PR #98 regression.
       - name: Install Linux build deps
-        run: sudo apt-get install -y rpm libarchive-tools
+        # `apt-get update` prefix: the cached package index on ubuntu-latest
+        # often points to .deb versions that have rolled off the mirror, so
+        # a bare install hits HTTP 404 / exit 100. Refresh the index first.
+        run: sudo apt-get update && sudo apt-get install -y rpm libarchive-tools
 
       # Build the full React UI so the APK has a working WebView.
       # bundleWebUi (Gradle preBuild dep) would do this too, but running

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -27,5 +27,16 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # Must run BEFORE the build — electron-builder's deb/rpm/pacman packagers
+      # run inside `npm run build` (see desktop/electron-builder.yml linux.target).
+      # PR #98 added rpm + pacman targets without updating CI, so every Desktop
+      # CI run since 2026-05-20 (commit 4679cc89) has been red on the same
+      # bsdtar-missing failure. Mirror desktop-release.yml's setup step:
+      #   libarchive-tools -> provides bsdtar, required by the pacman target
+      #   rpm              -> required by the rpm target
+      - name: Install Linux build deps
+        run: sudo apt-get install -y rpm libarchive-tools
+        working-directory: .
+
       - name: Build
         run: npm run build

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -35,7 +35,11 @@ jobs:
       #   libarchive-tools -> provides bsdtar, required by the pacman target
       #   rpm              -> required by the rpm target
       - name: Install Linux build deps
-        run: sudo apt-get install -y rpm libarchive-tools
+        # apt-get update prefix: the cached package index on ubuntu-latest
+        # frequently points to .deb versions that have already rolled off
+        # the mirror, so a bare `install` fails with HTTP 404 / exit 100.
+        # Refresh the index first.
+        run: sudo apt-get update && sudo apt-get install -y rpm libarchive-tools
         working-directory: .
 
       - name: Build

--- a/.github/workflows/desktop-test-build.yml
+++ b/.github/workflows/desktop-test-build.yml
@@ -43,7 +43,10 @@ jobs:
       # run inside `npm run build`. See desktop-ci.yml for the PR #98 backstory.
       - name: Install Linux build deps
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y rpm libarchive-tools
+        # `apt-get update` prefix: the cached package index on ubuntu-latest
+        # often points to .deb versions that have rolled off the mirror, so
+        # a bare install hits HTTP 404 / exit 100. Refresh the index first.
+        run: sudo apt-get update && sudo apt-get install -y rpm libarchive-tools
         working-directory: .
 
       - name: Build

--- a/.github/workflows/desktop-test-build.yml
+++ b/.github/workflows/desktop-test-build.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # Must run BEFORE the build — electron-builder's deb/rpm/pacman packagers
+      # run inside `npm run build`. See desktop-ci.yml for the PR #98 backstory.
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y rpm libarchive-tools
+        working-directory: .
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Summary

Master CI has been red since PR #98 (\`4679cc89\`, 2026-05-20) — both Desktop CI and Android CI failing the same way:

\`\`\`
{message: \"Process failed: /bin/bash failed (exit code 127). Full command was:
[\"/bin/bash\", \"-c\", \"LANG=C bsdtar -czf .MTREE ...\"]\"}
⨯ fpm process failed 1
\`\`\`

PR #98 added \`rpm\` and \`pacman\` targets to \`desktop/electron-builder.yml\` \`linux.target\`, and updated \`desktop-release.yml\` to install \`rpm\` + \`libarchive-tools\` (which provides bsdtar) before the build — but missed the four other workflows that also run \`npm run build\` on \`ubuntu-latest\`. So every CI run since hit pacman packaging with no bsdtar on the runner → exit 127.

This PR mirrors release.yml's setup step into:

- \`desktop-ci.yml\`         (per-push verification — main offender)
- \`android-ci.yml\`         (bundleWebUi → scripts/build-web-ui.sh → npm run build)
- \`android-test-build.yml\` (workflow_dispatch parity build)
- \`desktop-test-build.yml\` (workflow_dispatch matrix; only Linux matrix slot, gated on runner.os)

No application code or build-output change. Pure CI runner-env fix.

## Failure baseline

Last green master CI: \`1f9af7da\` (PR #97). Every push after PR #98 has been red on both CI workflows with the same trace. Verified via:

\`\`\`
gh run list --workflow=desktop-ci.yml --branch=master --limit=5
\`\`\`

## Test plan
- [ ] This PR's own CI goes green
- [ ] After merge, re-run Desktop CI + Android CI on master and confirm green
- [ ] Reopen / land #100 (compaction fix) on top of the now-green master

🤖 Generated with [Claude Code](https://claude.com/claude-code)