### PR TITLE
Project & sync management UX — picker slim-down, unified Add flow, Project View sync hub

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -1915,7 +1915,10 @@ export function registerIpcHandlers(
   // module owns the singleton engine/manager/roots.
   ipcMain.handle(IPC.SYNC_SPACES_STATUS, () => syncSpacesStatus());
   ipcMain.handle(IPC.SYNC_SPACES_ENABLE, (_e, enabled: boolean) => syncSpacesEnable(!!enabled));
-  ipcMain.handle(IPC.SYNC_SPACES_SYNC_NOW, () => syncSpacesSyncNow());
+  // spaceId (optional) narrows the sync to one space for the Project View
+  // "Sync now" button; SyncPanel calls with no arg = sync everything.
+  ipcMain.handle(IPC.SYNC_SPACES_SYNC_NOW, (_e, spaceId?: string) =>
+    syncSpacesSyncNow(spaceId ? String(spaceId) : undefined));
   ipcMain.handle(IPC.SYNC_SPACES_CREATE_PROJECT, (_e, name: string) => syncSpacesCreateProject(String(name ?? '')));
   ipcMain.handle(IPC.SYNC_SPACES_IMPORT_PROJECT, (_e, sourcePath: string, name: string) =>
     // Live-cwd guard input: the folder must not move under a running session.

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -733,7 +733,8 @@ contextBridge.exposeInMainWorld('claude', {
   syncSpaces: {
     status: () => ipcRenderer.invoke(IPC.SYNC_SPACES_STATUS),
     enable: (enabled: boolean) => ipcRenderer.invoke(IPC.SYNC_SPACES_ENABLE, enabled),
-    syncNow: () => ipcRenderer.invoke(IPC.SYNC_SPACES_SYNC_NOW),
+    // Optional spaceId narrows to one space (Project View "Sync now"); omit for all.
+    syncNow: (spaceId?: string) => ipcRenderer.invoke(IPC.SYNC_SPACES_SYNC_NOW, spaceId),
     createProject: (name: string) => ipcRenderer.invoke(IPC.SYNC_SPACES_CREATE_PROJECT, name),
     // Spec §3 import: move an existing folder into ~/YouCoded/Projects/<name>.
     importProject: (sourcePath: string, name: string) =>

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -1123,7 +1123,9 @@ export class RemoteServer {
         break;
       }
       case 'syncspaces:sync-now': {
-        this.respond(client.ws, type, id, await syncSpacesSyncNow());
+        // Optional spaceId narrows to one space (Project View "Sync now"); omit for all.
+        this.respond(client.ws, type, id, await syncSpacesSyncNow(
+          payload?.spaceId ? String(payload.spaceId) : undefined));
         break;
       }
       case 'syncspaces:create-project': {

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -38,12 +38,15 @@ export function setSyncSpacesRemoteBroadcaster(fn: ((e: SpaceSyncEvent) => void)
 }
 
 function broadcast(e: SpaceSyncEvent): void {
-  recentEvents = [...recentEvents.slice(-49), e];
+  // Stamp at emit time — the renderer derives "Last synced N min ago" from it,
+  // so every stored + fanned-out copy must carry the same timestamp.
+  const stamped: SpaceSyncEvent = { ...e, at: Date.now() };
+  recentEvents = [...recentEvents.slice(-49), stamped];
   for (const w of BrowserWindow.getAllWindows()) {
-    try { w.webContents.send('syncspaces:event', e); } catch { /* window closing */ }
+    try { w.webContents.send('syncspaces:event', stamped); } catch { /* window closing */ }
   }
   // Fan out to remote clients too (see comment on remoteBroadcast above).
-  try { remoteBroadcast?.(e); } catch { /* remote server not up / closing */ }
+  try { remoteBroadcast?.(stamped); } catch { /* remote server not up / closing */ }
 }
 
 /** Called once from main.ts after app ready. Roots always exist (the picker
@@ -126,8 +129,15 @@ export async function syncSpacesEnable(enabled: boolean) {
   return syncSpacesStatus();
 }
 
-export async function syncSpacesSyncNow() {
-  if (engine && roots) for (const s of roots.spaces()) void engine.syncSpace(s);
+export async function syncSpacesSyncNow(spaceId?: string) {
+  // spaceId narrows to one space (the Project View hero's "Sync now" button);
+  // no arg keeps the SyncPanel's existing sync-everything behavior.
+  if (engine && roots) {
+    for (const s of roots.spaces()) {
+      if (spaceId && s.id !== spaceId) continue;
+      void engine.syncSpace(s);
+    }
+  }
   return { ok: true };
 }
 

--- a/desktop/src/main/sync-spaces/types.ts
+++ b/desktop/src/main/sync-spaces/types.ts
@@ -34,8 +34,12 @@ export interface SyncTransport {
   history(space: SyncSpace, limit?: number): Promise<SpaceVersion[]>;
 }
 
-export type SpaceSyncEvent =
+// `at` is stamped by service.broadcast() at emit time (ms epoch). Optional so
+// replayed or older payloads without it still typecheck. The renderer derives
+// "Last synced N minutes ago" (Project View hero) from it.
+export type SpaceSyncEvent = (
   | { type: 'synced'; spaceId: string; pushed: boolean; updated: boolean }
   | { type: 'conflict'; spaceId: string; copies: string[] }
   | { type: 'oversize'; spaceId: string; files: string[] }
-  | { type: 'error'; spaceId: string; message: string };
+  | { type: 'error'; spaceId: string; message: string }
+) & { at?: number };

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2417,7 +2417,13 @@ function AppInner() {
                 <div className="layer-surface w-full p-3 flex flex-col gap-2">
                   <div>
                     <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Project Folder</label>
-                    <FolderSwitcher value={welcomeCwd} onChange={setWelcomeCwd} />
+                    {/* Match SessionStrip: the picker's "Manage projects…"
+                        footer opens Project View (where adding lives). */}
+                    <FolderSwitcher
+                      value={welcomeCwd}
+                      onChange={setWelcomeCwd}
+                      onManageProjects={() => dispatchArtifact({ type: 'PROJECT_VIEW_OPENED' })}
+                    />
                   </div>
                   <div>
                     <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -334,13 +334,41 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true, onM
 
           {/* Footer: the ONLY action — everything about adding/importing/
               syncing projects lives in Project View (spec decision 3). */}
-          {onManageProjects && (
+          {onManageProjects ? (
             <div className="border-t border-edge">
               <button
                 onClick={() => { setOpen(false); onManageProjects(); }}
                 className="w-full px-2.5 py-2 text-xs text-fg-dim hover:bg-inset hover:text-fg transition-colors flex items-center justify-center gap-1.5"
               >
                 Manage projects…
+              </button>
+            </div>
+          ) : (
+            // WHY: the main picker deliberately has no add actions (spec
+            // decision 3 — Project View owns adding), but windows WITHOUT
+            // Project View (the buddy window has no ArtifactProvider) need a
+            // minimal escape hatch to add a folder — otherwise there is NO way
+            // to add one there (a regression). This row renders ONLY when
+            // onManageProjects is absent.
+            <div className="border-t border-edge">
+              <button
+                onClick={async () => {
+                  try {
+                    const folder = await (window as any).claude.dialog.openFolder();
+                    if (folder) {
+                      await (window as any).claude.folders.add(folder);
+                      await load();
+                      onChange(folder);
+                      setOpen(false);
+                    }
+                  } catch {
+                    // Swallow: user cancel resolves to null (handled above);
+                    // anything thrown here (e.g. dialog unavailable) is a no-op.
+                  }
+                }}
+                className="w-full px-2.5 py-2 text-xs text-fg-dim hover:bg-inset hover:text-fg transition-colors flex items-center justify-center gap-1.5"
+              >
+                Browse for folder…
               </button>
             </div>
           )}

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -1,15 +1,22 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+// desktop/src/renderer/components/FolderSwitcher.tsx
+// The session picker's folder dropdown. Per the 2026-07-09 project-sync UX
+// spec this component ONLY picks: adding/importing/syncing projects moved to
+// Project View, reached via the single "Manage projects…" footer entry.
+// Each row carries a sync dot (green syncing / red problem / gray not in
+// sync) whose tooltip holds the full plain-language phrase.
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
-import ImportProjectModal from './ImportProjectModal';
+import { syncDotFor, type SyncStatusData } from './sync-dot-state';
 
 interface SavedFolder {
   path: string;
   nickname: string;
   addedAt: number;
   exists: boolean;
-  // Set by FOLDERS_LIST for YouCoded-managed sync projects (~/YouCoded/Projects/*),
-  // which appear here automatically. Drives the "synced project" badge below.
+  // Still set by FOLDERS_LIST for managed projects; the dot supersedes the old
+  // text badge but the flag keeps rename/remove semantics cheap to reason about.
   managed?: boolean;
 }
 
@@ -20,25 +27,36 @@ interface Props {
   onChange: (path: string) => void;
   /** Auto-select the first saved folder when value is empty (default: true) */
   autoSelect?: boolean;
+  /** Opens Project View ("Manage projects…"). Omitted where Project View
+   *  doesn't exist (the buddy window) — the footer row hides itself. */
+  onManageProjects?: () => void;
 }
 
-export default function FolderSwitcher({ value, onChange, autoSelect = true }: Props) {
+// Dot colors: status colors are theme-independent by design-system rule.
+// Red matches the app's existing #DD4444; green mirrors the SessionDot green.
+const DOT_CLASS: Record<'green' | 'red' | 'gray', string> = {
+  green: 'bg-[#44A05C]',
+  red: 'bg-[#DD4444]',
+  gray: 'bg-fg-faint',
+};
+
+export default function FolderSwitcher({ value, onChange, autoSelect = true, onManageProjects }: Props) {
   const [folders, setFolders] = useState<SavedFolder[]>([]);
   const [open, setOpen] = useState(false);
   const [editingPath, setEditingPath] = useState<string | null>(null);
   const [editNickname, setEditNickname] = useState('');
+  const [syncStatus, setSyncStatus] = useState<SyncStatusData | null>(null);
   const editRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // The dropdown panel is PORTALED to document.body (see render below), so it
+  // needs its own ref for the outside-click check — it is no longer a DOM
+  // child of wrapperRef.
+  const panelRef = useRef<HTMLDivElement>(null);
   const listRef = useScrollFade<HTMLDivElement>();
-
-  // New managed project (spec §3): creates ~/YouCoded/Projects/<name>, which
-  // then appears in this picker automatically via the FOLDERS_LIST merge.
-  const [newProjectName, setNewProjectName] = useState('');
-  const [projectError, setProjectError] = useState<string | null>(null);
-
-  // Import-existing-folder flow (spec §3): which folder the consent modal is
-  // showing for. Set by the row action (flow 1) or the picker button (flow 2).
-  const [importTarget, setImportTarget] = useState<{ sourcePath: string; defaultName: string } | null>(null);
+  // Fixed-position coordinates for the portaled dropdown, computed from the
+  // trigger button's screen rect whenever the dropdown opens (and on resize).
+  const [panelPos, setPanelPos] = useState<{ top: number; left: number; maxHeight: number } | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -53,11 +71,52 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
 
   useEffect(() => { load(); }, [load]);
 
-  // Close panel on outside click/tap
+  // Fetch sync state when the dropdown opens. catch → null: on Android the
+  // shim has no syncspaces handlers (30s reject) — rows simply render no dot.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (window as any).claude.syncSpaces.status()
+      .then((s: SyncStatusData) => { if (!cancelled) setSyncStatus(s); })
+      .catch(() => { if (!cancelled) setSyncStatus(null); });
+    return () => { cancelled = true; };
+  }, [open]);
+
+  // Position the portaled dropdown under the trigger, clamped to the viewport.
+  // WHY a portal + fixed positioning at all: this picker lives inside the
+  // SessionStrip's new-session menu, whose rounded-corner containers use
+  // overflow-hidden — an absolutely-positioned child gets CLIPPED at the menu
+  // edges (cut-off icons, truncated list). Portaling to document.body lets the
+  // dropdown float above the host menu instead of being squeezed inside it.
+  const PANEL_WIDTH = 288; // w-72
+  const measure = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const margin = 8;
+    const left = Math.min(
+      Math.max(rect.left + rect.width / 2 - PANEL_WIDTH / 2, margin),
+      window.innerWidth - PANEL_WIDTH - margin
+    );
+    const top = rect.bottom + 4;
+    // Never extend past the viewport bottom — the panel scrolls instead.
+    const maxHeight = Math.max(window.innerHeight - top - margin, 120);
+    setPanelPos({ top, left, maxHeight });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) { setPanelPos(null); return; }
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [open, measure]);
+
+  // Close panel on outside click/tap. The panel is portaled, so "inside" means
+  // inside the trigger wrapper OR inside the floating panel itself.
   useEffect(() => {
     if (!open) return;
     const handler = (e: Event) => {
-      if (wrapperRef.current?.contains(e.target as Node)) return;
+      const t = e.target as Node;
+      if (wrapperRef.current?.contains(t) || panelRef.current?.contains(t)) return;
       setOpen(false);
       setEditingPath(null);
     };
@@ -84,63 +143,6 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
       editRef.current.select();
     }
   }, [editingPath]);
-
-  const handleBrowseAndAdd = useCallback(async () => {
-    try {
-      const folder = await (window as any).claude.dialog.openFolder();
-      if (!folder) return;
-      await (window as any).claude.folders.add(folder);
-      await load();
-      onChange(folder);
-    } catch {}
-  }, [onChange, load]);
-
-  const createProject = useCallback(async () => {
-    const name = newProjectName.trim();
-    if (!name) return;
-    // try/catch: a REJECTED invoke (e.g. bridge timeout — Android has no
-    // syncspaces handlers yet, so remote-shim rejects after 30s) must surface
-    // as an inline error here, not escape as an unhandled promise rejection.
-    try {
-      const r = await (window as any).claude.syncSpaces.createProject(name);
-      // On success: clear the field, reload the folder list (reuses `load`, the
-      // existing folders.list() refresh) so the new project shows up, and select it.
-      if (r?.ok) { setNewProjectName(''); setProjectError(null); await load(); onChange(r.path); }
-      else setProjectError(r?.error ?? 'Could not create project');
-    } catch (err: any) {
-      setProjectError(String(err?.message ?? err));
-    }
-  }, [newProjectName, load, onChange]);
-
-  // Import flow 1: the per-row "Sync this project" hover action. Seeds the
-  // consent modal with the existing folder's path + its basename as the
-  // default project name. stopPropagation so the row-click select doesn't fire.
-  const startImportForRow = useCallback((e: React.MouseEvent, folder: SavedFolder) => {
-    e.stopPropagation();
-    const base = folder.path.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? folder.nickname;
-    setImportTarget({ sourcePath: folder.path, defaultName: base });
-  }, []);
-
-  // Import flow 2: pick any on-device folder via the native picker, then open
-  // the consent modal for it. Empty catch: cancelling the dialog is not an error.
-  const startImportFromPicker = useCallback(async () => {
-    try {
-      const folder = await (window as any).claude.dialog.openFolder();
-      if (!folder) return;
-      const base = folder.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
-      setImportTarget({ sourcePath: folder, defaultName: base });
-    } catch {}
-  }, []);
-
-  // After a successful move: close the modal, reload the list, and select the
-  // project at its NEW home (also covers the case where the moved folder was
-  // the current selection — the old path no longer exists on disk).
-  const handleImportDone = useCallback(async (newPath: string) => {
-    setImportTarget(null);
-    await load();
-    onChange(newPath);
-    setOpen(false);
-  }, [load, onChange]);
 
   const handleSelect = useCallback((path: string) => {
     onChange(path);
@@ -184,6 +186,7 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
     <div ref={wrapperRef} className="relative">
       {/* Trigger button — shows current selection */}
       <button
+        ref={triggerRef}
         onClick={() => setOpen(!open)}
         className="w-full text-left px-2.5 py-1.5 bg-inset border border-edge rounded-md text-xs text-fg-2 hover:border-edge transition-colors truncate flex items-center gap-1.5"
       >
@@ -204,19 +207,27 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
       )}
 
       {/* Dropdown panel — uses .layer-surface for theme-driven background,
-          border, shadow, and glassmorphism (blur/opacity from --panels-* vars). */}
-      {open && (
+          border, shadow, and glassmorphism (blur/opacity from --panels-* vars).
+          PORTALED to document.body with fixed positioning so the host menu's
+          overflow-hidden can't clip it (see the WHY on `measure` above).
+          zIndex 9001: the SessionStrip menu that hosts this picker is the
+          documented z-[9000] exception (PITFALLS → Overlays) — a popover
+          spawned FROM that menu must render above its own host. */}
+      {open && panelPos && createPortal(
         <div
-          className="layer-surface absolute top-full mt-1 left-1/2 w-72 overflow-hidden"
-          style={{ transform: 'translateX(-50%)', zIndex: 50, animation: 'dropdown-in 120ms cubic-bezier(0.16, 1, 0.3, 1) both' }}
+          ref={panelRef}
+          className="layer-surface fixed w-72 overflow-hidden flex flex-col"
+          style={{ top: panelPos.top, left: panelPos.left, maxHeight: panelPos.maxHeight, zIndex: 9001, animation: 'dropdown-in 120ms cubic-bezier(0.16, 1, 0.3, 1) both' }}
         >
-          {/* Saved folders list */}
+          {/* Saved folders list — min-h-0 lets flexbox shrink the list first
+              when the viewport-clamped panel height is tight. */}
           {folders.length > 0 && (
-            <div ref={listRef} className="scroll-fade max-h-48">
+            <div ref={listRef} className="scroll-fade max-h-48 min-h-0">
               <div className="py-1">
               {folders.map((f) => {
                 const isSelected = f.path === value;
                 const isEditing = editingPath === f.path;
+                const dot = syncDotFor(f.path, syncStatus);
 
                 return (
                   <div
@@ -252,11 +263,7 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
                         />
                       ) : (
                         <>
-                          <div className="text-xs truncate">
-                            {f.nickname}
-                            {/* Plain-word badge for YouCoded-managed sync projects — no status glyphs. */}
-                            {f.managed && <span className="text-xs text-fg-muted ml-1">synced project</span>}
-                          </div>
+                          <div className="text-xs truncate">{f.nickname}</div>
                           <div className="text-[10px] text-fg-faint truncate" title={f.path}>
                             {f.path}
                           </div>
@@ -274,19 +281,6 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
                     {/* Action buttons — visible on hover */}
                     {!isEditing && (
                       <div className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover/folder:opacity-100 transition-opacity">
-                        {/* Sync this project (spec §3 flow 1) — move into ~/YouCoded/Projects/.
-                            Only for real, non-managed folders: managed ones already sync. */}
-                        {f.exists && !f.managed && (
-                          <button
-                            onClick={(e) => startImportForRow(e, f)}
-                            className="w-5 h-5 flex items-center justify-center rounded-sm text-fg-faint hover:text-fg hover:bg-inset transition-colors"
-                            title="Sync this project (moves it into ~/YouCoded/Projects/)"
-                          >
-                            <svg className="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M5.5 9a7.5 7.5 0 0113-2.5M18.5 15a7.5 7.5 0 01-13 2.5" />
-                            </svg>
-                          </button>
-                        )}
                         {/* Rename */}
                         <button
                           onClick={(e) => handleStartRename(e, f)}
@@ -316,6 +310,17 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
                         <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                       </svg>
                     )}
+
+                    {/* Sync dot — green syncing / red problem / gray not in
+                        sync; the tooltip carries the full phrase. Renders only
+                        when syncSpaces.status() resolved (desktop). */}
+                    {dot && !isEditing && (
+                      <span
+                        className={`w-2 h-2 rounded-full shrink-0 ${DOT_CLASS[dot.color]}`}
+                        title={dot.label}
+                        aria-label={dot.label}
+                      />
+                    )}
                   </div>
                 );
               })}
@@ -323,54 +328,20 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true }: P
             </div>
           )}
 
-          {/* Add new folder button */}
-          <div className="border-t border-edge">
-            <button
-              onClick={handleBrowseAndAdd}
-              className="w-full px-2.5 py-2 text-xs text-fg-dim hover:bg-inset hover:text-fg transition-colors flex items-center justify-center gap-1.5"
-            >
-              <span className="text-sm leading-none">+</span>
-              <span>Browse for folder</span>
-            </button>
-
-            {/* New managed sync project — creates ~/YouCoded/Projects/<name>. */}
-            <div className="px-2.5 pb-2">
-              <div className="flex items-center gap-2 mt-2">
-                <input
-                  value={newProjectName}
-                  onChange={e => setNewProjectName(e.target.value)}
-                  onKeyDown={e => { if (e.key === 'Enter') void createProject(); }}
-                  placeholder="New project name…"
-                  className="flex-1 bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim"
-                />
-                <button onClick={() => void createProject()} className="text-sm px-2 py-1 rounded bg-accent text-on-accent">
-                  Create
-                </button>
-              </div>
-              {projectError && <div className="text-xs text-red-500 mt-1">{projectError}</div>}
-
-              {/* Spec §3 flow 2: import any on-device folder via the native picker. */}
+          {/* Footer: the ONLY action — everything about adding/importing/
+              syncing projects lives in Project View (spec decision 3). */}
+          {onManageProjects && (
+            <div className="border-t border-edge">
               <button
-                onClick={() => void startImportFromPicker()}
-                className="mt-1.5 w-full text-left text-[11px] text-fg-dim hover:text-fg transition-colors"
+                onClick={() => { setOpen(false); onManageProjects(); }}
+                className="w-full px-2.5 py-2 text-xs text-fg-dim hover:bg-inset hover:text-fg transition-colors flex items-center justify-center gap-1.5"
               >
-                or move an existing folder into sync…
+                Manage projects…
               </button>
             </div>
-          </div>
-        </div>
-      )}
-
-      {/* Consent modal — rendered OUTSIDE the {open && (…)} dropdown so it
-          survives the dropdown's outside-click close (mousedown outside
-          wrapperRef closes the dropdown; the modal must stay up). */}
-      {importTarget && (
-        <ImportProjectModal
-          sourcePath={importTarget.sourcePath}
-          defaultName={importTarget.defaultName}
-          onClose={() => setImportTarget(null)}
-          onDone={(p) => void handleImportDone(p)}
-        />
+          )}
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -15,8 +15,9 @@ interface SavedFolder {
   nickname: string;
   addedAt: number;
   exists: boolean;
-  // Still set by FOLDERS_LIST for managed projects; the dot supersedes the old
-  // text badge but the flag keeps rename/remove semantics cheap to reason about.
+  // Kept solely to mirror the FOLDERS_LIST IPC payload shape — rows arrive
+  // with this flag, but nothing in this file reads it anymore (the sync dot
+  // supersedes the old "synced project" managed badge).
   managed?: boolean;
 }
 
@@ -88,7 +89,10 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true, onM
   // overflow-hidden — an absolutely-positioned child gets CLIPPED at the menu
   // edges (cut-off icons, truncated list). Portaling to document.body lets the
   // dropdown float above the host menu instead of being squeezed inside it.
-  const PANEL_WIDTH = 288; // w-72
+  // Must match the `w-72` Tailwind class on the panel div (288px = 18rem) —
+  // if one changes, change the other, or the clamping math here silently
+  // drifts from the panel's real rendered width.
+  const PANEL_WIDTH = 288;
   const measure = useCallback(() => {
     const rect = triggerRef.current?.getBoundingClientRect();
     if (!rect) return;

--- a/desktop/src/renderer/components/HeaderBar.tsx
+++ b/desktop/src/renderer/components/HeaderBar.tsx
@@ -189,8 +189,10 @@ interface Props {
 
 /** Projects button — always visible (projects are persistent, not session-local).
  *  Opens ProjectView as a full-screen overlay via PROJECT_VIEW_OPENED dispatch.
- *  Isolated into its own component so it can safely call useArtifact() without
- *  requiring the parent HeaderBar to be inside an ArtifactContext. */
+ *  HeaderBar must always render inside ArtifactProvider (its only render site,
+ *  App.tsx, does) — useArtifact() needs a provider ancestor regardless of which
+ *  component calls it. Keeping this in its own small component is just code
+ *  organization; SessionStrip now also calls useArtifact() at its top level. */
 function ProjectsButton() {
   const { dispatch } = useArtifact();
   return (

--- a/desktop/src/renderer/components/ImportProjectModal.tsx
+++ b/desktop/src/renderer/components/ImportProjectModal.tsx
@@ -18,6 +18,12 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
   const [name, setName] = useState(defaultName);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Honesty rule (spec decision 6): when global Sync is off, every sync
+  // promise softens. This modal is reached from the Project View hero's "Turn
+  // on sync" button DIRECTLY (not only via AddProjectModal), so it must carry
+  // the note itself. null = unknown (Android has no syncspaces handlers) → no
+  // note, matching AddProjectModal's convention.
+  const [syncEnabled, setSyncEnabled] = useState<boolean | null>(null);
   // Post-success state: when the move produced warnings we keep the modal open
   // to show them (closing instantly would hide "delete the old copy manually").
   const [doneWarnings, setDoneWarnings] = useState<string[] | null>(null);
@@ -29,6 +35,11 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
   const cancelledRef = useRef(false);
   useEffect(() => {
     cancelledRef.current = false;
+    // Fetch Sync's on/off state so the honesty note can render. catch → null
+    // (unknown) shows no note — same convention AddProjectModal uses.
+    (window as any).claude.syncSpaces.status()
+      .then((s: any) => { if (!cancelledRef.current) setSyncEnabled(!!s?.enabled); })
+      .catch(() => { if (!cancelledRef.current) setSyncEnabled(null); });
     return () => { cancelledRef.current = true; };
   }, []);
 
@@ -75,6 +86,15 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
     }
   }, [name, busy, sourcePath, onDone]);
 
+  // Same note copy/styling AddProjectModal uses — shown only in the pre-move
+  // consent state (once the move succeeds the folder IS in the sync home).
+  const syncOffNote = syncEnabled === false && (
+    <div className="mt-3 rounded-md border border-edge bg-inset px-3 py-2 text-xs text-fg-dim" role="note">
+      <span className="text-fg-2 font-medium">Sync is currently turned off.</span>{' '}
+      This project will start syncing once you turn on Sync in Settings.
+    </div>
+  );
+
   return (
     <>
       <Scrim layer={2} onClick={busy ? undefined : dismiss} />
@@ -115,6 +135,7 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
               autoFocus
             />
             {error && <div role="alert" className="mt-2 text-xs text-red-500">{error}</div>}
+            {syncOffNote}
             <div className="mt-4 flex justify-end gap-2">
               <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
               <button onClick={() => void confirm()} disabled={busy || !name.trim()} className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50">

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -8,6 +8,7 @@ import { ModelInfoTooltip } from './ModelPickerPopup';
 import { SkipPermissionsInfoTooltip } from './SkipPermissionsInfoTooltip';
 import { packSessions, type SessionMeasurement, type PackResult } from './header/pack-sessions';
 import { useScrollFade } from '../hooks/useScrollFade';
+import { useArtifact } from '../state/ArtifactContext';
 
 interface SessionEntry {
   id: string;
@@ -155,6 +156,10 @@ export default function SessionStrip({
   geminiEnabled,
   windowDirectory, myWindowId,
 }: Props) {
+  // Artifact dispatch — SessionStrip renders only in the main window, inside
+  // the ArtifactContext provider, so calling the hook at top level is safe.
+  // Used by the FolderSwitcher "Manage projects…" footer to open Project View.
+  const { dispatch: artifactDispatch } = useArtifact();
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [shiftNavIdx, setShiftNavIdx] = useState<number>(-1);
@@ -945,7 +950,13 @@ export default function SessionStrip({
             <div className="p-3 flex flex-col gap-2 rounded-b-lg overflow-hidden">
               <div>
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Project Folder</label>
-                <FolderSwitcher value={newCwd} onChange={setNewCwd} />
+                <FolderSwitcher
+                  value={newCwd}
+                  onChange={setNewCwd}
+                  // "Manage projects…" bridges to Project View (same action as
+                  // the header button) and closes the session menu behind it.
+                  onManageProjects={() => { setMenuOpen(false); artifactDispatch({ type: 'PROJECT_VIEW_OPENED' }); }}
+                />
               </div>
               {/* Model selector — grayed out when Gemini is selected */}
               <div style={{ opacity: isGemini ? 0.4 : 1, pointerEvents: isGemini ? 'none' : 'auto', transition: 'opacity 200ms' }}>

--- a/desktop/src/renderer/components/project-view/AddProjectModal.tsx
+++ b/desktop/src/renderer/components/project-view/AddProjectModal.tsx
@@ -1,0 +1,199 @@
+// desktop/src/renderer/components/project-view/AddProjectModal.tsx
+// The unified "Add a project" flow (2026-07-09 project-sync UX spec §3).
+// A thin ROUTER over existing machinery — no new main-process flows:
+//   Start something new        → syncSpaces.createProject(name)
+//   Use existing → keep        → folders.add(path)
+//   Use existing → move+sync   → the existing ImportProjectModal (consent+move)
+// Step 1 asks the only question a new user can answer instantly (new or
+// existing?); step 2 makes the sync decision explicit with its consequence.
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Scrim, OverlayPanel } from '../overlays/Overlay';
+import { useEscClose } from '../../hooks/use-esc-close';
+import ImportProjectModal from '../ImportProjectModal';
+
+interface Props {
+  onClose: () => void;
+  /** Called with the project path after ANY successful add path. */
+  onAdded: (path: string) => void;
+}
+
+type Step =
+  | { kind: 'choose' }
+  | { kind: 'existing'; path: string; baseName: string }
+  | { kind: 'move'; path: string; baseName: string };
+
+export default function AddProjectModal({ onClose, onAdded }: Props) {
+  const [step, setStep] = useState<Step>({ kind: 'choose' });
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Honesty rule: when global Sync is off, every sync promise softens to
+  // "will sync once you turn on Sync in Settings". null = unknown (e.g.
+  // Android where syncspaces handlers don't exist) — show no note.
+  const [syncEnabled, setSyncEnabled] = useState<boolean | null>(null);
+  const cancelledRef = useRef(false);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    (window as any).claude.syncSpaces.status()
+      .then((s: any) => { if (!cancelledRef.current) setSyncEnabled(!!s?.enabled); })
+      .catch(() => { if (!cancelledRef.current) setSyncEnabled(null); });
+    return () => { cancelledRef.current = true; };
+  }, []);
+
+  // The move step delegates entirely to ImportProjectModal (it owns the
+  // consent copy, name confirm, warnings). ESC/scrim for THIS modal only
+  // apply outside the move step (ImportProjectModal manages its own).
+  useEscClose(step.kind !== 'move' && !busy, onClose);
+
+  const createNew = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed || inFlightRef.current) return;
+    inFlightRef.current = true;
+    setBusy(true);
+    setError(null);
+    // try/catch: on Android the shim rejects after 30s — surface inline.
+    try {
+      const r = await (window as any).claude.syncSpaces.createProject(trimmed);
+      if (cancelledRef.current) return;
+      if (r?.ok) onAdded(r.path);
+      else setError(r?.error ?? 'Could not create the project');
+    } catch (err: any) {
+      if (!cancelledRef.current) setError(String(err?.message ?? err));
+    } finally {
+      inFlightRef.current = false;
+      if (!cancelledRef.current) setBusy(false);
+    }
+  }, [name, onAdded]);
+
+  const pickExisting = useCallback(async () => {
+    try {
+      const folder: string | null = await (window as any).claude.dialog.openFolder();
+      if (!folder || cancelledRef.current) return;
+      const baseName = folder.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
+      setError(null);
+      setStep({ kind: 'existing', path: folder, baseName });
+    } catch { /* dialog unavailable (remote) — nothing to do */ }
+  }, []);
+
+  const keepInPlace = useCallback(async () => {
+    if (step.kind !== 'existing' || inFlightRef.current) return;
+    inFlightRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      await (window as any).claude.folders.add(step.path);
+      if (!cancelledRef.current) onAdded(step.path);
+    } catch (err: any) {
+      if (!cancelledRef.current) setError(String(err?.message ?? err));
+    } finally {
+      inFlightRef.current = false;
+      if (!cancelledRef.current) setBusy(false);
+    }
+  }, [step, onAdded]);
+
+  const syncOffNote = syncEnabled === false && (
+    <div className="mt-3 rounded-md border border-edge bg-inset px-3 py-2 text-xs text-fg-dim" role="note">
+      <span className="text-fg-2 font-medium">Sync is currently turned off.</span>{' '}
+      This project will start syncing once you turn on Sync in Settings.
+    </div>
+  );
+
+  if (step.kind === 'move') {
+    return (
+      <ImportProjectModal
+        sourcePath={step.path}
+        defaultName={step.baseName}
+        onClose={() => setStep({ kind: 'existing', path: step.path, baseName: step.baseName })}
+        onDone={(p) => onAdded(p)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Scrim layer={2} onClick={busy ? undefined : onClose} />
+      <OverlayPanel
+        layer={2}
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[26rem] max-w-[calc(100vw-2rem)] p-4"
+        role="dialog"
+        aria-modal
+        aria-labelledby="add-project-title"
+      >
+        {step.kind === 'choose' ? (
+          <>
+            <div id="add-project-title" className="text-sm font-medium text-fg">Add a project</div>
+
+            {/* Choice 1: start new (inline name + create) */}
+            <div className="mt-3 rounded-lg border border-edge p-3">
+              <div className="text-[13px] font-semibold text-fg">Start something new</div>
+              <div className="mt-0.5 text-xs text-fg-dim">Creates an empty project in YouCoded that syncs across your devices.</div>
+              <div className="mt-2 flex items-center gap-2">
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') void createNew(); }}
+                  placeholder="Project name…"
+                  className="flex-1 bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
+                />
+                <button
+                  onClick={() => void createNew()}
+                  disabled={busy || !name.trim()}
+                  className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50"
+                >
+                  {busy ? 'Creating…' : 'Create'}
+                </button>
+              </div>
+            </div>
+
+            {/* Choice 2: existing folder → step 2 */}
+            <button
+              onClick={() => void pickExisting()}
+              disabled={busy}
+              className="mt-2 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
+            >
+              <div className="text-[13px] font-semibold text-fg">Use a folder already on this computer</div>
+              <div className="mt-0.5 text-xs text-fg-dim">Pick any folder — you'll choose whether it syncs next.</div>
+            </button>
+
+            {error && <div className="mt-2 text-xs text-red-500" role="alert">{error}</div>}
+            {syncOffNote}
+            <div className="mt-4 flex justify-end">
+              <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div id="add-project-title" className="text-sm font-medium text-fg">How should “{step.baseName}” work?</div>
+
+            <button
+              onClick={() => void keepInPlace()}
+              disabled={busy}
+              className="mt-3 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
+            >
+              <div className="text-[13px] font-semibold text-fg">Keep it where it is</div>
+              <div className="mt-0.5 text-xs text-fg-dim">Only on this computer. The folder doesn't move and nothing changes.</div>
+            </button>
+
+            <button
+              onClick={() => setStep({ kind: 'move', path: step.path, baseName: step.baseName })}
+              disabled={busy}
+              className="mt-2 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
+            >
+              <div className="text-[13px] font-semibold text-fg">Move it into YouCoded so it syncs</div>
+              <div className="mt-0.5 text-xs text-fg-dim">The folder moves to ~/YouCoded/Projects/ and syncs across your devices. Anything pointing at the old location (shortcuts, open terminals) will need the new path.</div>
+            </button>
+
+            {error && <div className="mt-2 text-xs text-red-500" role="alert">{error}</div>}
+            {syncOffNote}
+            <div className="mt-4 flex justify-between">
+              <button onClick={() => { setError(null); setStep({ kind: 'choose' }); }} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Back</button>
+              <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
+            </div>
+          </>
+        )}
+      </OverlayPanel>
+    </>
+  );
+}

--- a/desktop/src/renderer/components/project-view/AddProjectModal.tsx
+++ b/desktop/src/renderer/components/project-view/AddProjectModal.tsx
@@ -74,7 +74,11 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
       const baseName = folder.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
       setError(null);
       setStep({ kind: 'existing', path: folder, baseName });
-    } catch { /* dialog unavailable (remote) — nothing to do */ }
+    } catch (err: any) {
+      // Cancel resolves to null (handled above), NOT a rejection — anything
+      // caught here is a genuine failure worth showing, not a user cancel.
+      if (!cancelledRef.current) setError(String(err?.message ?? err));
+    }
   }, []);
 
   const keepInPlace = useCallback(async () => {
@@ -130,6 +134,8 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
               <div className="text-[13px] font-semibold text-fg">Start something new</div>
               <div className="mt-0.5 text-xs text-fg-dim">Creates an empty project in YouCoded that syncs across your devices.</div>
               <div className="mt-2 flex items-center gap-2">
+                {/* No autoFocus (deliberate): the choose step presents two co-equal
+                    choices — auto-focusing would bias toward create-new and pre-arm Enter. */}
                 <input
                   value={name}
                   onChange={(e) => setName(e.target.value)}
@@ -177,7 +183,9 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
             </button>
 
             <button
-              onClick={() => setStep({ kind: 'move', path: step.path, baseName: step.baseName })}
+              // Clear any stale keep-in-place error so it doesn't reappear after
+              // Cancel-ing back from ImportProjectModal.
+              onClick={() => { setError(null); setStep({ kind: 'move', path: step.path, baseName: step.baseName }); }}
               disabled={busy}
               className="mt-2 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
             >

--- a/desktop/src/renderer/components/project-view/ProjectHero.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectHero.tsx
@@ -10,8 +10,10 @@
 // The project name is a clickable switcher trigger (opens <ProjectSwitcher>,
 // Task 2.3) and MUST NOT truncate — it wraps. The ONE accent use in this card is
 // the New Conversation primary button.
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { CentralIndexProject } from '../../../shared/artifacts/types';
+import { getPlatform } from '../../platform';
+import { type SyncDot } from '../sync-dot-state';
 
 // Live, computed-in-ProjectView stats (NOT the stale stats.artifactCount).
 interface HeroStats {
@@ -40,12 +42,26 @@ interface HeroRepo {
   name?: string;
 }
 
+// Per-project sync props, derived in ProjectView from syncSpaces.status().
+interface HeroSync {
+  dot: SyncDot;
+  spaceId: string | null;
+  lastSynced: string | null;
+  errorMessage: string | null;
+}
+
 interface ProjectHeroProps {
   project: CentralIndexProject;
   stats: HeroStats;
   repo: HeroRepo | null;
   onOpenSwitcher: () => void;
   onNewConversation: (cwd: string) => void;
+  sync: HeroSync | null;             // null → syncSpaces unavailable: render no sync line
+  onTurnOnSync: () => void;
+  onSyncNow: (spaceId: string) => void;
+  onRenamed: () => void;             // parent refreshes the list after a nickname rename
+  canRemove: boolean;                // false for synced projects (move-out is deferred)
+  onRemove: () => void;
 }
 
 // lucide-style chevron-down (matches prototype IC.chevDown).
@@ -79,8 +95,33 @@ export function ProjectHero({
   repo,
   onOpenSwitcher,
   onNewConversation,
+  sync,
+  onTurnOnSync,
+  onSyncNow,
+  onRenamed,
+  canRemove,
+  onRemove,
 }: ProjectHeroProps) {
   const showRepoSlug = !!(repo?.webUrl && repo.owner && repo.name);
+  const isElectron = getPlatform() === 'electron';
+
+  // Nickname rename — inline field on the actions row. Resets whenever the
+  // active project changes (keyed on path) so a half-typed name from the last
+  // project doesn't bleed into the next.
+  const [renaming, setRenaming] = useState(false);
+  const [nickname, setNickname] = useState(project.name);
+  useEffect(() => { setNickname(project.name); setRenaming(false); }, [project.path]);
+  const commitRename = async () => {
+    const n = nickname.trim();
+    setRenaming(false);
+    if (!n || n === project.name) return;
+    // Nickname only — NEVER the folder on disk. A folder rename would change the
+    // sync identity (the repo name is derived from the folder), which the spec
+    // defers. folders.rename updates the picker nickname, which
+    // buildSavedFolderProjects prefers for the display name.
+    await (window.claude as any).folders.rename(project.path, n).catch(() => {});
+    onRenamed();
+  };
 
   return (
     <div className="layer-surface p-5 flex items-start justify-between gap-4">
@@ -123,6 +164,59 @@ export function ProjectHero({
           )}
         </div>
 
+        {/* Sync status line (2026-07-09 spec §4). Plain words + the one action
+            that matters for the state. Hidden when syncSpaces is unavailable. */}
+        {sync && (
+          <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg bg-inset px-3 py-2">
+            {sync.dot.color === 'green' && (
+              <>
+                <span className="text-[13px] font-semibold text-[#44A05C]">Syncs across your devices</span>
+                {sync.lastSynced && <span className="text-xs text-fg-muted">Last synced {sync.lastSynced}</span>}
+                {sync.spaceId && (
+                  <button
+                    type="button"
+                    onClick={() => onSyncNow(sync.spaceId!)}
+                    className="px-2.5 py-1 rounded-md bg-panel border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors"
+                  >
+                    Sync now
+                  </button>
+                )}
+              </>
+            )}
+            {sync.dot.color === 'red' && (
+              <>
+                <span className="text-[13px] font-semibold text-[#DD4444]">Sync isn't working</span>
+                {sync.errorMessage && <span className="text-xs text-fg-dim">{sync.errorMessage}</span>}
+                {sync.spaceId && (
+                  <button
+                    type="button"
+                    onClick={() => onSyncNow(sync.spaceId!)}
+                    className="px-2.5 py-1 rounded-md bg-panel border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors"
+                  >
+                    Try again
+                  </button>
+                )}
+              </>
+            )}
+            {sync.dot.color === 'gray' && sync.spaceId && (
+              // Managed but global Sync is off — the honesty rule.
+              <span className="text-[13px] text-fg-dim">Sync is turned off — this project will sync once you turn it on in Settings</span>
+            )}
+            {sync.dot.color === 'gray' && !sync.spaceId && (
+              <>
+                <span className="text-[13px] font-semibold text-fg-2">Only on this computer</span>
+                <button
+                  type="button"
+                  onClick={onTurnOnSync}
+                  className="px-3 py-1 rounded-md bg-accent text-on-accent text-xs hover:opacity-90 transition-opacity"
+                >
+                  Turn on sync for this project
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
         {/* Stat row — dot-separated. */}
         <div className="flex flex-wrap gap-4 mt-3 text-xs text-fg-muted">
           <span><b className="text-fg-2 font-semibold">{stats.artifacts}</b> artifacts</span>
@@ -130,6 +224,41 @@ export function ProjectHero({
           <span><b className="text-fg-2 font-semibold">{stats.conversations}</b> conversations</span>
           <span><b className="text-fg-2 font-semibold">{stats.contextFiles}</b> context files</span>
           <span>active <b className="text-fg-2 font-semibold">{stats.activeLabel}</b></span>
+        </div>
+
+        {/* Management actions (spec §4). Rename = picker nickname only. Remove
+            hides for synced projects (move-out-of-sync is a deferred flow). */}
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {renaming ? (
+            <input
+              value={nickname}
+              autoFocus
+              onChange={(e) => setNickname(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void commitRename(); if (e.key === 'Escape') { setNickname(project.name); setRenaming(false); } }}
+              onBlur={() => void commitRename()}
+              className="bg-inset text-fg text-xs rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
+            />
+          ) : (
+            <button type="button" onClick={() => setRenaming(true)} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors">
+              Rename
+            </button>
+          )}
+          {isElectron && (
+            <button
+              type="button"
+              onClick={() => void (window.claude as any).shell.openPath(project.path)}
+              className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors"
+            >
+              Open in File Explorer
+            </button>
+          )}
+          {canRemove ? (
+            <button type="button" onClick={onRemove} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-[#DD4444] transition-colors">
+              Remove from YouCoded
+            </button>
+          ) : (
+            <span className="text-[11px] text-fg-faint">Managed by sync</span>
+          )}
         </div>
       </div>
 

--- a/desktop/src/renderer/components/project-view/ProjectSwitcher.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectSwitcher.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
 import type { CentralIndexProject } from '../../../shared/artifacts/types';
+import { syncDotFor, findSpaceFor, type SyncStatusData } from '../sync-dot-state';
 
 interface ProjectSwitcherProps {
   projects: CentralIndexProject[];
@@ -21,6 +22,9 @@ interface ProjectSwitcherProps {
   // parent). The palette is the project-list surface now that the rail is gone,
   // so the hover-revealed × delete lives on each row here.
   onDeleteProject?: (project: CentralIndexProject) => void;
+  // Per-project sync state (spec §4) — drives the row sync dots and hides the
+  // remove-× on synced rows. null → syncSpaces unavailable (no dots at all).
+  syncStatus?: SyncStatusData | null;
 }
 
 // Shared glyphs — see ./icons.tsx. (The check is the active-project indicator,
@@ -34,6 +38,7 @@ export function ProjectSwitcher({
   onClose,
   onAddProject,
   onDeleteProject,
+  syncStatus,
 }: ProjectSwitcherProps) {
   const [query, setQuery] = useState('');
   const [highlightIndex, setHighlightIndex] = useState(0);
@@ -201,6 +206,19 @@ export function ProjectSwitcher({
                       </span>
                     );
                   })()}
+                  {/* Sync dot (spec §4) — green synced / red errored / gray
+                      only-on-this-computer. Hidden entirely when syncStatus is
+                      null (Android). Tooltip carries the plain-words label. */}
+                  {(() => {
+                    const dot = syncDotFor(p.path, syncStatus ?? null);
+                    return dot ? (
+                      <span
+                        className={`w-2 h-2 rounded-full shrink-0 ml-1 ${dot.color === 'green' ? 'bg-[#44A05C]' : dot.color === 'red' ? 'bg-[#DD4444]' : 'bg-fg-faint'}`}
+                        title={dot.label}
+                        aria-label={dot.label}
+                      />
+                    ) : null;
+                  })()}
                   {/* Active check (NOT a status glyph). */}
                   {isActive && (
                     <span className="text-fg shrink-0 ml-1">
@@ -209,8 +227,10 @@ export function ProjectSwitcher({
                   )}
                 </button>
                 {/* Hover-revealed remove-from-YouCoded × (opens the confirm modal
-                    in the parent). Does not delete files. */}
-                {onDeleteProject && (
+                    in the parent). Does not delete files. Hidden for SYNCED rows —
+                    removing a folder that's managed by sync is a deferred
+                    move-out flow, not a simple un-list. */}
+                {onDeleteProject && !findSpaceFor(p.path, syncStatus ?? null) && (
                   <button
                     type="button"
                     className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-6 h-6 rounded-md inline-flex items-center justify-center text-fg-muted hover:text-fg hover:bg-well"

--- a/desktop/src/renderer/components/project-view/ProjectView.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectView.tsx
@@ -366,6 +366,34 @@ export function ProjectView(props: ProjectViewProps) {
     return () => { cancelled = true; };
   }, [state.projectViewOpen, refreshKey, countsKey, activeProject?.path]);
 
+  // Live refresh: "Sync now"/background syncs must update the hero line + dots
+  // live; the open-gated fetch alone goes stale (the red→green flip and "Last
+  // synced" would sit frozen until the next view-open). The sync engine
+  // broadcasts synced/error events on the syncspaces:event push channel —
+  // refetch status() on each, trailing-debounced 500ms to coalesce bursts (one
+  // sync can emit several events back-to-back). Cleanup drops BOTH the
+  // subscription and any pending timer so a late tick can't setState after
+  // close/unmount. catch → null, same convention as the fetch above.
+  useEffect(() => {
+    if (!state.projectViewOpen) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsubscribe = (window.claude as any).syncSpaces.onEvent(() => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        (window.claude as any).syncSpaces.status()
+          .then((s: SyncStatusData) => { if (!cancelled) setSyncStatus(s); })
+          .catch(() => { if (!cancelled) setSyncStatus(null); });
+      }, 500);
+    });
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      unsubscribe();
+    };
+  }, [state.projectViewOpen]);
+
   if (!state.projectViewOpen) return null;
 
   // Add a project = open the unified AddProjectModal (spec §3). It routes to
@@ -383,13 +411,21 @@ export function ProjectView(props: ProjectViewProps) {
   const handleAdded = async (path: string) => {
     setAddOpen(false);
     setTurnOnSyncFor(null);
-    const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
-    if (res?.ok) {
-      setProjects(res.projects);
-      const added = res.projects.find(
-        (p: CentralIndexProject) => p.path.replace(/\\/g, '/').toLowerCase() === path.replace(/\\/g, '/').toLowerCase()
-      );
-      if (added) setActiveProject(added);
+    // try/catch: the modals are already closed by the time this runs, so a
+    // listProjectsIndex rejection would otherwise float as an unhandled
+    // rejection with no UI to land in. Swallow it — the next natural refresh
+    // (view re-open / refreshKey bump) recovers the list.
+    try {
+      const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
+      if (res?.ok) {
+        setProjects(res.projects);
+        const added = res.projects.find(
+          (p: CentralIndexProject) => p.path.replace(/\\/g, '/').toLowerCase() === path.replace(/\\/g, '/').toLowerCase()
+        );
+        if (added) setActiveProject(added);
+      }
+    } catch (err) {
+      console.warn('post-add project list refresh failed', err);
     }
   };
 
@@ -494,11 +530,20 @@ export function ProjectView(props: ProjectViewProps) {
                 onTurnOnSync={() => setTurnOnSyncFor({ path: activeProject.path, name: activeProject.name })}
                 onSyncNow={(spaceId) => { void (window.claude as any).syncSpaces.syncNow(spaceId); }}
                 onRenamed={async () => {
-                  const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
-                  if (res?.ok) {
-                    setProjects(res.projects);
-                    const cur = res.projects.find((p: CentralIndexProject) => p.path === activeProject.path);
-                    if (cur) setActiveProject(cur);
+                  // try/catch + slash/case-normalized match — same conventions
+                  // as handleAdded (exact === path compare is a latent Windows
+                  // drive-case/slash footgun).
+                  try {
+                    const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
+                    if (res?.ok) {
+                      setProjects(res.projects);
+                      const cur = res.projects.find(
+                        (p: CentralIndexProject) => p.path.replace(/\\/g, '/').toLowerCase() === activeProject.path.replace(/\\/g, '/').toLowerCase()
+                      );
+                      if (cur) setActiveProject(cur);
+                    }
+                  } catch (err) {
+                    console.warn('post-rename project list refresh failed', err);
                   }
                 }}
                 canRemove={!heroSpace}

--- a/desktop/src/renderer/components/project-view/ProjectView.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectView.tsx
@@ -29,6 +29,9 @@ import { ContextTab } from './tabs/ContextTab';
 import { ConversationPreview } from './ConversationPreview';
 import { ProjectHero, formatFileCount } from './ProjectHero';
 import { ProjectSwitcher } from './ProjectSwitcher';
+import { syncDotFor, findSpaceFor, lastSyncedLabel, type SyncStatusData } from '../sync-dot-state';
+import AddProjectModal from './AddProjectModal';
+import ImportProjectModal from '../ImportProjectModal';
 import { FileFilterPopover } from './FileFilterPopover';
 import { HowContextWorksPopup } from './HowContextWorksPopup';
 import { ContextEditorOverlay } from './ContextEditorOverlay';
@@ -166,6 +169,13 @@ export function ProjectView(props: ProjectViewProps) {
   // Project deletion modal state.
   const [deletingProject, setDeletingProject] = useState<CentralIndexProject | null>(null);
   const [alsoDeleteSidecar, setAlsoDeleteSidecar] = useState(false);
+
+  // Per-project sync state (spec §4) — feeds the hero sync line + switcher dots.
+  const [syncStatus, setSyncStatus] = useState<SyncStatusData | null>(null);
+  // Unified "Add a project" modal (replaces the old direct folder-picker flow).
+  const [addOpen, setAddOpen] = useState(false);
+  // Turn-on-sync consent modal for the ACTIVE project (hero button).
+  const [turnOnSyncFor, setTurnOnSyncFor] = useState<{ path: string; name: string } | null>(null);
 
   // Context tab selection state. The ContextTab bubbles a clicked file (to edit)
   // or a clicked group's (i) info button (to explain the scope) up to here;
@@ -343,30 +353,44 @@ export function ProjectView(props: ProjectViewProps) {
     // context come back from the per-project cache on those refreshes (instant).
   }, [activeProject?.id, activeProject?.path, refreshKey, countsKey]);
 
+  // Per-project sync state for the hero + switcher dots. Refetched whenever the
+  // view opens, the project list refreshes (add/exclude), or the active project
+  // changes. catch → null (Android has no syncspaces handlers; the UI simply
+  // shows no sync affordances when status is unavailable).
+  useEffect(() => {
+    if (!state.projectViewOpen) return;
+    let cancelled = false;
+    (window.claude as any).syncSpaces.status()
+      .then((s: SyncStatusData) => { if (!cancelled) setSyncStatus(s); })
+      .catch(() => { if (!cancelled) setSyncStatus(null); });
+    return () => { cancelled = true; };
+  }, [state.projectViewOpen, refreshKey, countsKey, activeProject?.path]);
+
   if (!state.projectViewOpen) return null;
 
-  // Add a project = add a saved folder. The project list IS the saved-folders
-  // store (youcoded-folders.json) now, so a real add flow exists: browse for a
-  // folder → folders.add → refresh the list and select it. (An earlier v1
-  // comment said no register flow existed — that predated the saved-folders
-  // refactor.)
-  const handleAddProject = async () => {
+  // Add a project = open the unified AddProjectModal (spec §3). It routes to
+  // create-new / keep-in-place / move+sync itself — this just opens it (and
+  // closes the switcher so the two overlays don't stack).
+  const handleAddProject = () => {
     setSwitcherOpen(false);
-    try {
-      const folder: string | null = await (window.claude as any).dialog.openFolder();
-      if (!folder) return;
-      await (window.claude as any).folders.add(folder);
-      const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
-      if (res?.ok) {
-        setProjects(res.projects);
-        // Select the newly-added folder (match by path suffix-insensitively via
-        // the canonical path the index builder stores).
-        const added = res.projects.find(
-          (p: CentralIndexProject) => p.path.replace(/\\/g, '/').toLowerCase() === folder.replace(/\\/g, '/').toLowerCase()
-        );
-        if (added) setActiveProject(added);
-      }
-    } catch { /* dialog unavailable (remote/Android) — leave the list as-is */ }
+    setAddOpen(true);
+  };
+
+  // Shared post-add handler for EVERY successful add path (create / keep /
+  // move+sync) AND the hero's turn-on-sync flow: refresh the project list and
+  // select the project at its (possibly new) path. Match by PATH — a synth
+  // project's id is its path until it gains a central-index entry.
+  const handleAdded = async (path: string) => {
+    setAddOpen(false);
+    setTurnOnSyncFor(null);
+    const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
+    if (res?.ok) {
+      setProjects(res.projects);
+      const added = res.projects.find(
+        (p: CentralIndexProject) => p.path.replace(/\\/g, '/').toLowerCase() === path.replace(/\\/g, '/').toLowerCase()
+      );
+      if (added) setActiveProject(added);
+    }
   };
 
   const confirmDelete = async () => {
@@ -414,6 +438,24 @@ export function ProjectView(props: ProjectViewProps) {
     { id: 'context', label: 'Context', icon: <DocIcon />, count: String(heroStats.contextFiles) },
   ];
 
+  // Per-active-project sync props for the hero. `dot` is null when syncStatus is
+  // unavailable (Android / status() rejected) → hero renders no sync line. The
+  // error message is the latest 'error' engine event for this space (friendly-
+  // error contract), surfaced only in the red state.
+  const heroDot = activeProject ? syncDotFor(activeProject.path, syncStatus) : null;
+  const heroSpace = activeProject ? findSpaceFor(activeProject.path, syncStatus) : null;
+  const heroSync = heroDot
+    ? {
+        dot: heroDot,
+        spaceId: heroSpace?.id ?? null,
+        lastSynced: heroSpace ? lastSyncedLabel(heroSpace.id, syncStatus) : null,
+        errorMessage: heroDot.color === 'red'
+          ? [...(syncStatus?.recentEvents ?? [])].reverse()
+              .find((e) => e.spaceId === heroSpace?.id && e.type === 'error')?.message ?? null
+          : null,
+      }
+    : null;
+
   return (
     <div className="fixed inset-0 bg-canvas z-[8000] flex flex-col">
       {/* Header: title + global search + Esc·Close */}
@@ -448,6 +490,19 @@ export function ProjectView(props: ProjectViewProps) {
                 repo={heroRepo}
                 onOpenSwitcher={() => setSwitcherOpen(true)}
                 onNewConversation={props.onNewConversation}
+                sync={heroSync}
+                onTurnOnSync={() => setTurnOnSyncFor({ path: activeProject.path, name: activeProject.name })}
+                onSyncNow={(spaceId) => { void (window.claude as any).syncSpaces.syncNow(spaceId); }}
+                onRenamed={async () => {
+                  const res = await (window.claude as any).artifacts.listProjectsIndex({ withCounts: true });
+                  if (res?.ok) {
+                    setProjects(res.projects);
+                    const cur = res.projects.find((p: CentralIndexProject) => p.path === activeProject.path);
+                    if (cur) setActiveProject(cur);
+                  }
+                }}
+                canRemove={!heroSpace}
+                onRemove={() => setDeletingProject(activeProject)}
               />
             ) : (
               <div className="text-sm text-fg-muted">Select a project to view its artifacts.</div>
@@ -644,6 +699,7 @@ export function ProjectView(props: ProjectViewProps) {
           onClose={() => setSwitcherOpen(false)}
           onAddProject={handleAddProject}
           onDeleteProject={(p) => setDeletingProject(p)}
+          syncStatus={syncStatus}
         />
       )}
 
@@ -696,6 +752,22 @@ export function ProjectView(props: ProjectViewProps) {
             </div>
           </OverlayPanel>
         </>
+      )}
+
+      {/* Unified add-project flow (spec §3). Routes create-new / keep-in-place /
+          move+sync itself; handleAdded refreshes + selects on any success. */}
+      {addOpen && (
+        <AddProjectModal onClose={() => setAddOpen(false)} onAdded={(p) => void handleAdded(p)} />
+      )}
+      {/* Turn-on-sync for the ACTIVE project (hero button) — the consent+move
+          modal, seeded with the project's current path + name. */}
+      {turnOnSyncFor && (
+        <ImportProjectModal
+          sourcePath={turnOnSyncFor.path}
+          defaultName={turnOnSyncFor.name}
+          onClose={() => setTurnOnSyncFor(null)}
+          onDone={(p) => void handleAdded(p)}
+        />
       )}
     </div>
   );

--- a/desktop/src/renderer/components/sync-dot-state.ts
+++ b/desktop/src/renderer/components/sync-dot-state.ts
@@ -1,0 +1,62 @@
+// desktop/src/renderer/components/sync-dot-state.ts
+// Pure derivation of per-project sync state from syncSpaces.status() data.
+// Renderer-safe (no fs/path — this file also ships to the Android WebView).
+// The three dot states and their exact wording are pinned by the 2026-07-09
+// project-sync-management-ux spec; the picker shows the dot, the tooltip and
+// the Project View hero show these words.
+
+export interface SyncStatusData {
+  enabled: boolean;
+  spaces: Array<{ id: string; root: string }>;
+  // Engine events since app boot (last 50). `at` is stamped at broadcast time
+  // (ms epoch); older payloads may lack it.
+  recentEvents: Array<{ type: string; spaceId: string; at?: number; message?: string }>;
+}
+
+export interface SyncDot { color: 'green' | 'red' | 'gray'; label: string }
+
+// Windows-tolerant normalize: forward slashes, no trailing slash, lowercased.
+// (canonicalize() lives in shared/artifacts but drags in more than we need
+// here; root-vs-root equality only needs slash/case folding.)
+const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+
+export function findSpaceFor(folderPath: string, status: SyncStatusData | null): { id: string; root: string } | null {
+  if (!status) return null;
+  return status.spaces.find((s) => norm(s.root) === norm(folderPath)) ?? null;
+}
+
+function latestEventFor(spaceId: string, status: SyncStatusData) {
+  for (let i = status.recentEvents.length - 1; i >= 0; i--) {
+    if (status.recentEvents[i].spaceId === spaceId) return status.recentEvents[i];
+  }
+  return null;
+}
+
+export function syncDotFor(folderPath: string, status: SyncStatusData | null): SyncDot | null {
+  if (!status) return null; // status() rejected (e.g. Android) — render no dot at all
+  const space = findSpaceFor(folderPath, status);
+  if (!space) return { color: 'gray', label: 'Only on this computer' };
+  if (!status.enabled) return { color: 'gray', label: 'Sync is turned off — will sync once you turn on Sync in Settings' };
+  const last = latestEventFor(space.id, status);
+  if (last?.type === 'error') return { color: 'red', label: "Sync isn't working — open Manage projects" };
+  return { color: 'green', label: 'Syncs across your devices' };
+}
+
+/** "just now" / "N minutes ago" / "N hours ago" / null when unknown.
+ *  `now` is injectable for tests. */
+export function lastSyncedLabel(spaceId: string, status: SyncStatusData | null, now: number = Date.now()): string | null {
+  if (!status) return null;
+  let latest: number | null = null;
+  for (const e of status.recentEvents) {
+    if (e.spaceId === spaceId && e.type === 'synced' && typeof e.at === 'number') {
+      if (latest === null || e.at > latest) latest = e.at;
+    }
+  }
+  if (latest === null) return null;
+  const mins = Math.floor((now - latest) / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins === 1) return '1 minute ago';
+  if (mins < 60) return `${mins} minutes ago`;
+  const hours = Math.floor(mins / 60);
+  return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
+}

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -254,7 +254,8 @@ declare global {
       syncSpaces?: {
         status: () => Promise<any>;
         enable: (enabled: boolean) => Promise<any>;
-        syncNow: () => Promise<{ ok: boolean }>;
+        // Optional spaceId narrows to one space (Project View "Sync now"); omit for all.
+        syncNow: (spaceId?: string) => Promise<{ ok: boolean }>;
         createProject: (name: string) => Promise<{ ok: true; path: string } | { ok: false; error: string }>;
         onEvent: (cb: (e: unknown) => void) => () => void;
       };

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1067,7 +1067,8 @@ export function installShim(): void {
     syncSpaces: {
       status: () => invoke('syncspaces:status'),
       enable: (enabled: boolean) => invoke('syncspaces:enable', { enabled }),
-      syncNow: () => invoke('syncspaces:sync-now'),
+      // Optional spaceId narrows to one space (Project View "Sync now"); omit for all.
+      syncNow: (spaceId?: string) => invoke('syncspaces:sync-now', { spaceId }),
       createProject: (name: string) => invoke('syncspaces:create-project', { name }),
       // Spec §3 import: move an existing folder into ~/YouCoded/Projects/<name>.
       // Shim wraps args in an object (the established convention).

--- a/desktop/tests/sync-dot-state.test.ts
+++ b/desktop/tests/sync-dot-state.test.ts
@@ -1,0 +1,76 @@
+// desktop/tests/sync-dot-state.test.ts
+import { describe, it, expect } from 'vitest';
+import { syncDotFor, findSpaceFor, lastSyncedLabel, type SyncStatusData } from '../src/renderer/components/sync-dot-state';
+
+const status = (over: Partial<SyncStatusData> = {}): SyncStatusData => ({
+  enabled: true,
+  spaces: [
+    { id: 'personal', root: 'C:\\Users\\x\\YouCoded\\Personal' },
+    { id: 'project:budget-app', root: 'C:\\Users\\x\\YouCoded\\Projects\\budget-app' },
+  ],
+  recentEvents: [],
+  ...over,
+});
+
+describe('findSpaceFor', () => {
+  it('matches a folder to its space by normalized root (slashes + case)', () => {
+    expect(findSpaceFor('c:/users/x/youcoded/projects/budget-app/', status())?.id).toBe('project:budget-app');
+  });
+  it('returns null for a folder with no space', () => {
+    expect(findSpaceFor('C:\\Users\\x\\elsewhere', status())).toBeNull();
+  });
+});
+
+describe('syncDotFor', () => {
+  it('returns null when status is unavailable (no dot rendered)', () => {
+    expect(syncDotFor('C:\\anything', null)).toBeNull();
+  });
+  it('gray "Only on this computer" for unmanaged folders', () => {
+    expect(syncDotFor('C:\\Users\\x\\elsewhere', status())).toEqual({ color: 'gray', label: 'Only on this computer' });
+  });
+  it('gray with the sync-off wording for managed folders while Sync is off', () => {
+    const d = syncDotFor('C:\\Users\\x\\YouCoded\\Projects\\budget-app', status({ enabled: false }));
+    expect(d?.color).toBe('gray');
+    expect(d?.label).toMatch(/turn on Sync in Settings/);
+  });
+  it('red when the space\'s LATEST event is an error', () => {
+    const d = syncDotFor('C:\\Users\\x\\YouCoded\\Projects\\budget-app', status({
+      recentEvents: [
+        { type: 'synced', spaceId: 'project:budget-app' },
+        { type: 'error', spaceId: 'project:budget-app' },
+      ],
+    }));
+    expect(d).toEqual({ color: 'red', label: "Sync isn't working — open Manage projects" });
+  });
+  it('green when a later synced event supersedes an earlier error', () => {
+    const d = syncDotFor('C:\\Users\\x\\YouCoded\\Projects\\budget-app', status({
+      recentEvents: [
+        { type: 'error', spaceId: 'project:budget-app' },
+        { type: 'synced', spaceId: 'project:budget-app' },
+      ],
+    }));
+    expect(d).toEqual({ color: 'green', label: 'Syncs across your devices' });
+  });
+  it('ignores other spaces\' events', () => {
+    const d = syncDotFor('C:\\Users\\x\\YouCoded\\Projects\\budget-app', status({
+      recentEvents: [{ type: 'error', spaceId: 'project:other' }],
+    }));
+    expect(d?.color).toBe('green');
+  });
+});
+
+describe('lastSyncedLabel', () => {
+  const NOW = 1_800_000_000_000;
+  it('formats the latest synced event\'s timestamp relatively', () => {
+    const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app', at: NOW - 2 * 60_000 }] });
+    expect(lastSyncedLabel('project:budget-app', s, NOW)).toBe('2 minutes ago');
+  });
+  it('returns null when no synced event carries a timestamp', () => {
+    const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app' }] });
+    expect(lastSyncedLabel('project:budget-app', s, NOW)).toBeNull();
+  });
+  it('says "just now" under a minute', () => {
+    const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app', at: NOW - 5_000 }] });
+    expect(lastSyncedLabel('project:budget-app', s, NOW)).toBe('just now');
+  });
+});

--- a/desktop/tests/sync-dot-state.test.ts
+++ b/desktop/tests/sync-dot-state.test.ts
@@ -73,4 +73,16 @@ describe('lastSyncedLabel', () => {
     const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app', at: NOW - 5_000 }] });
     expect(lastSyncedLabel('project:budget-app', s, NOW)).toBe('just now');
   });
+  it('uses the singular "1 minute ago" at exactly one minute', () => {
+    const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app', at: NOW - 60_000 }] });
+    expect(lastSyncedLabel('project:budget-app', s, NOW)).toBe('1 minute ago');
+  });
+  it('uses the singular "1 hour ago" at exactly one hour', () => {
+    const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app', at: NOW - 60 * 60_000 }] });
+    expect(lastSyncedLabel('project:budget-app', s, NOW)).toBe('1 hour ago');
+  });
+  it('pluralizes hours ("3 hours ago")', () => {
+    const s = status({ recentEvents: [{ type: 'synced', spaceId: 'project:budget-app', at: NOW - 3 * 60 * 60_000 }] });
+    expect(lastSyncedLabel('project:budget-app', s, NOW)).toBe('3 hours ago');
+  });
 });

--- a/desktop/tests/sync-spaces-service.test.ts
+++ b/desktop/tests/sync-spaces-service.test.ts
@@ -11,18 +11,36 @@ const h = vi.hoisted(() => {
   class FakeEngine {
     stopped = false;
     added: string[] = [];
+    // syncSpace is a spy so the per-space / sync-everything tests can assert
+    // which spaces were reconciled.
+    syncSpace = vi.fn(async (_space: { id: string }): Promise<void> => {});
     // Test releases this to let a blocked addSpace proceed — simulates the
     // real engine suspending on chokidar's ready await mid-startEngine.
     releaseAddSpace: (() => void) | null = null;
-    constructor() { h.engines.push(this); }
+    // Capture the onEvent callback (service.broadcast) so a test can fire an
+    // engine event the way the real engine would, and assert on the stamp.
+    constructor(_transport?: unknown, opts?: { onEvent?: (e: unknown) => void }) {
+      h.onEvent = opts?.onEvent ?? null;
+      h.engines.push(this);
+    }
     async addSpace(space: { id: string }): Promise<void> {
+      // The timestamp/per-space tests want enable() to resolve without manual
+      // gating; the serialization tests keep the blocking gate (autoAddSpace off).
+      if (h.autoAddSpace) { this.added.push(space.id); return; }
       await new Promise<void>((res) => { this.releaseAddSpace = res; });
       this.added.push(space.id);
     }
-    async syncSpace(): Promise<void> {}
     async stop(): Promise<void> { this.stopped = true; }
   }
-  return { engines: [] as InstanceType<typeof FakeEngine>[], FakeEngine };
+  return {
+    engines: [] as InstanceType<typeof FakeEngine>[],
+    FakeEngine,
+    // Default single space keeps the existing serialization tests unchanged;
+    // the per-space tests widen this to two projects.
+    spaces: [{ id: 'personal', kind: 'personal', root: '/fake/personal' }] as Array<{ id: string; kind: string; root: string }>,
+    autoAddSpace: false,
+    onEvent: null as null | ((e: unknown) => void),
+  };
 });
 
 vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
@@ -31,9 +49,8 @@ vi.mock('../src/main/sync-spaces/managed-roots', () => ({
   ManagedRoots: class {
     ensure(): void {}
     listProjects(): Array<{ name: string; path: string }> { return []; }
-    spaces(): Array<{ id: string; kind: string; root: string }> {
-      return [{ id: 'personal', kind: 'personal', root: '/fake/personal' }];
-    }
+    // Reads the hoisted list live so a test can widen the space set before enable.
+    spaces(): Array<{ id: string; kind: string; root: string }> { return h.spaces; }
   },
 }));
 vi.mock('../src/main/sync-spaces/space-manager', () => ({
@@ -74,7 +91,14 @@ async function waitForGate(index: number): Promise<void> {
 }
 
 describe('sync-spaces service transition serialization', () => {
-  beforeEach(() => { h.engines.length = 0; });
+  beforeEach(() => {
+    h.engines.length = 0;
+    // Reset per-test knobs so the serialization tests keep the default single
+    // space + blocking addSpace gate they were written against.
+    h.spaces = [{ id: 'personal', kind: 'personal', root: '/fake/personal' }];
+    h.autoAddSpace = false;
+    h.onEvent = null;
+  });
 
   it('disable issued mid-start waits for the start, then stops that engine (no interleave)', async () => {
     const svc = await freshService();
@@ -111,5 +135,48 @@ describe('sync-spaces service transition serialization', () => {
     expect(h.engines[1].stopped).toBe(false);
     expect(h.engines[1].added).toEqual(['personal']);
     expect((await svc.syncSpacesStatus()).enabled).toBe(true);
+  });
+
+  // ---- Per-space sync-now + event timestamps (Project View UX, Task 2) ----
+
+  // These use autoAddSpace so enable() resolves without manual gating, and a
+  // two-project space set so "sync one" vs "sync everything" are distinguishable.
+  async function enabledMultiSpaceService() {
+    h.autoAddSpace = true;
+    h.spaces = [
+      { id: 'personal', kind: 'personal', root: '/fake/personal' },
+      { id: 'project:alpha', kind: 'project', root: '/fake/alpha' },
+      { id: 'project:beta', kind: 'project', root: '/fake/beta' },
+    ];
+    const svc = await freshService();
+    await svc.syncSpacesEnable(true);
+    return svc;
+  }
+
+  it('syncSpacesSyncNow(spaceId) syncs ONLY the matching space', async () => {
+    const svc = await enabledMultiSpaceService();
+    const engine = h.engines[0];
+    engine.syncSpace.mockClear(); // drop the initial-reconcile calls from enable
+    await svc.syncSpacesSyncNow('project:beta');
+    expect(engine.syncSpace).toHaveBeenCalledTimes(1);
+    expect(engine.syncSpace.mock.calls[0][0].id).toBe('project:beta');
+  });
+
+  it('syncSpacesSyncNow() with no arg still syncs every space', async () => {
+    const svc = await enabledMultiSpaceService();
+    const engine = h.engines[0];
+    engine.syncSpace.mockClear();
+    await svc.syncSpacesSyncNow();
+    expect(engine.syncSpace.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('broadcast stamps events with an `at` timestamp', async () => {
+    const svc = await enabledMultiSpaceService();
+    // Fire the engine's onEvent hook (= service.broadcast) the way the real
+    // engine would when a space finishes syncing.
+    h.onEvent!({ type: 'synced', spaceId: 'project:beta', pushed: true, updated: false });
+    const st = await svc.syncSpacesStatus();
+    const e = st.recentEvents.find((x: any) => x.spaceId === 'project:beta');
+    expect(typeof (e as any).at).toBe('number');
   });
 });


### PR DESCRIPTION
## What this is

Implements the approved spec [`docs/superpowers/specs/2026-07-09-project-sync-management-ux-design.md`](https://github.com/itsdestin/youcoded-dev) (workspace repo). The session picker's three confusing add-a-thing actions are gone; Project View becomes the management hub; sync state is visible everywhere as plain words or a colored dot.

## The three surfaces

**1. Session picker (FolderSwitcher — rewritten)**
- Rows keep nickname/path/rename/remove, and gain a sync dot (green = syncs across your devices, red = sync isn't working, gray = only on this computer / sync turned off). Tooltip carries the full phrase.
- Single footer entry: **Manage projects…** → opens Project View. No add/create/import actions in the picker (spec decision 3).
- Dropdown is now **portaled to document.body** (fixed positioning, z-9001) — includes the live-session clipping hotfix that was uncommitted in the main checkout; that working-tree change is subsumed here.
- Buddy window (no Project View there): the footer falls back to a minimal "Browse for folder…" instead. If the buddy window ever gains Project View, delete that fallback rather than keeping a second add path.

**2. Add a project (new AddProjectModal, Project View)**
- Step 1: "Start something new" (creates a synced project) or "Use a folder already on this computer".
- Step 2 (existing folder): "Keep it where it is" vs "Move it into YouCoded so it syncs" (delegates to ImportProjectModal).
- Honesty rule: when global Sync is off, an inline note says the project will start syncing once Sync is turned on (also added to ImportProjectModal, which the hero reaches directly).

**3. Project View management hub**
- Hero sync line with four states: synced (+ Last synced X ago + Sync now), sync error (+ friendly message + Try again), managed-but-Sync-off, unmanaged (+ Turn on sync for this project).
- Management actions: Rename (picker nickname only — never the folder on disk), Open in File Explorer (Electron-gated), Remove from YouCoded (unsynced only; synced shows "Managed by sync" — move-out-of-sync is a deferred flow).
- ProjectSwitcher rows carry the same dots; remove-× hidden for synced rows.
- Live updates: ProjectView subscribes to `syncspaces:event` and refreshes status (debounced), so Sync now visibly lands.

## Backend (small)

- `SpaceSyncEvent` gains an optional `at` timestamp stamped in `broadcast()` — sole source for "Last synced" (no persistence).
- `syncspaces:sync-now` accepts an optional `spaceId` across all parity surfaces (service / ipc-handlers / preload / remote-shim / remote-server). No-arg behavior unchanged (SyncPanel). Android untouched by design.

## Verification

- Full suite: 1426 passed / 34 skipped; `tsc --noEmit` clean; `npm run build` clean.
- New unit tests: `sync-dot-state.test.ts` (14 — labels + supersession + relative time), 3 new service tests (per-space sync-now, timestamp stamping).
- Copy rules verified byte-exact (two sync phrases, honesty wording ×3, no status glyphs).
- Built via subagent-driven development: every task passed an independent spec-compliance review and code-quality review; whole-branch final review approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)