### PR TITLE
Cross-device sync Phase 1a: sync spaces foundation

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -22,6 +22,10 @@ import { isBundledPlugin } from '../shared/bundled-plugins';
 import { ThemeMarketplaceProvider } from './theme-marketplace-provider';
 import { generateThemePreview } from './theme-preview-generator';
 import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dismissWarning, addBackend, removeBackend, updateBackend, pushBackend, pullBackend, getSyncService, type SyncWarning } from './sync-state';
+// Cross-device sync spaces (spec 2026-07-03) — the folder-based sync engine.
+import {
+  syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, getManagedRoots,
+} from './sync-spaces/service';
 import { getConfig as getMarketplaceConfig, setConfig as setMarketplaceConfig } from './marketplace-config-store';
 import { readComponent, type ComponentKind } from './marketplace-file-reader';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
@@ -804,10 +808,21 @@ export function registerIpcHandlers(
       writeFolders(folders);
     }
     // Annotate each folder with whether the path still exists on disk
-    return folders.map(f => ({
+    const result: any[] = folders.map(f => ({
       ...f,
       exists: fs.existsSync(f.path),
     }));
+    // Managed projects (spec §3) always appear in the session-creation picker,
+    // deduped against saved folders by normalized path. `managed: true` lets
+    // the renderer badge them. addedAt:0 sorts them below user-added folders.
+    const managed = getManagedRoots()?.listProjects() ?? [];
+    const known = new Set(result.map(f => path.resolve(f.path).toLowerCase()));
+    for (const p of managed) {
+      if (!known.has(path.resolve(p.path).toLowerCase())) {
+        result.push({ path: p.path, nickname: p.name, addedAt: 0, exists: true, managed: true });
+      }
+    }
+    return result;
   });
 
   ipcMain.handle(IPC.FOLDERS_ADD, async (_event, folderPath: string, nickname?: string) => {
@@ -1904,6 +1919,14 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC.SYNC_FORCE, () => forceSync());
   ipcMain.handle(IPC.SYNC_GET_LOG, (_e, lines) => getSyncLog(lines));
   ipcMain.handle(IPC.SYNC_DISMISS_WARNING, (_e, warning) => dismissWarning(warning));
+
+  // Cross-device sync spaces (spec 2026-07-03) — folder-based sync engine,
+  // distinct from the legacy sync:* backup control plane above. The service
+  // module owns the singleton engine/manager/roots.
+  ipcMain.handle(IPC.SYNC_SPACES_STATUS, () => syncSpacesStatus());
+  ipcMain.handle(IPC.SYNC_SPACES_ENABLE, (_e, enabled: boolean) => syncSpacesEnable(!!enabled));
+  ipcMain.handle(IPC.SYNC_SPACES_SYNC_NOW, () => syncSpacesSyncNow());
+  ipcMain.handle(IPC.SYNC_SPACES_CREATE_PROJECT, (_e, name: string) => syncSpacesCreateProject(String(name ?? '')));
 
   // V2: Per-instance backend management (storage backends + multi-instance support)
   ipcMain.handle('sync:add-backend', (_e, instance) => addBackend(instance));

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -16,7 +16,9 @@ import { log, rotateLog } from './logger';
 import { registerThemeProtocol } from './theme-protocol';
 import { FirstRunManager } from './first-run';
 import { SyncService } from './sync-service';
-import { setSyncService } from './sync-state';
+import { setSyncService, getSyncConfig } from './sync-state';
+// Cross-device sync spaces (spec 2026-07-03) — folder-based sync engine.
+import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster } from './sync-spaces/service';
 import { initRestoreService } from './restore-service';
 import { createAuthStore } from './marketplace-auth-store';
 import { registerMarketplaceApiHandlers } from './marketplace-api-handlers';
@@ -1432,6 +1434,30 @@ app.whenReady().then(async () => {
   // Initialize restore service after sync is live — it needs SyncService to
   // flip restoreInProgress, which pauses the push loop during restore/undo.
   initRestoreService(syncService, app.getPath('userData'));
+
+  // Cross-device sync spaces (spec 2026-07-03). Roots always ensured (the
+  // session picker lists them); the engine runs only when the user enabled
+  // sync. Wire the remote broadcaster first so engine events fired during the
+  // initial reconcile still reach any already-connected remote clients.
+  setSyncSpacesRemoteBroadcaster((e) => remoteServer.broadcast({ type: 'syncspaces:event', payload: e }));
+  startSyncSpaces(
+    async () => {
+      // Daily dated backup targets come from the SAME backend config the legacy
+      // system uses — drive + iCloud only (GitHub is sync, not backup; spec §11).
+      // getSyncConfig is async and exposes the backends array as `.backends`
+      // (each BackendInstance carries type-specific fields in `.config`).
+      const cfg = await getSyncConfig();
+      return (cfg?.backends ?? [])
+        .filter((b) => b.type === 'drive' || b.type === 'icloud')
+        .map((b) => b.type === 'drive'
+          ? { type: 'drive' as const, base: `${b.config?.rcloneRemote ?? 'gdrive'}:${b.config?.DRIVE_ROOT ?? 'Claude'}` }
+          // iCloud base is a local folder path — drop backends that never set one.
+          : { type: 'icloud' as const, base: b.config?.ICLOUD_PATH ?? '' })
+        .filter((t) => t.base.length > 0);
+    },
+    (m) => log('INFO', 'SyncSpaces', m),
+  ).catch(e => log('ERROR', 'Main', 'SyncSpaces start failed', { error: String(e) }));
+
   // Push session JSONL on session close (replaces session-end-sync.sh)
   sessionManager.on('session-exit', (sessionId: string) => {
     syncService.pushSession(sessionId).catch(e =>
@@ -1445,6 +1471,8 @@ app.on('window-all-closed', () => {
   sessionManager.destroyAll();
   hookRelay.stop();
   remoteServer.stop();
+  // Stop the cross-device sync-spaces engine (clears its backup timer + watchers).
+  try { void stopSyncSpaces(); } catch {}
   // Stop sync service — clears timer, releases locks, removes .app-sync-active marker
   try { setSyncService(null); } catch {}
   app.quit();

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1472,7 +1472,9 @@ app.on('window-all-closed', () => {
   hookRelay.stop();
   remoteServer.stop();
   // Stop the cross-device sync-spaces engine (clears its backup timer + watchers).
-  try { void stopSyncSpaces(); } catch {}
+  // .catch, not try/catch: it's an async fn, so a failure arrives as a rejected
+  // promise — the old `void` call left that rejection unhandled at quit.
+  stopSyncSpaces().catch(() => {});
   // Stop sync service — clears timer, releases locks, removes .app-sync-active marker
   try { setSyncService(null); } catch {}
   app.quit();

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -164,6 +164,12 @@ const IPC = {
   SYNC_FORCE: 'sync:force',
   SYNC_GET_LOG: 'sync:get-log',
   SYNC_DISMISS_WARNING: 'sync:dismiss-warning',
+  // Cross-device sync spaces (spec 2026-07-03) — distinct from the legacy sync:* above
+  SYNC_SPACES_STATUS: 'syncspaces:status',
+  SYNC_SPACES_ENABLE: 'syncspaces:enable',
+  SYNC_SPACES_SYNC_NOW: 'syncspaces:sync-now',
+  SYNC_SPACES_CREATE_PROJECT: 'syncspaces:create-project',
+  SYNC_SPACES_EVENT: 'syncspaces:event',
   // Restore from backup (directional pull — see restore-service.ts)
   SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
   SYNC_RESTORE_PREVIEW: 'sync:restore:preview',
@@ -642,6 +648,22 @@ contextBridge.exposeInMainWorld('claude', {
         ipcRenderer.on(IPC.SYNC_RESTORE_PROGRESS, handler);
         return () => ipcRenderer.removeListener(IPC.SYNC_RESTORE_PROGRESS, handler);
       },
+    },
+  },
+  // Cross-device sync spaces (spec 2026-07-03) — the new folder-based sync
+  // engine. Kept as its own namespace so it never entangles with the legacy
+  // sync.* backup API above.
+  syncSpaces: {
+    status: () => ipcRenderer.invoke(IPC.SYNC_SPACES_STATUS),
+    enable: (enabled: boolean) => ipcRenderer.invoke(IPC.SYNC_SPACES_ENABLE, enabled),
+    syncNow: () => ipcRenderer.invoke(IPC.SYNC_SPACES_SYNC_NOW),
+    createProject: (name: string) => ipcRenderer.invoke(IPC.SYNC_SPACES_CREATE_PROJECT, name),
+    // Returns an unsubscribe function — callers MUST invoke it on unmount to
+    // avoid leaking listeners across mounts (matches restore.onProgress above).
+    onEvent: (cb: (e: unknown) => void) => {
+      const listener = (_: unknown, e: unknown) => cb(e);
+      ipcRenderer.on(IPC.SYNC_SPACES_EVENT, listener);
+      return () => ipcRenderer.removeListener(IPC.SYNC_SPACES_EVENT, listener);
     },
   },
   getFavorites: () => ipcRenderer.invoke('favorites:get'),

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -15,6 +15,9 @@ import { readTranscriptMeta } from './transcript-utils';
 import { listPastSessions, loadHistory } from './session-browser';
 import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dismissWarning, addBackend, removeBackend, updateBackend, pushBackend, pullBackend } from './sync-state';
 import { getRestoreService } from './restore-service';
+// Cross-device sync spaces (spec 2026-07-03) — same service functions the
+// Electron IPC handlers call, so remote browsers get identical behavior.
+import { syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject } from './sync-spaces/service';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
 
 const PTY_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB per session — enough for full conversation replay
@@ -1104,6 +1107,27 @@ export class RemoteServer {
         // falling back to the whole object (which would be a silent no-op).
         await dismissWarning(payload?.warning ?? '');
         this.respond(client.ws, type, id, { ok: true });
+        break;
+      }
+
+      // Cross-device sync spaces (spec 2026-07-03). Remote-shim sends payloads
+      // wrapped as { enabled } / { name }; unwrap the same way the sync:* cases
+      // above do. The syncspaces:event push reaches remote clients via the
+      // broadcast in service.ts (see broadcastToRenderers wiring below).
+      case 'syncspaces:status': {
+        this.respond(client.ws, type, id, await syncSpacesStatus());
+        break;
+      }
+      case 'syncspaces:enable': {
+        this.respond(client.ws, type, id, await syncSpacesEnable(!!payload?.enabled));
+        break;
+      }
+      case 'syncspaces:sync-now': {
+        this.respond(client.ws, type, id, await syncSpacesSyncNow());
+        break;
+      }
+      case 'syncspaces:create-project': {
+        this.respond(client.ws, type, id, await syncSpacesCreateProject(String(payload?.name ?? '')));
         break;
       }
 

--- a/desktop/src/main/sync-spaces/daily-backup.ts
+++ b/desktop/src/main/sync-spaces/daily-backup.ts
@@ -1,0 +1,92 @@
+// Spec §11: once per day, copy ALL synced spaces to each configured Drive /
+// iCloud backend into a dated folder, then prune by age. Runs ALONGSIDE the
+// legacy backup in 1a (legacy is untouched until conversations move in Phase 2).
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { DEFAULT_IGNORES } from './guards';
+import type { SyncSpace } from './types';
+
+const execFileAsync = promisify(execFile);
+const RCLONE_TIMEOUT = 10 * 60 * 1000;
+
+// ---- pure helpers (unit-tested) ----
+export function datedFolderName(now: Date): string { return now.toISOString().slice(0, 10); }
+
+export function isBackupDue(markerContent: string | null, now: Date): boolean {
+  return markerContent !== datedFolderName(now);
+}
+
+export function foldersToPrune(names: string[], now: Date, keepDays: number): string[] {
+  const cutoff = now.getTime() - keepDays * 24 * 60 * 60 * 1000;
+  return names.filter(n => /^\d{4}-\d{2}-\d{2}$/.test(n) && new Date(`${n}T00:00:00Z`).getTime() < cutoff);
+}
+
+// ---- job ----
+export interface BackupTarget {
+  type: 'drive' | 'icloud';
+  /** drive: rclone remote+root e.g. "gdrive:Claude"; icloud: absolute folder path */
+  base: string;
+}
+
+export class DailyBackup {
+  private markerPath: string;
+
+  constructor(opts?: { markerPath?: string }) {
+    this.markerPath = opts?.markerPath ?? path.join(os.homedir(), '.claude', '.spaces-backup-marker');
+  }
+
+  /** Call from an hourly timer; no-ops until a new UTC day. Never throws. */
+  async runIfDue(spaces: SyncSpace[], targets: BackupTarget[], log: (msg: string) => void): Promise<void> {
+    let marker: string | null = null;
+    try { marker = fs.readFileSync(this.markerPath, 'utf8').trim(); } catch { /* first run */ }
+    const now = new Date();
+    if (!isBackupDue(marker, now) || targets.length === 0) return;
+    const dated = datedFolderName(now);
+    for (const target of targets) {
+      for (const space of spaces) {
+        try { await this.copySpace(space, target, dated); }
+        catch (e: any) { log(`spaces-backup failed for ${space.id} → ${target.type}: ${String(e?.message ?? e)}`); }
+      }
+      try { await this.prune(target, now, log); } catch { /* prune is best-effort */ }
+    }
+    fs.writeFileSync(this.markerPath, dated);
+    log(`spaces-backup completed for ${dated} (${spaces.length} spaces, ${targets.length} targets)`);
+  }
+
+  private async copySpace(space: SyncSpace, target: BackupTarget, dated: string): Promise<void> {
+    if (target.type === 'drive') {
+      const dest = `${target.base}/Backup/spaces/${dated}/${space.id.replace(':', '-')}`;
+      const excludes = DEFAULT_IGNORES.flatMap(p => ['--exclude', p.endsWith('/') ? `${p}**` : p]);
+      await execFileAsync('rclone', ['copy', space.root, dest, ...excludes], { timeout: RCLONE_TIMEOUT });
+    } else {
+      const dest = path.join(target.base, 'Backup', 'spaces', dated, space.id.replace(':', '-'));
+      fs.mkdirSync(dest, { recursive: true });
+      fs.cpSync(space.root, dest, {
+        recursive: true,
+        filter: (src) => !/([\\/])(node_modules|\.youcoded|\.git)([\\/]|$)/.test(src) && !path.basename(src).startsWith('.env'),
+      });
+    }
+  }
+
+  private async prune(target: BackupTarget, now: Date, log: (m: string) => void): Promise<void> {
+    if (target.type === 'drive') {
+      const { stdout } = await execFileAsync('rclone', ['lsf', '--dirs-only', `${target.base}/Backup/spaces/`], { timeout: RCLONE_TIMEOUT });
+      const names = stdout.split('\n').map(s => s.replace(/\/$/, '')).filter(Boolean);
+      for (const name of foldersToPrune(names, now, 30)) {
+        await execFileAsync('rclone', ['purge', `${target.base}/Backup/spaces/${name}`], { timeout: RCLONE_TIMEOUT });
+        log(`spaces-backup pruned ${name}`);
+      }
+    } else {
+      const dir = path.join(target.base, 'Backup', 'spaces');
+      let names: string[] = [];
+      try { names = fs.readdirSync(dir); } catch { return; }
+      for (const name of foldersToPrune(names, now, 30)) {
+        fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+        log(`spaces-backup pruned ${name}`);
+      }
+    }
+  }
+}

--- a/desktop/src/main/sync-spaces/daily-backup.ts
+++ b/desktop/src/main/sync-spaces/daily-backup.ts
@@ -52,7 +52,10 @@ export class DailyBackup {
       }
       try { await this.prune(target, now, log); } catch { /* prune is best-effort */ }
     }
-    fs.writeFileSync(this.markerPath, dated);
+    // Guarded so runIfDue honors its "never throws" contract — a missing or
+    // read-only ~/.claude must not become an unhandled rejection in the timer.
+    try { fs.writeFileSync(this.markerPath, dated); }
+    catch (e: any) { log(`spaces-backup: could not write marker: ${String(e?.message ?? e)}`); }
     log(`spaces-backup completed for ${dated} (${spaces.length} spaces, ${targets.length} targets)`);
   }
 
@@ -63,8 +66,11 @@ export class DailyBackup {
       await execFileAsync('rclone', ['copy', space.root, dest, ...excludes], { timeout: RCLONE_TIMEOUT });
     } else {
       const dest = path.join(target.base, 'Backup', 'spaces', dated, space.id.replace(':', '-'));
-      fs.mkdirSync(dest, { recursive: true });
-      fs.cpSync(space.root, dest, {
+      // Why async fs: this runs in the Electron main process — a synchronous
+      // deep copy would freeze UI/IPC/PTY for the duration of a large space
+      // copy. The Drive path is already async via rclone.
+      await fs.promises.mkdir(dest, { recursive: true });
+      await fs.promises.cp(space.root, dest, {
         recursive: true,
         // Backups scrub exactly what sync scrubs (DEFAULT_IGNORES) — secrets
         // like *.pem / id_rsa* must not land in iCloud any more than in a repo.
@@ -84,9 +90,10 @@ export class DailyBackup {
     } else {
       const dir = path.join(target.base, 'Backup', 'spaces');
       let names: string[] = [];
-      try { names = fs.readdirSync(dir); } catch { return; }
+      // Async fs for the same main-process reason as the copy above.
+      try { names = await fs.promises.readdir(dir); } catch { return; }
       for (const name of foldersToPrune(names, now, 30)) {
-        fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+        await fs.promises.rm(path.join(dir, name), { recursive: true, force: true });
         log(`spaces-backup pruned ${name}`);
       }
     }

--- a/desktop/src/main/sync-spaces/daily-backup.ts
+++ b/desktop/src/main/sync-spaces/daily-backup.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { DEFAULT_IGNORES } from './guards';
+import { DEFAULT_IGNORES, isIgnoredPath } from './guards';
 import type { SyncSpace } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -66,7 +66,9 @@ export class DailyBackup {
       fs.mkdirSync(dest, { recursive: true });
       fs.cpSync(space.root, dest, {
         recursive: true,
-        filter: (src) => !/([\\/])(node_modules|\.youcoded|\.git)([\\/]|$)/.test(src) && !path.basename(src).startsWith('.env'),
+        // Backups scrub exactly what sync scrubs (DEFAULT_IGNORES) — secrets
+        // like *.pem / id_rsa* must not land in iCloud any more than in a repo.
+        filter: (src) => !isIgnoredPath(path.relative(space.root, src)),
       });
     }
   }

--- a/desktop/src/main/sync-spaces/engine.ts
+++ b/desktop/src/main/sync-spaces/engine.ts
@@ -20,6 +20,10 @@ interface SpaceState {
   rerun: boolean;
 }
 
+// Coarse watcher-level filter only — intentionally narrower than the git layer's
+// DEFAULT_IGNORES, which stays authoritative about what actually syncs. Each
+// regex means: "this directory name appears anywhere in the path, with either
+// slash style" (Windows \ or POSIX /).
 const WATCH_IGNORED = [/(^|[\\/])\.youcoded([\\/]|$)/, /(^|[\\/])node_modules([\\/]|$)/, /(^|[\\/])\.git([\\/]|$)/];
 
 export class SpaceSyncEngine {
@@ -62,6 +66,10 @@ export class SpaceSyncEngine {
     });
     const st: SpaceState = { space, watcher, debounce: null, syncing: false, rerun: false };
     watcher.on('all', () => this.schedule(st));
+    // A watcher that dies after startup (inotify exhaustion, permissions) must
+    // surface as a sync error, not crash the app — an unhandled 'error' on a
+    // Node EventEmitter throws. 'all' does NOT receive error events.
+    watcher.on('error', (e: any) => this.onEvent({ type: 'error', spaceId: space.id, message: String(e?.message ?? e) }));
     this.states.set(space.id, st);
   }
 
@@ -74,6 +82,8 @@ export class SpaceSyncEngine {
   async syncSpace(space: SyncSpace): Promise<void> {
     const st = this.states.get(space.id);
     if (!st) return;
+    // Single-flight: if a sync is already running, flag exactly ONE follow-up
+    // rerun (the finally block below fires it) — extra requests coalesce.
     if (st.syncing) { st.rerun = true; return; }
     st.syncing = true;
     try {

--- a/desktop/src/main/sync-spaces/engine.ts
+++ b/desktop/src/main/sync-spaces/engine.ts
@@ -18,6 +18,10 @@ interface SpaceState {
   debounce: ReturnType<typeof setTimeout> | null;
   syncing: boolean;
   rerun: boolean;
+  // The in-flight sync's promise, so stop() can await it. Without this, quit
+  // teardown (and tests' temp-dir cleanup) races the git subprocesses a sync
+  // spawns — on Windows their cwd/file handles block directory removal.
+  current: Promise<void> | null;
 }
 
 // Coarse watcher-level filter only — intentionally narrower than the git layer's
@@ -64,7 +68,7 @@ export class SpaceSyncEngine {
       watcher.once('ready', () => resolve());
       watcher.once('error', () => resolve());
     });
-    const st: SpaceState = { space, watcher, debounce: null, syncing: false, rerun: false };
+    const st: SpaceState = { space, watcher, debounce: null, syncing: false, rerun: false, current: null };
     watcher.on('all', () => this.schedule(st));
     // A watcher that dies after startup (inotify exhaustion, permissions) must
     // surface as a sync error, not crash the app — an unhandled 'error' on a
@@ -86,26 +90,39 @@ export class SpaceSyncEngine {
     // rerun (the finally block below fires it) — extra requests coalesce.
     if (st.syncing) { st.rerun = true; return; }
     st.syncing = true;
-    try {
-      const pull = await this.transport.pull(space);
-      if (pull.conflictCopies.length) this.onEvent({ type: 'conflict', spaceId: space.id, copies: pull.conflictCopies });
-      const push = await this.transport.push(space, `sync from ${space.id}`);
-      if (push.oversize.length) this.onEvent({ type: 'oversize', spaceId: space.id, files: push.oversize });
-      this.onEvent({ type: 'synced', spaceId: space.id, pushed: push.pushed, updated: pull.updated });
-    } catch (e: any) {
-      this.onEvent({ type: 'error', spaceId: space.id, message: String(e?.message ?? e) });
-    } finally {
-      st.syncing = false;
-      if (st.rerun) { st.rerun = false; void this.syncSpace(space); }
-    }
+    // Keep the whole pull+push chain as a promise on the state so stop() can
+    // await an in-flight sync instead of resolving with git still running.
+    st.current = (async () => {
+      try {
+        const pull = await this.transport.pull(space);
+        if (pull.conflictCopies.length) this.onEvent({ type: 'conflict', spaceId: space.id, copies: pull.conflictCopies });
+        const push = await this.transport.push(space, `sync from ${space.id}`);
+        if (push.oversize.length) this.onEvent({ type: 'oversize', spaceId: space.id, files: push.oversize });
+        this.onEvent({ type: 'synced', spaceId: space.id, pushed: push.pushed, updated: pull.updated });
+      } catch (e: any) {
+        this.onEvent({ type: 'error', spaceId: space.id, message: String(e?.message ?? e) });
+      } finally {
+        st.syncing = false;
+        st.current = null;
+        if (st.rerun) { st.rerun = false; void this.syncSpace(space); }
+      }
+    })();
+    await st.current;
   }
 
   async stop(): Promise<void> {
     if (this.pollTimer) clearInterval(this.pollTimer);
-    for (const st of this.states.values()) {
+    // Snapshot then clear FIRST: a finishing sync's queued rerun re-enters
+    // syncSpace, which early-returns once the state map is empty — otherwise
+    // stop() could leave a fresh git chain running after it resolves.
+    const states = [...this.states.values()];
+    this.states.clear();
+    for (const st of states) {
       if (st.debounce) clearTimeout(st.debounce);
       await st.watcher.close();
+      // Await the in-flight sync: its git subprocesses hold handles inside the
+      // space root, which blocks folder removal on Windows (app quit, tests).
+      if (st.current) await st.current.catch(() => {});
     }
-    this.states.clear();
   }
 }

--- a/desktop/src/main/sync-spaces/engine.ts
+++ b/desktop/src/main/sync-spaces/engine.ts
@@ -1,0 +1,101 @@
+// desktop/src/main/sync-spaces/engine.ts
+// Watch → debounce → sync (pull-then-push) per space, plus a poll loop that
+// stands in for SyncHub signals until Plan 1b. Single-flight per space: a
+// change arriving mid-sync queues exactly one follow-up sync.
+import path from 'path';
+import chokidar, { FSWatcher } from 'chokidar';
+import type { SpaceSyncEvent, SyncSpace, SyncTransport } from './types';
+
+interface EngineOpts {
+  debounceMs?: number;  // default 15s (spec §8)
+  pollMs?: number;      // default 120s (spec §6 degradation path); 0 disables
+  onEvent: (e: SpaceSyncEvent) => void;
+}
+
+interface SpaceState {
+  space: SyncSpace;
+  watcher: FSWatcher;
+  debounce: ReturnType<typeof setTimeout> | null;
+  syncing: boolean;
+  rerun: boolean;
+}
+
+const WATCH_IGNORED = [/(^|[\\/])\.youcoded([\\/]|$)/, /(^|[\\/])node_modules([\\/]|$)/, /(^|[\\/])\.git([\\/]|$)/];
+
+export class SpaceSyncEngine {
+  private states = new Map<string, SpaceState>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private debounceMs: number;
+  private pollMs: number;
+  private onEvent: (e: SpaceSyncEvent) => void;
+
+  constructor(private transport: SyncTransport, opts: EngineOpts) {
+    this.debounceMs = opts.debounceMs ?? 15_000;
+    this.pollMs = opts.pollMs ?? 120_000;
+    this.onEvent = opts.onEvent;
+    if (this.pollMs > 0) {
+      this.pollTimer = setInterval(() => {
+        for (const st of this.states.values()) void this.syncSpace(st.space);
+      }, this.pollMs);
+      // Don't keep the process alive for polling alone.
+      (this.pollTimer as any).unref?.();
+    }
+  }
+
+  async addSpace(space: SyncSpace): Promise<void> {
+    if (this.states.has(space.id)) return;
+    await this.transport.init(space);
+    const watcher = chokidar.watch(space.root, {
+      ignored: WATCH_IGNORED,
+      ignoreInitial: true,
+      followSymlinks: false,       // spec §8: symlinks are not synced
+      awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
+    });
+    // Wait for chokidar's initial scan to complete before returning. With
+    // ignoreInitial:true, any file written *before* 'ready' is treated as a
+    // pre-existing file and silently NOT emitted — so callers that write right
+    // after addSpace() (and the engine tests) would never trigger a sync. The
+    // 'error' path resolves too so a watch failure can't hang startup.
+    await new Promise<void>(resolve => {
+      watcher.once('ready', () => resolve());
+      watcher.once('error', () => resolve());
+    });
+    const st: SpaceState = { space, watcher, debounce: null, syncing: false, rerun: false };
+    watcher.on('all', () => this.schedule(st));
+    this.states.set(space.id, st);
+  }
+
+  private schedule(st: SpaceState): void {
+    if (st.debounce) clearTimeout(st.debounce);
+    st.debounce = setTimeout(() => { st.debounce = null; void this.syncSpace(st.space); }, this.debounceMs);
+  }
+
+  /** Pull first (reduces non-fast-forward pushes), then push. Never throws. */
+  async syncSpace(space: SyncSpace): Promise<void> {
+    const st = this.states.get(space.id);
+    if (!st) return;
+    if (st.syncing) { st.rerun = true; return; }
+    st.syncing = true;
+    try {
+      const pull = await this.transport.pull(space);
+      if (pull.conflictCopies.length) this.onEvent({ type: 'conflict', spaceId: space.id, copies: pull.conflictCopies });
+      const push = await this.transport.push(space, `sync from ${space.id}`);
+      if (push.oversize.length) this.onEvent({ type: 'oversize', spaceId: space.id, files: push.oversize });
+      this.onEvent({ type: 'synced', spaceId: space.id, pushed: push.pushed, updated: pull.updated });
+    } catch (e: any) {
+      this.onEvent({ type: 'error', spaceId: space.id, message: String(e?.message ?? e) });
+    } finally {
+      st.syncing = false;
+      if (st.rerun) { st.rerun = false; void this.syncSpace(space); }
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollTimer) clearInterval(this.pollTimer);
+    for (const st of this.states.values()) {
+      if (st.debounce) clearTimeout(st.debounce);
+      await st.watcher.close();
+    }
+    this.states.clear();
+  }
+}

--- a/desktop/src/main/sync-spaces/git-transport.ts
+++ b/desktop/src/main/sync-spaces/git-transport.ts
@@ -34,10 +34,36 @@ export class GitTransport implements SyncTransport {
   private async git(space: SyncSpace, args: string[]): Promise<ExecResult> {
     const env = { ...process.env, GIT_DIR: this.gitDir(space), GIT_WORK_TREE: space.root };
     try {
-      const { stdout, stderr } = await execFileAsync('git', args, { cwd: space.root, env, timeout: GIT_TIMEOUT });
+      // Why maxBuffer 64MB: Node's default is only 1MB and it KILLS the child
+      // when output exceeds it — on a big space that silently breaks history()
+      // and the name-only file listings this class depends on.
+      const { stdout, stderr } = await execFileAsync('git', args,
+        { cwd: space.root, env, timeout: GIT_TIMEOUT, maxBuffer: 64 * 1024 * 1024 });
       return { code: 0, stdout, stderr };
     } catch (e: any) {
       return { code: typeof e.code === 'number' ? e.code : 1, stdout: e.stdout || '', stderr: e.stderr || String(e) };
+    }
+  }
+
+  /** Read one side of a conflicted file (stage 2 = ours, 3 = theirs) as raw
+   *  BYTES. The string-returning git() helper must never be used for file
+   *  CONTENT: utf8 decoding mangles binary files, and a too-small buffer cap
+   *  rejects large ones. Returns null when the stage doesn't exist (e.g. the
+   *  file is a remote-only add). WHY the maxBuffer must stay ≥ maxFileBytes:
+   *  the conflict loop treats null as "no local version to preserve" and lets
+   *  checkout --theirs overwrite the file — if this buffer were smaller than
+   *  the sync size cap, a big-but-legal local edit would come back null and be
+   *  silently DROPPED with no conflict copy. */
+  private async showStage(space: SyncSpace, stage: 2 | 3, rel: string): Promise<Buffer | null> {
+    const env = { ...process.env, GIT_DIR: this.gitDir(space), GIT_WORK_TREE: space.root };
+    try {
+      const { stdout } = await execFileAsync('git', ['show', `:${stage}:${rel}`], {
+        cwd: space.root, env, timeout: GIT_TIMEOUT,
+        encoding: 'buffer', maxBuffer: this.maxFileBytes + 1024 * 1024,
+      });
+      return stdout as unknown as Buffer;
+    } catch {
+      return null;
     }
   }
 
@@ -154,16 +180,21 @@ export class GitTransport implements SyncTransport {
       .split('\0').filter(Boolean);
     const copies: string[] = [];
     for (const rel of conflicted) {
-      // Stage 2 = ours (this device), stage 3 = theirs (remote).
-      const ours = await this.git(space, ['show', `:2:${rel}`]);
-      const theirs = await this.git(space, ['show', `:3:${rel}`]);
-      if (ours.code === 0) {
+      // Stage 2 = ours (this device), stage 3 = theirs (remote). Content is
+      // read as raw bytes via showStage so binary and >1MB files survive the
+      // copy intact (utf8 strings would corrupt bytes; Node's 1MB default
+      // buffer would reject big files and silently skip the copy).
+      const ours = await this.showStage(space, 2, rel);
+      if (ours !== null) {
         const copyRel = this.freeCopyName(space, rel);
         fs.mkdirSync(path.dirname(path.join(space.root, copyRel)), { recursive: true });
-        fs.writeFileSync(path.join(space.root, copyRel), ours.stdout);
+        fs.writeFileSync(path.join(space.root, copyRel), ours);
         await this.git(space, ['add', copyRel]);
         copies.push(copyRel);
       }
+      // Cheap existence probe — the canonical restore stays checkout --theirs
+      // (git writes the content itself, so it's already byte-faithful).
+      const theirs = await this.git(space, ['cat-file', '-e', `:3:${rel}`]);
       if (theirs.code === 0) {
         await this.git(space, ['checkout', '--theirs', '--', rel]);
         await this.git(space, ['add', rel]);

--- a/desktop/src/main/sync-spaces/git-transport.ts
+++ b/desktop/src/main/sync-spaces/git-transport.ts
@@ -139,7 +139,14 @@ export class GitTransport implements SyncTransport {
     const behind = await this.git(space, ['rev-list', '--count', 'main..origin/main']);
     if (behind.code !== 0 || behind.stdout.trim() === '0') return { updated: false, conflictCopies: [] };
 
-    const merge = await this.git(space, ['merge', '--no-edit', 'origin/main']);
+    // Fix: --allow-unrelated-histories covers the mainline "second device" case —
+    // a device that enables sync on a space that ALREADY has content (e.g. the
+    // Personal space in use on two machines) commits its own unrelated root, and
+    // without this flag git refuses the merge ("refusing to merge unrelated
+    // histories"), leaving both devices silently stuck forever. Conflicting files
+    // still route through the convergent conflict-copy resolution below;
+    // non-overlapping files simply union.
+    const merge = await this.git(space, ['merge', '--no-edit', '--allow-unrelated-histories', 'origin/main']);
     if (merge.code === 0) return { updated: true, conflictCopies: [] };
 
     // Conflicts: resolve each convergently.

--- a/desktop/src/main/sync-spaces/git-transport.ts
+++ b/desktop/src/main/sync-spaces/git-transport.ts
@@ -1,0 +1,193 @@
+// desktop/src/main/sync-spaces/git-transport.ts
+// SyncTransport implementation over a HIDDEN git repo (spec §7).
+//
+// CRITICAL MECHANISM: we do NOT use `git init --separate-git-dir` — that writes
+// a `.git` FILE into the worktree, which would collide with a developer's own
+// .git in the same project. Instead every git call runs with GIT_DIR pointing
+// at <root>/.youcoded/sync.git and GIT_WORK_TREE at <root>. The user's tree
+// never contains any git artifact of ours; their own repo is untouched.
+import fs from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { DEFAULT_IGNORES, MAX_SYNC_FILE_BYTES, conflictCopyName } from './guards';
+import type { PullResult, PushResult, SpaceVersion, SyncSpace, SyncTransport } from './types';
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT = 5 * 60 * 1000; // mirrors sync-service.ts GIT_TIMEOUT
+
+interface ExecResult { code: number; stdout: string; stderr: string; }
+
+export class GitTransport implements SyncTransport {
+  private deviceName: string;
+  private maxFileBytes: number;
+
+  constructor(opts: { deviceName: string; maxFileBytes?: number }) {
+    this.deviceName = opts.deviceName;
+    this.maxFileBytes = opts.maxFileBytes ?? MAX_SYNC_FILE_BYTES;
+  }
+
+  private gitDir(space: SyncSpace): string {
+    return path.join(space.root, '.youcoded', 'sync.git');
+  }
+
+  private async git(space: SyncSpace, args: string[]): Promise<ExecResult> {
+    const env = { ...process.env, GIT_DIR: this.gitDir(space), GIT_WORK_TREE: space.root };
+    try {
+      const { stdout, stderr } = await execFileAsync('git', args, { cwd: space.root, env, timeout: GIT_TIMEOUT });
+      return { code: 0, stdout, stderr };
+    } catch (e: any) {
+      return { code: typeof e.code === 'number' ? e.code : 1, stdout: e.stdout || '', stderr: e.stderr || String(e) };
+    }
+  }
+
+  async init(space: SyncSpace): Promise<void> {
+    const gd = this.gitDir(space);
+    if (!fs.existsSync(path.join(gd, 'HEAD'))) {
+      fs.mkdirSync(gd, { recursive: true });
+      await this.git(space, ['init', '--initial-branch=main']);
+      await this.git(space, ['config', 'user.name', `YouCoded Sync (${this.deviceName})`]);
+      await this.git(space, ['config', 'user.email', 'sync@youcoded.local']);
+      // Byte-faithful storage: `* -text` disables ALL end-of-line conversion so
+      // bytes round-trip identically on every platform. Fix: the earlier
+      // `* text=auto` OVERRODE core.autocrlf=false and re-introduced LF→CRLF on
+      // Windows checkout — a sync tool must never rewrite the user's line endings.
+      // Set via repo-local info/attributes (never a .gitattributes in the user's tree).
+      await this.git(space, ['config', 'core.autocrlf', 'false']);
+      fs.writeFileSync(path.join(gd, 'info', 'attributes'), '* -text\n');
+    }
+    // info/exclude is OURS (rewritten on every init so ignore updates roll out).
+    // The user's own .gitignore still applies on top for their repo, not ours.
+    fs.writeFileSync(path.join(gd, 'info', 'exclude'), DEFAULT_IGNORES.join('\n') + '\n');
+  }
+
+  async hasRemote(space: SyncSpace): Promise<boolean> {
+    const r = await this.git(space, ['remote', 'get-url', 'origin']);
+    return r.code === 0;
+  }
+
+  async setRemote(space: SyncSpace, url: string): Promise<void> {
+    const existing = await this.git(space, ['remote', 'get-url', 'origin']);
+    if (existing.code === 0) await this.git(space, ['remote', 'set-url', 'origin', url]);
+    else await this.git(space, ['remote', 'add', 'origin', url]);
+  }
+
+  /** Stage everything, unstage+exclude oversize files, commit, push. */
+  async push(space: SyncSpace, message: string): Promise<PushResult> {
+    await this.git(space, ['add', '-A']);
+    const oversize = await this.unstageOversize(space);
+    const staged = await this.git(space, ['diff', '--cached', '--name-only']);
+    let commit: string | undefined;
+    if (staged.stdout.trim().length > 0) {
+      const c = await this.git(space, ['commit', '-m', message]);
+      if (c.code !== 0) return { pushed: false, oversize };
+      commit = (await this.git(space, ['rev-parse', 'HEAD'])).stdout.trim();
+    }
+    if (!(await this.hasRemote(space))) return { pushed: false, commit, oversize };
+    const ahead = await this.git(space, ['rev-list', '--count', 'origin/main..main']);
+    // origin/main may not exist yet (first push) — rev-list fails; push anyway.
+    if (ahead.code === 0 && ahead.stdout.trim() === '0' && !commit) return { pushed: false, oversize };
+    const p = await this.git(space, ['push', '-u', 'origin', 'main']);
+    if (p.code !== 0) {
+      // Non-fast-forward: another device pushed first. Merge, then push again.
+      await this.pull(space);
+      const retry = await this.git(space, ['push', '-u', 'origin', 'main']);
+      return { pushed: retry.code === 0, commit, oversize };
+    }
+    return { pushed: true, commit, oversize };
+  }
+
+  private async unstageOversize(space: SyncSpace): Promise<string[]> {
+    const staged = (await this.git(space, ['diff', '--cached', '--name-only', '-z'])).stdout
+      .split('\0').filter(Boolean);
+    const oversize: string[] = [];
+    for (const rel of staged) {
+      try {
+        if (fs.statSync(path.join(space.root, rel)).size > this.maxFileBytes) oversize.push(rel);
+      } catch { /* deleted while staging — fine */ }
+    }
+    if (oversize.length) {
+      await this.git(space, ['reset', '--', ...oversize]);
+      // Persist the exclusion so the watcher doesn't re-stage it every cycle.
+      fs.appendFileSync(path.join(this.gitDir(space), 'info', 'exclude'),
+        oversize.map(o => `/${o}`).join('\n') + '\n');
+    }
+    return oversize;
+  }
+
+  /** Commit local pending, fetch, merge. Convergent conflict rule (spec §8):
+   *  REMOTE wins the canonical filename; LOCAL content is preserved as a
+   *  visible conflict copy. Both devices converge to identical trees. */
+  async pull(space: SyncSpace): Promise<PullResult> {
+    // Snapshot local changes first so merge never runs on a dirty tree.
+    await this.git(space, ['add', '-A']);
+    await this.unstageOversize(space);
+    const dirty = (await this.git(space, ['diff', '--cached', '--name-only'])).stdout.trim();
+    if (dirty) await this.git(space, ['commit', '-m', `local snapshot before merge (${this.deviceName})`]);
+
+    if (!(await this.hasRemote(space))) return { updated: false, conflictCopies: [] };
+    const fetch = await this.git(space, ['fetch', 'origin', 'main']);
+    if (fetch.code !== 0) return { updated: false, conflictCopies: [] }; // offline — never block (spec §13)
+    // Fix: a fresh device has no local `main` yet (nothing committed). `main..origin/main`
+    // errors on an unborn branch, so adopt the remote wholesale on first sync — this is
+    // what lets a second device actually receive the first device's push.
+    const localMain = await this.git(space, ['rev-parse', '--verify', '--quiet', 'main']);
+    if (localMain.code !== 0) {
+      const co = await this.git(space, ['checkout', '-B', 'main', 'origin/main']);
+      return { updated: co.code === 0, conflictCopies: [] };
+    }
+    const behind = await this.git(space, ['rev-list', '--count', 'main..origin/main']);
+    if (behind.code !== 0 || behind.stdout.trim() === '0') return { updated: false, conflictCopies: [] };
+
+    const merge = await this.git(space, ['merge', '--no-edit', 'origin/main']);
+    if (merge.code === 0) return { updated: true, conflictCopies: [] };
+
+    // Conflicts: resolve each convergently.
+    const conflicted = (await this.git(space, ['diff', '--name-only', '--diff-filter=U', '-z'])).stdout
+      .split('\0').filter(Boolean);
+    const copies: string[] = [];
+    for (const rel of conflicted) {
+      // Stage 2 = ours (this device), stage 3 = theirs (remote).
+      const ours = await this.git(space, ['show', `:2:${rel}`]);
+      const theirs = await this.git(space, ['show', `:3:${rel}`]);
+      if (ours.code === 0) {
+        const copyRel = this.freeCopyName(space, rel);
+        fs.mkdirSync(path.dirname(path.join(space.root, copyRel)), { recursive: true });
+        fs.writeFileSync(path.join(space.root, copyRel), ours.stdout);
+        await this.git(space, ['add', copyRel]);
+        copies.push(copyRel);
+      }
+      if (theirs.code === 0) {
+        await this.git(space, ['checkout', '--theirs', '--', rel]);
+        await this.git(space, ['add', rel]);
+      } else {
+        await this.git(space, ['rm', '--force', '--', rel]); // deleted remotely → deletion wins canonical
+      }
+    }
+    const commit = await this.git(space, ['commit', '--no-edit']);
+    if (commit.code !== 0) {
+      // Merge could not complete — bail out rather than leave a wedged repo.
+      await this.git(space, ['merge', '--abort']);
+      return { updated: false, conflictCopies: [] };
+    }
+    return { updated: true, conflictCopies: copies };
+  }
+
+  private freeCopyName(space: SyncSpace, rel: string): string {
+    let candidate = conflictCopyName(rel, this.deviceName, new Date());
+    let i = 2;
+    while (fs.existsSync(path.join(space.root, candidate))) {
+      candidate = conflictCopyName(rel, `${this.deviceName} ${i++}`, new Date());
+    }
+    return candidate;
+  }
+
+  async history(space: SyncSpace, limit = 50): Promise<SpaceVersion[]> {
+    const r = await this.git(space, ['log', `--max-count=${limit}`, '--format=%H%x1f%cI%x1f%s']);
+    if (r.code !== 0) return [];
+    return r.stdout.split('\n').filter(Boolean).map(line => {
+      const [commit, date, message] = line.split('\x1f');
+      return { commit, date, message };
+    });
+  }
+}

--- a/desktop/src/main/sync-spaces/guards.ts
+++ b/desktop/src/main/sync-spaces/guards.ts
@@ -1,0 +1,48 @@
+// Pure helpers for the sync-spaces subsystem. NO fs/os imports — keeps this
+// unit-testable without mocks (same rule as local-theme-synthesizer).
+
+// Why: a name created on macOS/Linux must not break a Windows device later.
+const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+const INVALID_CHARS = /[<>:"|?*\x00-\x1f/\\]/;
+
+/** Returns an error message, or null when the name is safe on every platform. */
+export function validateSyncName(name: string): string | null {
+  if (!name || name === '.' || name === '..') return 'Name is empty or invalid';
+  if (WINDOWS_RESERVED.test(name)) return `"${name}" is a reserved name on Windows`;
+  if (INVALID_CHARS.test(name)) return 'Name contains a character not allowed on all platforms (< > : " | ? * / \\)';
+  if (/[. ]$/.test(name)) return 'Name cannot end with a dot or space (Windows restriction)';
+  if (name.length > 100) return 'Name is too long (max 100 characters)';
+  return null;
+}
+
+// Spec §8 default ignore set: build junk + secrets. gitignore syntax — written
+// into each hidden repo's info/exclude (never into the user's tree).
+export const DEFAULT_IGNORES: string[] = [
+  'node_modules/', '.git/', '.youcoded/', 'dist/', 'build/', 'out/', 'target/',
+  '.venv/', 'venv/', '__pycache__/', '.pytest_cache/', '.gradle/',
+  '.DS_Store', 'Thumbs.db', 'desktop.ini',
+  '.env', '.env.*', '*.pem', '*.key', 'id_rsa*', 'id_ed25519*', '*.credentials.json',
+];
+
+/** Spec §7: files over this cap don't live-sync (daily backup covers them). */
+export const MAX_SYNC_FILE_BYTES = 50 * 1024 * 1024;
+
+/** Spec §8: "notes (from Laptop, 2026-07-03).md" — the visible conflict copy. */
+export function conflictCopyName(relPath: string, deviceName: string, when: Date): string {
+  const date = when.toISOString().slice(0, 10);
+  const dot = relPath.lastIndexOf('.');
+  const slash = Math.max(relPath.lastIndexOf('/'), relPath.lastIndexOf('\\'));
+  const suffix = ` (from ${deviceName}, ${date})`;
+  if (dot > slash + 1) return `${relPath.slice(0, dot)}${suffix}${relPath.slice(dot)}`;
+  return `${relPath}${suffix}`;
+}
+
+/** Case-insensitive collision groups — these break macOS/Windows checkouts. */
+export function findCaseCollisions(paths: string[]): string[][] {
+  const byLower = new Map<string, string[]>();
+  for (const p of paths) {
+    const k = p.toLowerCase();
+    byLower.set(k, [...(byLower.get(k) ?? []), p]);
+  }
+  return [...byLower.values()].filter(g => g.length > 1);
+}

--- a/desktop/src/main/sync-spaces/guards.ts
+++ b/desktop/src/main/sync-spaces/guards.ts
@@ -24,6 +24,29 @@ export const DEFAULT_IGNORES: string[] = [
   '.env', '.env.*', '*.pem', '*.key', 'id_rsa*', 'id_ed25519*', '*.credentials.json',
 ];
 
+/** True when a relative path matches the DEFAULT_IGNORES set. Interprets the
+ *  gitignore-style entries for non-git consumers (the iCloud backup filter):
+ *  'name/' matches a path segment anywhere; 'name' matches a basename exactly;
+ *  simple '*' globs match against the basename. Why: backups must scrub the
+ *  same secrets/junk the sync layer scrubs — a narrower filter here would leak
+ *  keys into backups that sync deliberately never transports. */
+export function isIgnoredPath(relPath: string): boolean {
+  const segments = relPath.split(/[\\/]/).filter(Boolean);
+  const base = segments[segments.length - 1] ?? '';
+  for (const pattern of DEFAULT_IGNORES) {
+    if (pattern.endsWith('/')) {
+      const dir = pattern.slice(0, -1);
+      if (segments.slice(0, -1).includes(dir) || base === dir) return true;
+    } else if (pattern.includes('*')) {
+      const re = new RegExp(`^${pattern.split('*').map(s => s.replace(/[.+?^${}()|[\]\\]/g, '\\$&')).join('.*')}$`);
+      if (re.test(base)) return true;
+    } else if (base === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Spec §7: files over this cap don't live-sync (daily backup covers them). */
 export const MAX_SYNC_FILE_BYTES = 50 * 1024 * 1024;
 

--- a/desktop/src/main/sync-spaces/managed-roots.ts
+++ b/desktop/src/main/sync-spaces/managed-roots.ts
@@ -1,0 +1,53 @@
+// desktop/src/main/sync-spaces/managed-roots.ts
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateSyncName } from './guards';
+import type { SyncSpace } from './types';
+
+export type CreateResult = { ok: true; path: string } | { ok: false; error: string };
+
+/** Owns ~/YouCoded/{Projects,Personal} (spec §3). baseDir is injectable for tests;
+ *  production passes os.homedir(). */
+export class ManagedRoots {
+  readonly youcodedRoot: string;
+  readonly projectsRoot: string;
+  readonly personalRoot: string;
+
+  constructor(baseDir: string = os.homedir()) {
+    this.youcodedRoot = path.join(baseDir, 'YouCoded');
+    this.projectsRoot = path.join(this.youcodedRoot, 'Projects');
+    this.personalRoot = path.join(this.youcodedRoot, 'Personal');
+  }
+
+  ensure(): void {
+    fs.mkdirSync(this.projectsRoot, { recursive: true });
+    fs.mkdirSync(this.personalRoot, { recursive: true });
+  }
+
+  listProjects(): Array<{ name: string; path: string }> {
+    let entries: fs.Dirent[] = [];
+    try { entries = fs.readdirSync(this.projectsRoot, { withFileTypes: true }); } catch { return []; }
+    return entries
+      .filter(e => e.isDirectory())
+      .map(e => ({ name: e.name, path: path.join(this.projectsRoot, e.name) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  createProject(name: string): CreateResult {
+    const err = validateSyncName(name);
+    if (err) return { ok: false, error: err };
+    const dir = path.join(this.projectsRoot, name);
+    if (fs.existsSync(dir)) return { ok: false, error: 'A project with that name already exists' };
+    fs.mkdirSync(dir, { recursive: true });
+    return { ok: true, path: dir };
+  }
+
+  /** Spec §4: one personal space + one space per managed project. */
+  spaces(): SyncSpace[] {
+    return [
+      { id: 'personal', kind: 'personal' as const, root: this.personalRoot },
+      ...this.listProjects().map(p => ({ id: `project:${p.name}`, kind: 'project' as const, root: p.path })),
+    ];
+  }
+}

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -19,6 +19,12 @@ let backupTimer: ReturnType<typeof setInterval> | null = null;
 let recentEvents: SpaceSyncEvent[] = [];
 let logFn: (m: string) => void = console.log;
 
+// Why: enable(true) racing enable(false) (two windows, or panel double-click)
+// would otherwise interleave — the disable stops the half-started engine and
+// the resuming start adds watchers to a dead instance. Chaining every
+// transition onto the previous one makes toggles strictly sequential.
+let transition: Promise<void> = Promise.resolve();
+
 // main.ts wires this to RemoteServer.broadcast so engine events also reach
 // remote browser / Android clients. There is NO central push forwarder in this
 // app — each emit site fans out to BOTH BrowserWindows and remote clients (see
@@ -63,16 +69,22 @@ export async function startSyncSpaces(getBackupTargets: () => Promise<BackupTarg
 
 async function startEngine(log: (m: string) => void): Promise<void> {
   const transport = new GitTransport({ deviceName: os.hostname() });
-  engine = new SpaceSyncEngine(transport, { onEvent: broadcast });
+  // Capture this start's instance locally: if a disable (or another start)
+  // supersedes us mid-loop, the module-level `engine` no longer points at `e`
+  // and we must stop OUR instance ourselves — otherwise its chokidar watchers
+  // leak with nothing left holding a reference to close them.
+  const e = new SpaceSyncEngine(transport, { onEvent: broadcast });
+  engine = e;
   for (const space of roots!.spaces()) {
+    if (engine !== e) { await e.stop(); return; } // superseded — clean up and bail
     try {
-      await engine.addSpace(space);
+      await e.addSpace(space);
       const url = await manager!.ensureRemote(space);
       await transport.setRemote(space, url);
-      void engine.syncSpace(space); // initial reconcile
-    } catch (e: any) {
-      log(`sync-spaces: failed to start space ${space.id}: ${String(e?.message ?? e)}`);
-      broadcast({ type: 'error', spaceId: space.id, message: String(e?.message ?? e) });
+      void e.syncSpace(space); // initial reconcile
+    } catch (err: any) {
+      log(`sync-spaces: failed to start space ${space.id}: ${String(err?.message ?? err)}`);
+      broadcast({ type: 'error', spaceId: space.id, message: String(err?.message ?? err) });
     }
   }
 }
@@ -94,8 +106,22 @@ export async function syncSpacesStatus() {
 
 export async function syncSpacesEnable(enabled: boolean) {
   manager!.setEnabled(enabled);
-  if (enabled && !engine) await startEngine(logFn);
-  if (!enabled && engine) { await engine.stop(); engine = null; }
+  // Chain this toggle onto the previous one (see `transition` comment above).
+  // The .catch() keeps a failed earlier transition from poisoning every later
+  // toggle — its error was already reported to the caller who triggered it.
+  const run = transition.catch(() => { /* previous transition already surfaced its error */ }).then(async () => {
+    if (enabled && !engine) await startEngine(logFn);
+    if (!enabled && engine) {
+      // Null BEFORE stopping so any still-in-flight start (the app-boot one
+      // isn't chained through `transition`) sees the supersession immediately
+      // and cleans up its own instance instead of watching a dead engine.
+      const current = engine;
+      engine = null;
+      await current.stop();
+    }
+  });
+  transition = run;
+  await run;
   return syncSpacesStatus();
 }
 
@@ -113,6 +139,8 @@ export async function syncSpacesCreateProject(name: string) {
       const transport = new GitTransport({ deviceName: os.hostname() });
       await transport.init(space);
       await transport.setRemote(space, await manager!.ensureRemote(space));
+      // No initial syncSpace here: a freshly created folder is empty — the
+      // first file change (debounce) or the 2-minute poll drives the first sync.
     } catch { /* engine events surface the failure */ }
   }
   return result;

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -1,0 +1,121 @@
+// desktop/src/main/sync-spaces/service.ts
+// Composition root: owns the singleton ManagedRoots/SpaceManager/Engine and
+// exposes the functions IPC + remote-server call. Mirrors the sync-state.ts
+// singleton pattern (setSyncService/getSyncService).
+import os from 'os';
+import { BrowserWindow } from 'electron';
+import { ManagedRoots } from './managed-roots';
+import { SpaceManager } from './space-manager';
+import { GitTransport } from './git-transport';
+import { SpaceSyncEngine } from './engine';
+import { DailyBackup, BackupTarget } from './daily-backup';
+import type { SpaceSyncEvent } from './types';
+
+let roots: ManagedRoots | null = null;
+let manager: SpaceManager | null = null;
+let engine: SpaceSyncEngine | null = null;
+let backup: DailyBackup | null = null;
+let backupTimer: ReturnType<typeof setInterval> | null = null;
+let recentEvents: SpaceSyncEvent[] = [];
+let logFn: (m: string) => void = console.log;
+
+// main.ts wires this to RemoteServer.broadcast so engine events also reach
+// remote browser / Android clients. There is NO central push forwarder in this
+// app — each emit site fans out to BOTH BrowserWindows and remote clients (see
+// how ipc-handlers.ts sends transcript/status pushes via webContents AND
+// remoteServer.broadcast). This keeps service.ts free of a remote-server import
+// (remote-server imports THIS module, so importing back would be circular).
+let remoteBroadcast: ((e: SpaceSyncEvent) => void) | null = null;
+export function setSyncSpacesRemoteBroadcaster(fn: ((e: SpaceSyncEvent) => void) | null): void {
+  remoteBroadcast = fn;
+}
+
+function broadcast(e: SpaceSyncEvent): void {
+  recentEvents = [...recentEvents.slice(-49), e];
+  for (const w of BrowserWindow.getAllWindows()) {
+    try { w.webContents.send('syncspaces:event', e); } catch { /* window closing */ }
+  }
+  // Fan out to remote clients too (see comment on remoteBroadcast above).
+  try { remoteBroadcast?.(e); } catch { /* remote server not up / closing */ }
+}
+
+/** Called once from main.ts after app ready. Roots always exist (the picker
+ *  needs them); the engine only starts when the user enabled sync.
+ *  getBackupTargets is async because the backend config read (getSyncConfig)
+ *  is async — the daily backup timer awaits it fresh each cycle. */
+export async function startSyncSpaces(getBackupTargets: () => Promise<BackupTarget[]>, log: (m: string) => void): Promise<void> {
+  logFn = log;
+  roots = new ManagedRoots();
+  roots.ensure();
+  manager = new SpaceManager();
+  if (manager.isEnabled()) await startEngine(logFn);
+  backup = new DailyBackup();
+  // runIfDue never throws by contract, but resolving the targets (async config
+  // read) can — guard so the hourly timer can never become an unhandled reject.
+  const runBackup = async () => {
+    try { await backup!.runIfDue(roots!.spaces(), await getBackupTargets(), logFn); }
+    catch (e: any) { logFn(`sync-spaces: daily backup check failed: ${String(e?.message ?? e)}`); }
+  };
+  backupTimer = setInterval(() => { void runBackup(); }, 60 * 60 * 1000);
+  (backupTimer as any).unref?.();
+  void runBackup();
+}
+
+async function startEngine(log: (m: string) => void): Promise<void> {
+  const transport = new GitTransport({ deviceName: os.hostname() });
+  engine = new SpaceSyncEngine(transport, { onEvent: broadcast });
+  for (const space of roots!.spaces()) {
+    try {
+      await engine.addSpace(space);
+      const url = await manager!.ensureRemote(space);
+      await transport.setRemote(space, url);
+      void engine.syncSpace(space); // initial reconcile
+    } catch (e: any) {
+      log(`sync-spaces: failed to start space ${space.id}: ${String(e?.message ?? e)}`);
+      broadcast({ type: 'error', spaceId: space.id, message: String(e?.message ?? e) });
+    }
+  }
+}
+
+export async function stopSyncSpaces(): Promise<void> {
+  if (backupTimer) clearInterval(backupTimer);
+  await engine?.stop();
+  engine = null;
+}
+
+// ---- IPC-facing functions (also used by remote-server cases) ----
+export async function syncSpacesStatus() {
+  return {
+    enabled: manager?.isEnabled() ?? false,
+    spaces: roots?.spaces().map(s => ({ ...s, remote: manager?.remoteFor(s.id) ?? null })) ?? [],
+    recentEvents,
+  };
+}
+
+export async function syncSpacesEnable(enabled: boolean) {
+  manager!.setEnabled(enabled);
+  if (enabled && !engine) await startEngine(logFn);
+  if (!enabled && engine) { await engine.stop(); engine = null; }
+  return syncSpacesStatus();
+}
+
+export async function syncSpacesSyncNow() {
+  if (engine && roots) for (const s of roots.spaces()) void engine.syncSpace(s);
+  return { ok: true };
+}
+
+export async function syncSpacesCreateProject(name: string) {
+  const result = roots!.createProject(name);
+  if (result.ok && engine) {
+    const space = roots!.spaces().find(s => s.id === `project:${name}`)!;
+    try {
+      await engine.addSpace(space);
+      const transport = new GitTransport({ deviceName: os.hostname() });
+      await transport.init(space);
+      await transport.setRemote(space, await manager!.ensureRemote(space));
+    } catch { /* engine events surface the failure */ }
+  }
+  return result;
+}
+
+export function getManagedRoots(): ManagedRoots | null { return roots; }

--- a/desktop/src/main/sync-spaces/space-manager.ts
+++ b/desktop/src/main/sync-spaces/space-manager.ts
@@ -17,13 +17,26 @@ export function repoNameForSpace(space: SyncSpace): string {
 }
 
 /** Creates a private repo via gh and returns its clone URL. Mirrors the
- *  createGithubRepo pattern in sync-setup-handlers.ts. */
+ *  createGithubRepo pattern in sync-setup-handlers.ts. An ALREADY-EXISTING
+ *  repo is success, not failure — the state file recording provisioned URLs
+ *  is per-device, so the user's second device re-runs this for repos the
+ *  first device already created. Without the recovery path, sync could
+ *  never start on any device but the first. */
 export async function provisionGithubRemote(repoName: string): Promise<string> {
-  // `gh repo create` prints the repo URL on success; --private is mandatory (spec §14).
-  const { stdout } = await execFileAsync('gh', ['repo', 'create', repoName, '--private'], { timeout: 60_000 });
-  const url = stdout.trim();
-  if (!/^https:\/\/github\.com\//.test(url)) throw new Error(`unexpected gh output: ${stdout}`);
-  return `${url}.git`;
+  try {
+    // `gh repo create` prints the repo URL on success; --private is mandatory (spec §14).
+    const { stdout } = await execFileAsync('gh', ['repo', 'create', repoName, '--private'], { timeout: 60_000 });
+    const url = stdout.trim();
+    if (!/^https:\/\/github\.com\//.test(url)) throw new Error(`unexpected gh output: ${stdout}`);
+    return `${url}.git`;
+  } catch (e: any) {
+    // Recovery: if the repo already exists (created by another device), reuse it.
+    const view = await execFileAsync('gh', ['repo', 'view', repoName, '--json', 'url', '-q', '.url'], { timeout: 60_000 })
+      .catch(() => null);
+    const url = view?.stdout.trim();
+    if (url && /^https:\/\/github\.com\//.test(url)) return `${url}.git`;
+    throw e; // genuinely failed (offline, not authed, invalid name) — surface the original error
+  }
 }
 
 interface SpaceManagerOpts {

--- a/desktop/src/main/sync-spaces/space-manager.ts
+++ b/desktop/src/main/sync-spaces/space-manager.ts
@@ -1,0 +1,75 @@
+// desktop/src/main/sync-spaces/space-manager.ts
+// Sync enable/disable state + per-space GitHub remote provisioning.
+// State lives at ~/.claude/toolkit-state/sync-spaces.json.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { SyncSpace } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export function repoNameForSpace(space: SyncSpace): string {
+  if (space.kind === 'personal') return 'youcoded-sync-personal';
+  const name = space.id.replace(/^project:/, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return `youcoded-sync-project-${name}`;
+}
+
+/** Creates a private repo via gh and returns its clone URL. Mirrors the
+ *  createGithubRepo pattern in sync-setup-handlers.ts. */
+export async function provisionGithubRemote(repoName: string): Promise<string> {
+  // `gh repo create` prints the repo URL on success; --private is mandatory (spec §14).
+  const { stdout } = await execFileAsync('gh', ['repo', 'create', repoName, '--private'], { timeout: 60_000 });
+  const url = stdout.trim();
+  if (!/^https:\/\/github\.com\//.test(url)) throw new Error(`unexpected gh output: ${stdout}`);
+  return `${url}.git`;
+}
+
+interface SpaceManagerOpts {
+  stateFile?: string; // injectable for tests
+  provisionRemote?: (repoName: string) => Promise<string>;
+}
+
+interface SpacesState {
+  enabled: boolean;
+  remotes: Record<string, string>; // spaceId -> clone URL
+}
+
+export class SpaceManager {
+  private stateFile: string;
+  private provisionRemote: (repoName: string) => Promise<string>;
+
+  constructor(opts: SpaceManagerOpts = {}) {
+    this.stateFile = opts.stateFile ?? path.join(os.homedir(), '.claude', 'toolkit-state', 'sync-spaces.json');
+    this.provisionRemote = opts.provisionRemote ?? provisionGithubRemote;
+  }
+
+  private read(): SpacesState {
+    try { return { enabled: false, remotes: {}, ...JSON.parse(fs.readFileSync(this.stateFile, 'utf8')) }; }
+    catch { return { enabled: false, remotes: {} }; }
+  }
+
+  private write(s: SpacesState): void {
+    fs.mkdirSync(path.dirname(this.stateFile), { recursive: true });
+    fs.writeFileSync(this.stateFile, JSON.stringify(s, null, 2));
+  }
+
+  isEnabled(): boolean { return this.read().enabled; }
+  setEnabled(v: boolean): void { this.write({ ...this.read(), enabled: v }); }
+  remoteFor(spaceId: string): string | null { return this.read().remotes[spaceId] ?? null; }
+  recordRemote(spaceId: string, url: string): void {
+    const s = this.read();
+    s.remotes[spaceId] = url;
+    this.write(s);
+  }
+
+  /** Idempotent: returns the recorded remote or provisions + records one. */
+  async ensureRemote(space: SyncSpace): Promise<string> {
+    const existing = this.remoteFor(space.id);
+    if (existing) return existing;
+    const url = await this.provisionRemote(repoNameForSpace(space));
+    this.recordRemote(space.id, url);
+    return url;
+  }
+}

--- a/desktop/src/main/sync-spaces/space-manager.ts
+++ b/desktop/src/main/sync-spaces/space-manager.ts
@@ -4,16 +4,28 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type { SyncSpace } from './types';
 
 const execFileAsync = promisify(execFile);
 
+/** Minimal exec shape — injectable so the gh recovery logic below is unit-testable. */
+type ExecFn = (file: string, args: string[], opts: object) => Promise<{ stdout: string }>;
+
 export function repoNameForSpace(space: SyncSpace): string {
   if (space.kind === 'personal') return 'youcoded-sync-personal';
-  const name = space.id.replace(/^project:/, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-  return `youcoded-sync-project-${name}`;
+  const raw = space.id.replace(/^project:/, '');
+  const name = raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  // Why the hash suffix: the repo name IS the sync identity. The slug alone is
+  // neither unique ('My App' and 'My-App' both slug to 'my-app' — two different
+  // projects would silently cross-sync into one repo) nor total (an all-symbol
+  // or non-Latin name slugs to ''). Hashing the LOWERCASED id keeps the name
+  // stable across devices (same folder name → same repo) while distinct
+  // folder names always get distinct repos. Do not "simplify" this away.
+  const short = createHash('sha1').update(raw.toLowerCase()).digest('hex').slice(0, 8);
+  return `youcoded-sync-project-${name || 'x'}-${short}`;
 }
 
 /** Creates a private repo via gh and returns its clone URL. Mirrors the
@@ -22,20 +34,29 @@ export function repoNameForSpace(space: SyncSpace): string {
  *  is per-device, so the user's second device re-runs this for repos the
  *  first device already created. Without the recovery path, sync could
  *  never start on any device but the first. */
-export async function provisionGithubRemote(repoName: string): Promise<string> {
+export async function provisionGithubRemote(repoName: string, exec: ExecFn = execFileAsync): Promise<string> {
   try {
     // `gh repo create` prints the repo URL on success; --private is mandatory (spec §14).
-    const { stdout } = await execFileAsync('gh', ['repo', 'create', repoName, '--private'], { timeout: 60_000 });
+    const { stdout } = await exec('gh', ['repo', 'create', repoName, '--private'], { timeout: 60_000 });
     const url = stdout.trim();
     if (!/^https:\/\/github\.com\//.test(url)) throw new Error(`unexpected gh output: ${stdout}`);
     return `${url}.git`;
   } catch (e: any) {
     // Recovery: if the repo already exists (created by another device), reuse it.
-    const view = await execFileAsync('gh', ['repo', 'view', repoName, '--json', 'url', '-q', '.url'], { timeout: 60_000 })
+    const view = await exec('gh', ['repo', 'view', repoName, '--json', 'url', '-q', '.url'], { timeout: 60_000 })
       .catch(() => null);
     const url = view?.stdout.trim();
     if (url && /^https:\/\/github\.com\//.test(url)) return `${url}.git`;
-    throw e; // genuinely failed (offline, not authed, invalid name) — surface the original error
+    // Why plain-language errors: raw gh/exec errors are cryptic for
+    // non-developers, and Task 9's sync panel shows these messages verbatim.
+    if (e?.code === 'ENOENT') {
+      throw new Error('GitHub CLI (gh) is not installed — sync needs it to create your private repos');
+    }
+    const stderr = String(e?.stderr ?? '');
+    if (stderr.includes('auth') || stderr.includes('gh auth login')) {
+      throw new Error('Not signed in to GitHub — run "gh auth login" and try again');
+    }
+    throw e; // genuinely failed (offline, invalid name, …) — surface the original error
   }
 }
 
@@ -59,13 +80,20 @@ export class SpaceManager {
   }
 
   private read(): SpacesState {
+    // A corrupt state file deliberately degrades to defaults and self-heals:
+    // ensureRemote re-provisions, and the already-exists recovery in
+    // provisionGithubRemote finds the repos the lost state pointed at.
     try { return { enabled: false, remotes: {}, ...JSON.parse(fs.readFileSync(this.stateFile, 'utf8')) }; }
     catch { return { enabled: false, remotes: {} }; }
   }
 
   private write(s: SpacesState): void {
     fs.mkdirSync(path.dirname(this.stateFile), { recursive: true });
-    fs.writeFileSync(this.stateFile, JSON.stringify(s, null, 2));
+    // Temp-file + rename: the dev instance and the built app share ~/.claude,
+    // and rename is atomic — a concurrent reader never sees a half-written file.
+    const tmp = `${this.stateFile}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(s, null, 2));
+    fs.renameSync(tmp, this.stateFile);
   }
 
   isEnabled(): boolean { return this.read().enabled; }

--- a/desktop/src/main/sync-spaces/types.ts
+++ b/desktop/src/main/sync-spaces/types.ts
@@ -1,0 +1,41 @@
+// desktop/src/main/sync-spaces/types.ts
+// The sync-space model from spec §4/§5. The SyncTransport seam is the
+// compatibility boundary for the future YouCoded Cloud transport (spec §16).
+
+export type SpaceKind = 'project' | 'personal';
+
+export interface SyncSpace {
+  id: string;        // 'personal' | 'project:<name>'
+  kind: SpaceKind;
+  root: string;      // absolute path to the space's folder on this device
+}
+
+export interface PushResult {
+  pushed: boolean;          // false when nothing changed or no remote configured
+  commit?: string;          // HEAD sha after commit, when one was made
+  oversize: string[];       // rel paths excluded for exceeding MAX_SYNC_FILE_BYTES
+}
+
+export interface PullResult {
+  updated: boolean;         // true when remote changes were applied
+  conflictCopies: string[]; // rel paths of conflict copies written this pull
+}
+
+export interface SpaceVersion { commit: string; date: string; message: string; }
+
+/** Spec §5: push/pull/subscribe/history. subscribe() is Plan 1b (SyncHub) —
+ *  1a polls instead, so the interface ships without it and 1b adds it. */
+export interface SyncTransport {
+  init(space: SyncSpace): Promise<void>;
+  hasRemote(space: SyncSpace): Promise<boolean>;
+  setRemote(space: SyncSpace, url: string): Promise<void>;
+  push(space: SyncSpace, message: string): Promise<PushResult>;
+  pull(space: SyncSpace): Promise<PullResult>;
+  history(space: SyncSpace, limit?: number): Promise<SpaceVersion[]>;
+}
+
+export type SpaceSyncEvent =
+  | { type: 'synced'; spaceId: string; pushed: boolean; updated: boolean }
+  | { type: 'conflict'; spaceId: string; copies: string[] }
+  | { type: 'oversize'; spaceId: string; files: string[] }
+  | { type: 'error'; spaceId: string; message: string };

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -93,11 +93,18 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
   const createProject = useCallback(async () => {
     const name = newProjectName.trim();
     if (!name) return;
-    const r = await (window as any).claude.syncSpaces.createProject(name);
-    // On success: clear the field, reload the folder list (reuses `load`, the
-    // existing folders.list() refresh) so the new project shows up, and select it.
-    if (r?.ok) { setNewProjectName(''); setProjectError(null); await load(); onChange(r.path); }
-    else setProjectError(r?.error ?? 'Could not create project');
+    // try/catch: a REJECTED invoke (e.g. bridge timeout — Android has no
+    // syncspaces handlers yet, so remote-shim rejects after 30s) must surface
+    // as an inline error here, not escape as an unhandled promise rejection.
+    try {
+      const r = await (window as any).claude.syncSpaces.createProject(name);
+      // On success: clear the field, reload the folder list (reuses `load`, the
+      // existing folders.list() refresh) so the new project shows up, and select it.
+      if (r?.ok) { setNewProjectName(''); setProjectError(null); await load(); onChange(r.path); }
+      else setProjectError(r?.error ?? 'Could not create project');
+    } catch (err: any) {
+      setProjectError(String(err?.message ?? err));
+    }
   }, [newProjectName, load, onChange]);
 
   const handleSelect = useCallback((path: string) => {

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -7,6 +7,9 @@ interface SavedFolder {
   nickname: string;
   addedAt: number;
   exists: boolean;
+  // Set by FOLDERS_LIST for YouCoded-managed sync projects (~/YouCoded/Projects/*),
+  // which appear here automatically. Drives the "synced project" badge below.
+  managed?: boolean;
 }
 
 interface Props {
@@ -26,6 +29,11 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
   const editRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const listRef = useScrollFade<HTMLDivElement>();
+
+  // New managed project (spec §3): creates ~/YouCoded/Projects/<name>, which
+  // then appears in this picker automatically via the FOLDERS_LIST merge.
+  const [newProjectName, setNewProjectName] = useState('');
+  const [projectError, setProjectError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -81,6 +89,16 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
       onChange(folder);
     } catch {}
   }, [onChange, load]);
+
+  const createProject = useCallback(async () => {
+    const name = newProjectName.trim();
+    if (!name) return;
+    const r = await (window as any).claude.syncSpaces.createProject(name);
+    // On success: clear the field, reload the folder list (reuses `load`, the
+    // existing folders.list() refresh) so the new project shows up, and select it.
+    if (r?.ok) { setNewProjectName(''); setProjectError(null); await load(); onChange(r.path); }
+    else setProjectError(r?.error ?? 'Could not create project');
+  }, [newProjectName, load, onChange]);
 
   const handleSelect = useCallback((path: string) => {
     onChange(path);
@@ -192,7 +210,11 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
                         />
                       ) : (
                         <>
-                          <div className="text-xs truncate">{f.nickname}</div>
+                          <div className="text-xs truncate">
+                            {f.nickname}
+                            {/* Plain-word badge for YouCoded-managed sync projects — no status glyphs. */}
+                            {f.managed && <span className="text-xs text-fg-muted ml-1">synced project</span>}
+                          </div>
                           <div className="text-[10px] text-fg-faint truncate" title={f.path}>
                             {f.path}
                           </div>
@@ -255,6 +277,23 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
               <span className="text-sm leading-none">+</span>
               <span>Browse for folder</span>
             </button>
+
+            {/* New managed sync project — creates ~/YouCoded/Projects/<name>. */}
+            <div className="px-2.5 pb-2">
+              <div className="flex items-center gap-2 mt-2">
+                <input
+                  value={newProjectName}
+                  onChange={e => setNewProjectName(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') void createProject(); }}
+                  placeholder="New project name…"
+                  className="flex-1 bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim"
+                />
+                <button onClick={() => void createProject()} className="text-sm px-2 py-1 rounded bg-accent text-on-accent">
+                  Create
+                </button>
+              </div>
+              {projectError && <div className="text-xs text-red-500 mt-1">{projectError}</div>}
+            </div>
           </div>
         </div>
       )}

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -381,6 +381,10 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
   // Restore flow: stash the backend the user picked so RestoreWizard can open.
   const [restoreTarget, setRestoreTarget] = useState<{ id: string; label: string; type: 'drive' | 'github' | 'icloud' } | null>(null);
   const [showSnapshots, setShowSnapshots] = useState(false);
+  // Cross-device sync spaces (spec 2026-07-03) — separate from the backend backups
+  // above. Status refetches whenever the engine emits an event so the list and
+  // per-space connected/local state stay live.
+  const [spacesStatus, setSpacesStatus] = useState<any>(null);
 
   const claude = (window as any).claude;
 
@@ -546,6 +550,16 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
     const timer = setTimeout(() => document.addEventListener('click', handler), 0);
     return () => { clearTimeout(timer); document.removeEventListener('click', handler); };
   }, [menuOpenId]);
+
+  // Load synced-spaces status now, and re-load on every engine event so the
+  // section reflects sync activity (conflicts, connect/disconnect) live.
+  useEffect(() => {
+    void (async () => setSpacesStatus(await (window as any).claude.syncSpaces.status()))();
+    const off = (window as any).claude.syncSpaces.onEvent?.(() => {
+      void (async () => setSpacesStatus(await (window as any).claude.syncSpaces.status()))();
+    });
+    return () => { off?.(); };
+  }, []);
 
   if (loading) {
     // Overlay layer L2 — theme-driven via Scrim/OverlayPanel (matches SettingsPanel popups).
@@ -782,6 +796,41 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                 </div>
               )}
             </div>
+
+            {/* 1b. Synced spaces (spec 2026-07-03) — folder-based cross-device sync,
+                distinct from the cloud backups above. */}
+            <section>
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-medium text-fg">Synced spaces</h3>
+                <label className="flex items-center gap-2 text-sm text-fg-2">
+                  <input
+                    type="checkbox"
+                    checked={!!spacesStatus?.enabled}
+                    onChange={async e => setSpacesStatus(await (window as any).claude.syncSpaces.enable(e.target.checked))}
+                  />
+                  Sync across devices
+                </label>
+              </div>
+              {spacesStatus?.enabled && (
+                <ul className="mt-2 space-y-1">
+                  {spacesStatus.spaces.map((s: any) => (
+                    <li key={s.id} className="text-sm text-fg-2 flex items-center justify-between">
+                      <span>{s.id === 'personal' ? 'Personal' : s.id.replace('project:', '')}</span>
+                      <span className="text-xs text-fg-muted">{s.remote ? 'connected' : 'local only'}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {spacesStatus?.recentEvents?.some((e: any) => e.type === 'conflict') && (
+                <p className="text-xs text-amber-600 mt-2">
+                  Some files had conflicting edits — the other device's copy was kept alongside yours
+                  (look for "(from …)" files).
+                </p>
+              )}
+              <button onClick={() => void (window as any).claude.syncSpaces.syncNow()} className="text-xs mt-2 underline text-fg-muted">
+                Sync now
+              </button>
+            </section>
 
             {/* 2. Sync Now bar */}
             <div className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-inset/50">

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -385,6 +385,13 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
   // above. Status refetches whenever the engine emits an event so the list and
   // per-space connected/local state stay live.
   const [spacesStatus, setSpacesStatus] = useState<any>(null);
+  // Local error from the enable toggle itself (a rejected invoke — e.g. bridge
+  // timeout on Android, which has no syncspaces handlers yet). Rendered in the
+  // same red note slot as engine error events below.
+  const [spacesError, setSpacesError] = useState<string | null>(null);
+  // First enable provisions GitHub repos and can take seconds — without a
+  // visible pending state the checkbox reads as "didn't take" to a non-developer.
+  const [enabling, setEnabling] = useState(false);
 
   const claude = (window as any).claude;
 
@@ -553,13 +560,32 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
 
   // Load synced-spaces status now, and re-load on every engine event so the
   // section reflects sync activity (conflicts, connect/disconnect) live.
-  useEffect(() => {
-    void (async () => setSpacesStatus(await (window as any).claude.syncSpaces.status()))();
-    const off = (window as any).claude.syncSpaces.onEvent?.(() => {
-      void (async () => setSpacesStatus(await (window as any).claude.syncSpaces.status()))();
-    });
-    return () => { off?.(); };
+  // catch {} matches the component's other fetches: a rejected invoke (e.g.
+  // 30s bridge timeout on Android, which has no syncspaces handlers yet) must
+  // not become an unhandled promise rejection — the section just stays empty.
+  const refreshSpacesStatus = useCallback(async () => {
+    try { setSpacesStatus(await (window as any).claude.syncSpaces.status()); } catch {}
   }, []);
+  useEffect(() => {
+    void refreshSpacesStatus();
+    const off = (window as any).claude.syncSpaces.onEvent?.(() => { void refreshSpacesStatus(); });
+    return () => { off?.(); };
+  }, [refreshSpacesStatus]);
+
+  // Enable/disable toggle. try/catch: on rejection, surface the message in the
+  // red note slot and re-fetch status so the checkbox reflects reality instead
+  // of silently staying out of sync with the engine.
+  const handleSpacesEnable = useCallback(async (enabled: boolean) => {
+    setEnabling(true);
+    try {
+      setSpacesStatus(await claude.syncSpaces.enable(enabled));
+      setSpacesError(null);
+    } catch (err: any) {
+      setSpacesError(String(err?.message ?? err));
+      await refreshSpacesStatus();
+    }
+    setEnabling(false);
+  }, [claude, refreshSpacesStatus]);
 
   if (loading) {
     // Overlay layer L2 — theme-driven via Scrim/OverlayPanel (matches SettingsPanel popups).
@@ -803,22 +829,25 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-medium text-fg">Synced spaces</h3>
                 <label className="flex items-center gap-2 text-sm text-fg-2">
+                  {/* Plain-word pending state — first enable provisions repos and takes seconds. */}
+                  {enabling && <span className="text-xs text-fg-muted">Setting up…</span>}
                   <input
                     type="checkbox"
                     checked={!!spacesStatus?.enabled}
-                    onChange={async e => setSpacesStatus(await (window as any).claude.syncSpaces.enable(e.target.checked))}
+                    disabled={enabling}
+                    onChange={e => void handleSpacesEnable(e.target.checked)}
                   />
                   Sync across devices
                 </label>
               </div>
               {spacesStatus?.enabled && (
                 <ul className="mt-2 space-y-1">
-                  {spacesStatus.spaces.map((s: any) => (
+                  {(spacesStatus.spaces?.map((s: any) => (
                     <li key={s.id} className="text-sm text-fg-2 flex items-center justify-between">
                       <span>{s.id === 'personal' ? 'Personal' : s.id.replace('project:', '')}</span>
                       <span className="text-xs text-fg-muted">{s.remote ? 'connected' : 'local only'}</span>
                     </li>
-                  ))}
+                  )) ?? [])}
                 </ul>
               )}
               {spacesStatus?.recentEvents?.some((e: any) => e.type === 'conflict') && (
@@ -827,7 +856,23 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                   (look for "(from …)" files).
                 </p>
               )}
-              <button onClick={() => void (window as any).claude.syncSpaces.syncNow()} className="text-xs mt-2 underline text-fg-muted">
+              {/* Error note — one slot, toggle rejection first, else the latest engine
+                  error event. space-manager.ts's friendly messages ("GitHub CLI (gh) is
+                  not installed…") arrive as broadcast {type:'error'} events on the enable
+                  path and are contractually "shown verbatim" here — without this, enable
+                  with gh missing checks the box with zero explanation. */}
+              {(() => {
+                const engineError = [...(spacesStatus?.recentEvents ?? [])].reverse()
+                  .find((e: any) => e.type === 'error');
+                const msg = spacesError ?? engineError?.message;
+                return msg ? <p className="text-xs text-red-500 mt-2">{msg}</p> : null;
+              })()}
+              {/* .catch: void doesn't swallow rejections — route a failed invoke
+                  (bridge timeout) into the red note slot instead of an unhandled rejection. */}
+              <button
+                onClick={() => void (window as any).claude.syncSpaces.syncNow().catch((err: any) => setSpacesError(String(err?.message ?? err)))}
+                className="text-xs mt-2 underline text-fg-muted"
+              >
                 Sync now
               </button>
             </section>

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -216,6 +216,16 @@ declare global {
         notifyStackState: (empty: boolean) => void;
         onBack: (cb: () => void) => () => void;
       };
+      // Cross-device sync spaces (spec 2026-07-03). Optional so remote/Android
+      // builds that predate the shim member don't break typecheck; the Task 9
+      // sync panel consumes these. onEvent returns an unsubscribe function.
+      syncSpaces?: {
+        status: () => Promise<any>;
+        enable: (enabled: boolean) => Promise<any>;
+        syncNow: () => Promise<{ ok: boolean }>;
+        createProject: (name: string) => Promise<{ ok: true; path: string } | { ok: false; error: string }>;
+        onEvent: (cb: (e: unknown) => void) => () => void;
+      };
     };
   }
 }

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -248,6 +248,12 @@ function handleMessage(data: string): void {
       // window.claude.sync.restore.onProgress(). Broadcast (no sessionId).
       dispatchEvent('sync:restore:progress', payload);
       break;
+    case 'syncspaces:event':
+      // Cross-device sync-space engine events (synced/conflict/oversize/error)
+      // flow to any listener registered via window.claude.syncSpaces.onEvent().
+      // Broadcast (no sessionId).
+      dispatchEvent('syncspaces:event', payload);
+      break;
     case 'chat:hydrate':
       // Full chat state snapshot sent by the host when a remote client connects.
       // Dispatched into the chat reducer via window.claude.on.chatHydrate in App.tsx.
@@ -1007,6 +1013,21 @@ export function installShim(): void {
           addListener('sync:restore:progress', handler);
           return () => removeListener('sync:restore:progress', handler);
         },
+      },
+    },
+    // Cross-device sync spaces (spec 2026-07-03). Same shared shape as
+    // preload.ts syncSpaces so React components render identically on remote
+    // browsers + Android (PITFALLS parity rule). onEvent returns an
+    // unsubscribe function to match preload's shape.
+    syncSpaces: {
+      status: () => invoke('syncspaces:status'),
+      enable: (enabled: boolean) => invoke('syncspaces:enable', { enabled }),
+      syncNow: () => invoke('syncspaces:sync-now'),
+      createProject: (name: string) => invoke('syncspaces:create-project', { name }),
+      onEvent: (cb: (e: unknown) => void) => {
+        const handler: Callback = (e: any) => cb(e);
+        addListener('syncspaces:event', handler);
+        return () => removeListener('syncspaces:event', handler);
       },
     },
     folders: {

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -762,6 +762,12 @@ export const IPC = {
   SYNC_FORCE: 'sync:force',
   SYNC_GET_LOG: 'sync:get-log',
   SYNC_DISMISS_WARNING: 'sync:dismiss-warning',
+  // Cross-device sync spaces (spec 2026-07-03) — distinct from the legacy sync:* above
+  SYNC_SPACES_STATUS: 'syncspaces:status',
+  SYNC_SPACES_ENABLE: 'syncspaces:enable',
+  SYNC_SPACES_SYNC_NOW: 'syncspaces:sync-now',
+  SYNC_SPACES_CREATE_PROJECT: 'syncspaces:create-project',
+  SYNC_SPACES_EVENT: 'syncspaces:event',
   // Multi-window detach subsystem (Renderer <-> Main)
   WINDOW_GET_ID: 'window:get-id',
   WINDOW_DIRECTORY_UPDATED: 'window:directory-updated',

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -483,3 +483,35 @@ describe('project:* channel parity', () => {
     for (const t of NEW_TYPES) expect(kt).toContain(`"${t}"`);
   });
 });
+
+// Cross-device sync spaces (spec 2026-07-03). Desktop-only in Phase 1a — no
+// Android surface yet — so parity is asserted across the four DESKTOP surfaces:
+// preload.ts, remote-shim.ts, ipc-handlers.ts, and remote-server.ts. preload
+// (inlined IPC object), remote-shim (invoke literal), and remote-server (switch
+// case) carry the literal string; ipc-handlers registers via the IPC.* constant
+// (matching the existing sync:* handlers), so its check maps to the constant
+// name — same "accepts the constant form" pattern as the artifact parity test.
+describe('syncspaces:* channel parity (desktop surfaces)', () => {
+  const channels: Array<[string, string]> = [
+    ['syncspaces:status', 'IPC.SYNC_SPACES_STATUS'],
+    ['syncspaces:enable', 'IPC.SYNC_SPACES_ENABLE'],
+    ['syncspaces:sync-now', 'IPC.SYNC_SPACES_SYNC_NOW'],
+    ['syncspaces:create-project', 'IPC.SYNC_SPACES_CREATE_PROJECT'],
+  ];
+  const preload = fs.readFileSync(path.join(__dirname, '../src/main/preload.ts'), 'utf8');
+  const shim = fs.readFileSync(path.join(__dirname, '../src/renderer/remote-shim.ts'), 'utf8');
+  const handlers = fs.readFileSync(path.join(__dirname, '../src/main/ipc-handlers.ts'), 'utf8');
+  const remoteServer = fs.readFileSync(path.join(__dirname, '../src/main/remote-server.ts'), 'utf8');
+  for (const [ch, constant] of channels) {
+    it(`${ch} present in preload, remote-shim, ipc-handlers, remote-server`, () => {
+      expect(preload).toContain(ch);
+      expect(shim).toContain(ch);
+      expect(handlers).toContain(constant);
+      expect(remoteServer).toContain(ch);
+    });
+  }
+  it('syncspaces:event push channel present in preload + remote-shim', () => {
+    expect(preload).toContain('syncspaces:event');
+    expect(shim).toContain('syncspaces:event');
+  });
+});

--- a/desktop/tests/sync-spaces-daily-backup.test.ts
+++ b/desktop/tests/sync-spaces-daily-backup.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { isBackupDue, datedFolderName, foldersToPrune } from '../src/main/sync-spaces/daily-backup';
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { isBackupDue, datedFolderName, foldersToPrune, DailyBackup } from '../src/main/sync-spaces/daily-backup';
+import type { SyncSpace } from '../src/main/sync-spaces/types';
 
 describe('isBackupDue', () => {
   it('due when no marker', () => expect(isBackupDue(null, new Date('2026-07-03T10:00:00Z'))).toBe(true));
@@ -16,5 +20,45 @@ describe('foldersToPrune', () => {
     const now = new Date('2026-07-03T00:00:00Z');
     expect(foldersToPrune(['2026-07-01', '2026-05-01', 'junk', '2026-06-04'], now, 30))
       .toEqual(['2026-05-01']);
+  });
+});
+
+// End-to-end async iCloud path: real tmp dirs, no mocks. Pins that the copy
+// scrubs DEFAULT_IGNORES, the marker gates same-day re-runs, and runIfDue
+// never throws — the contract the hourly timer (Task 8) relies on.
+describe('DailyBackup.runIfDue (icloud end-to-end)', () => {
+  let tmp: string;
+  afterEach(() => { if (tmp) fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('copies scrubbed, writes marker, no-ops same UTC day', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'spaces-backup-'));
+    const root = path.join(tmp, 'space');
+    const base = path.join(tmp, 'icloud');
+    fs.mkdirSync(path.join(root, 'node_modules', 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'notes.md'), 'hello');
+    fs.writeFileSync(path.join(root, '.env'), 'SECRET=1');
+    fs.writeFileSync(path.join(root, 'node_modules', 'pkg', 'i.js'), 'x');
+    const markerPath = path.join(tmp, 'marker');
+    const logs: string[] = [];
+    const space: SyncSpace = { id: 'project:demo', kind: 'project', root };
+    const job = new DailyBackup({ markerPath });
+
+    await job.runIfDue([space], [{ type: 'icloud', base }], m => logs.push(m));
+
+    // Read the dated folder back from the marker so a run that straddles UTC
+    // midnight can't flake the test.
+    const marker = fs.readFileSync(markerPath, 'utf8');
+    expect(marker).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const dest = path.join(base, 'Backup', 'spaces', marker, 'project-demo');
+    expect(fs.readFileSync(path.join(dest, 'notes.md'), 'utf8')).toBe('hello');
+    expect(fs.existsSync(path.join(dest, '.env'))).toBe(false);
+    expect(fs.existsSync(path.join(dest, 'node_modules'))).toBe(false);
+    expect(logs.some(m => m.includes('spaces-backup completed'))).toBe(true);
+
+    // Same UTC day → second call must no-op (marker gate), so a file added
+    // after the backup does not appear in the dated folder.
+    fs.writeFileSync(path.join(root, 'later.md'), 'x');
+    await job.runIfDue([space], [{ type: 'icloud', base }], m => logs.push(m));
+    expect(fs.existsSync(path.join(dest, 'later.md'))).toBe(false);
   });
 });

--- a/desktop/tests/sync-spaces-daily-backup.test.ts
+++ b/desktop/tests/sync-spaces-daily-backup.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isBackupDue, datedFolderName, foldersToPrune } from '../src/main/sync-spaces/daily-backup';
+
+describe('isBackupDue', () => {
+  it('due when no marker', () => expect(isBackupDue(null, new Date('2026-07-03T10:00:00Z'))).toBe(true));
+  it('not due same UTC day', () => expect(isBackupDue('2026-07-03', new Date('2026-07-03T23:00:00Z'))).toBe(false));
+  it('due on a new UTC day', () => expect(isBackupDue('2026-07-02', new Date('2026-07-03T00:10:00Z'))).toBe(true));
+});
+
+describe('datedFolderName', () => {
+  it('is the UTC date', () => expect(datedFolderName(new Date('2026-07-03T14:00:00Z'))).toBe('2026-07-03'));
+});
+
+describe('foldersToPrune', () => {
+  it('keeps 30 days, prunes older, ignores non-date names', () => {
+    const now = new Date('2026-07-03T00:00:00Z');
+    expect(foldersToPrune(['2026-07-01', '2026-05-01', 'junk', '2026-06-04'], now, 30))
+      .toEqual(['2026-05-01']);
+  });
+});

--- a/desktop/tests/sync-spaces-engine.test.ts
+++ b/desktop/tests/sync-spaces-engine.test.ts
@@ -1,0 +1,72 @@
+// desktop/tests/sync-spaces-engine.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { SpaceSyncEngine } from '../src/main/sync-spaces/engine';
+import type { SyncSpace, SyncTransport, SpaceSyncEvent } from '../src/main/sync-spaces/types';
+
+function fakeTransport(): SyncTransport & { pushes: string[]; pulls: string[] } {
+  const t: any = {
+    pushes: [] as string[], pulls: [] as string[],
+    init: vi.fn(async () => {}),
+    hasRemote: vi.fn(async () => true),
+    setRemote: vi.fn(async () => {}),
+    push: vi.fn(async (s: SyncSpace) => { t.pushes.push(s.id); return { pushed: true, oversize: [] }; }),
+    pull: vi.fn(async (s: SyncSpace) => { t.pulls.push(s.id); return { updated: false, conflictCopies: [] }; }),
+    history: vi.fn(async () => []),
+  };
+  return t;
+}
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-eng-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe('SpaceSyncEngine', () => {
+  it('debounces file changes into one sync (pull then push)', async () => {
+    const t = fakeTransport();
+    const events: SpaceSyncEvent[] = [];
+    const engine = new SpaceSyncEngine(t, { debounceMs: 150, pollMs: 0, onEvent: e => events.push(e) });
+    const space: SyncSpace = { id: 'project:x', kind: 'project', root: tmp };
+    await engine.addSpace(space);
+    fs.writeFileSync(path.join(tmp, 'a.md'), '1');
+    fs.writeFileSync(path.join(tmp, 'b.md'), '2');
+    await vi.waitFor(() => expect(t.pushes.length).toBe(1), { timeout: 5000 });
+    expect(t.pulls.length).toBe(1);                 // pull-before-push ordering
+    expect(events.some(e => e.type === 'synced')).toBe(true);
+    await engine.stop();
+  });
+
+  it('ignores changes under .youcoded/ and node_modules/', async () => {
+    const t = fakeTransport();
+    const engine = new SpaceSyncEngine(t, { debounceMs: 100, pollMs: 0, onEvent: () => {} });
+    await engine.addSpace({ id: 'project:x', kind: 'project', root: tmp });
+    fs.mkdirSync(path.join(tmp, '.youcoded'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.youcoded', 'sync.log'), 'x');
+    fs.mkdirSync(path.join(tmp, 'node_modules'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'node_modules', 'y.js'), 'x');
+    await new Promise(r => setTimeout(r, 500));
+    expect(t.pushes.length).toBe(0);
+    await engine.stop();
+  });
+
+  it('poll timer pulls without local changes', async () => {
+    const t = fakeTransport();
+    const engine = new SpaceSyncEngine(t, { debounceMs: 5000, pollMs: 120, onEvent: () => {} });
+    await engine.addSpace({ id: 'personal', kind: 'personal', root: tmp });
+    await vi.waitFor(() => expect(t.pulls.length).toBeGreaterThanOrEqual(1), { timeout: 5000 });
+    await engine.stop();
+  });
+
+  it('emits error events instead of throwing (never-block, spec §13)', async () => {
+    const t = fakeTransport();
+    (t.push as any).mockImplementation(async () => { throw new Error('boom'); });
+    const events: SpaceSyncEvent[] = [];
+    const engine = new SpaceSyncEngine(t, { debounceMs: 100, pollMs: 0, onEvent: e => events.push(e) });
+    await engine.addSpace({ id: 'project:x', kind: 'project', root: tmp });
+    fs.writeFileSync(path.join(tmp, 'a.md'), '1');
+    await vi.waitFor(() => expect(events.some(e => e.type === 'error')).toBe(true), { timeout: 5000 });
+    await engine.stop();
+  });
+});

--- a/desktop/tests/sync-spaces-engine.test.ts
+++ b/desktop/tests/sync-spaces-engine.test.ts
@@ -59,6 +59,37 @@ describe('SpaceSyncEngine', () => {
     await engine.stop();
   });
 
+  it('single-flight: overlapping sync requests coalesce into exactly one rerun', async () => {
+    const t = fakeTransport();
+    // Make the FIRST pull hang until we release it, so we can pile up sync
+    // requests while a sync is genuinely in flight.
+    let releaseFirstPull: () => void = () => {};
+    let firstPull = true;
+    (t.pull as any).mockImplementation(async (s: SyncSpace) => {
+      t.pulls.push(s.id);
+      if (firstPull) {
+        firstPull = false;
+        await new Promise<void>(r => { releaseFirstPull = r; });
+      }
+      return { updated: false, conflictCopies: [] };
+    });
+    const engine = new SpaceSyncEngine(t, { debounceMs: 60_000, pollMs: 0, onEvent: () => {} });
+    const space: SyncSpace = { id: 'project:x', kind: 'project', root: tmp };
+    await engine.addSpace(space);
+    const first = engine.syncSpace(space);                       // starts, blocks inside pull
+    await vi.waitFor(() => expect(t.pulls.length).toBe(1), { timeout: 5000 });
+    void engine.syncSpace(space);                                // mid-sync: sets the rerun flag
+    void engine.syncSpace(space);                                // mid-sync again: must NOT queue a second rerun
+    releaseFirstPull();
+    await first;
+    // Exactly two syncs total: the original + one coalesced rerun.
+    await vi.waitFor(() => expect(t.pushes.length).toBe(2), { timeout: 5000 });
+    await new Promise(r => setTimeout(r, 300));                  // settle: no third sync sneaks in
+    expect(t.pushes.length).toBe(2);
+    expect(t.pulls.length).toBe(2);
+    await engine.stop();
+  });
+
   it('emits error events instead of throwing (never-block, spec §13)', async () => {
     const t = fakeTransport();
     (t.push as any).mockImplementation(async () => { throw new Error('boom'); });

--- a/desktop/tests/sync-spaces-git-transport.test.ts
+++ b/desktop/tests/sync-spaces-git-transport.test.ts
@@ -1,0 +1,49 @@
+// desktop/tests/sync-spaces-git-transport.test.ts
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { GitTransport } from '../src/main/sync-spaces/git-transport';
+import type { SyncSpace } from '../src/main/sync-spaces/types';
+import { describeTransportContract, TransportHarness } from './sync-transport-contract';
+
+// Real git, local bare repo as the "GitHub" remote. Needs git on PATH (CI has it).
+async function makeHarness(): Promise<TransportHarness> {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-gt-'));
+  const bare = path.join(tmp, 'remote.git');
+  fs.mkdirSync(bare);
+  execFileSync('git', ['init', '--bare', '--initial-branch=main', bare]);
+  let n = 0;
+  const transport = new GitTransport({ deviceName: 'TestDevice' });
+  return {
+    transport,
+    async makeDeviceSpace(): Promise<SyncSpace> {
+      const root = path.join(tmp, `device-${n++}`);
+      fs.mkdirSync(root, { recursive: true });
+      const space: SyncSpace = { id: 'project:contract', kind: 'project', root };
+      await transport.init(space);
+      await transport.setRemote(space, bare);
+      return space;
+    },
+    async cleanup() { fs.rmSync(tmp, { recursive: true, force: true }); },
+  };
+}
+
+describeTransportContract('GitTransport', makeHarness);
+
+describe('GitTransport specifics', () => {
+  it('oversize files are excluded from sync and reported', async () => {
+    const h = await makeHarness();
+    const a = await h.makeDeviceSpace();
+    // 50MB cap — write cap+1 bytes sparsely is slow; instead the transport takes
+    // an injectable cap for tests:
+    const small = new GitTransport({ deviceName: 'T', maxFileBytes: 10 });
+    fs.writeFileSync(path.join(a.root, 'big.bin'), 'x'.repeat(11));
+    fs.writeFileSync(path.join(a.root, 'ok.md'), 'fine');
+    const r = await small.push(a, 'mixed');
+    expect(r.pushed).toBe(true);
+    expect(r.oversize).toEqual(['big.bin']);
+    await h.cleanup();
+  }, 30000);
+});

--- a/desktop/tests/sync-spaces-guards.test.ts
+++ b/desktop/tests/sync-spaces-guards.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateSyncName, DEFAULT_IGNORES, MAX_SYNC_FILE_BYTES,
+  conflictCopyName, findCaseCollisions,
+} from '../src/main/sync-spaces/guards';
+
+describe('validateSyncName', () => {
+  it('accepts normal names', () => {
+    expect(validateSyncName('budget-app')).toBeNull();
+    expect(validateSyncName('My Notes 2026')).toBeNull();
+  });
+  it('rejects Windows reserved device names (any case, with extension)', () => {
+    expect(validateSyncName('CON')).toMatch(/reserved/i);
+    expect(validateSyncName('aux.txt')).toMatch(/reserved/i);
+    expect(validateSyncName('com1')).toMatch(/reserved/i);
+  });
+  it('rejects characters invalid on Windows', () => {
+    for (const bad of ['a<b', 'a>b', 'a:b', 'a"b', 'a|b', 'a?b', 'a*b']) {
+      expect(validateSyncName(bad)).toMatch(/character/i);
+    }
+  });
+  it('rejects empty, dot-only, and trailing dot/space names', () => {
+    expect(validateSyncName('')).toBeTruthy();
+    expect(validateSyncName('.')).toBeTruthy();
+    expect(validateSyncName('name.')).toBeTruthy();
+    expect(validateSyncName('name ')).toBeTruthy();
+  });
+});
+
+describe('DEFAULT_IGNORES', () => {
+  it('covers the spec §8 credential + junk set', () => {
+    for (const p of ['node_modules/', '.youcoded/', '.git/', '.env', '*.pem', '.DS_Store']) {
+      expect(DEFAULT_IGNORES).toContain(p);
+    }
+  });
+});
+
+describe('MAX_SYNC_FILE_BYTES', () => {
+  it('is 50MB per spec §7', () => expect(MAX_SYNC_FILE_BYTES).toBe(50 * 1024 * 1024));
+});
+
+describe('conflictCopyName', () => {
+  const d = new Date('2026-07-03T14:00:00Z');
+  it('inserts device + date before the extension', () => {
+    expect(conflictCopyName('docs/notes.md', 'Laptop', d))
+      .toBe('docs/notes (from Laptop, 2026-07-03).md');
+  });
+  it('handles extensionless files', () => {
+    expect(conflictCopyName('Makefile', 'Laptop', d))
+      .toBe('Makefile (from Laptop, 2026-07-03)');
+  });
+});
+
+describe('findCaseCollisions', () => {
+  it('groups paths differing only by case', () => {
+    expect(findCaseCollisions(['a/Readme.md', 'a/readme.md', 'b/x.ts']))
+      .toEqual([['a/Readme.md', 'a/readme.md']]);
+  });
+  it('returns empty when no collisions', () => {
+    expect(findCaseCollisions(['a.ts', 'b.ts'])).toEqual([]);
+  });
+});

--- a/desktop/tests/sync-spaces-guards.test.ts
+++ b/desktop/tests/sync-spaces-guards.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   validateSyncName, DEFAULT_IGNORES, MAX_SYNC_FILE_BYTES,
-  conflictCopyName, findCaseCollisions,
+  conflictCopyName, findCaseCollisions, isIgnoredPath,
 } from '../src/main/sync-spaces/guards';
 
 describe('validateSyncName', () => {
@@ -32,6 +32,38 @@ describe('DEFAULT_IGNORES', () => {
     for (const p of ['node_modules/', '.youcoded/', '.git/', '.env', '*.pem', '.DS_Store']) {
       expect(DEFAULT_IGNORES).toContain(p);
     }
+  });
+});
+
+describe('isIgnoredPath', () => {
+  it('matches directory patterns anywhere in the path', () => {
+    expect(isIgnoredPath('node_modules/x/i.js')).toBe(true);
+    expect(isIgnoredPath('dist/bundle.js')).toBe(true);
+    expect(isIgnoredPath('sub/__pycache__/mod.pyc')).toBe(true);
+    // The directory itself (no children yet) is also ignored.
+    expect(isIgnoredPath('node_modules')).toBe(true);
+  });
+  it('matches exact-basename patterns at any depth', () => {
+    expect(isIgnoredPath('.env')).toBe(true);
+    expect(isIgnoredPath('sub/dir/.env')).toBe(true);
+    expect(isIgnoredPath('.DS_Store')).toBe(true);
+  });
+  it('matches * glob patterns against the basename (secrets)', () => {
+    expect(isIgnoredPath('secrets/server.pem')).toBe(true);
+    expect(isIgnoredPath('id_rsa')).toBe(true);
+    expect(isIgnoredPath('id_rsa.pub')).toBe(true);
+    expect(isIgnoredPath('.env.local')).toBe(true);
+    expect(isIgnoredPath('app/gcp.credentials.json')).toBe(true);
+  });
+  it('does not match ordinary project files', () => {
+    expect(isIgnoredPath('docs/notes.md')).toBe(false);
+    expect(isIgnoredPath('src/main.ts')).toBe(false);
+    // '.environment' is NOT '.env' (exact) nor '.env.*' (needs a dot after
+    // env) — same as gitignore semantics, so backups match sync exactly.
+    expect(isIgnoredPath('.environment')).toBe(false);
+  });
+  it('never ignores the space root itself (relative path is empty)', () => {
+    expect(isIgnoredPath('')).toBe(false);
   });
 });
 

--- a/desktop/tests/sync-spaces-managed-roots.test.ts
+++ b/desktop/tests/sync-spaces-managed-roots.test.ts
@@ -1,0 +1,45 @@
+// desktop/tests/sync-spaces-managed-roots.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ManagedRoots } from '../src/main/sync-spaces/managed-roots';
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-roots-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe('ManagedRoots', () => {
+  it('ensure() creates Projects and Personal under the base', () => {
+    const r = new ManagedRoots(tmp);
+    r.ensure();
+    expect(fs.existsSync(path.join(tmp, 'YouCoded', 'Projects'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'YouCoded', 'Personal'))).toBe(true);
+  });
+  it('listProjects() returns directories only, sorted', () => {
+    const r = new ManagedRoots(tmp);
+    r.ensure();
+    fs.mkdirSync(path.join(r.projectsRoot, 'zeta'));
+    fs.mkdirSync(path.join(r.projectsRoot, 'alpha'));
+    fs.writeFileSync(path.join(r.projectsRoot, 'stray.txt'), 'x');
+    expect(r.listProjects().map(p => p.name)).toEqual(['alpha', 'zeta']);
+    expect(r.listProjects()[0].path).toBe(path.join(r.projectsRoot, 'alpha'));
+  });
+  it('createProject() validates the name and rejects duplicates', () => {
+    const r = new ManagedRoots(tmp);
+    r.ensure();
+    expect(r.createProject('my-app')).toEqual({ ok: true, path: path.join(r.projectsRoot, 'my-app') });
+    expect(r.createProject('my-app')).toEqual({ ok: false, error: 'A project with that name already exists' });
+    const bad = r.createProject('aux');
+    expect(bad.ok).toBe(false);
+  });
+  it('spaces() returns personal + one space per project with stable ids', () => {
+    const r = new ManagedRoots(tmp);
+    r.ensure();
+    r.createProject('my-app');
+    const spaces = r.spaces();
+    expect(spaces.map(s => s.id)).toEqual(['personal', 'project:my-app']);
+    expect(spaces[0].root).toBe(r.personalRoot);
+    expect(spaces[1].kind).toBe('project');
+  });
+});

--- a/desktop/tests/sync-spaces-service.test.ts
+++ b/desktop/tests/sync-spaces-service.test.ts
@@ -1,0 +1,115 @@
+// Pins the enable/disable transition serialization in sync-spaces/service.ts:
+// enable(true) racing enable(false) must run strictly sequentially, and a
+// superseded engine start must stop its own instance (no orphaned watchers).
+// All collaborators are mocked — this tests ONLY the composition root's
+// transition chaining, not the engine/transport themselves.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted above imports, so shared fake state must be
+// created via vi.hoisted for the factories to close over it.
+const h = vi.hoisted(() => {
+  class FakeEngine {
+    stopped = false;
+    added: string[] = [];
+    // Test releases this to let a blocked addSpace proceed — simulates the
+    // real engine suspending on chokidar's ready await mid-startEngine.
+    releaseAddSpace: (() => void) | null = null;
+    constructor() { h.engines.push(this); }
+    async addSpace(space: { id: string }): Promise<void> {
+      await new Promise<void>((res) => { this.releaseAddSpace = res; });
+      this.added.push(space.id);
+    }
+    async syncSpace(): Promise<void> {}
+    async stop(): Promise<void> { this.stopped = true; }
+  }
+  return { engines: [] as InstanceType<typeof FakeEngine>[], FakeEngine };
+});
+
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+vi.mock('../src/main/sync-spaces/engine', () => ({ SpaceSyncEngine: h.FakeEngine }));
+vi.mock('../src/main/sync-spaces/managed-roots', () => ({
+  ManagedRoots: class {
+    ensure(): void {}
+    listProjects(): Array<{ name: string; path: string }> { return []; }
+    spaces(): Array<{ id: string; kind: string; root: string }> {
+      return [{ id: 'personal', kind: 'personal', root: '/fake/personal' }];
+    }
+  },
+}));
+vi.mock('../src/main/sync-spaces/space-manager', () => ({
+  SpaceManager: class {
+    private enabled = false;
+    isEnabled(): boolean { return this.enabled; }
+    setEnabled(v: boolean): void { this.enabled = v; }
+    remoteFor(): string | null { return null; }
+    async ensureRemote(): Promise<string> { return 'https://github.com/x/y.git'; }
+  },
+}));
+vi.mock('../src/main/sync-spaces/git-transport', () => ({
+  GitTransport: class {
+    async init(): Promise<void> {}
+    async setRemote(): Promise<void> {}
+  },
+}));
+vi.mock('../src/main/sync-spaces/daily-backup', () => ({
+  DailyBackup: class { async runIfDue(): Promise<void> {} },
+}));
+
+async function freshService() {
+  vi.resetModules();
+  h.engines.length = 0;
+  const svc = await import('../src/main/sync-spaces/service');
+  await svc.startSyncSpaces(async () => [], () => {});
+  return svc;
+}
+
+/** Wait until the Nth engine exists AND is suspended inside addSpace. Polls
+ *  the live array — the engine is constructed asynchronously (inside the
+ *  chained transition), so it can't be captured before calling this. */
+async function waitForGate(index: number): Promise<void> {
+  await vi.waitFor(() => {
+    expect(h.engines.length).toBeGreaterThan(index);
+    expect(h.engines[index].releaseAddSpace).toBeTruthy();
+  });
+}
+
+describe('sync-spaces service transition serialization', () => {
+  beforeEach(() => { h.engines.length = 0; });
+
+  it('disable issued mid-start waits for the start, then stops that engine (no interleave)', async () => {
+    const svc = await freshService();
+    const p1 = svc.syncSpacesEnable(true);
+    await waitForGate(0);
+    const e1 = h.engines[0];
+    // Disable while the start is suspended inside addSpace. Serialization
+    // means this must NOT stop the engine yet.
+    const p2 = svc.syncSpacesEnable(false);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(e1.stopped).toBe(false);
+    // Release the start; it completes, THEN the queued disable stops it.
+    e1.releaseAddSpace!();
+    const [s1, s2] = await Promise.all([p1, p2]);
+    expect(e1.added).toEqual(['personal']); // start finished cleanly, not abandoned mid-loop
+    expect(e1.stopped).toBe(true);          // queued disable then stopped it
+    expect(s1.enabled).toBe(false);         // status reads run after BOTH queued transitions
+    expect(s2.enabled).toBe(false);
+    expect((await svc.syncSpacesStatus()).enabled).toBe(false);
+  });
+
+  it('rapid enable→disable→enable leaves exactly one live engine, all others stopped', async () => {
+    const svc = await freshService();
+    const p1 = svc.syncSpacesEnable(true);
+    await waitForGate(0);
+    const p2 = svc.syncSpacesEnable(false);
+    const p3 = svc.syncSpacesEnable(true);
+    h.engines[0].releaseAddSpace!();
+    // Second start blocks on its own addSpace gate once the disable ran.
+    await waitForGate(1);
+    h.engines[1].releaseAddSpace!();
+    await Promise.all([p1, p2, p3]);
+    expect(h.engines[0].stopped).toBe(true);
+    expect(h.engines[1].stopped).toBe(false);
+    expect(h.engines[1].added).toEqual(['personal']);
+    expect((await svc.syncSpacesStatus()).enabled).toBe(true);
+  });
+});

--- a/desktop/tests/sync-spaces-space-manager.test.ts
+++ b/desktop/tests/sync-spaces-space-manager.test.ts
@@ -2,13 +2,81 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { SpaceManager, repoNameForSpace } from '../src/main/sync-spaces/space-manager';
+import { SpaceManager, repoNameForSpace, provisionGithubRemote } from '../src/main/sync-spaces/space-manager';
 import type { SyncSpace } from '../src/main/sync-spaces/types';
 
 describe('repoNameForSpace', () => {
   it('maps personal and project spaces to stable private repo names', () => {
     expect(repoNameForSpace({ id: 'personal', kind: 'personal', root: '/x' })).toBe('youcoded-sync-personal');
-    expect(repoNameForSpace({ id: 'project:My App', kind: 'project', root: '/x' })).toBe('youcoded-sync-project-my-app');
+    // Project names carry a short hash of the lowercased id for uniqueness.
+    expect(repoNameForSpace({ id: 'project:My App', kind: 'project', root: '/x' }))
+      .toMatch(/^youcoded-sync-project-my-app-[0-9a-f]{8}$/);
+  });
+
+  it('is case-insensitive: the same folder name in different case maps to the SAME repo', () => {
+    const a = repoNameForSpace({ id: 'project:My App', kind: 'project', root: '/x' });
+    const b = repoNameForSpace({ id: 'project:my app', kind: 'project', root: '/x' });
+    expect(a).toBe(b);
+  });
+
+  it('distinct folder names that slug identically get DIFFERENT repos', () => {
+    const a = repoNameForSpace({ id: 'project:My App', kind: 'project', root: '/x' });
+    const b = repoNameForSpace({ id: 'project:My-App', kind: 'project', root: '/x' });
+    expect(a).not.toBe(b);
+  });
+
+  it('all-symbol names still produce a valid, unique repo name', () => {
+    expect(repoNameForSpace({ id: 'project:###', kind: 'project', root: '/x' }))
+      .toMatch(/^youcoded-sync-project-x-[0-9a-f]{8}$/);
+  });
+});
+
+describe('provisionGithubRemote (injected exec)', () => {
+  it('returns the created repo URL with .git suffix', async () => {
+    const exec = vi.fn(async () => ({ stdout: 'https://github.com/u/youcoded-sync-personal\n' }));
+    await expect(provisionGithubRemote('youcoded-sync-personal', exec))
+      .resolves.toBe('https://github.com/u/youcoded-sync-personal.git');
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec.mock.calls[0][1]).toEqual(['repo', 'create', 'youcoded-sync-personal', '--private']);
+  });
+
+  it('recovers when create fails but the repo already exists (second device)', async () => {
+    const exec = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('create failed'), { stderr: 'Name already exists on this account' }))
+      .mockResolvedValueOnce({ stdout: 'https://github.com/u/youcoded-sync-personal\n' });
+    await expect(provisionGithubRemote('youcoded-sync-personal', exec))
+      .resolves.toBe('https://github.com/u/youcoded-sync-personal.git');
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec.mock.calls[1][1].slice(0, 3)).toEqual(['repo', 'view', 'youcoded-sync-personal']);
+  });
+
+  it('propagates the ORIGINAL create error when view also fails', async () => {
+    const original = new Error('network trouble');
+    const exec = vi.fn()
+      .mockRejectedValueOnce(original)
+      .mockRejectedValueOnce(new Error('view also failed'));
+    await expect(provisionGithubRemote('r', exec)).rejects.toBe(original);
+  });
+
+  it('throws "unexpected gh output" when create prints garbage and view fails', async () => {
+    const exec = vi.fn()
+      .mockResolvedValueOnce({ stdout: 'something weird\n' })
+      .mockRejectedValueOnce(new Error('view failed'));
+    await expect(provisionGithubRemote('r', exec)).rejects.toThrow('unexpected gh output');
+  });
+
+  it('maps a missing gh binary (ENOENT) to a plain-language error', async () => {
+    const enoent = Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' });
+    const exec = vi.fn().mockRejectedValue(enoent);
+    await expect(provisionGithubRemote('r', exec))
+      .rejects.toThrow('GitHub CLI (gh) is not installed');
+  });
+
+  it('maps a gh auth failure to a plain-language error', async () => {
+    const authErr = Object.assign(new Error('exit 4'), { stderr: 'To get started with GitHub CLI, please run: gh auth login' });
+    const exec = vi.fn().mockRejectedValue(authErr);
+    await expect(provisionGithubRemote('r', exec))
+      .rejects.toThrow('Not signed in to GitHub');
   });
 });
 
@@ -54,5 +122,15 @@ describe('SpaceManager state', () => {
     await expect(m.ensureRemote(space)).resolves.toBe('https://github.com/u/youcoded-sync-personal.git');
     expect(m.remoteFor('personal')).toBe('https://github.com/u/youcoded-sync-personal.git');
     expect(provisionRemote).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades to defaults when the state file is corrupt, and self-heals on write', () => {
+    const stateFile = path.join(tmp, 'sync-spaces.json');
+    fs.writeFileSync(stateFile, '{not json!!');
+    const m = new SpaceManager({ stateFile, provisionRemote: vi.fn() });
+    expect(m.isEnabled()).toBe(false);
+    expect(m.remoteFor('personal')).toBe(null);
+    m.setEnabled(true);
+    expect(new SpaceManager({ stateFile, provisionRemote: vi.fn() }).isEnabled()).toBe(true);
   });
 });

--- a/desktop/tests/sync-spaces-space-manager.test.ts
+++ b/desktop/tests/sync-spaces-space-manager.test.ts
@@ -38,4 +38,21 @@ describe('SpaceManager state', () => {
     expect(url2).toBe(url1);
     expect(provisionRemote).toHaveBeenCalledTimes(1);
   });
+
+  it('a failed provision propagates and does not record a remote', async () => {
+    const stateFile = path.join(tmp, 'sync-spaces.json');
+    // First call fails (e.g. offline / not authed); second succeeds. The failure
+    // must NOT poison the state file — remoteFor stays null so a retry can provision.
+    const provisionRemote = vi.fn()
+      .mockRejectedValueOnce(new Error('gh: not signed in'))
+      .mockResolvedValueOnce('https://github.com/u/youcoded-sync-personal.git');
+    const m = new SpaceManager({ stateFile, provisionRemote });
+    const space: SyncSpace = { id: 'personal', kind: 'personal', root: tmp };
+    await expect(m.ensureRemote(space)).rejects.toThrow('gh: not signed in');
+    expect(m.remoteFor('personal')).toBe(null);
+    // Retry after the transient failure provisions and records normally.
+    await expect(m.ensureRemote(space)).resolves.toBe('https://github.com/u/youcoded-sync-personal.git');
+    expect(m.remoteFor('personal')).toBe('https://github.com/u/youcoded-sync-personal.git');
+    expect(provisionRemote).toHaveBeenCalledTimes(2);
+  });
 });

--- a/desktop/tests/sync-spaces-space-manager.test.ts
+++ b/desktop/tests/sync-spaces-space-manager.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { SpaceManager, repoNameForSpace } from '../src/main/sync-spaces/space-manager';
+import type { SyncSpace } from '../src/main/sync-spaces/types';
+
+describe('repoNameForSpace', () => {
+  it('maps personal and project spaces to stable private repo names', () => {
+    expect(repoNameForSpace({ id: 'personal', kind: 'personal', root: '/x' })).toBe('youcoded-sync-personal');
+    expect(repoNameForSpace({ id: 'project:My App', kind: 'project', root: '/x' })).toBe('youcoded-sync-project-my-app');
+  });
+});
+
+describe('SpaceManager state', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-sm-')); });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('persists enabled flag + per-space remotes in sync-spaces.json', () => {
+    const stateFile = path.join(tmp, 'sync-spaces.json');
+    const m = new SpaceManager({ stateFile, provisionRemote: vi.fn() });
+    expect(m.isEnabled()).toBe(false);
+    m.setEnabled(true);
+    expect(new SpaceManager({ stateFile, provisionRemote: vi.fn() }).isEnabled()).toBe(true);
+    m.recordRemote('personal', 'https://github.com/u/youcoded-sync-personal.git');
+    expect(m.remoteFor('personal')).toBe('https://github.com/u/youcoded-sync-personal.git');
+  });
+
+  it('ensureRemote provisions once and caches the URL', async () => {
+    const stateFile = path.join(tmp, 'sync-spaces.json');
+    const provisionRemote = vi.fn(async (name: string) => `https://github.com/u/${name}.git`);
+    const m = new SpaceManager({ stateFile, provisionRemote });
+    const space: SyncSpace = { id: 'personal', kind: 'personal', root: tmp };
+    const url1 = await m.ensureRemote(space);
+    const url2 = await m.ensureRemote(space);
+    expect(url1).toBe('https://github.com/u/youcoded-sync-personal.git');
+    expect(url2).toBe(url1);
+    expect(provisionRemote).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/tests/sync-spaces-two-device.test.ts
+++ b/desktop/tests/sync-spaces-two-device.test.ts
@@ -1,0 +1,53 @@
+// desktop/tests/sync-spaces-two-device.test.ts
+// Spec §15 two-instance matrix, transport+engine layers only (no Electron):
+// two ManagedRoots + engines sharing one bare remote must converge.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { ManagedRoots } from '../src/main/sync-spaces/managed-roots';
+import { GitTransport } from '../src/main/sync-spaces/git-transport';
+import { SpaceSyncEngine } from '../src/main/sync-spaces/engine';
+import type { SpaceSyncEvent } from '../src/main/sync-spaces/types';
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-e2e-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+it('laptop → desktop file propagation via engines', async () => {
+  const bare = path.join(tmp, 'remote.git');
+  fs.mkdirSync(bare);
+  execFileSync('git', ['init', '--bare', '--initial-branch=main', bare]);
+
+  const laptop = new ManagedRoots(path.join(tmp, 'laptop'));
+  const desktop = new ManagedRoots(path.join(tmp, 'desktop'));
+  laptop.ensure(); desktop.ensure();
+  laptop.createProject('app'); desktop.createProject('app');
+  const [lSpace] = laptop.spaces().filter(s => s.kind === 'project');
+  const [dSpace] = desktop.spaces().filter(s => s.kind === 'project');
+
+  const lT = new GitTransport({ deviceName: 'Laptop' });
+  const dT = new GitTransport({ deviceName: 'Desktop' });
+  const events: SpaceSyncEvent[] = [];
+  const lEngine = new SpaceSyncEngine(lT, { debounceMs: 200, pollMs: 0, onEvent: e => events.push(e) });
+  const dEngine = new SpaceSyncEngine(dT, { debounceMs: 200, pollMs: 300, onEvent: e => events.push(e) });
+
+  await lEngine.addSpace(lSpace); await lT.setRemote(lSpace, bare);
+  await dEngine.addSpace(dSpace); await dT.setRemote(dSpace, bare);
+
+  fs.writeFileSync(path.join(lSpace.root, 'CLAUDE.md'), '# project instructions\n');
+  // Laptop watcher debounces → pushes; desktop poll loop pulls.
+  await waitFor(() => fs.existsSync(path.join(dSpace.root, 'CLAUDE.md')), 20_000);
+  expect(fs.readFileSync(path.join(dSpace.root, 'CLAUDE.md'), 'utf8')).toBe('# project instructions\n');
+
+  await lEngine.stop(); await dEngine.stop();
+}, 30_000);
+
+async function waitFor(cond: () => boolean, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timeout waiting for condition');
+    await new Promise(r => setTimeout(r, 250));
+  }
+}

--- a/desktop/tests/sync-spaces-two-device.test.ts
+++ b/desktop/tests/sync-spaces-two-device.test.ts
@@ -13,7 +13,11 @@ import type { SpaceSyncEvent } from '../src/main/sync-spaces/types';
 
 let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-e2e-')); });
-afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+afterEach(() => {
+  // Windows releases chokidar/git handles asynchronously after close() —
+  // retry the temp-dir removal instead of flaking on EPERM/ENOTEMPTY.
+  fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+});
 
 it('laptop → desktop file propagation via engines', async () => {
   const bare = path.join(tmp, 'remote.git');

--- a/desktop/tests/sync-transport-contract.ts
+++ b/desktop/tests/sync-transport-contract.ts
@@ -101,5 +101,31 @@ export function describeTransportContract(name: string, makeHarness: () => Promi
       expect(hist.length).toBeGreaterThanOrEqual(2);
       expect(hist[0].message).toBe('second');
     });
+
+    it('two devices with pre-existing unrelated content converge on first sync', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      // Both devices have content BEFORE ever syncing (e.g. Personal space in use
+      // on two machines) — histories are unrelated at first contact.
+      fs.writeFileSync(path.join(a.root, 'a-only.md'), 'from A\n');
+      fs.writeFileSync(path.join(b.root, 'b-only.md'), 'from B\n');
+      fs.writeFileSync(path.join(a.root, 'shared.md'), 'A content\n');
+      fs.writeFileSync(path.join(b.root, 'shared.md'), 'B content\n');
+      await h.transport.push(a, 'A initial');
+      const bPull = await h.transport.pull(b);
+      expect(bPull.updated).toBe(true);
+      // Non-overlapping files union; overlapping file resolves convergently
+      // (remote/A wins canonical, B's content preserved as a conflict copy).
+      expect(fs.readFileSync(path.join(b.root, 'a-only.md'), 'utf8')).toBe('from A\n');
+      expect(fs.existsSync(path.join(b.root, 'b-only.md'))).toBe(true);
+      expect(fs.readFileSync(path.join(b.root, 'shared.md'), 'utf8')).toBe('A content\n');
+      expect(bPull.conflictCopies.length).toBe(1);
+      // After B pushes, A converges to the identical tree.
+      await h.transport.push(b, 'B merge');
+      const aPull = await h.transport.pull(a);
+      expect(fs.readFileSync(path.join(a.root, 'shared.md'), 'utf8')).toBe('A content\n');
+      expect(fs.existsSync(path.join(a.root, 'b-only.md'))).toBe(true);
+    }, 30000);
   });
 }

--- a/desktop/tests/sync-transport-contract.ts
+++ b/desktop/tests/sync-transport-contract.ts
@@ -1,7 +1,7 @@
 // desktop/tests/sync-transport-contract.ts
 // Contract every SyncTransport implementation must satisfy (spec §15).
 // Called from a concrete transport's .test.ts with a factory.
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -16,6 +16,12 @@ export interface TransportHarness {
 
 export function describeTransportContract(name: string, makeHarness: () => Promise<TransportHarness>) {
   describe(`SyncTransport contract: ${name}`, () => {
+    // Real transports are I/O-bound (git spawns today, network later) — the
+    // slowest contract test does ~6 sequential git round-trips (~8s on Windows).
+    // Own a generous timeout here so bare `vitest run` stays green while the
+    // global default stays tight for fast unit tests.
+    vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
     let h: TransportHarness;
     beforeEach(async () => { h = await makeHarness(); });
     afterEach(async () => { await h.cleanup(); });
@@ -126,6 +132,43 @@ export function describeTransportContract(name: string, makeHarness: () => Promi
       const aPull = await h.transport.pull(a);
       expect(fs.readFileSync(path.join(a.root, 'shared.md'), 'utf8')).toBe('A content\n');
       expect(fs.existsSync(path.join(a.root, 'b-only.md'))).toBe(true);
-    }, 30000);
+    });
+
+    it('conflict copies preserve >1MB content byte-for-byte', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      fs.writeFileSync(path.join(a.root, 'big.txt'), 'base\n');
+      await h.transport.push(a, 'base');
+      await h.transport.pull(b);
+      const aContent = `A${'x'.repeat(2 * 1024 * 1024)}\n`;
+      const bContent = `B${'y'.repeat(2 * 1024 * 1024)}\n`;
+      fs.writeFileSync(path.join(a.root, 'big.txt'), aContent);
+      await h.transport.push(a, 'A big edit');
+      fs.writeFileSync(path.join(b.root, 'big.txt'), bContent);
+      const pull = await h.transport.pull(b);
+      expect(pull.conflictCopies.length).toBe(1);
+      expect(fs.readFileSync(path.join(b.root, 'big.txt'), 'utf8')).toBe(aContent);
+      expect(fs.readFileSync(path.join(b.root, pull.conflictCopies[0]), 'utf8')).toBe(bContent);
+    });
+
+    it('conflict copies preserve binary content exactly', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      const base = Buffer.from([0, 1, 2, 3, 255, 254, 10, 13, 0, 42]);
+      fs.writeFileSync(path.join(a.root, 'data.bin'), base);
+      await h.transport.push(a, 'base');
+      await h.transport.pull(b);
+      const aBytes = Buffer.from([9, 8, 7, 0, 200, 201, 13, 10, 0, 1]);
+      const bBytes = Buffer.from([5, 5, 5, 0, 128, 129, 10, 0, 2, 3]);
+      fs.writeFileSync(path.join(a.root, 'data.bin'), aBytes);
+      await h.transport.push(a, 'A bin edit');
+      fs.writeFileSync(path.join(b.root, 'data.bin'), bBytes);
+      const pull = await h.transport.pull(b);
+      expect(pull.conflictCopies.length).toBe(1);
+      expect(Buffer.compare(fs.readFileSync(path.join(b.root, 'data.bin')), aBytes)).toBe(0);
+      expect(Buffer.compare(fs.readFileSync(path.join(b.root, pull.conflictCopies[0])), bBytes)).toBe(0);
+    });
   });
 }

--- a/desktop/tests/sync-transport-contract.ts
+++ b/desktop/tests/sync-transport-contract.ts
@@ -1,0 +1,105 @@
+// desktop/tests/sync-transport-contract.ts
+// Contract every SyncTransport implementation must satisfy (spec §15).
+// Called from a concrete transport's .test.ts with a factory.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { SyncSpace, SyncTransport } from '../src/main/sync-spaces/types';
+
+export interface TransportHarness {
+  transport: SyncTransport;
+  /** Make a fresh device root attached to the SAME logical remote. */
+  makeDeviceSpace(): Promise<SyncSpace>;
+  cleanup(): Promise<void>;
+}
+
+export function describeTransportContract(name: string, makeHarness: () => Promise<TransportHarness>) {
+  describe(`SyncTransport contract: ${name}`, () => {
+    let h: TransportHarness;
+    beforeEach(async () => { h = await makeHarness(); });
+    afterEach(async () => { await h.cleanup(); });
+
+    it('init is idempotent and touches nothing outside .youcoded/', async () => {
+      const s = await h.makeDeviceSpace();
+      await h.transport.init(s);
+      await h.transport.init(s);
+      const entries = fs.readdirSync(s.root).filter(e => e !== '.youcoded');
+      expect(entries).toEqual([]);            // no .git file/dir, no stray files
+      expect(fs.existsSync(path.join(s.root, '.git'))).toBe(false);
+    });
+
+    it('push then pull round-trips a file to a second device', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      fs.mkdirSync(path.join(a.root, 'docs'), { recursive: true });
+      fs.writeFileSync(path.join(a.root, 'docs', 'notes.md'), 'hello from A\n');
+      const push = await h.transport.push(a, 'test change');
+      expect(push.pushed).toBe(true);
+      const pull = await h.transport.pull(b);
+      expect(pull.updated).toBe(true);
+      expect(fs.readFileSync(path.join(b.root, 'docs', 'notes.md'), 'utf8')).toBe('hello from A\n');
+    });
+
+    it('push with no changes reports pushed:false', async () => {
+      const a = await h.makeDeviceSpace();
+      await h.transport.init(a);
+      const r = await h.transport.push(a, 'noop');
+      expect(r.pushed).toBe(false);
+    });
+
+    it('divergent edits converge: remote wins canonical, local kept as conflict copy', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      fs.writeFileSync(path.join(a.root, 'plan.md'), 'base\n');
+      await h.transport.push(a, 'base');
+      await h.transport.pull(b);
+      // Both edit the same line "offline"
+      fs.writeFileSync(path.join(a.root, 'plan.md'), 'A version\n');
+      await h.transport.push(a, 'A edit');
+      fs.writeFileSync(path.join(b.root, 'plan.md'), 'B version\n');
+      const pull = await h.transport.pull(b);   // B pulls A's push → conflict
+      expect(pull.conflictCopies.length).toBe(1);
+      // Canonical file holds the REMOTE (A) content — convergent rule, spec §8
+      expect(fs.readFileSync(path.join(b.root, 'plan.md'), 'utf8')).toBe('A version\n');
+      // Conflict copy holds B's content
+      const copy = path.join(b.root, pull.conflictCopies[0]);
+      expect(fs.readFileSync(copy, 'utf8')).toBe('B version\n');
+      // After B pushes, A pulls and converges with NO further conflict
+      await h.transport.push(b, 'merge');
+      const aPull = await h.transport.pull(a);
+      expect(aPull.conflictCopies).toEqual([]);
+      expect(fs.readFileSync(path.join(a.root, 'plan.md'), 'utf8')).toBe('A version\n');
+      expect(fs.existsSync(path.join(a.root, pull.conflictCopies[0]))).toBe(true);
+    });
+
+    it('default ignores are honored (node_modules, .env never travel)', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      fs.mkdirSync(path.join(a.root, 'node_modules', 'x'), { recursive: true });
+      fs.writeFileSync(path.join(a.root, 'node_modules', 'x', 'i.js'), 'x');
+      fs.writeFileSync(path.join(a.root, '.env'), 'SECRET=1');
+      fs.writeFileSync(path.join(a.root, 'real.md'), 'content');
+      await h.transport.push(a, 'with junk');
+      await h.transport.pull(b);
+      expect(fs.existsSync(path.join(b.root, 'real.md'))).toBe(true);
+      expect(fs.existsSync(path.join(b.root, 'node_modules'))).toBe(false);
+      expect(fs.existsSync(path.join(b.root, '.env'))).toBe(false);
+    });
+
+    it('history lists pushed versions, newest first', async () => {
+      const a = await h.makeDeviceSpace();
+      await h.transport.init(a);
+      fs.writeFileSync(path.join(a.root, 'f.md'), '1');
+      await h.transport.push(a, 'first');
+      fs.writeFileSync(path.join(a.root, 'f.md'), '2');
+      await h.transport.push(a, 'second');
+      const hist = await h.transport.history(a, 10);
+      expect(hist.length).toBeGreaterThanOrEqual(2);
+      expect(hist[0].message).toBe('second');
+    });
+  });
+}


### PR DESCRIPTION
Implements Phase 1a of docs/superpowers/specs/2026-07-03-cross-device-sync-design.md (youcoded-dev):
managed ~/YouCoded roots, SyncTransport + GitTransport (hidden GIT_DIR repos), SpaceSyncEngine
(watch/debounce/poll, convergent conflict copies), SpaceManager (gh remote provisioning),
dated daily space backups to Drive/iCloud, syncspaces:* IPC + picker/SyncPanel UI.

SyncHub (signals) is Plan 1b. Legacy sync-service untouched.

Notable hardening beyond the plan (all review-driven, pinned by tests):
- `* -text` attributes (byte-faithful on Windows; `text=auto` overrides autocrlf and CRLF-mangles checkouts)
- unrelated-histories merge + unborn-main adoption (second device with pre-existing content converges instead of silently sticking)
- Buffer-safe conflict copies (>1MB / binary files survived byte-for-byte; utf8+1MB maxBuffer silently dropped them)
- collision-proof repo naming (lowercased-id hash suffix — distinct projects can never cross-sync into one repo)
- already-exists recovery in gh provisioning (per-device state file; device 2 reuses device 1's repos)
- engine: chokidar ready-wait, persistent error handler, stop() quiesces in-flight git chains, serialized enable/disable
- iCloud backups scrub the full DEFAULT_IGNORES set (secrets no longer leak into backups)
- SyncPanel surfaces sync errors + pending state; Android degrades gracefully (30s invoke timeout, no Kotlin surface in 1a by design)

Verified: 1283 tests green (incl. 10-test transport contract suite + two-device convergence integration), tsc + full build clean, live dev-window smoke test (picker create → disk → badge; Synced spaces panel; sync never enabled against real GitHub).

Plan checkboxes + execution log/corrections + PITFALLS "Sync Spaces" section land in youcoded-dev on branch spec/cross-device-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)