### PR TITLE
Sync spaces: import existing folders (spec §3 flows 1+2)

### DIFF
--- a/desktop/src/main/artifacts/central-index.ts
+++ b/desktop/src/main/artifacts/central-index.ts
@@ -85,6 +85,9 @@ export async function remapProjectPath(
   await mutateIndex(claudeDir, (idx) => {
     const p = idx.projects.find((x) => x.path === oldCanonicalPath);
     if (!p) return;
+    // Fix: don't create two entries sharing a path — drop any stale entry
+    // already sitting at the destination before we move this one onto it.
+    idx.projects = idx.projects.filter((x) => x === p || x.path !== newCanonicalPath);
     p.path = newCanonicalPath;
     if (newName) p.name = newName;
   });

--- a/desktop/src/main/artifacts/central-index.ts
+++ b/desktop/src/main/artifacts/central-index.ts
@@ -70,3 +70,22 @@ export async function listProjects(claudeDir: string): Promise<CentralIndexProje
   const idx = await readIndex(claudeDir);
   return idx.projects;
 }
+
+/** Rewrite a project entry's path (and optionally name) when its folder is
+ *  MOVED on disk (the sync-spaces import flow). Matching is by canonical path
+ *  — the store key — so the entry keeps its ULID id and stats, which is what
+ *  keeps artifact history attached to the project across the move. No-op when
+ *  no entry matches (a never-indexed folder has nothing to remap). */
+export async function remapProjectPath(
+  claudeDir: string,
+  oldCanonicalPath: string,
+  newCanonicalPath: string,
+  newName?: string
+): Promise<void> {
+  await mutateIndex(claudeDir, (idx) => {
+    const p = idx.projects.find((x) => x.path === oldCanonicalPath);
+    if (!p) return;
+    p.path = newCanonicalPath;
+    if (newName) p.name = newName;
+  });
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -24,7 +24,7 @@ import { generateThemePreview } from './theme-preview-generator';
 import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dismissWarning, addBackend, removeBackend, updateBackend, pushBackend, pullBackend, getSyncService, type SyncWarning } from './sync-state';
 // Cross-device sync spaces (spec 2026-07-03) — the folder-based sync engine.
 import {
-  syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, getManagedRoots,
+  syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject, getManagedRoots,
 } from './sync-spaces/service';
 import { getConfig as getMarketplaceConfig, setConfig as setMarketplaceConfig } from './marketplace-config-store';
 import { readComponent, type ComponentKind } from './marketplace-file-reader';
@@ -790,10 +790,17 @@ export function registerIpcHandlers(
       folders = [{ path: home, nickname: 'Home', addedAt: Date.now() }];
       writeFolders(folders);
     }
-    // Annotate each folder with whether the path still exists on disk
+    // Annotate each folder with whether the path still exists on disk.
+    // A saved folder that lives under ~/YouCoded/Projects/ IS a managed sync
+    // project (the import flow rewrites saved entries to their new managed
+    // path) — badge it like the synthesized managed rows below.
+    const projectsRoot = getManagedRoots()?.projectsRoot;
+    const projectsPrefix = projectsRoot ? path.resolve(projectsRoot).toLowerCase() + path.sep : null;
     const result: any[] = folders.map(f => ({
       ...f,
       exists: fs.existsSync(f.path),
+      ...(projectsPrefix && path.resolve(f.path).toLowerCase().startsWith(projectsPrefix)
+        ? { managed: true } : {}),
     }));
     // Managed projects (spec §3) always appear in the session-creation picker,
     // deduped against saved folders by normalized path. `managed: true` lets
@@ -1910,6 +1917,10 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC.SYNC_SPACES_ENABLE, (_e, enabled: boolean) => syncSpacesEnable(!!enabled));
   ipcMain.handle(IPC.SYNC_SPACES_SYNC_NOW, () => syncSpacesSyncNow());
   ipcMain.handle(IPC.SYNC_SPACES_CREATE_PROJECT, (_e, name: string) => syncSpacesCreateProject(String(name ?? '')));
+  ipcMain.handle(IPC.SYNC_SPACES_IMPORT_PROJECT, (_e, sourcePath: string, name: string) =>
+    // Live-cwd guard input: the folder must not move under a running session.
+    syncSpacesImportProject(String(sourcePath ?? ''), String(name ?? ''),
+      sessionManager.listSessions().filter(s => s.status !== 'destroyed').map(s => s.cwd)));
 
   // V2: Per-instance backend management (storage backends + multi-instance support)
   ipcMain.handle('sync:add-backend', (_e, instance) => addBackend(instance));

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -40,6 +40,8 @@ import { getChangelog } from './changelog-service';
 // ~/.claude/youcoded-analytics.json; runAnalyticsOnLaunch (wired in main.ts)
 // short-circuits when optIn is false.
 import { getOptIn as getAnalyticsOptIn, setOptIn as setAnalyticsOptIn } from './analytics-service';
+// Saved-folder store — extracted so sync-spaces/ can share the reader/writer.
+import { SavedFolder, readFolders, writeFolders } from './saved-folders';
 import { loadConfigSync, writeConfig, getAppliedAtLaunch, getCachedGpu } from './performance-config';
 import type { PerformanceConfigSnapshot } from '../shared/types';
 import { ARTIFACT_IPC } from './artifacts/ipc-channels';
@@ -776,29 +778,10 @@ export function registerIpcHandlers(
   });
 
   // --- Folder switcher persistence ---
-  const foldersPrefPath = path.join(os.homedir(), '.claude', 'youcoded-folders.json');
-
-  interface SavedFolder {
-    path: string;
-    nickname: string;
-    addedAt: number;
-  }
-
-  function readFolders(): SavedFolder[] {
-    try {
-      const raw = fs.readFileSync(foldersPrefPath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-
-  function writeFolders(folders: SavedFolder[]) {
-    fs.mkdirSync(path.dirname(foldersPrefPath), { recursive: true });
-    fs.writeFileSync(foldersPrefPath, JSON.stringify(folders, null, 2));
-  }
-
+  // Reader/writer + SavedFolder type now live in ./saved-folders (imported
+  // above) so the sync-spaces import flow can rewrite an entry when a folder
+  // moves. The FOLDERS_* handlers below call the no-arg forms, which default
+  // to the same ~/.claude/youcoded-folders.json path.
   ipcMain.handle(IPC.FOLDERS_LIST, async () => {
     let folders = readFolders();
     // Seed with home directory on first use
@@ -2092,7 +2075,8 @@ export function registerIpcHandlers(
     try {
       const result = await installWorkspace(send);
       // Register the workspace as a known project folder.
-      // readFolders / writeFolders / SavedFolder are already in scope above.
+      // readFolders / writeFolders / SavedFolder come from the ./saved-folders
+      // module imported at the top of this file (no-arg = default store path).
       try {
         const normalized = path.resolve(result.path);
         const folders = readFolders();

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -169,6 +169,7 @@ const IPC = {
   SYNC_SPACES_ENABLE: 'syncspaces:enable',
   SYNC_SPACES_SYNC_NOW: 'syncspaces:sync-now',
   SYNC_SPACES_CREATE_PROJECT: 'syncspaces:create-project',
+  SYNC_SPACES_IMPORT_PROJECT: 'syncspaces:import-project',
   SYNC_SPACES_EVENT: 'syncspaces:event',
   // Restore from backup (directional pull — see restore-service.ts)
   SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
@@ -658,6 +659,9 @@ contextBridge.exposeInMainWorld('claude', {
     enable: (enabled: boolean) => ipcRenderer.invoke(IPC.SYNC_SPACES_ENABLE, enabled),
     syncNow: () => ipcRenderer.invoke(IPC.SYNC_SPACES_SYNC_NOW),
     createProject: (name: string) => ipcRenderer.invoke(IPC.SYNC_SPACES_CREATE_PROJECT, name),
+    // Spec §3 import: move an existing folder into ~/YouCoded/Projects/<name>.
+    importProject: (sourcePath: string, name: string) =>
+      ipcRenderer.invoke(IPC.SYNC_SPACES_IMPORT_PROJECT, sourcePath, name),
     // Returns an unsubscribe function — callers MUST invoke it on unmount to
     // avoid leaking listeners across mounts (matches restore.onProgress above).
     onEvent: (cb: (e: unknown) => void) => {

--- a/desktop/src/main/project-conversations.ts
+++ b/desktop/src/main/project-conversations.ts
@@ -23,7 +23,7 @@ const SAFE_ID_RE = /^[A-Za-z0-9._-]+$/;
 // so the slug matches CC's directory name. Windows paths are case-insensitive,
 // so this only normalizes the drive letter; the rest of the path is untouched.
 // Without this, project-filtered conversations come back EMPTY on Windows.
-function ccProjectSlug(projectPath: string): string {
+export function ccProjectSlug(projectPath: string): string {
   const driveNormalized = projectPath.replace(/^([a-z]):/, (_m, d) => `${d.toUpperCase()}:`);
   return cwdToProjectSlug(driveNormalized);
 }

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -17,7 +17,7 @@ import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dis
 import { getRestoreService } from './restore-service';
 // Cross-device sync spaces (spec 2026-07-03) — same service functions the
 // Electron IPC handlers call, so remote browsers get identical behavior.
-import { syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject } from './sync-spaces/service';
+import { syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject } from './sync-spaces/service';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
 
 const PTY_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB per session — enough for full conversation replay
@@ -1128,6 +1128,12 @@ export class RemoteServer {
       }
       case 'syncspaces:create-project': {
         this.respond(client.ws, type, id, await syncSpacesCreateProject(String(payload?.name ?? '')));
+        break;
+      }
+      case 'syncspaces:import-project': {
+        this.respond(client.ws, type, id, await syncSpacesImportProject(
+          String(payload?.sourcePath ?? ''), String(payload?.name ?? ''),
+          this.sessionManager.listSessions().filter(s => s.status !== 'destroyed').map(s => s.cwd)));
         break;
       }
 

--- a/desktop/src/main/saved-folders.ts
+++ b/desktop/src/main/saved-folders.ts
@@ -28,7 +28,12 @@ export function readFolders(file: string = foldersFilePath()): SavedFolder[] {
 
 export function writeFolders(folders: SavedFolder[], file: string = foldersFilePath()): void {
   fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(folders, null, 2));
+  // Temp-file + rename: the import flow widened this store's writers, and the
+  // dev instance and built app share ~/.claude. rename is atomic, so a
+  // concurrent reader (readFolders) never sees a half-written file.
+  const tmp = `${file}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(folders, null, 2));
+  fs.renameSync(tmp, file);
 }
 
 // Case-insensitive on Windows for the same reason FOLDERS_REMOVE compares that

--- a/desktop/src/main/saved-folders.ts
+++ b/desktop/src/main/saved-folders.ts
@@ -30,10 +30,21 @@ export function writeFolders(folders: SavedFolder[], file: string = foldersFileP
   fs.mkdirSync(path.dirname(file), { recursive: true });
   // Temp-file + rename: the import flow widened this store's writers, and the
   // dev instance and built app share ~/.claude. rename is atomic, so a
-  // concurrent reader (readFolders) never sees a half-written file.
-  const tmp = `${file}.tmp`;
+  // concurrent reader (readFolders) never sees a half-written file. The tmp
+  // name is unique per writer (pid + time) — a fixed `.tmp` would let two
+  // concurrent processes interleave writes to the SAME tmp path.
+  // NOTE: the store is best-effort read-modify-write (no file lock like
+  // central-index's mutateFileUnderLock) — deliberate given the low write
+  // rate, not an oversight.
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
   fs.writeFileSync(tmp, JSON.stringify(folders, null, 2));
-  fs.renameSync(tmp, file);
+  try {
+    fs.renameSync(tmp, file);
+  } catch (e) {
+    // Don't leave the orphaned tmp behind on a failed rename.
+    try { fs.rmSync(tmp, { force: true }); } catch { /* best-effort */ }
+    throw e;
+  }
 }
 
 // Case-insensitive on Windows for the same reason FOLDERS_REMOVE compares that

--- a/desktop/src/main/saved-folders.ts
+++ b/desktop/src/main/saved-folders.ts
@@ -1,0 +1,54 @@
+// The session picker's saved-folder store (~/.claude/youcoded-folders.json).
+// Extracted from ipc-handlers.ts so other main-process code (the sync-spaces
+// import flow rewrites an entry's path when a folder is MOVED into
+// ~/YouCoded/Projects/) can share one reader/writer instead of duplicating the
+// file format. The file is a bare JSON array of SavedFolder.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export interface SavedFolder {
+  path: string;
+  nickname: string;
+  addedAt: number;
+}
+
+export function foldersFilePath(): string {
+  return path.join(os.homedir(), '.claude', 'youcoded-folders.json');
+}
+
+export function readFolders(file: string = foldersFilePath()): SavedFolder[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeFolders(folders: SavedFolder[], file: string = foldersFilePath()): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(folders, null, 2));
+}
+
+// Case-insensitive on Windows for the same reason FOLDERS_REMOVE compares that
+// way: callers hold canonical (lowercase-drive) paths while the store holds
+// path.resolve (uppercase-drive) form. A case-sensitive compare silently
+// fails to match on Windows.
+function samePath(a: string, b: string): boolean {
+  const ra = path.resolve(a);
+  const rb = path.resolve(b);
+  return process.platform === 'win32' ? ra.toLowerCase() === rb.toLowerCase() : ra === rb;
+}
+
+/** Rewrite one entry's path (used when a folder is moved on disk). Returns
+ *  false when no entry matched — callers treat that as fine (the folder may
+ *  never have been saved; the managed-projects merge will list it anyway). */
+export function updateFolderPath(oldPath: string, newPath: string, file: string = foldersFilePath()): boolean {
+  const folders = readFolders(file);
+  const entry = folders.find(f => samePath(f.path, oldPath));
+  if (!entry) return false;
+  entry.path = path.resolve(newPath);
+  writeFolders(folders, file);
+  return true;
+}

--- a/desktop/src/main/sync-spaces/guards.ts
+++ b/desktop/src/main/sync-spaces/guards.ts
@@ -50,6 +50,13 @@ export function isIgnoredPath(relPath: string): boolean {
 /** Spec §7: files over this cap don't live-sync (daily backup covers them). */
 export const MAX_SYNC_FILE_BYTES = 50 * 1024 * 1024;
 
+// Spec §18 watcher-scale guardrail, applied at IMPORT time: folders with more
+// files than this are refused with a clear message instead of silently hanging
+// chokidar. An engine-level guardrail (for folders that GROW past the cap
+// after import) is Plan 1b scope. Count excludes DEFAULT_IGNORES (node_modules
+// etc.) — those never sync, so they shouldn't disqualify a folder either.
+export const MAX_IMPORT_FILE_COUNT = 20_000;
+
 /** Spec §8: "notes (from Laptop, 2026-07-03).md" — the visible conflict copy. */
 export function conflictCopyName(relPath: string, deviceName: string, when: Date): string {
   const date = when.toISOString().slice(0, 10);

--- a/desktop/src/main/sync-spaces/import-project.ts
+++ b/desktop/src/main/sync-spaces/import-project.ts
@@ -157,6 +157,14 @@ function moveFolder(src: string, dest: string): string[] {
     return [];
   } catch (e: any) {
     if (e?.code === 'EXDEV') {
+      // Re-check dest existence: rename(2) reports EXDEV from the filesystem
+      // comparison BEFORE it ever looks at dest, so a dest created in the
+      // checkImport→move window (the sync engine materializing a same-named
+      // project from another device, or the dev + built app both running)
+      // would be silently MERGED into by cpSync — and then DELETED by the
+      // failure cleanup below. Refuse instead: never touch a folder this
+      // import didn't create.
+      if (fs.existsSync(dest)) throw new Error('A project with that name already exists');
       try {
         fs.cpSync(src, dest, { recursive: true });
       } catch {

--- a/desktop/src/main/sync-spaces/import-project.ts
+++ b/desktop/src/main/sync-spaces/import-project.ts
@@ -157,13 +157,28 @@ function moveFolder(src: string, dest: string): string[] {
     return [];
   } catch (e: any) {
     if (e?.code === 'EXDEV') {
-      fs.cpSync(src, dest, { recursive: true });
+      try {
+        fs.cpSync(src, dest, { recursive: true });
+      } catch {
+        // A half-copied dest would shadow checkImport's name guard ("A project
+        // with that name already exists") on EVERY retry, permanently blocking
+        // the import. The source is untouched (rmSync(src) hasn't run yet), so
+        // clean up the partial dest best-effort and tell the user to retry.
+        try { fs.rmSync(dest, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); } catch { /* best-effort */ }
+        throw new Error('Copying the folder to its new drive failed partway. Nothing was lost — your folder is still in its original place. Free up space (or close whatever is using the files) and try again.');
+      }
       try {
         fs.rmSync(src, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
         return [];
       } catch {
         return [`The folder was copied to its new home, but the original at ${src} could not be fully removed — delete it manually so you don't keep editing the old copy.`];
       }
+    }
+    // A dest created BETWEEN checkImport and renameSync (TOCTOU — see module
+    // header) surfaces as EEXIST/ENOTEMPTY; without this branch it fell into
+    // the "another program is using this folder" message, which is wrong.
+    if (e?.code === 'EEXIST' || e?.code === 'ENOTEMPTY') {
+      throw new Error('A project with that name already exists');
     }
     if (e?.code === 'EBUSY' || e?.code === 'EPERM' || e?.code === 'EACCES') {
       throw new Error('Another program is using this folder (an open terminal, editor, or file). Close it and try again.');
@@ -194,7 +209,11 @@ async function remapSidecarManualPaths(newRoot: string, oldRoot: string): Promis
   cur.manualIncludes = nextIncludes;
   cur.manualExcludes = nextExcludes;
   cur.updatedAt = new Date().toISOString();
-  await writeSidecar(newRoot, expected, cur);
+  const res = await writeSidecar(newRoot, expected, cur);
+  // Every remap failure must surface as a warning (this module's contract) —
+  // a silently-dropped CAS miss would lose the rewrite invisibly. The
+  // orchestrator's catch converts this throw into the user-facing warning.
+  if (!res.committed) throw new Error('sidecar-cas-miss');
 }
 
 /** CC's transcript dirs are keyed by a slug DERIVED from the cwd

--- a/desktop/src/main/sync-spaces/import-project.ts
+++ b/desktop/src/main/sync-spaces/import-project.ts
@@ -182,11 +182,10 @@ async function remapSidecarManualPaths(newRoot: string, oldRoot: string): Promis
   const oldCanon = canonicalize(oldRoot, null);
   const newCanon = canonicalize(newRoot, null);
   const remapStr = (p: string) => (isUnder(p, oldCanon) ? newCanon + p.slice(oldCanon.length) : p);
-  // manualExcludes is string[]; manualIncludes is ManualInclude[] ({path,…}).
-  // Older synced sidecars may still carry bare strings in either list, so the
-  // include remapper handles both shapes and preserves whichever it got.
-  const remapInclude = (inc: ManualInclude): ManualInclude =>
-    typeof inc === 'string' ? (remapStr(inc) as any) : { ...inc, path: remapStr(inc.path) };
+  // manualExcludes is string[]; manualIncludes is ManualInclude[] — objects
+  // whose .path is the canonical absolute path. Rewrite only the path; the
+  // addedAt/addedBy provenance survives the move untouched.
+  const remapInclude = (inc: ManualInclude): ManualInclude => ({ ...inc, path: remapStr(inc.path) });
   const nextIncludes = cur.manualIncludes.map(remapInclude);
   const nextExcludes = cur.manualExcludes.map(remapStr);
   if (JSON.stringify(nextIncludes) === JSON.stringify(cur.manualIncludes) &&

--- a/desktop/src/main/sync-spaces/import-project.ts
+++ b/desktop/src/main/sync-spaces/import-project.ts
@@ -11,9 +11,15 @@
 // or a session having opened in the folder — it cannot assume checkImport's
 // answer still holds when it runs.
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { validateSyncName, isIgnoredPath, MAX_IMPORT_FILE_COUNT } from './guards';
 import { canonicalize } from '../../shared/artifacts/canonicalize';
+import { updateFolderPath } from '../saved-folders';
+import { remapProjectPath } from '../artifacts/central-index';
+import { readSidecar, writeSidecar } from '../artifacts/artifact-store';
+import { ccProjectSlug } from '../project-conversations';
+import type { ManualInclude } from '../../shared/artifacts/types';
 
 export interface ImportCheckOpts {
   sourcePath: string;
@@ -128,4 +134,119 @@ export function checkImport(opts: ImportCheckOpts): string | null {
   }
 
   return null;
+}
+
+export type ImportResult =
+  | { ok: true; path: string; warnings: string[] }
+  | { ok: false; error: string };
+
+export interface ImportOpts extends ImportCheckOpts {
+  /** Injectable for tests; defaults to ~/.claude */
+  claudeDir?: string;
+}
+
+/** Move src → dest. rename when possible; EXDEV (another drive) falls back to
+ *  copy-then-delete — still MOVE semantics per spec §3 (a surviving copy at
+ *  the old path silently forks the user's work), so a failed source delete is
+ *  surfaced as a warning, never ignored. Returns warnings; throws with a
+ *  user-facing message on a blocked move (Windows EBUSY/EPERM when another
+ *  process holds the folder). */
+function moveFolder(src: string, dest: string): string[] {
+  try {
+    fs.renameSync(src, dest);
+    return [];
+  } catch (e: any) {
+    if (e?.code === 'EXDEV') {
+      fs.cpSync(src, dest, { recursive: true });
+      try {
+        fs.rmSync(src, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+        return [];
+      } catch {
+        return [`The folder was copied to its new home, but the original at ${src} could not be fully removed — delete it manually so you don't keep editing the old copy.`];
+      }
+    }
+    if (e?.code === 'EBUSY' || e?.code === 'EPERM' || e?.code === 'EACCES') {
+      throw new Error('Another program is using this folder (an open terminal, editor, or file). Close it and try again.');
+    }
+    throw e;
+  }
+}
+
+/** The sidecar rides inside the folder, so after the move it's already at the
+ *  new root — but manualIncludes/manualExcludes hold canonical ABSOLUTE paths
+ *  (PITFALLS → Artifact Viewer), which still point at the old location.
+ *  Rewrite the old-root prefix. */
+async function remapSidecarManualPaths(newRoot: string, oldRoot: string): Promise<void> {
+  const cur = await readSidecar(newRoot);
+  if (cur === null || 'corrupted' in cur) return;
+  const oldCanon = canonicalize(oldRoot, null);
+  const newCanon = canonicalize(newRoot, null);
+  const remapStr = (p: string) => (isUnder(p, oldCanon) ? newCanon + p.slice(oldCanon.length) : p);
+  // manualExcludes is string[]; manualIncludes is ManualInclude[] ({path,…}).
+  // Older synced sidecars may still carry bare strings in either list, so the
+  // include remapper handles both shapes and preserves whichever it got.
+  const remapInclude = (inc: ManualInclude): ManualInclude =>
+    typeof inc === 'string' ? (remapStr(inc) as any) : { ...inc, path: remapStr(inc.path) };
+  const nextIncludes = cur.manualIncludes.map(remapInclude);
+  const nextExcludes = cur.manualExcludes.map(remapStr);
+  if (JSON.stringify(nextIncludes) === JSON.stringify(cur.manualIncludes) &&
+      JSON.stringify(nextExcludes) === JSON.stringify(cur.manualExcludes)) return;
+  const expected = cur.updatedAt;
+  cur.manualIncludes = nextIncludes;
+  cur.manualExcludes = nextExcludes;
+  cur.updatedAt = new Date().toISOString();
+  await writeSidecar(newRoot, expected, cur);
+}
+
+/** CC's transcript dirs are keyed by a slug DERIVED from the cwd
+ *  (~/.claude/projects/<slug>/), not stored — so a move silently orphans every
+ *  past conversation unless the dir is renamed to the new path's slug. When
+ *  the new slug dir already exists (rare), merge file-by-file, never clobber. */
+function remapTranscriptDir(oldPath: string, newPath: string, claudeDir: string): void {
+  const projectsDir = path.join(claudeDir, 'projects');
+  const oldDir = path.join(projectsDir, ccProjectSlug(oldPath));
+  const newDir = path.join(projectsDir, ccProjectSlug(newPath));
+  if (!fs.existsSync(oldDir)) return; // no conversations for this folder — nothing to remap
+  if (!fs.existsSync(newDir)) {
+    fs.renameSync(oldDir, newDir);
+    return;
+  }
+  for (const entry of fs.readdirSync(oldDir)) {
+    const from = path.join(oldDir, entry);
+    const to = path.join(newDir, entry);
+    if (!fs.existsSync(to)) fs.renameSync(from, to);
+  }
+  try { fs.rmdirSync(oldDir); } catch { /* leftovers (all-duplicate names) — harmless */ }
+}
+
+/** Guards → move → best-effort remaps. Remap failures become warnings, not
+ *  errors: the folder has already moved, and each store degrades gracefully
+ *  (spec §3) — e.g. a missed index remap only means artifact history restarts. */
+export async function importProjectFolder(opts: ImportOpts): Promise<ImportResult> {
+  const claudeDir = opts.claudeDir ?? path.join(os.homedir(), '.claude');
+  const err = checkImport(opts);
+  if (err) return { ok: false, error: err };
+
+  const dest = path.join(opts.projectsRoot, opts.name);
+  let warnings: string[];
+  try {
+    warnings = moveFolder(opts.sourcePath, dest);
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+
+  const foldersFile = path.join(claudeDir, 'youcoded-folders.json');
+  try { updateFolderPath(opts.sourcePath, dest, foldersFile); }
+  catch { warnings.push('The saved-folders list could not be updated — remove the old entry from the picker manually.'); }
+
+  try { await remapProjectPath(claudeDir, canonicalize(opts.sourcePath, null), canonicalize(dest, null), opts.name); }
+  catch { warnings.push('The artifact index could not be updated — artifact history may restart for this project.'); }
+
+  try { await remapSidecarManualPaths(dest, opts.sourcePath); }
+  catch { warnings.push('Manually added files in the artifact drawer may need re-adding.'); }
+
+  try { remapTranscriptDir(opts.sourcePath, dest, claudeDir); }
+  catch { warnings.push('Past conversations could not be re-linked to the new location.'); }
+
+  return { ok: true, path: dest, warnings };
 }

--- a/desktop/src/main/sync-spaces/import-project.ts
+++ b/desktop/src/main/sync-spaces/import-project.ts
@@ -1,0 +1,93 @@
+// Spec §3 import flows: move an existing on-device folder into
+// ~/YouCoded/Projects/<name>/ so it becomes a synced project. This module owns
+// the guards, the move itself, and the remap of every store that keys on the
+// folder's absolute path. Space/remote initialization stays in service.ts (it
+// owns the engine singletons).
+import fs from 'fs';
+import path from 'path';
+import { validateSyncName, isIgnoredPath, MAX_IMPORT_FILE_COUNT } from './guards';
+import { canonicalize } from '../../shared/artifacts/canonicalize';
+
+export interface ImportCheckOpts {
+  sourcePath: string;
+  name: string;
+  projectsRoot: string;
+  youcodedRoot: string;
+  /** cwds of live (non-destroyed) sessions — a folder in use must not move */
+  liveCwds: string[];
+}
+
+// Canonical prefix containment. canonicalize() yields forward slashes + a
+// lowercased drive, so string prefix is safe here. (Byte-case differences in
+// the REST of a Windows path aren't normalized — acceptable: every caller
+// feeds paths from the same pickers/stores, not hand-typed variants.)
+function isUnder(child: string, parent: string): boolean {
+  return child === parent || child.startsWith(parent + '/');
+}
+
+/** Count real files under root, skipping DEFAULT_IGNORES (node_modules etc. —
+ *  they never sync so they shouldn't disqualify the folder) and never
+ *  following symlinks. Stops at limit+1: callers only need "over or not". */
+export function countFilesBounded(root: string, limit: number): number {
+  let count = 0;
+  const walk = (dir: string, rel: string): boolean => {
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return true; }
+    for (const e of entries) {
+      const childRel = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isSymbolicLink()) continue;
+      if (e.isDirectory()) {
+        // isIgnoredPath matches directory patterns like 'node_modules/' against
+        // a path SEGMENT, so pass the bare relative path (no trailing slash) —
+        // guards.ts splits on separators and checks each segment.
+        if (isIgnoredPath(childRel)) continue;
+        if (!walk(path.join(dir, e.name), childRel)) return false;
+      } else if (e.isFile()) {
+        if (isIgnoredPath(childRel)) continue;
+        count++;
+        if (count > limit) return false;
+      }
+    }
+    return true;
+  };
+  walk(root, '');
+  return count;
+}
+
+/** Every reason an import must be refused, checked BEFORE anything moves.
+ *  Returns a user-facing message, or null when the import may proceed. */
+export function checkImport(opts: ImportCheckOpts): string | null {
+  const { sourcePath, name, projectsRoot, youcodedRoot, liveCwds } = opts;
+
+  let st: fs.Stats;
+  try { st = fs.statSync(sourcePath); } catch { return 'That folder no longer exists'; }
+  if (!st.isDirectory()) return 'That path is a file, not a folder';
+
+  const nameErr = validateSyncName(name);
+  if (nameErr) return nameErr;
+
+  const srcCanon = canonicalize(sourcePath, null);
+  const ycCanon = canonicalize(youcodedRoot, null);
+  // Moving a folder that's already inside ~/YouCoded is a no-op at best; moving
+  // one that CONTAINS ~/YouCoded would recursively move the destination into
+  // itself. Both are refused up front.
+  if (isUnder(srcCanon, ycCanon)) return 'This folder is already inside your YouCoded folder';
+  if (isUnder(ycCanon, srcCanon)) return "This folder contains your YouCoded folder, so it can't be moved inside it";
+
+  if (fs.existsSync(path.join(projectsRoot, name))) return 'A project with that name already exists';
+
+  // A live session with its cwd inside the source would break mid-move (its
+  // working dir vanishes). Refuse and let the user close it first.
+  for (const cwd of liveCwds) {
+    if (isUnder(canonicalize(cwd, null), srcCanon)) {
+      return 'A session is currently open in this folder — close it first, then try again';
+    }
+  }
+
+  const count = countFilesBounded(sourcePath, MAX_IMPORT_FILE_COUNT);
+  if (count > MAX_IMPORT_FILE_COUNT) {
+    return `This folder has too many files to live-sync (more than ${MAX_IMPORT_FILE_COUNT.toLocaleString()}). Move what you need into a smaller folder and import that instead.`;
+  }
+
+  return null;
+}

--- a/desktop/src/main/sync-spaces/import-project.ts
+++ b/desktop/src/main/sync-spaces/import-project.ts
@@ -3,6 +3,13 @@
 // the guards, the move itself, and the remap of every store that keys on the
 // folder's absolute path. Space/remote initialization stays in service.ts (it
 // owns the engine singletons).
+//
+// NOTE: checkImport() is a UX PRE-FLIGHT, not an authoritative gate. It runs
+// before the move to give a friendly refusal, but the world can change between
+// the check and the move (TOCTOU). The move path (Task 4) must independently
+// tolerate the source having vanished, the destination name having been claimed,
+// or a session having opened in the folder — it cannot assume checkImport's
+// answer still holds when it runs.
 import fs from 'fs';
 import path from 'path';
 import { validateSyncName, isIgnoredPath, MAX_IMPORT_FILE_COUNT } from './guards';
@@ -21,17 +28,48 @@ export interface ImportCheckOpts {
 // lowercased drive, so string prefix is safe here. (Byte-case differences in
 // the REST of a Windows path aren't normalized — acceptable: every caller
 // feeds paths from the same pickers/stores, not hand-typed variants.)
+// NOTE: the isUnder(ycCanon, srcCanon) check in checkImport is a SAFETY guard
+// (it prevents moving a folder that contains ~/YouCoded into itself), not just
+// a UX nicety — so it too relies on pickers/stores yielding consistently-cased
+// paths. A caller that fed a differently-cased variant could slip past it.
 function isUnder(child: string, parent: string): boolean {
   return child === parent || child.startsWith(parent + '/');
 }
 
+// Depth + wall-clock caps mirror the sibling bounded walk in
+// artifacts/project-file-discovery.ts (which uses files/dirs/depth caps + a
+// time budget). The §18 guardrail must never itself hang the Electron main
+// thread while probing a folder the user picked.
+const MAX_DEPTH = 100;         // 100-deep nesting = pathological or a junction cycle
+const WALK_BUDGET_MS = 2000;   // hard wall-clock cap regardless of tree shape
+
 /** Count real files under root, skipping DEFAULT_IGNORES (node_modules etc. —
  *  they never sync so they shouldn't disqualify the folder) and never
- *  following symlinks. Stops at limit+1: callers only need "over or not". */
+ *  following symlinks. Stops at limit+1: callers only need "over or not".
+ *
+ *  Bounded THREE ways so it can never hang the main process: file count, plus
+ *  recursion depth (MAX_DEPTH) and wall-clock time (WALK_BUDGET_MS). WHY the
+ *  depth + time caps are load-bearing, not belt-and-suspenders: e.isSymbolicLink()
+ *  does NOT detect NTFS junctions — a junction reports isDirectory() === true —
+ *  so a junction CYCLE that contains no files would recurse forever (the
+ *  file-count limit never trips because it never finds a file to count). On
+ *  either cap we return the over-limit signal (limit + 1), NOT the partial
+ *  count: a 100-deep tree, or a walk we couldn't finish in 2s, is either
+ *  pathological or a cycle, and the honest answer is "too big/weird to
+ *  live-sync" — treating it as "fine, N files" would let a monster tree (or an
+ *  endless junction loop) through the guardrail. */
 export function countFilesBounded(root: string, limit: number): number {
   let count = 0;
-  const walk = (dir: string, rel: string): boolean => {
+  let over = false;
+  const deadline = Date.now() + WALK_BUDGET_MS;
+  const walk = (dir: string, rel: string, depth: number): boolean => {
+    // Depth/time exhaustion => treat the whole walk as over-limit (see fn doc).
+    if (depth > MAX_DEPTH || Date.now() > deadline) { over = true; return false; }
     let entries: fs.Dirent[];
+    // An unreadable directory yields no files here. If the ROOT itself is
+    // unreadable, the count is 0 and the import proceeds past this guard — it
+    // then fails at MOVE time with the OS error instead. Accepted trade-off:
+    // the pre-flight isn't authoritative (see the module header TOCTOU note).
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return true; }
     for (const e of entries) {
       const childRel = rel ? `${rel}/${e.name}` : e.name;
@@ -41,7 +79,7 @@ export function countFilesBounded(root: string, limit: number): number {
         // a path SEGMENT, so pass the bare relative path (no trailing slash) —
         // guards.ts splits on separators and checks each segment.
         if (isIgnoredPath(childRel)) continue;
-        if (!walk(path.join(dir, e.name), childRel)) return false;
+        if (!walk(path.join(dir, e.name), childRel, depth + 1)) return false;
       } else if (e.isFile()) {
         if (isIgnoredPath(childRel)) continue;
         count++;
@@ -50,8 +88,8 @@ export function countFilesBounded(root: string, limit: number): number {
     }
     return true;
   };
-  walk(root, '');
-  return count;
+  walk(root, '', 0);
+  return over ? limit + 1 : count;
 }
 
 /** Every reason an import must be refused, checked BEFORE anything moves.

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -9,6 +9,7 @@ import { SpaceManager } from './space-manager';
 import { GitTransport } from './git-transport';
 import { SpaceSyncEngine } from './engine';
 import { DailyBackup, BackupTarget } from './daily-backup';
+import { importProjectFolder } from './import-project';
 import type { SpaceSyncEvent } from './types';
 
 let roots: ManagedRoots | null = null;
@@ -142,6 +143,33 @@ export async function syncSpacesCreateProject(name: string) {
       // No initial syncSpace here: a freshly created folder is empty — the
       // first file change (debounce) or the 2-minute poll drives the first sync.
     } catch { /* engine events surface the failure */ }
+  }
+  return result;
+}
+
+/** Spec §3 import flows: move an existing folder into ~/YouCoded/Projects/ and
+ *  make it a synced space. liveCwds comes from the caller (ipc-handlers /
+ *  remote-server own the SessionManager) so this module stays free of a
+ *  session-manager import. Unlike createProject, an imported folder HAS
+ *  content — kick an immediate syncSpace instead of waiting for the poll. */
+export async function syncSpacesImportProject(sourcePath: string, name: string, liveCwds: string[]) {
+  if (!roots) return { ok: false as const, error: 'Sync is still starting up — try again in a moment' };
+  const result = await importProjectFolder({
+    sourcePath, name, liveCwds,
+    projectsRoot: roots.projectsRoot,
+    youcodedRoot: roots.youcodedRoot,
+  });
+  if (result.ok && engine) {
+    const space = roots.spaces().find(s => s.id === `project:${name}`);
+    if (space) {
+      try {
+        await engine.addSpace(space);
+        const transport = new GitTransport({ deviceName: os.hostname() });
+        await transport.init(space);
+        await transport.setRemote(space, await manager!.ensureRemote(space));
+        void engine.syncSpace(space); // imported content should reach the remote now, not at the next poll
+      } catch { /* engine error events surface the failure (same contract as createProject) */ }
+    }
   }
   return result;
 }

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -49,7 +49,7 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
         onChange(list[0].path);
       }
     } catch {}
-  }, [value, onChange]);
+  }, [value, onChange, autoSelect]);
 
   useEffect(() => { load(); }, [load]);
 

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
+import ImportProjectModal from './ImportProjectModal';
 
 interface SavedFolder {
   path: string;
@@ -34,6 +35,10 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
   // then appears in this picker automatically via the FOLDERS_LIST merge.
   const [newProjectName, setNewProjectName] = useState('');
   const [projectError, setProjectError] = useState<string | null>(null);
+
+  // Import-existing-folder flow (spec §3): which folder the consent modal is
+  // showing for. Set by the row action (flow 1) or the picker button (flow 2).
+  const [importTarget, setImportTarget] = useState<{ sourcePath: string; defaultName: string } | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -106,6 +111,36 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
       setProjectError(String(err?.message ?? err));
     }
   }, [newProjectName, load, onChange]);
+
+  // Import flow 1: the per-row "Sync this project" hover action. Seeds the
+  // consent modal with the existing folder's path + its basename as the
+  // default project name. stopPropagation so the row-click select doesn't fire.
+  const startImportForRow = useCallback((e: React.MouseEvent, folder: SavedFolder) => {
+    e.stopPropagation();
+    const base = folder.path.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? folder.nickname;
+    setImportTarget({ sourcePath: folder.path, defaultName: base });
+  }, []);
+
+  // Import flow 2: pick any on-device folder via the native picker, then open
+  // the consent modal for it. Empty catch: cancelling the dialog is not an error.
+  const startImportFromPicker = useCallback(async () => {
+    try {
+      const folder = await (window as any).claude.dialog.openFolder();
+      if (!folder) return;
+      const base = folder.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
+      setImportTarget({ sourcePath: folder, defaultName: base });
+    } catch {}
+  }, []);
+
+  // After a successful move: close the modal, reload the list, and select the
+  // project at its NEW home (also covers the case where the moved folder was
+  // the current selection — the old path no longer exists on disk).
+  const handleImportDone = useCallback(async (newPath: string) => {
+    setImportTarget(null);
+    await load();
+    onChange(newPath);
+    setOpen(false);
+  }, [load, onChange]);
 
   const handleSelect = useCallback((path: string) => {
     onChange(path);
@@ -239,6 +274,19 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
                     {/* Action buttons — visible on hover */}
                     {!isEditing && (
                       <div className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover/folder:opacity-100 transition-opacity">
+                        {/* Sync this project (spec §3 flow 1) — move into ~/YouCoded/Projects/.
+                            Only for real, non-managed folders: managed ones already sync. */}
+                        {f.exists && !f.managed && (
+                          <button
+                            onClick={(e) => startImportForRow(e, f)}
+                            className="w-5 h-5 flex items-center justify-center rounded-sm text-fg-faint hover:text-fg hover:bg-inset transition-colors"
+                            title="Sync this project (moves it into ~/YouCoded/Projects/)"
+                          >
+                            <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M5.5 9a7.5 7.5 0 0113-2.5M18.5 15a7.5 7.5 0 01-13 2.5" />
+                            </svg>
+                          </button>
+                        )}
                         {/* Rename */}
                         <button
                           onClick={(e) => handleStartRename(e, f)}
@@ -300,9 +348,29 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
                 </button>
               </div>
               {projectError && <div className="text-xs text-red-500 mt-1">{projectError}</div>}
+
+              {/* Spec §3 flow 2: import any on-device folder via the native picker. */}
+              <button
+                onClick={() => void startImportFromPicker()}
+                className="mt-1.5 w-full text-left text-[11px] text-fg-dim hover:text-fg transition-colors"
+              >
+                or move an existing folder into sync…
+              </button>
             </div>
           </div>
         </div>
+      )}
+
+      {/* Consent modal — rendered OUTSIDE the {open && (…)} dropdown so it
+          survives the dropdown's outside-click close (mousedown outside
+          wrapperRef closes the dropdown; the modal must stay up). */}
+      {importTarget && (
+        <ImportProjectModal
+          sourcePath={importTarget.sourcePath}
+          defaultName={importTarget.defaultName}
+          onClose={() => setImportTarget(null)}
+          onDone={(p) => void handleImportDone(p)}
+        />
       )}
     </div>
   );

--- a/desktop/src/renderer/components/ImportProjectModal.tsx
+++ b/desktop/src/renderer/components/ImportProjectModal.tsx
@@ -1,0 +1,95 @@
+// desktop/src/renderer/components/ImportProjectModal.tsx
+// Consent + name-confirm modal shared by BOTH spec-§3 import flows (row action
+// and folder-picker). The move is consequence-gated: the copy spells out that
+// the folder itself MOVES (old path stops existing) before anything happens.
+import React, { useState, useCallback } from 'react';
+import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { useEscClose } from '../hooks/use-esc-close';
+
+interface Props {
+  sourcePath: string;
+  defaultName: string;
+  onClose: () => void;
+  /** Called with the new project path after a successful import */
+  onDone: (newPath: string) => void;
+}
+
+export default function ImportProjectModal({ sourcePath, defaultName, onClose, onDone }: Props) {
+  const [name, setName] = useState(defaultName);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Post-success state: when the move produced warnings we keep the modal open
+  // to show them (closing instantly would hide "delete the old copy manually").
+  const [doneWarnings, setDoneWarnings] = useState<string[] | null>(null);
+  const [donePath, setDonePath] = useState<string | null>(null);
+
+  useEscClose(true, onClose);
+
+  const confirm = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed || busy) return;
+    setBusy(true);
+    setError(null);
+    // try/catch: on Android the shim has no syncspaces handlers and rejects
+    // after 30s — surface inline, never as an unhandled rejection.
+    try {
+      const r = await (window as any).claude.syncSpaces.importProject(sourcePath, trimmed);
+      if (r?.ok) {
+        if (r.warnings?.length) { setDoneWarnings(r.warnings); setDonePath(r.path); }
+        else onDone(r.path);
+      } else {
+        setError(r?.error ?? 'Could not move the folder');
+      }
+    } catch (err: any) {
+      setError(String(err?.message ?? err));
+    } finally {
+      setBusy(false);
+    }
+  }, [name, busy, sourcePath, onDone]);
+
+  return (
+    <>
+      <Scrim layer={2} onClick={busy ? undefined : onClose} />
+      <OverlayPanel layer={2} className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[26rem] max-w-[calc(100vw-2rem)] p-4">
+        {doneWarnings ? (
+          <>
+            <div className="text-sm font-medium text-fg">Folder moved</div>
+            <div className="mt-2 text-xs text-fg-2">The folder now lives at <span className="text-fg break-all">{donePath}</span> and will sync across your devices. A couple of things need your attention:</div>
+            <ul className="mt-2 space-y-1 text-xs text-fg-dim list-disc pl-4">
+              {doneWarnings.map((w, i) => <li key={i}>{w}</li>)}
+            </ul>
+            <div className="mt-4 flex justify-end">
+              <button onClick={() => onDone(donePath!)} className="text-sm px-3 py-1 rounded bg-accent text-on-accent">Done</button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-sm font-medium text-fg">Move and sync this folder?</div>
+            <div className="mt-2 text-xs text-fg-2">
+              YouCoded will <span className="text-fg">move</span> <span className="break-all">{sourcePath}</span> to{' '}
+              <span className="text-fg break-all">~/YouCoded/Projects/{name.trim() || '…'}/</span> so it can sync across your devices.
+            </div>
+            <div className="mt-1 text-xs text-fg-dim">
+              The folder itself moves — anything pointing at the old location (shortcuts, open terminals, editors) will need the new path.
+            </div>
+            <label className="block mt-3 text-[10px] uppercase tracking-wide text-fg-muted">Project name</label>
+            <input
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') void confirm(); }}
+              className="mt-1 w-full bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
+              autoFocus
+            />
+            {error && <div className="mt-2 text-xs text-red-500">{error}</div>}
+            <div className="mt-4 flex justify-end gap-2">
+              <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
+              <button onClick={() => void confirm()} disabled={busy || !name.trim()} className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50">
+                {busy ? 'Moving…' : 'Move and sync'}
+              </button>
+            </div>
+          </>
+        )}
+      </OverlayPanel>
+    </>
+  );
+}

--- a/desktop/src/renderer/components/ImportProjectModal.tsx
+++ b/desktop/src/renderer/components/ImportProjectModal.tsx
@@ -2,7 +2,7 @@
 // Consent + name-confirm modal shared by BOTH spec-§3 import flows (row action
 // and folder-picker). The move is consequence-gated: the copy spells out that
 // the folder itself MOVES (old path stops existing) before anything happens.
-import React, { useState, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 
@@ -23,17 +23,43 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
   const [doneWarnings, setDoneWarnings] = useState<string[] | null>(null);
   const [donePath, setDonePath] = useState<string | null>(null);
 
-  useEscClose(true, onClose);
+  // cancelledRef — prevent setState after unmount for the async import chain
+  // (mirrors RatingSubmitModal): if the modal is closed while the move is in
+  // flight, the late resolve must not setState on an unmounted component.
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => { cancelledRef.current = true; };
+  }, []);
+
+  // In-flight latch — a ref, not state, because held-Enter key-repeat can fire
+  // confirm() twice BEFORE the `busy` re-render lands, and the folder move is
+  // non-idempotent (a second concurrent call would race the first).
+  const inFlightRef = useRef(false);
+
+  // After a successful move, EVERY dismissal path (ESC, Scrim click, Done
+  // button) must go through onDone so the parent reconciles the folder list —
+  // the old path no longer exists on disk. Only the pre-move state may cancel
+  // via plain onClose.
+  const dismiss = doneWarnings && donePath ? () => onDone(donePath) : onClose;
+
+  // ESC is gated on !busy so it matches the Scrim/Cancel guards — dismissing
+  // mid-move would unmount the modal and lose the success/warnings handoff.
+  useEscClose(!busy, dismiss);
 
   const confirm = useCallback(async () => {
     const trimmed = name.trim();
     if (!trimmed || busy) return;
+    // Ref latch catches double-fires that land before the busy state re-renders.
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     setBusy(true);
     setError(null);
     // try/catch: on Android the shim has no syncspaces handlers and rejects
     // after 30s — surface inline, never as an unhandled rejection.
     try {
       const r = await (window as any).claude.syncSpaces.importProject(sourcePath, trimmed);
+      if (cancelledRef.current) return;
       if (r?.ok) {
         if (r.warnings?.length) { setDoneWarnings(r.warnings); setDonePath(r.path); }
         else onDone(r.path);
@@ -41,19 +67,27 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
         setError(r?.error ?? 'Could not move the folder');
       }
     } catch (err: any) {
+      if (cancelledRef.current) return;
       setError(String(err?.message ?? err));
     } finally {
-      setBusy(false);
+      inFlightRef.current = false;
+      if (!cancelledRef.current) setBusy(false);
     }
   }, [name, busy, sourcePath, onDone]);
 
   return (
     <>
-      <Scrim layer={2} onClick={busy ? undefined : onClose} />
-      <OverlayPanel layer={2} className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[26rem] max-w-[calc(100vw-2rem)] p-4">
+      <Scrim layer={2} onClick={busy ? undefined : dismiss} />
+      <OverlayPanel
+        layer={2}
+        role="dialog"
+        aria-modal
+        aria-labelledby="import-project-title"
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[26rem] max-w-[calc(100vw-2rem)] p-4"
+      >
         {doneWarnings ? (
           <>
-            <div className="text-sm font-medium text-fg">Folder moved</div>
+            <div id="import-project-title" className="text-sm font-medium text-fg">Folder moved</div>
             <div className="mt-2 text-xs text-fg-2">The folder now lives at <span className="text-fg break-all">{donePath}</span> and will sync across your devices. A couple of things need your attention:</div>
             <ul className="mt-2 space-y-1 text-xs text-fg-dim list-disc pl-4">
               {doneWarnings.map((w, i) => <li key={i}>{w}</li>)}
@@ -64,7 +98,7 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
           </>
         ) : (
           <>
-            <div className="text-sm font-medium text-fg">Move and sync this folder?</div>
+            <div id="import-project-title" className="text-sm font-medium text-fg">Move and sync this folder?</div>
             <div className="mt-2 text-xs text-fg-2">
               YouCoded will <span className="text-fg">move</span> <span className="break-all">{sourcePath}</span> to{' '}
               <span className="text-fg break-all">~/YouCoded/Projects/{name.trim() || '…'}/</span> so it can sync across your devices.
@@ -80,7 +114,7 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
               className="mt-1 w-full bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
               autoFocus
             />
-            {error && <div className="mt-2 text-xs text-red-500">{error}</div>}
+            {error && <div role="alert" className="mt-2 text-xs text-red-500">{error}</div>}
             <div className="mt-4 flex justify-end gap-2">
               <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
               <button onClick={() => void confirm()} disabled={busy || !name.trim()} className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50">

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1024,6 +1024,10 @@ export function installShim(): void {
       enable: (enabled: boolean) => invoke('syncspaces:enable', { enabled }),
       syncNow: () => invoke('syncspaces:sync-now'),
       createProject: (name: string) => invoke('syncspaces:create-project', { name }),
+      // Spec §3 import: move an existing folder into ~/YouCoded/Projects/<name>.
+      // Shim wraps args in an object (the established convention).
+      importProject: (sourcePath: string, name: string) =>
+        invoke('syncspaces:import-project', { sourcePath, name }),
       onEvent: (cb: (e: unknown) => void) => {
         const handler: Callback = (e: any) => cb(e);
         addListener('syncspaces:event', handler);

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -767,6 +767,7 @@ export const IPC = {
   SYNC_SPACES_ENABLE: 'syncspaces:enable',
   SYNC_SPACES_SYNC_NOW: 'syncspaces:sync-now',
   SYNC_SPACES_CREATE_PROJECT: 'syncspaces:create-project',
+  SYNC_SPACES_IMPORT_PROJECT: 'syncspaces:import-project',
   SYNC_SPACES_EVENT: 'syncspaces:event',
   // Multi-window detach subsystem (Renderer <-> Main)
   WINDOW_GET_ID: 'window:get-id',

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -497,6 +497,7 @@ describe('syncspaces:* channel parity (desktop surfaces)', () => {
     ['syncspaces:enable', 'IPC.SYNC_SPACES_ENABLE'],
     ['syncspaces:sync-now', 'IPC.SYNC_SPACES_SYNC_NOW'],
     ['syncspaces:create-project', 'IPC.SYNC_SPACES_CREATE_PROJECT'],
+    ['syncspaces:import-project', 'IPC.SYNC_SPACES_IMPORT_PROJECT'],
   ];
   const preload = fs.readFileSync(path.join(__dirname, '../src/main/preload.ts'), 'utf8');
   const shim = fs.readFileSync(path.join(__dirname, '../src/renderer/remote-shim.ts'), 'utf8');

--- a/desktop/tests/saved-folders.test.ts
+++ b/desktop/tests/saved-folders.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { readFolders, writeFolders, updateFolderPath } from '../src/main/saved-folders';
+
+let tmp: string;
+let file: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-folders-'));
+  file = path.join(tmp, 'youcoded-folders.json');
+});
+afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+describe('saved-folders store', () => {
+  it('readFolders returns [] for a missing file', () => {
+    expect(readFolders(file)).toEqual([]);
+  });
+
+  it('readFolders returns [] for corrupt JSON', () => {
+    fs.writeFileSync(file, '{nope');
+    expect(readFolders(file)).toEqual([]);
+  });
+
+  it('write/read round-trips entries', () => {
+    const entries = [{ path: 'C:\\proj', nickname: 'Proj', addedAt: 123 }];
+    writeFolders(entries, file);
+    expect(readFolders(file)).toEqual(entries);
+  });
+
+  it('updateFolderPath rewrites the matching entry, preserving nickname and addedAt', () => {
+    writeFolders([
+      { path: path.join(tmp, 'old'), nickname: 'Budget', addedAt: 42 },
+      { path: path.join(tmp, 'other'), nickname: 'Other', addedAt: 7 },
+    ], file);
+    const ok = updateFolderPath(path.join(tmp, 'old'), path.join(tmp, 'new'), file);
+    expect(ok).toBe(true);
+    const after = readFolders(file);
+    expect(after[0]).toEqual({ path: path.join(tmp, 'new'), nickname: 'Budget', addedAt: 42 });
+    expect(after[1].path).toBe(path.join(tmp, 'other'));
+  });
+
+  it('updateFolderPath returns false when no entry matches', () => {
+    writeFolders([{ path: path.join(tmp, 'a'), nickname: 'A', addedAt: 1 }], file);
+    expect(updateFolderPath(path.join(tmp, 'zzz'), path.join(tmp, 'new'), file)).toBe(false);
+  });
+});

--- a/desktop/tests/sync-spaces-import.test.ts
+++ b/desktop/tests/sync-spaces-import.test.ts
@@ -63,6 +63,20 @@ describe('countFilesBounded', () => {
     for (let i = 0; i < 10; i++) fs.writeFileSync(path.join(root, `f${i}.txt`), 'x');
     expect(countFilesBounded(root, 3)).toBe(4); // limit+1: enough to know it's over
   });
+
+  it('treats a walk deeper than MAX_DEPTH (100) as over-limit', () => {
+    // Build a 120-level-deep chain of single-char dirs with one file at the
+    // bottom. This stands in for the junction-cycle hazard: isSymbolicLink()
+    // misses NTFS junctions, so an unbounded walk would recurse forever. The
+    // depth cap must fire and return the over-limit signal (> limit) even
+    // though only one real file exists. Short segment names keep us under
+    // Windows MAX_PATH (modern Node uses the \\?\ long-path prefix anyway).
+    let deep = path.join(tmp, 'deep');
+    for (let i = 0; i < 120; i++) deep = path.join(deep, 'd');
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(path.join(deep, 'bottom.txt'), 'x');
+    expect(countFilesBounded(path.join(tmp, 'deep'), 100)).toBeGreaterThan(100);
+  });
 });
 
 describe('checkImport', () => {

--- a/desktop/tests/sync-spaces-import.test.ts
+++ b/desktop/tests/sync-spaces-import.test.ts
@@ -254,6 +254,29 @@ describe('importProjectFolder', () => {
     expect(fs.existsSync(s.source)).toBe(true);
   });
 
+  it('degrades a store-remap failure to ok:true + warning (corrupt central index)', async () => {
+    const s = await setup();
+    // Corrupt the index AFTER setup wrote a valid one: remapProjectPath's
+    // parseIndex (JSON.parse inside mutateFileUnderLock) throws on this, which
+    // must surface as a WARNING while the move itself still succeeds.
+    fs.writeFileSync(path.join(s.claudeDir, 'youcoded-projects-index.json'), '{not json');
+    const result = await importProjectFolder({
+      sourcePath: s.source, name: 'budget-app',
+      projectsRoot: s.projectsRoot, youcodedRoot: s.youcodedRoot,
+      liveCwds: [], claudeDir: s.claudeDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.warnings).toContain(
+      'The artifact index could not be updated — artifact history may restart for this project.'
+    );
+    // The move and the OTHER remaps still went through.
+    const dest = path.join(s.projectsRoot, 'budget-app');
+    expect(fs.existsSync(s.source)).toBe(false);
+    expect(fs.existsSync(path.join(dest, 'docs', 'plan.md'))).toBe(true);
+    expect(fs.existsSync(path.join(s.claudeDir, 'projects', ccProjectSlug(dest), 'session1.jsonl'))).toBe(true);
+  });
+
   it('merges into an existing slug dir instead of failing when the new slug already exists', async () => {
     const s = await setup();
     const dest = path.join(s.projectsRoot, 'budget-app');

--- a/desktop/tests/sync-spaces-import.test.ts
+++ b/desktop/tests/sync-spaces-import.test.ts
@@ -185,7 +185,13 @@ describe('importProjectFolder', () => {
     await writeSidecar(source, null, {
       $schema: SIDECAR_SCHEMA_VERSION, projectId: 'ULIDBUDGET', name: 'budget-app',
       createdAt: now, updatedAt: now, artifacts: [],
-      manualExcludes: [], manualIncludes: [canonicalize(path.join(source, 'docs', 'plan.md'), null)],
+      manualExcludes: [],
+      // Real ManualInclude shape ({path, addedAt, addedBy}) — the remap must
+      // rewrite ONLY .path and carry the provenance fields through untouched.
+      manualIncludes: [{
+        path: canonicalize(path.join(source, 'docs', 'plan.md'), null),
+        addedAt: now, addedBy: 'user',
+      }],
     });
 
     // CC transcript dir for the OLD path (drive-case-normalized slug)
@@ -194,7 +200,7 @@ describe('importProjectFolder', () => {
     fs.mkdirSync(slugDir, { recursive: true });
     fs.writeFileSync(path.join(slugDir, 'session1.jsonl'), '{}');
 
-    return { claudeDir, youcodedRoot, projectsRoot, source, foldersFile };
+    return { claudeDir, youcodedRoot, projectsRoot, source, foldersFile, includeAddedAt: now };
   }
 
   it('moves the folder and remaps saved folders, central index, sidecar includes, and the transcript slug dir', async () => {
@@ -224,10 +230,13 @@ describe('importProjectFolder', () => {
     expect(projects[0].id).toBe('ULIDBUDGET');
     expect(projects[0].path).toBe(canonicalize(dest, null));
 
-    // sidecar traveled with the folder; manual include re-pointed inside it
+    // sidecar traveled with the folder; manual include re-pointed inside it,
+    // provenance fields (addedAt/addedBy) carried through untouched
     const sidecar = await readSidecar(dest);
-    expect(sidecar && !('corrupted' in sidecar) && sidecar.manualIncludes[0])
-      .toBe(canonicalize(path.join(dest, 'docs', 'plan.md'), null));
+    expect(sidecar && !('corrupted' in sidecar) && sidecar.manualIncludes[0]).toEqual({
+      path: canonicalize(path.join(dest, 'docs', 'plan.md'), null),
+      addedAt: s.includeAddedAt, addedBy: 'user',
+    });
 
     // transcript slug dir renamed to the new path's slug
     expect(fs.existsSync(path.join(s.claudeDir, 'projects', ccProjectSlug(s.source)))).toBe(false);

--- a/desktop/tests/sync-spaces-import.test.ts
+++ b/desktop/tests/sync-spaces-import.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { MAX_IMPORT_FILE_COUNT } from '../src/main/sync-spaces/guards';
+import { ccProjectSlug } from '../src/main/project-conversations';
+import { upsertProject, remapProjectPath, listProjects } from '../src/main/artifacts/central-index';
+import { canonicalize } from '../src/shared/artifacts/canonicalize';
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-import-')); });
+afterEach(() => fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }));
+
+describe('import enablers', () => {
+  it('MAX_IMPORT_FILE_COUNT is a sane positive bound', () => {
+    expect(MAX_IMPORT_FILE_COUNT).toBeGreaterThan(1000);
+  });
+
+  it('ccProjectSlug is exported and uppercases the drive before slugifying', () => {
+    // On non-Windows paths this is a plain slugify; the drive-case rule only
+    // fires on the ^[a-z]: prefix.
+    expect(ccProjectSlug('c:/Users/x/proj')).toBe(ccProjectSlug('C:/Users/x/proj'));
+  });
+
+  it('remapProjectPath rewrites path (and name) of the entry matching the old canonical path', async () => {
+    const oldRoot = path.join(tmp, 'oldproj');
+    const newRoot = path.join(tmp, 'newproj');
+    await upsertProject(tmp, {
+      id: 'ULID1', name: 'oldproj', path: canonicalize(oldRoot, null),
+      lastIndexed: new Date().toISOString(), lastSession: null,
+      contentTypes: ['artifacts'], stats: { artifactCount: 3 },
+    } as any);
+    await remapProjectPath(tmp, canonicalize(oldRoot, null), canonicalize(newRoot, null), 'newproj');
+    const projects = await listProjects(tmp);
+    expect(projects).toHaveLength(1);
+    expect(projects[0].path).toBe(canonicalize(newRoot, null));
+    expect(projects[0].name).toBe('newproj');
+    expect(projects[0].id).toBe('ULID1');            // identity survives the move
+    expect(projects[0].stats.artifactCount).toBe(3); // stats survive the move
+  });
+
+  it('remapProjectPath is a no-op when no entry matches', async () => {
+    await remapProjectPath(tmp, canonicalize(path.join(tmp, 'ghost'), null), canonicalize(path.join(tmp, 'x'), null));
+    expect(await listProjects(tmp)).toEqual([]);
+  });
+});

--- a/desktop/tests/sync-spaces-import.test.ts
+++ b/desktop/tests/sync-spaces-import.test.ts
@@ -6,7 +6,10 @@ import { MAX_IMPORT_FILE_COUNT } from '../src/main/sync-spaces/guards';
 import { ccProjectSlug } from '../src/main/project-conversations';
 import { upsertProject, remapProjectPath, listProjects } from '../src/main/artifacts/central-index';
 import { canonicalize } from '../src/shared/artifacts/canonicalize';
-import { checkImport, countFilesBounded } from '../src/main/sync-spaces/import-project';
+import { checkImport, countFilesBounded, importProjectFolder } from '../src/main/sync-spaces/import-project';
+import { writeFolders as writeSavedFolders, readFolders as readSavedFolders } from '../src/main/saved-folders';
+import { readSidecar, writeSidecar } from '../src/main/artifacts/artifact-store';
+import { SIDECAR_SCHEMA_VERSION } from '../src/shared/artifacts/types';
 
 let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-import-')); });
@@ -43,6 +46,26 @@ describe('import enablers', () => {
   it('remapProjectPath is a no-op when no entry matches', async () => {
     await remapProjectPath(tmp, canonicalize(path.join(tmp, 'ghost'), null), canonicalize(path.join(tmp, 'x'), null));
     expect(await listProjects(tmp)).toEqual([]);
+  });
+
+  it('remapProjectPath drops a stale entry already sitting at the destination path', async () => {
+    const oldRoot = path.join(tmp, 'oldproj');
+    const newRoot = path.join(tmp, 'newproj');
+    await upsertProject(tmp, {
+      id: 'ULID1', name: 'oldproj', path: canonicalize(oldRoot, null),
+      lastIndexed: new Date().toISOString(), lastSession: null,
+      contentTypes: ['artifacts'], stats: { artifactCount: 1 },
+    } as any);
+    await upsertProject(tmp, {
+      id: 'STALE', name: 'stale', path: canonicalize(newRoot, null),
+      lastIndexed: new Date().toISOString(), lastSession: null,
+      contentTypes: ['artifacts'], stats: { artifactCount: 9 },
+    } as any);
+    await remapProjectPath(tmp, canonicalize(oldRoot, null), canonicalize(newRoot, null));
+    const projects = await listProjects(tmp);
+    expect(projects).toHaveLength(1);          // stale entry dropped, not shadowed
+    expect(projects[0].id).toBe('ULID1');      // the moved project wins
+    expect(projects[0].path).toBe(canonicalize(newRoot, null));
   });
 });
 
@@ -131,5 +154,110 @@ describe('checkImport', () => {
     expect(checkImport({ ...c, liveCwds: [path.join(c.sourcePath, 'sub')] })).toMatch(/session is currently open/);
     expect(checkImport({ ...c, liveCwds: [c.sourcePath] })).toMatch(/session is currently open/);
     expect(checkImport({ ...c, liveCwds: [path.join(tmp, 'elsewhere')] })).toBeNull();
+  });
+});
+
+describe('importProjectFolder', () => {
+  // Full fake home: claudeDir + YouCoded roots + a source folder with content,
+  // a saved-folder entry, a central-index entry, a sidecar with a manual
+  // include, and a fake CC transcript slug dir.
+  async function setup() {
+    const claudeDir = path.join(tmp, '.claude');
+    const youcodedRoot = path.join(tmp, 'YouCoded');
+    const projectsRoot = path.join(youcodedRoot, 'Projects');
+    fs.mkdirSync(projectsRoot, { recursive: true });
+    fs.mkdirSync(claudeDir, { recursive: true });
+
+    const source = path.join(tmp, 'budget-app');
+    fs.mkdirSync(path.join(source, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'docs', 'plan.md'), 'the plan');
+
+    const foldersFile = path.join(claudeDir, 'youcoded-folders.json');
+    writeSavedFolders([{ path: source, nickname: 'Budget', addedAt: 99 }], foldersFile);
+
+    await upsertProject(claudeDir, {
+      id: 'ULIDBUDGET', name: 'budget-app', path: canonicalize(source, null),
+      lastIndexed: new Date().toISOString(), lastSession: null,
+      contentTypes: ['artifacts'], stats: { artifactCount: 1 },
+    } as any);
+
+    const now = new Date().toISOString();
+    await writeSidecar(source, null, {
+      $schema: SIDECAR_SCHEMA_VERSION, projectId: 'ULIDBUDGET', name: 'budget-app',
+      createdAt: now, updatedAt: now, artifacts: [],
+      manualExcludes: [], manualIncludes: [canonicalize(path.join(source, 'docs', 'plan.md'), null)],
+    });
+
+    // CC transcript dir for the OLD path (drive-case-normalized slug)
+    const oldSlug = ccProjectSlug(source);
+    const slugDir = path.join(claudeDir, 'projects', oldSlug);
+    fs.mkdirSync(slugDir, { recursive: true });
+    fs.writeFileSync(path.join(slugDir, 'session1.jsonl'), '{}');
+
+    return { claudeDir, youcodedRoot, projectsRoot, source, foldersFile };
+  }
+
+  it('moves the folder and remaps saved folders, central index, sidecar includes, and the transcript slug dir', async () => {
+    const s = await setup();
+    const result = await importProjectFolder({
+      sourcePath: s.source, name: 'budget-app',
+      projectsRoot: s.projectsRoot, youcodedRoot: s.youcodedRoot,
+      liveCwds: [], claudeDir: s.claudeDir,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const dest = path.join(s.projectsRoot, 'budget-app');
+    expect(result.path).toBe(dest);
+    expect(result.warnings).toEqual([]);
+
+    // folder moved (content intact, source gone)
+    expect(fs.readFileSync(path.join(dest, 'docs', 'plan.md'), 'utf8')).toBe('the plan');
+    expect(fs.existsSync(s.source)).toBe(false);
+
+    // saved-folders entry rewritten, nickname kept
+    const folders = readSavedFolders(s.foldersFile);
+    expect(folders[0].nickname).toBe('Budget');
+    expect(path.resolve(folders[0].path)).toBe(path.resolve(dest));
+
+    // central index remapped, identity kept
+    const projects = await listProjects(s.claudeDir);
+    expect(projects[0].id).toBe('ULIDBUDGET');
+    expect(projects[0].path).toBe(canonicalize(dest, null));
+
+    // sidecar traveled with the folder; manual include re-pointed inside it
+    const sidecar = await readSidecar(dest);
+    expect(sidecar && !('corrupted' in sidecar) && sidecar.manualIncludes[0])
+      .toBe(canonicalize(path.join(dest, 'docs', 'plan.md'), null));
+
+    // transcript slug dir renamed to the new path's slug
+    expect(fs.existsSync(path.join(s.claudeDir, 'projects', ccProjectSlug(s.source)))).toBe(false);
+    expect(fs.readFileSync(path.join(s.claudeDir, 'projects', ccProjectSlug(dest), 'session1.jsonl'), 'utf8')).toBe('{}');
+  });
+
+  it('refuses (ok:false) when a guard fails, without touching the source', async () => {
+    const s = await setup();
+    const result = await importProjectFolder({
+      sourcePath: s.source, name: 'budget-app',
+      projectsRoot: s.projectsRoot, youcodedRoot: s.youcodedRoot,
+      liveCwds: [s.source], claudeDir: s.claudeDir,
+    });
+    expect(result.ok).toBe(false);
+    expect(fs.existsSync(s.source)).toBe(true);
+  });
+
+  it('merges into an existing slug dir instead of failing when the new slug already exists', async () => {
+    const s = await setup();
+    const dest = path.join(s.projectsRoot, 'budget-app');
+    const newSlugDir = path.join(s.claudeDir, 'projects', ccProjectSlug(dest));
+    fs.mkdirSync(newSlugDir, { recursive: true });
+    fs.writeFileSync(path.join(newSlugDir, 'existing.jsonl'), '{}');
+    const result = await importProjectFolder({
+      sourcePath: s.source, name: 'budget-app',
+      projectsRoot: s.projectsRoot, youcodedRoot: s.youcodedRoot,
+      liveCwds: [], claudeDir: s.claudeDir,
+    });
+    expect(result.ok).toBe(true);
+    expect(fs.existsSync(path.join(newSlugDir, 'session1.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(newSlugDir, 'existing.jsonl'))).toBe(true);
   });
 });

--- a/desktop/tests/sync-spaces-import.test.ts
+++ b/desktop/tests/sync-spaces-import.test.ts
@@ -6,6 +6,7 @@ import { MAX_IMPORT_FILE_COUNT } from '../src/main/sync-spaces/guards';
 import { ccProjectSlug } from '../src/main/project-conversations';
 import { upsertProject, remapProjectPath, listProjects } from '../src/main/artifacts/central-index';
 import { canonicalize } from '../src/shared/artifacts/canonicalize';
+import { checkImport, countFilesBounded } from '../src/main/sync-spaces/import-project';
 
 let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-import-')); });
@@ -42,5 +43,79 @@ describe('import enablers', () => {
   it('remapProjectPath is a no-op when no entry matches', async () => {
     await remapProjectPath(tmp, canonicalize(path.join(tmp, 'ghost'), null), canonicalize(path.join(tmp, 'x'), null));
     expect(await listProjects(tmp)).toEqual([]);
+  });
+});
+
+describe('countFilesBounded', () => {
+  it('counts regular files and skips DEFAULT_IGNORES dirs', () => {
+    const root = path.join(tmp, 'proj');
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'node_modules', 'x'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'a.txt'), 'a');
+    fs.writeFileSync(path.join(root, 'src', 'b.ts'), 'b');
+    fs.writeFileSync(path.join(root, 'node_modules', 'x', 'huge.js'), 'x');
+    expect(countFilesBounded(root, 100)).toBe(2);
+  });
+
+  it('stops early once the limit is exceeded', () => {
+    const root = path.join(tmp, 'many');
+    fs.mkdirSync(root, { recursive: true });
+    for (let i = 0; i < 10; i++) fs.writeFileSync(path.join(root, `f${i}.txt`), 'x');
+    expect(countFilesBounded(root, 3)).toBe(4); // limit+1: enough to know it's over
+  });
+});
+
+describe('checkImport', () => {
+  function ctx(over: Partial<Parameters<typeof checkImport>[0]> = {}) {
+    const youcodedRoot = path.join(tmp, 'YouCoded');
+    const projectsRoot = path.join(youcodedRoot, 'Projects');
+    fs.mkdirSync(projectsRoot, { recursive: true });
+    const source = path.join(tmp, 'mywork');
+    fs.mkdirSync(source, { recursive: true });
+    fs.writeFileSync(path.join(source, 'notes.md'), 'hi');
+    return { sourcePath: source, name: 'mywork', projectsRoot, youcodedRoot, liveCwds: [] as string[], ...over };
+  }
+
+  it('passes for a plain folder', () => {
+    expect(checkImport(ctx())).toBeNull();
+  });
+
+  it('rejects a missing source', () => {
+    expect(checkImport(ctx({ sourcePath: path.join(tmp, 'ghost') }))).toMatch(/no longer exists/);
+  });
+
+  it('rejects a file source', () => {
+    const f = path.join(tmp, 'file.txt');
+    fs.writeFileSync(f, 'x');
+    expect(checkImport(ctx({ sourcePath: f }))).toMatch(/file, not a folder/);
+  });
+
+  it('passes validateSyncName failures through verbatim', () => {
+    expect(checkImport(ctx({ name: 'bad:name' }))).toMatch(/character not allowed/);
+  });
+
+  it('rejects a source already inside ~/YouCoded', () => {
+    const c = ctx();
+    const inside = path.join(c.youcodedRoot, 'Personal', 'notes');
+    fs.mkdirSync(inside, { recursive: true });
+    expect(checkImport({ ...c, sourcePath: inside })).toMatch(/already inside your YouCoded folder/);
+  });
+
+  it('rejects a source that CONTAINS ~/YouCoded (would move the destination into itself)', () => {
+    const c = ctx();
+    expect(checkImport({ ...c, sourcePath: tmp, name: 'everything' })).toMatch(/contains your YouCoded folder/);
+  });
+
+  it('rejects when the destination name is taken', () => {
+    const c = ctx();
+    fs.mkdirSync(path.join(c.projectsRoot, 'mywork'), { recursive: true });
+    expect(checkImport(c)).toMatch(/already exists/);
+  });
+
+  it('rejects while a live session has its cwd inside the source', () => {
+    const c = ctx();
+    expect(checkImport({ ...c, liveCwds: [path.join(c.sourcePath, 'sub')] })).toMatch(/session is currently open/);
+    expect(checkImport({ ...c, liveCwds: [c.sourcePath] })).toMatch(/session is currently open/);
+    expect(checkImport({ ...c, liveCwds: [path.join(tmp, 'elsewhere')] })).toBeNull();
   });
 });


### PR DESCRIPTION
## What this is

The **Phase 1-followup** the spec marks as required before the sync rebuild counts as complete (spec §3 / §17): existing folders can now be brought into sync, not just folders born inside `~/YouCoded/`.

**Stacked on `feat/sync-spaces` (PR #107)** — retarget to `master` after #107 merges.

## The two flows (both in the session-creation folder picker)

1. **"Sync this project"** — hover action on any existing non-managed saved folder.
2. **"or move an existing folder into sync…"** — native folder picker under the new-project form.

Both open the same consent modal: plain-language warning that the folder itself **MOVES** to `~/YouCoded/Projects/<name>/`, an editable project name (validated by the same rules as new projects), and a warnings summary if any post-move cleanup needs the user's attention.

## What the move does (main process, `sync-spaces/import-project.ts`)

- **Guards first:** folder exists, valid name, not already inside `~/YouCoded/`, doesn't CONTAIN `~/YouCoded/`, name free, **no live session using the folder**, and not too many files to live-sync (20k cap, bounded by depth + wall-clock so junction cycles can't hang the app).
- **Move:** atomic rename; cross-drive falls back to copy-then-delete with cleanup + a clear error if the copy fails partway (nothing is ever lost — the source stays intact until the copy fully lands).
- **Remaps every store keyed on the old path** (each degrades to a user-facing warning, never an error): saved-folders entry (nickname kept), artifact central index (identity + history kept, stale destination entries dropped), sidecar manual includes/excludes, and **the Claude Code transcript directory** — past conversations follow the folder instead of orphaning.
- If sync is enabled, the space is initialized + provisioned and an immediate sync kicks off (imported folders have content — no waiting for the poll).

## Testing

- Full suite: **1309 passed / 34 skipped / 0 failed** (env-stripped), tsc + `npm run build` clean. 25 new/updated tests across `saved-folders.test.ts` + `sync-spaces-import.test.ts` (guards, bounded count incl. depth-cap, end-to-end move + all four remaps, slug-dir merge, index collision, warning degradation).
- Live dev-window smoke (worktree dev instance, CDP-driven): flow 1 through the real UI end to end (modal copy, prefilled name, move, "synced project" badge, no dup rows); live-session guard blocks then clears after session close; cross-check of disk + picker state. Flow 2's unique step is the native OS dialog (not headless-drivable); it feeds the identical modal + IPC path.
- Review process: fresh Opus implementer per task + spec review + quality review; the loops caught 8 real defects before merge (junction-cycle recursion, wrong-typed manualIncludes, EXDEV partial-dest retry lockout, TOCTOU dest merge/delete hazard, silent CAS miss, tmp-file race, ESC busy-guard bypass, wrong EEXIST message). Details in the plan's execution log (`youcoded-dev` → `docs/superpowers/plans/2026-07-09-sync-spaces-import-existing-folders.md`).

## Notes

- Android: no Kotlin handlers, same as all of 1a (shim timeout + inline error) — stubs come with the mobile phase.
- Resolves the `docs/knowledge-debt.md` entry "Sync spaces: no import path for existing folders" (removed on the docs branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)