### PR TITLE
fix(android): repair artifact-viewer Kotlin compile break on master

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3155,7 +3155,11 @@ class SessionService : Service() {
                 // resolves to context.filesDir/home/.claude-mobile parent; the Kotlin
                 // artifact helpers expect the ~/.claude equivalent, which on Android is
                 // the same parent (session-manager sets CLAUDE_HOME there).
-                val claudeDir = java.io.File(bootstrap?.homeDir ?: android.os.Environment.getExternalStorageDirectory().path, ".claude")
+                // Fix: Bootstrap.homeDir is a java.io.File, so mixing it with a String
+                // in the Elvis made the expression type `Any` and broke compilation
+                // (master Android CI red since the artifact-viewer merge). Take .path
+                // so both Elvis arms are Strings.
+                val claudeDir = java.io.File(bootstrap?.homeDir?.path ?: android.os.Environment.getExternalStorageDirectory().path, ".claude")
                     .absolutePath
                 val ensured = ensureProject(claudeDir, projectRoot, sessionId)
                 applyGitTreatment(projectRoot)
@@ -3181,8 +3185,10 @@ class SessionService : Service() {
                         .put("kind",        args.optString("type", "edit"))
                         .put("by",          args.optString("author", "agent")))
                 })
+                // Fix: Kotlin appendVersion returns a plain Boolean (committed or not),
+                // not an object — `.committed` didn't exist and broke compilation.
                 msg.id?.let { bridgeServer.respond(ws, msg.type, it,
-                    org.json.JSONObject().put("ok", result.committed)) }
+                    org.json.JSONObject().put("ok", result)) }
             }
 
             // ── Desktop-only channels: return not-implemented so the React layer


### PR DESCRIPTION
Master's Android CI has been red since the artifact-viewer merge (`dd85cdfd`) — Desktop CI passed so the break slipped through. Two type errors in `SessionService.kt`'s artifacts handlers:

1. `Bootstrap.homeDir` is a `java.io.File`; the Elvis mixed it with a String path, typing the expression `Any` — no `File` constructor matched. Fixed by taking `.path` so both arms are Strings.
2. Kotlin's `appendVersion` returns a plain `Boolean`; `.committed` doesn't exist. Fixed to use the Boolean directly.

Verified locally: `:app:compileDebugKotlin` builds. No behavior change intended beyond making the merged code compile as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)