### PR TITLE
fix: extend stray-Enter prompt gating to Android and UI-triggered sends

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/parser/EventBridge.kt
+++ b/app/src/main/kotlin/com/youcoded/app/parser/EventBridge.kt
@@ -207,6 +207,17 @@ class EventBridge(private val socketName: String) {
         try { socket.close() } catch (_: Exception) {}
     }
 
+    /**
+     * True while any PermissionRequest socket is held open. In that window
+     * Claude Code's TUI is showing a live Ink select menu (permission prompt /
+     * AskUserQuestion / plan approval) — automated PTY writers must not send
+     * bytes to this session or they act as menu keystrokes (a trailing `\r`
+     * selects the highlighted option, silently answering the prompt).
+     * EventBridge is per-session (one per PtyBridge), so no session filter is
+     * needed. Desktop equivalent: HookRelay.hasPendingPermission (youcoded#110).
+     */
+    fun hasPendingPermission(): Boolean = pendingSockets.isNotEmpty()
+
     fun stop() {
         // Close all pending sockets
         for ((_, socket) in pendingSockets) {

--- a/app/src/main/kotlin/com/youcoded/app/runtime/ManagedSession.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/ManagedSession.kt
@@ -115,6 +115,12 @@ class ManagedSession(
     fun writeInput(text: String) {
         ptyBridge?.writeInput(text) ?: directShellBridge?.writeInput(text)
     }
+    /** True while a permission/AskUserQuestion hook request is held open for
+     *  this session — its TUI is showing a live Ink select menu, so automated
+     *  writers (e.g. the /reload-plugins write) must not type into it.
+     *  See EventBridge.hasPendingPermission (stray-Enter fix, youcoded#110). */
+    fun hasPendingPermission(): Boolean =
+        ptyBridge?.getEventBridge()?.hasPendingPermission() ?: false
     val screenVersion: StateFlow<Int> get() =
         ptyBridge?.screenVersion ?: directShellBridge?.screenVersion ?: MutableStateFlow(0)
 

--- a/app/src/main/kotlin/com/youcoded/app/runtime/PtyBridge.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/PtyBridge.kt
@@ -233,6 +233,19 @@ class PtyBridge(
                 val preamble = text.dropLast(1)
                 session?.write(preamble)
                 android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                    // Deferred-Enter gate for plain-text sends (stray-Enter fix,
+                    // youcoded#110): if a permission/AskUserQuestion request
+                    // arrived during the 600 ms gap, the TUI now shows a live
+                    // Ink select menu and this `\r` would press Enter on the
+                    // highlighted option. Skip it — the renderer-side submit
+                    // retry (gated in pty-input-gate.ts) recovers a genuinely
+                    // lost send. Menu-navigation payloads (hasEscape) are
+                    // EXEMPT: driving the live menu is their whole purpose
+                    // (sendApproval, sign-in/theme/trust pre-session menus).
+                    if (!hasEscape && eventBridge?.hasPendingPermission() == true) {
+                        android.util.Log.w("PtyBridge", "Deferred \\r suppressed — permission request pending")
+                        return@postDelayed
+                    }
                     session?.write("\r")
                 }, 600)
             }

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -20,6 +20,7 @@ import com.youcoded.app.analytics.AnalyticsService
 import com.youcoded.app.bridge.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -289,9 +290,28 @@ class SessionService : Service() {
         // handles all install/uninstall routing (consolidates SessionService logic)
         skillProvider?.pluginInstaller = pluginInstaller
         skillProvider?.onPluginsChanged = {
-            sessionRegistry.getCurrentSession()
-                ?.takeIf { !it.shellMode && it.isRunning }
-                ?.writeInput("/reload-plugins\r")
+            // Mirror of desktop's SessionManager.broadcastReloadPlugins gating
+            // (stray-Enter fix, youcoded#110): typing "/reload-plugins\r" while a
+            // permission/AskUserQuestion request is pending lands on Claude
+            // Code's live Ink select menu — the trailing \r presses Enter on the
+            // highlighted option and silently answers the prompt. Delay so CC is
+            // ready for input, then defer with bounded retries while a request
+            // is pending. A missed reload is recoverable (next install or a
+            // manual /reload-plugins); an auto-answered prompt is not.
+            serviceScope.launch {
+                delay(1500)
+                var attempts = 0
+                while (true) {
+                    val session = sessionRegistry.getCurrentSession()
+                    if (session == null || session.shellMode || !session.isRunning) return@launch
+                    if (!session.hasPendingPermission()) {
+                        session.writeInput("/reload-plugins\r")
+                        return@launch
+                    }
+                    if (++attempts >= 24) return@launch // ~2 min of deferral, then give up
+                    delay(5000)
+                }
+            }
         }
 
         // Decomposition v3 §9.2: reconcile plugin hooks-manifest.json into

--- a/app/src/test/kotlin/com/youcoded/app/parser/EventBridgePendingPermissionTest.kt
+++ b/app/src/test/kotlin/com/youcoded/app/parser/EventBridgePendingPermissionTest.kt
@@ -1,0 +1,22 @@
+package com.youcoded.app.parser
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * hasPendingPermission is the Android side of the stray-Enter fix (youcoded
+ * PR #110): while a PermissionRequest socket is held open, the session's PTY
+ * shows a live Ink select menu, so automated writers (the /reload-plugins
+ * write, PtyBridge's deferred Enter) must not type into it.
+ *
+ * The held-socket path needs a real LocalSocket (Android runtime), so the
+ * positive case is covered by the release-test APK flow rather than JVM unit
+ * tests; this pins the empty-state contract and that the API exists.
+ */
+class EventBridgePendingPermissionTest {
+    @Test
+    fun `no pending permission on a fresh bridge`() {
+        val bridge = EventBridge("test-socket-name")
+        assertFalse(bridge.hasPendingPermission())
+    }
+}

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -29,6 +29,8 @@ import { categorizeArtifact } from '../shared/artifacts/categorization';
 import { dispatchSlashCommand } from './state/slash-command-dispatcher';
 import { GameProvider, useGameState, useGameDispatch } from './state/game-context';
 import { hookEventToAction } from './state/hook-dispatcher';
+import { hasPendingInteraction } from './state/pty-input-gate';
+import { buildOutgoingMessage } from './components/outgoing-message';
 import type { SyncWarning } from '../main/sync-state';
 import { usePromptDetector } from './hooks/usePromptDetector';
 import { useVisualViewport } from './hooks/useVisualViewport';
@@ -375,6 +377,31 @@ function AppInner() {
   // up-to-date compactionPending state without re-subscribing on every reducer tick.
   const chatStateMapRef = useRef(chatStateMap);
   useEffect(() => { chatStateMapRef.current = chatStateMap; }, [chatStateMap]);
+
+  // Guarded PTY send for command-shaped writes triggered by UI actions
+  // (command drawer, skill runs, /sync, /config, /model, Settings sends).
+  // While a permission/AskUserQuestion/plan request is pending, CC's native
+  // Ink select menu is live in the PTY — the sent text would be eaten as menu
+  // input and its trailing \r would press Enter on the highlighted option,
+  // silently answering the prompt (stray-Enter fix, youcoded#110). Same rule
+  // InputBar.sendMessage applies to typed messages. Deliberate menu-driving
+  // writes (ToolCard plan keys, TrustGate, prompt option clicks, terminal
+  // view) must NOT use this helper. Returns false when the send was refused.
+  const notifyIfPtyBlocked = useCallback((sid: string): boolean => {
+    const session = chatStateMapRef.current.get(sid);
+    if (session && hasPendingInteraction(session)) {
+      setToast('Claude is waiting for your response — answer the prompt first.');
+      setTimeout(() => setToast(null), 3000);
+      return true;
+    }
+    return false;
+  }, []);
+
+  const guardedPtySend = useCallback((sid: string, text: string): boolean => {
+    if (notifyIfPtyBlocked(sid)) return false;
+    window.claude.session.sendInput(sid, text);
+    return true;
+  }, [notifyIfPtyBlocked]);
 
   // Compaction watchdog: activity-aware — resets on any reducer update for a
   // session with compactionPending set. Any transcript event bumps the timer
@@ -1457,6 +1484,10 @@ function AppInner() {
     if (!sessionId) return;
     const idx = MODELS.indexOf(currentModel);
     const next = MODELS[(idx + 1) % MODELS.length];
+    // Send first, guarded: while a prompt is pending, "/model …\r" would land
+    // on CC's live Ink menu and answer it. Refusing BEFORE the optimistic
+    // state writes also keeps the model pill truthful when nothing was sent.
+    if (!guardedPtySend(sessionId, `/model ${next}\r`)) return;
     setSessionModels((prev) => new Map(prev).set(sessionId, next));
     setPendingModel(next);
     // Fix: don't verify against in-flight events from the current turn —
@@ -1466,8 +1497,7 @@ function AppInner() {
     // verification is just a safety net. If verification later shows a
     // mismatch, the failure handler overwrites with the actual model.
     (window.claude as any).model?.setPreference(next);
-    window.claude.session.sendInput(sessionId, `/model ${next}\r`);
-  }, [currentModel, sessionId]);
+  }, [currentModel, sessionId, guardedPtySend]);
   cycleModelRef.current = cycleModel;
 
   useEffect(() => {
@@ -1655,7 +1685,7 @@ function AppInner() {
         });
         if (result.handled) {
           if (result.alsoSendToPty) {
-            window.claude.session.sendInput(sessionId, result.alsoSendToPty);
+            guardedPtySend(sessionId, result.alsoSendToPty);
           }
           return;
         }
@@ -1665,15 +1695,17 @@ function AppInner() {
       // Filesystem commands (and any unhandled YouCoded command) — send the
       // slash command to the PTY so Claude Code executes it. Also record the
       // optimistic user prompt so the chat timeline shows the action.
+      // Send first, guarded (pending-prompt gate) — dispatching the bubble for
+      // a refused send would leave a stale pending entry in the timeline.
+      if (!guardedPtySend(sessionId, `${entry.name}\r`)) return;
       dispatch({
         type: 'USER_PROMPT',
         sessionId,
         content: entry.name,
         timestamp: Date.now(),
       });
-      window.claude.session.sendInput(sessionId, `${entry.name}\r`);
     },
-    [sessionId, dispatch, viewModes, getUsageSnapshot],
+    [sessionId, dispatch, viewModes, getUsageSnapshot, guardedPtySend],
   );
 
   const handleSelectSkill = useCallback(
@@ -1706,21 +1738,30 @@ function AppInner() {
         });
         if (result.handled) {
           if (result.alsoSendToPty) {
-            window.claude.session.sendInput(sessionId, result.alsoSendToPty);
+            guardedPtySend(sessionId, result.alsoSendToPty);
           }
           return;
         }
       }
 
+      // Sanitize through the same one-source helper InputBar uses: skill
+      // prompts can be multiline, and (a) raw newlines written to the PTY act
+      // as premature Enter presses on short sends, (b) the optimistic bubble
+      // must exactly match the sanitized text or the transcript confirm never
+      // clears its pending flag (see outgoing-message.ts).
+      const outgoing = buildOutgoingMessage(skill.prompt, []);
+      if (!outgoing) return;
+      // Send first, guarded (pending-prompt gate) — dispatching the bubble for
+      // a refused send would leave a stale pending entry in the timeline.
+      if (!guardedPtySend(sessionId, outgoing.ptyText + '\r')) return;
       dispatch({
         type: 'USER_PROMPT',
         sessionId,
-        content: skill.prompt,
+        content: outgoing.content,
         timestamp: Date.now(),
       });
-      window.claude.session.sendInput(sessionId, skill.prompt + '\r');
     },
-    [sessionId, dispatch, viewModes, getUsageSnapshot],
+    [sessionId, dispatch, viewModes, getUsageSnapshot, guardedPtySend],
   );
 
   const createSession = useCallback(async (cwd: string, dangerous: boolean, sessionModel?: string, provider?: 'claude' | 'gemini', launchInNewWindow?: boolean) => {
@@ -2313,8 +2354,10 @@ function AppInner() {
                     setSettingsOpen(true);
                   }}
                   onRunSync={!trustGateActive && sessionId ? () => {
+                    // Send first, guarded — a refused send must not leave a
+                    // stale pending "/sync" bubble in the timeline.
+                    if (!guardedPtySend(sessionId, '/sync\r')) return;
                     dispatch({ type: 'USER_PROMPT', sessionId, content: '/sync', timestamp: Date.now() });
-                    window.claude.session.sendInput(sessionId, '/sync\r');
                   } : undefined}
                   model={currentModel}
                   onCycleModel={cycleModel}
@@ -2350,7 +2393,7 @@ function AppInner() {
                     // COMPACTION_PENDING / CLEAR_TIMELINE reducer actions already update the timeline, so a
                     // USER_PROMPT bubble would render redundantly alongside them.
                     if (result.handled && result.alsoSendToPty) {
-                      window.claude.session.sendInput(sessionId, result.alsoSendToPty);
+                      guardedPtySend(sessionId, result.alsoSendToPty);
                     }
                   }}
                   openTasksCounts={sessionId ? { running: openTasks.counts.running, pending: openTasks.counts.pending } : undefined}
@@ -2460,10 +2503,9 @@ function AppInner() {
         open={settingsOpen}
         onClose={() => { setSettingsOpen(false); setSyncAutoOpen(false); }}
         onSendInput={(text) => {
-          if (sessionId) {
-            const claude = (window as any).claude;
-            claude.session.sendInput(sessionId, text + '\r');
-          }
+          // Guarded: with a permission/question pending, the text would land on
+          // CC's live Ink menu and the trailing \r would answer it.
+          if (sessionId) guardedPtySend(sessionId, text + '\r');
         }}
         hasActiveSession={!!sessionId}
         onOpenThemeMarketplace={() => { setSettingsOpen(false); openMarketplace('themes'); }}
@@ -2505,8 +2547,9 @@ function AppInner() {
           setViewModes((prev) => new Map(prev).set(sessionId, 'terminal'));
           // Small delay so the view switch happens before input lands.
           // pty-worker will auto-split "/config\r" into "/config" + 600ms + "\r"
-          // to avoid Ink's paste timer swallowing Enter.
-          setTimeout(() => window.claude.session.sendInput(sessionId, '/config\r'), 50);
+          // to avoid Ink's paste timer swallowing Enter. Guarded: with a prompt
+          // pending, "/config\r" would answer CC's live Ink menu instead.
+          setTimeout(() => guardedPtySend(sessionId, '/config\r'), 50);
         }}
       />
       <ModelPickerPopup
@@ -2516,11 +2559,14 @@ function AppInner() {
         currentModel={currentModel}
         onSelectModel={(m) => {
           if (!sessionId) return;
+          // Send first, guarded (pending-prompt gate) — refusing before the
+          // optimistic state writes keeps the model pill truthful when the
+          // command never reached CC. Mirrors cycleModel.
+          if (!guardedPtySend(sessionId, `/model ${m}\r`)) return;
           setSessionModels((prev) => new Map(prev).set(sessionId, m));
           setPendingModel(m);
           postSwitchTurnReady.current = false;
           (window.claude as any).model?.setPreference(m);
-          window.claude.session.sendInput(sessionId, `/model ${m}\r`);
         }}
       />
       {/* Open Tasks popup — rendered at App root so it escapes any inner stacking context.


### PR DESCRIPTION
## What

Follow-up to #110, closing the two exposures that PR called out:

**Android parity**
- `SessionService.onPluginsChanged` typed `/reload-plugins⏎` into the current session immediately and ungated. Now mirrors desktop's gated broadcast: 1.5s readiness delay, deferral while `EventBridge` holds a pending PermissionRequest socket, bounded retries (5s × 24), then give up.
- `PtyBridge.writeInput`'s 600ms-deferred `\r` re-checks `hasPendingPermission` before firing, so a permission arriving during the gap can't be answered by the deferred Enter. Menu-navigation payloads (`hasEscape` — `sendApproval`, sign-in/theme/trust menus) are exempt: driving the live menu is their purpose.
- New `EventBridge.hasPendingPermission()` (per-session bridge; desktop equivalent is `HookRelay.hasPendingPermission`).

**Desktop UI-triggered sends**
User-initiated command-shaped sends now route through a `guardedPtySend` helper in App.tsx (pending-prompt gate + toast, same rule InputBar applies to typed messages): command drawer runs, skill runs, `/sync`, `/config`, `/model` (pill cycle + picker), Settings sends, and popup-dispatched `alsoSendToPty`. Optimistic bubbles and model-pill state now update only when the send was actually delivered. Skill prompts are sanitized through `buildOutgoingMessage` (multiline prompts could fire premature Enters and left forever-pending bubbles).

Deliberate menu-driving writes (ToolCard plan keys, TrustGate, prompt option clicks, terminal view, ESC interrupt, Shift+Tab) remain ungated by design.

## Verification

- `./gradlew :app:testDebugUnitTest` green; new `EventBridgePendingPermissionTest` executed (positive held-socket case needs a real `LocalSocket`, covered by the releaseTest APK flow — noted in the test header).
- Desktop: `tsc --noEmit` clean, vitest 1335 passing.
- Stale mid-build `assets/web` bundle regeneration was reverted, not committed — CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)