### PR TITLE
Provider seam (platform Phase 0): native runtime seam + Gemini removal

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -50,7 +50,7 @@ The Chat View timeline is built from four event sources:
 - **Never use `process.env`** in renderer code — it doesn't exist in the browser. Use `import.meta.env` with `VITE_` prefixed vars if you need build-time env injection, but note the tsconfig uses `module: "commonjs"` so `import.meta` will fail `tsc`. Prefer constants or IPC for config the renderer needs.
 - **Never use `require()`** in renderer code — use ES `import` only.
 - **`node-pty`** cannot load in Electron's main process (ABI mismatch). It runs in a separate `node` child process via `pty-worker.js`. The worker's `case 'input'` handler implements Windows-ConPTY-aware submit logic — passthrough for non-CR writes, atomic single-write when `body + \r` ≤ 56 bytes (`SAFE_ATOMIC_LEN`, with an 8-byte margin under the empirically-measured 64-byte ConPTY paste threshold), and **echo-driven submit** for longer text (chunk the body in ≤56-byte pieces, wait for CC's stdout echo, then write a bare `\r`). See `docs/PITFALLS.md` → "PTY Writes" before changing how input is written. Android's `PtyBridge.writeInput` still uses a 600 ms gap because Linux PTY doesn't have ConPTY's gap-collapse issue.
-- **Preload** is sandboxed — no `require()`, no relative imports, no `process.env`. IPC channel names are inlined as string literals.
+- **Preload** is sandboxed — no `require()` of app modules, no relative imports. IPC channel names are inlined as string literals. Electron's polyfilled `process` IS available (including `process.env` — verified empirically 2026-07-10 against the built preload in a sandboxed window; `window.claude.native.supported` reads `YOUCODED_NATIVE` this way).
 
 ## Dev Commands
 

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -717,7 +717,6 @@ export function registerIpcHandlers(
     skipPermissions: false,
     model: 'sonnet',
     projectFolder: '',
-    geminiEnabled: false, // Opt-in: show Gemini CLI option in new session form
     permissionOverrides: { ...PERMISSION_OVERRIDES_DEFAULT },
   };
 

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -950,9 +950,10 @@ contextBridge.exposeInMainWorld('claude', {
   app: {
     restart: (): Promise<void> => ipcRenderer.invoke(IPC.APP_RESTART),
   },
-  // Native runtime (YouCoded first-party harness — platform roadmap Phase 1+).
-  // Hard-false until Phase 1 ships the local engine + harness. Dev builds can
-  // force the dormant UI with YOUCODED_NATIVE=1 (run-dev.sh environment).
+  // Native runtime — the Phase 0 seam for YouCoded's first-party harness
+  // (ships in platform roadmap Phase 1). Hard-false until then. To preview the
+  // dormant UI in dev, prefix the launch: YOUCODED_NATIVE=1 bash scripts/run-dev.sh
+  // (run-dev.sh does not set this var itself — it must come from your shell).
   native: {
     supported: process.env.YOUCODED_NATIVE === '1',
   },

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -950,6 +950,12 @@ contextBridge.exposeInMainWorld('claude', {
   app: {
     restart: (): Promise<void> => ipcRenderer.invoke(IPC.APP_RESTART),
   },
+  // Native runtime (YouCoded first-party harness — platform roadmap Phase 1+).
+  // Hard-false until Phase 1 ships the local engine + harness. Dev builds can
+  // force the dormant UI with YOUCODED_NATIVE=1 (run-dev.sh environment).
+  native: {
+    supported: process.env.YOUCODED_NATIVE === '1',
+  },
   // System namespace — platform integrations like hardware back button.
   // Desktop no-op stub: notifyStackState / onBack are only meaningful on
   // Android, where MainActivity uses them to enable/disable

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -279,7 +279,7 @@ const IPC = {
 
 contextBridge.exposeInMainWorld('claude', {
   session: {
-    create: (opts: { name: string; cwd: string; skipPermissions: boolean; cols?: number; rows?: number; resumeSessionId?: string; provider?: 'claude' | 'gemini'; model?: string }) =>
+    create: (opts: { name: string; cwd: string; skipPermissions: boolean; cols?: number; rows?: number; resumeSessionId?: string; provider?: 'claude' | 'native'; model?: string }) =>
       ipcRenderer.invoke(IPC.SESSION_CREATE, opts),
     destroy: (sessionId: string) =>
       ipcRenderer.invoke(IPC.SESSION_DESTROY, sessionId),

--- a/desktop/src/main/session-manager.ts
+++ b/desktop/src/main/session-manager.ts
@@ -47,20 +47,23 @@ export class SessionManager extends EventEmitter {
     // Resolve CWD: fall back to home directory if empty or nonexistent
     const resolvedCwd = (opts.cwd && fs.existsSync(opts.cwd)) ? opts.cwd : os.homedir();
 
-    // Build CLI args — Gemini CLI has no equivalent for Claude's flags
-    const args: string[] = [];
-    if (provider === 'claude') {
-      if (opts.skipPermissions) {
-        args.push('--dangerously-skip-permissions');
-      }
-      if (opts.resumeSessionId) {
-        args.push('--resume', opts.resumeSessionId);
-      }
-      if (opts.model) {
-        args.push('--model', opts.model);
-      }
+    // Build Claude CLI args. The 'native' provider (platform roadmap Phase 1+)
+    // never reaches this PTY path — SessionManager will branch before the
+    // worker spawn once the native harness exists. Guarded here so a stray
+    // native create fails loudly instead of spawning a broken PTY.
+    if (provider !== 'claude') {
+      throw new Error(`SessionManager: provider '${provider}' has no runtime yet (Phase 1)`);
     }
-    // Gemini CLI launches with no special args for now
+    const args: string[] = [];
+    if (opts.skipPermissions) {
+      args.push('--dangerously-skip-permissions');
+    }
+    if (opts.resumeSessionId) {
+      args.push('--resume', opts.resumeSessionId);
+    }
+    if (opts.model) {
+      args.push('--model', opts.model);
+    }
 
     // Spawn a separate Node.js process for node-pty so it uses Node's
     // native binary instead of Electron's (which requires electron-rebuild).
@@ -152,14 +155,14 @@ export class SessionManager extends EventEmitter {
     try {
       worker.send({
         type: 'spawn',
-        command: provider === 'gemini' ? 'gemini' : 'claude',
+        command: 'claude',
         args,
         cwd: resolvedCwd,
         cols: opts.cols || 80,
         rows: opts.rows || 24,
-        // Claude-specific: session ID + pipe name for hook event correlation
-        sessionId: provider === 'claude' ? id : '',
-        pipeName: provider === 'claude' ? this.pipeName : '',
+        // Session ID + pipe name for hook event correlation
+        sessionId: id,
+        pipeName: this.pipeName,
       });
     } catch {
       // The 'error' handler above will clean up the session asynchronously.

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -317,7 +317,7 @@ function AppInner() {
     }).catch(() => {});
   }, []);
 
-  const [sessionDefaults, setSessionDefaults] = useState({ skipPermissions: false, model: 'sonnet', projectFolder: '', geminiEnabled: false });
+  const [sessionDefaults, setSessionDefaults] = useState({ skipPermissions: false, model: 'sonnet', projectFolder: '' });
 
   // Check first-run state with a 3-second safety timeout — never hang the app
   useEffect(() => {
@@ -679,8 +679,10 @@ function AppInner() {
         setSessionId(info.id);
         return [...prev, info];
       });
-      // Gemini sessions are terminal-only (no transcript watcher), so default to terminal view
-      const defaultView = (info.provider && info.provider !== 'claude') ? 'terminal' : 'chat';
+      // Native harness sessions (roadmap Phase 1+) are chat-first — they have
+      // no PTY, so 'terminal' would be an empty pane. Claude sessions also
+      // default to chat. (Gemini, the old terminal-only provider, is gone.)
+      const defaultView = 'chat';
       setViewModes((prev) => prev.has(info.id) ? prev : new Map(prev).set(info.id, defaultView));
       setPermissionModes((prev) => prev.has(info.id) ? prev : new Map(prev).set(info.id, info.permissionMode || 'normal'));
       setSessionModels((prev) => {
@@ -689,7 +691,7 @@ function AppInner() {
         const alias = MODELS.find((m) => info.model?.includes(m.replace(/\[.*\]/, ''))) ?? 'sonnet';
         return new Map(prev).set(info.id, alias);
       });
-      // Non-Claude providers (e.g. Gemini) don't emit hook events, so they'd
+      // Native harness sessions (roadmap Phase 1+) have no hook relay, so they'd
       // never trigger the "first hook = initialized" gate. Mark them ready immediately.
       if (info.provider && info.provider !== 'claude') {
         setInitializedSessions((prev) => {
@@ -1307,7 +1309,10 @@ function AppInner() {
         return [...prev, sessionInfo];
       });
       dispatch({ type: 'SESSION_INIT', sessionId: sid });
-      const defaultView = (sessionInfo.provider && sessionInfo.provider !== 'claude') ? 'terminal' : 'chat';
+      // Native harness sessions (roadmap Phase 1+) are chat-first — they have
+      // no PTY, so 'terminal' would be an empty pane. Claude sessions also
+      // default to chat. (Gemini, the old terminal-only provider, is gone.)
+      const defaultView = 'chat';
       setViewModes((prev) => prev.has(sid) ? prev : new Map(prev).set(sid, defaultView));
       setPermissionModes((prev) => prev.has(sid) ? prev : new Map(prev).set(sid, sessionInfo.permissionMode || 'normal'));
       // Transferred sessions were already initialized on the source — skip the
@@ -1769,11 +1774,11 @@ function AppInner() {
     [sessionId, dispatch, viewModes, getUsageSnapshot, guardedPtySend],
   );
 
-  const createSession = useCallback(async (cwd: string, dangerous: boolean, sessionModel?: string, provider?: 'claude' | 'gemini', launchInNewWindow?: boolean) => {
+  const createSession = useCallback(async (cwd: string, dangerous: boolean, sessionModel?: string, provider?: 'claude' | 'native', launchInNewWindow?: boolean) => {
     // Use the explicitly chosen model; fall back to the current session's model
     const m = sessionModel || currentModel;
     const info = await (window.claude.session.create as any)({
-      name: provider === 'gemini' ? 'Gemini Session' : 'New Session',
+      name: 'New Session',
       cwd,
       skipPermissions: dangerous,
       model: m,
@@ -2255,7 +2260,6 @@ function AppInner() {
                 defaultModel={sessionDefaults.model}
                 defaultSkipPermissions={sessionDefaults.skipPermissions}
                 defaultProjectFolder={sessionDefaults.projectFolder}
-                geminiEnabled={sessionDefaults.geminiEnabled}
                 windowDirectory={windowDirectory}
                 myWindowId={myWindowId}
               />

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2251,8 +2251,6 @@ function AppInner() {
                 onToggleGamePanel={() => gameDispatch({ type: 'TOGGLE_PANEL' })}
                 gameConnected={gameState.connected}
                 challengePending={gameState.challengeFrom !== null}
-                permissionMode={currentPermissionMode}
-                onCyclePermission={cyclePermission}
                 settingsOpen={settingsOpen}
                 onToggleSettings={() => setSettingsOpen(prev => !prev)}
                 settingsBadge={settingsBadge}

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -872,14 +872,27 @@ function AppInner() {
             agentId: event.data.agentId,
           });
           break;
-        case 'assistant-thinking':
-          // Extended-thinking heartbeat — bumps lastActivityAt and clears
-          // any stale attention banner. No timeline change.
-          batchTranscriptDispatch({
-            type: 'TRANSCRIPT_THINKING_HEARTBEAT',
-            sessionId: event.sessionId,
-          });
+        case 'assistant-thinking': {
+          // Text payload → real reasoning content (collapsible in chat).
+          // No payload → lifecycle heartbeat only (existing behavior:
+          // bumps lastActivityAt and clears any stale attention banner).
+          if (event.data?.text) {
+            batchTranscriptDispatch({
+              type: 'TRANSCRIPT_ASSISTANT_REASONING',
+              sessionId: event.sessionId,
+              uuid: event.uuid,
+              text: event.data.text,
+              timestamp: event.timestamp,
+              partId: (event.data as any).partId,
+            });
+          } else {
+            batchTranscriptDispatch({
+              type: 'TRANSCRIPT_THINKING_HEARTBEAT',
+              sessionId: event.sessionId,
+            });
+          }
           break;
+        }
         case 'compact-summary': {
           // Canonical compaction-complete signal — fired by the transcript
           // watcher when Claude Code writes an isCompactSummary entry. Works

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1926,6 +1926,9 @@ function AppInner() {
 
   const currentSession = sessions.find((s) => s.id === sessionId);
   const canBypass = currentSession?.skipPermissions ?? false;
+  // Native sessions: permission modes are a harness policy (Phase 2), not a
+  // PTY shift+tab cycle — hide the badge + cycle affordance for them.
+  const isNativeSession = currentSession?.provider === 'native';
   const currentPermissionMode = sessionId ? (permissionModes.get(sessionId) || 'normal') : 'normal';
 
   // Shift+Tab cycles permission mode in chat view
@@ -2284,6 +2287,7 @@ function AppInner() {
                       sessionId={s.id}
                       visible={s.id === sessionId && (viewModes.get(s.id) || 'chat') === 'chat'}
                       resumeInfo={resumeInfo}
+                      provider={s.provider}
                       cwd={s.cwd}
                       // Game pane lives in the active session's framed-shell
                       // right slot. Only the active session renders it (others
@@ -2370,8 +2374,8 @@ function AppInner() {
                   } : undefined}
                   model={currentModel}
                   onCycleModel={cycleModel}
-                  permissionMode={currentPermissionMode}
-                  onCyclePermission={cyclePermission}
+                  permissionMode={isNativeSession ? undefined : currentPermissionMode}
+                  onCyclePermission={isNativeSession ? undefined : cyclePermission}
                   fast={fastMode}
                   effort={effortLevel}
                   onOpenModelPicker={() => setModelPickerOpen(true)}
@@ -2583,6 +2587,7 @@ function AppInner() {
           postSwitchTurnReady.current = false;
           (window.claude as any).model?.setPreference(m);
         }}
+        provider={currentSession?.provider}
       />
       {/* Open Tasks popup — rendered at App root so it escapes any inner stacking context.
           Reads from the single `openTasks` useSessionTasks instance declared in AppInner. */}

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -883,7 +883,7 @@ function AppInner() {
               uuid: event.uuid,
               text: event.data.text,
               timestamp: event.timestamp,
-              partId: (event.data as any).partId,
+              partId: event.data.partId,
             });
           } else {
             batchTranscriptDispatch({

--- a/desktop/src/renderer/components/AssistantTurnBubble.tsx
+++ b/desktop/src/renderer/components/AssistantTurnBubble.tsx
@@ -31,6 +31,33 @@ const STOP_REASON_COPY: Record<string, string> = {
   interrupted: 'Interrupted.',
 };
 
+// Collapsible disclosure for the model's reasoning / chain of thought.
+// Collapsed by default — user explicitly chose this UX so reasoning doesn't
+// dominate the chat view. Expanding reveals the full markdown body.
+// Used by AssistantTurnBubble when a VisualBubble carries reasoning content
+// (always streamed before its associated text bubble).
+function ReasoningSection({ content }: { content: string }) {
+  const [expanded, setExpanded] = useState(() => getInitialExpanded());
+  useExpandAllToggle(() => setExpanded(true), () => setExpanded(false));
+  return (
+    <div className="mb-2">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-1 text-[11px] text-fg-muted hover:text-fg-dim select-none"
+        title="Show the model's reasoning"
+      >
+        <ChevronIcon className="w-3 h-3" expanded={expanded} />
+        <span className="italic">{expanded ? 'Hide reasoning' : 'Show reasoning'}</span>
+      </button>
+      {expanded && (
+        <div className="mt-1 pl-2 border-l-2 border-edge-dim text-[12.5px] text-fg-dim">
+          <MarkdownContent content={content} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 function StopReasonFooter({ reason }: { reason: string }) {
   const copy = STOP_REASON_COPY[reason] ?? `Response ended: ${reason}.`;
   return (
@@ -131,6 +158,12 @@ export function CollapsedToolGroup({ tools, sessionId }: { tools: ToolCallState[
  */
 interface VisualBubble {
   key: string;
+  // Reasoning segments accumulated since the last text/plan/tool-group are
+  // attached to the next bubble as a collapsible disclosure (joined by
+  // double-newline if there were multiple). When a turn ends with reasoning
+  // and no following text (still streaming, or model never produced output),
+  // a reasoning-only bubble is emitted so the user still sees activity.
+  reasoning?: { content: string; messageId: string };
   text?: { content: string; messageId: string };
   plan?: { content: string; messageId: string; planFilePath?: string; allowedPrompts?: unknown };
   toolGroupIds: string[];
@@ -139,22 +172,38 @@ interface VisualBubble {
 function splitIntoBubbles(turn: AssistantTurn): VisualBubble[] {
   const bubbles: VisualBubble[] = [];
   let current: VisualBubble | null = null;
+  // Buffer of reasoning content seen since the last bubble boundary.
+  // Drained into the next bubble's `reasoning` field, or flushed as a
+  // standalone reasoning bubble if the turn ends with reasoning unattached.
+  let pendingReasoning: { content: string; messageId: string } | null = null;
 
   for (const seg of turn.segments) {
-    if (seg.type === 'text') {
-      // Start a new bubble for this text
+    if (seg.type === 'reasoning') {
+      // Stash; will attach to the next text/plan/tool bubble.
+      if (pendingReasoning) {
+        pendingReasoning = {
+          content: `${pendingReasoning.content}\n\n${seg.content}`,
+          messageId: pendingReasoning.messageId,
+        };
+      } else {
+        pendingReasoning = { content: seg.content, messageId: seg.messageId };
+      }
+    } else if (seg.type === 'text') {
       if (current) bubbles.push(current);
       current = {
         key: seg.messageId,
+        reasoning: pendingReasoning ?? undefined,
         text: { content: seg.content, messageId: seg.messageId },
         toolGroupIds: [],
       };
+      pendingReasoning = null;
     } else if (seg.type === 'plan') {
       // Plan bubble: its own distinct bubble, rendered differently from text.
       // The following ExitPlanMode tool-group naturally attaches below.
       if (current) bubbles.push(current);
       current = {
         key: seg.messageId,
+        reasoning: pendingReasoning ?? undefined,
         plan: {
           content: seg.content,
           messageId: seg.messageId,
@@ -163,15 +212,31 @@ function splitIntoBubbles(turn: AssistantTurn): VisualBubble[] {
         },
         toolGroupIds: [],
       };
+      pendingReasoning = null;
     } else {
       // tool-group: attach to current bubble, or create a tools-only bubble
       if (!current) {
-        current = { key: `tools-${seg.groupId}`, toolGroupIds: [] };
+        current = {
+          key: `tools-${seg.groupId}`,
+          reasoning: pendingReasoning ?? undefined,
+          toolGroupIds: [],
+        };
+        pendingReasoning = null;
       }
       current.toolGroupIds.push(seg.groupId);
     }
   }
   if (current) bubbles.push(current);
+  // Trailing reasoning with no text after it — the model is mid-stream or
+  // produced reasoning only. Emit a reasoning-only bubble so the user sees
+  // it and can expand to read the chain of thought.
+  if (pendingReasoning) {
+    bubbles.push({
+      key: `reasoning-${pendingReasoning.messageId}`,
+      reasoning: pendingReasoning,
+      toolGroupIds: [],
+    });
+  }
   return bubbles;
 }
 
@@ -215,11 +280,16 @@ export default React.memo(function AssistantTurnBubble({ turn, toolGroups, toolC
       {bubbles.map((bubble, i) => {
         const hasTools = bubble.toolGroupIds.length > 0;
         const hasContent = !!(bubble.text || bubble.plan);
-        const toolsOnly = hasTools && !hasContent;
+        const hasReasoning = !!bubble.reasoning;
+        const toolsOnly = hasTools && !hasContent && !hasReasoning;
+        const reasoningOnly = hasReasoning && !hasContent && !hasTools;
         const isLastBubble = i === bubbles.length - 1;
         return (
           <div key={bubble.key} className="flex justify-start px-4 py-0.5">
-            <div className={`assistant-bubble max-w-[85%] break-words rounded-2xl rounded-bl-sm bg-inset text-sm text-fg px-5 ${toolsOnly ? 'py-2.5' : hasTools ? 'pt-4 pb-3' : 'py-3.5'}`}>
+            <div className={`assistant-bubble max-w-[85%] break-words rounded-2xl rounded-bl-sm bg-inset text-sm text-fg px-5 ${toolsOnly ? 'py-2.5' : hasTools ? 'pt-4 pb-3' : reasoningOnly ? 'py-2.5' : 'py-3.5'}`}>
+              {bubble.reasoning && (
+                <ReasoningSection content={bubble.reasoning.content} />
+              )}
               {bubble.text && (
                 // Pass sessionId so MarkdownContent can render inline FilepathToken chips
                 // for detected file paths in this session's artifact set.

--- a/desktop/src/renderer/components/ChatView.tsx
+++ b/desktop/src/renderer/components/ChatView.tsx
@@ -27,6 +27,9 @@ interface Props {
    *  active session's ChatView receives this — App passes null otherwise. When
    *  present it takes precedence over the artifact drawer in the right slot. */
   gamePane?: React.ReactNode;
+  /** Runtime backend — forwarded to useAttentionClassifier so it
+   *  short-circuits for sessions without a PTY (native harness). */
+  provider?: 'claude' | 'native';
 }
 
 function HistoryExpandButton({ sessionId, resumeInfo }: {
@@ -71,7 +74,7 @@ function HistoryExpandButton({ sessionId, resumeInfo }: {
   );
 }
 
-export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane }: Props) {
+export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane, provider }: Props) {
   const state = useChatState(sessionId);
   const dispatch = useChatDispatch();
   const { showTimestamps } = useTheme();
@@ -203,6 +206,7 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
     hasAwaitingApproval,
     visible,
     currentAttentionState: state.attentionState,
+    provider,
   });
 
   // Scroll container directly to scrollHeight instead of using

--- a/desktop/src/renderer/components/HeaderBar.tsx
+++ b/desktop/src/renderer/components/HeaderBar.tsx
@@ -161,7 +161,7 @@ interface Props {
   sessions: SessionEntry[];
   activeSessionId: string | null;
   onSelectSession: (id: string) => void;
-  onCreateSession: (cwd: string, dangerous: boolean, model: string, provider?: 'claude' | 'gemini') => void;
+  onCreateSession: (cwd: string, dangerous: boolean, model: string, provider?: 'claude' | 'native') => void;
   onCloseSession: (id: string) => void;
   viewMode: 'chat' | 'terminal';
   onToggleView: (mode: 'chat' | 'terminal') => void;
@@ -182,7 +182,6 @@ interface Props {
   defaultModel?: string;
   defaultSkipPermissions?: boolean;
   defaultProjectFolder?: string;
-  geminiEnabled?: boolean;
   windowDirectory?: any;
   myWindowId?: number | null;
 }
@@ -291,7 +290,6 @@ export default function HeaderBar({
   settingsOpen, onToggleSettings, settingsBadge, settingsDangerBadge, sessionStatuses, onResumeSession,
   onOpenResumeBrowser, onReorderSessions,
   defaultModel, defaultSkipPermissions, defaultProjectFolder,
-  geminiEnabled,
   windowDirectory, myWindowId,
 }: Props) {
   // Pill doesn't track live button widths — it pins to the active button's
@@ -620,7 +618,6 @@ export default function HeaderBar({
         defaultModel={defaultModel}
         defaultSkipPermissions={defaultSkipPermissions}
         defaultProjectFolder={defaultProjectFolder}
-        geminiEnabled={geminiEnabled}
         windowDirectory={windowDirectory}
         myWindowId={myWindowId}
       />

--- a/desktop/src/renderer/components/HeaderBar.tsx
+++ b/desktop/src/renderer/components/HeaderBar.tsx
@@ -154,6 +154,8 @@ interface SessionEntry {
   name: string;
   cwd: string;
   permissionMode: string;
+  /** Runtime backend — mirrors SessionInfo.provider. */
+  provider?: 'claude' | 'native';
 }
 
 
@@ -310,6 +312,11 @@ export default function HeaderBar({
 
   const headerRef = useRef<HTMLDivElement>(null);
   const [showToggleLabels, setShowToggleLabels] = useState(true);
+
+  // Native harness sessions have no PTY — the chat/terminal toggle would show
+  // an empty terminal pane. Hide it for them.
+  const activeSessionProvider = sessions.find(s => s.id === activeSessionId)?.provider;
+  const showToggle = activeSessionProvider !== 'native';
 
   // Measure whether the header has room for the toggle labels. The labels
   // are the first things to drop; below that threshold, flex still has
@@ -597,7 +604,7 @@ export default function HeaderBar({
             REMOTE
           </span>
         )}
-        {toggleOnLeft && toggleElement}
+        {toggleOnLeft && showToggle && toggleElement}
       </div>
 
       {/* Center — session strip.
@@ -630,7 +637,7 @@ export default function HeaderBar({
         className={`${clusterFlexClass}flex items-center justify-end gap-1 sm:gap-2`}
         style={clusterStyle}
       >
-        {!toggleOnLeft && toggleElement}
+        {!toggleOnLeft && showToggle && toggleElement}
         <div className="bg-inset rounded-md p-0.5 hidden sm:block">
           <button
             onClick={onToggleGamePanel}

--- a/desktop/src/renderer/components/HeaderBar.tsx
+++ b/desktop/src/renderer/components/HeaderBar.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useLayoutEffect, useEffect, useCallback, useState } from
 import { ChatIcon, TerminalIcon, GamepadIcon } from './Icons';
 import SessionStrip from './SessionStrip';
 import type { SessionStatusColor } from './StatusDot';
-import type { PermissionMode } from '../../shared/types';
 import { isAndroid, isRemoteMode } from '../platform';
 // Artifact drawer trigger — reads session artifact count for the badge.
 import { useArtifact } from '../state/ArtifactContext';
@@ -171,8 +170,6 @@ interface Props {
   onToggleGamePanel: () => void;
   gameConnected: boolean;
   challengePending: boolean;
-  permissionMode: PermissionMode;
-  onCyclePermission: () => void;
   settingsOpen: boolean;
   onToggleSettings: () => void;
   settingsBadge?: boolean;
@@ -288,7 +285,6 @@ export default function HeaderBar({
   sessions, activeSessionId, onSelectSession, onCreateSession, onCloseSession,
   viewMode, onToggleView,
   gamePanelOpen, onToggleGamePanel, gameConnected, challengePending,
-  permissionMode, onCyclePermission,
   settingsOpen, onToggleSettings, settingsBadge, settingsDangerBadge, sessionStatuses, onResumeSession,
   onOpenResumeBrowser, onReorderSessions,
   defaultModel, defaultSkipPermissions, defaultProjectFolder,

--- a/desktop/src/renderer/components/ModelPickerPopup.tsx
+++ b/desktop/src/renderer/components/ModelPickerPopup.tsx
@@ -131,9 +131,13 @@ interface Props {
   sessionId: string | null;
   currentModel: ModelAlias | null;
   onSelectModel: (m: ModelAlias) => void;
+  /** Runtime backend — Phase 1 replaces this guard with a provider-scoped
+   *  model catalog; in Phase 0 native sessions cannot exist, so this only
+   *  pins the seam. */
+  provider?: 'claude' | 'native';
 }
 
-export default function ModelPickerPopup({ open, onClose, sessionId, currentModel, onSelectModel }: Props) {
+export default function ModelPickerPopup({ open, onClose, sessionId, currentModel, onSelectModel, provider }: Props) {
   useEscClose(open, onClose);
   const [fast, setFast] = useState(false);
   const [effort, setEffort] = useState<EffortLevel>('auto');
@@ -202,6 +206,11 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
   };
 
   if (!open) return null;
+
+  // Native sessions get a provider-scoped picker in Phase 1. Until then
+  // (and they can't be created yet), render nothing rather than a Claude
+  // alias list that would send /model down a nonexistent PTY.
+  if (provider === 'native') return null;
 
   // "max" effort is top-tier-only (Opus 1M + Fable); disable the button otherwise.
   const maxAllowed = currentModel != null && MAX_EFFORT_MODELS.includes(currentModel);

--- a/desktop/src/renderer/components/ResumeBrowser.tsx
+++ b/desktop/src/renderer/components/ResumeBrowser.tsx
@@ -573,7 +573,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
           <div className="px-4 pt-4 pb-3 border-b border-edge">
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-sm font-bold text-fg">Resume Session</h2>
-              {/* Show Complete — same toggle pattern as Skip Permissions + Gemini CLI
+              {/* Show Complete — same toggle pattern as Skip Permissions
                   in SessionStrip, but accent-colored to signal "on" rather than "danger". */}
               <div className="flex items-center gap-2">
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted">Show Complete</label>

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { SessionStatusColor } from './StatusDot';
-import { isAndroid } from '../platform';
+import { isAndroid, isRemoteMode } from '../platform';
 import { MODELS, type ModelAlias } from './StatusBar';
 import FolderSwitcher from './FolderSwitcher';
 import { ModelInfoTooltip } from './ModelPickerPopup';
@@ -165,6 +165,15 @@ export default function SessionStrip({
   const [newCwd, setNewCwd] = useState('');
   const [dangerous, setDangerous] = useState(false);
   const [newModel, setNewModel] = useState<string>('sonnet');
+  // Runtime selector (platform roadmap Phase 0 seam). Renders only when the
+  // native runtime capability is on — with a single runtime there is nothing
+  // to select. The YouCoded option is visible-but-disabled until Phase 1
+  // ships the engine + harness.
+  // Phase 1 wires this into handleCreate — for now it never leaves 'claude'.
+  type Runtime = 'claude' | 'native';
+  const [runtime, setRuntime] = useState<Runtime>('claude');
+  const nativeSupported = !isAndroid() && !isRemoteMode()
+    && (window as any).claude?.native?.supported === true;
   // Launch the new session in its own peer window instead of this one.
   // Hidden on platforms without multi-window support (Android / remote-shim).
   const [launchInNewWindow, setLaunchInNewWindow] = useState(false);
@@ -958,6 +967,32 @@ export default function SessionStrip({
                   onManageProjects={() => { setMenuOpen(false); artifactDispatch({ type: 'PROJECT_VIEW_OPENED' }); }}
                 />
               </div>
+              {/* Runtime selector — Claude Code vs the YouCoded native harness.
+                  Hidden when native.supported is false (the common case until
+                  Phase 1): one runtime = no selector. */}
+              {nativeSupported && (
+                <div>
+                  <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Runtime</label>
+                  <div className="inline-flex rounded border border-edge overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => setRuntime('claude')}
+                      className={`px-3 py-1 text-xs ${runtime === 'claude' ? 'bg-accent text-on-accent' : 'bg-panel text-fg hover:bg-inset'}`}
+                    >
+                      Claude Code
+                    </button>
+                    <button
+                      type="button"
+                      disabled
+                      title="The YouCoded runtime arrives in a future update"
+                      className="px-3 py-1 text-xs bg-panel text-fg-faint cursor-not-allowed"
+                    >
+                      YouCoded
+                    </button>
+                  </div>
+                  <p className="text-[10px] text-fg-faint mt-1">YouCoded runtime — coming soon</p>
+                </div>
+              )}
               {/* Model selector */}
               <div>
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -28,7 +28,7 @@ interface Props {
   sessions: SessionEntry[];
   activeSessionId: string | null;
   onSelectSession: (id: string) => void;
-  onCreateSession: (cwd: string, dangerous: boolean, model: string, provider?: 'claude' | 'gemini', launchInNewWindow?: boolean) => void;
+  onCreateSession: (cwd: string, dangerous: boolean, model: string, provider?: 'claude' | 'native', launchInNewWindow?: boolean) => void;
   onCloseSession: (id: string) => void;
   sessionStatuses?: Map<string, SessionStatusColor>;
   onResumeSession: (sessionId: string, projectSlug: string, projectPath: string, model?: string, dangerous?: boolean) => void;
@@ -37,8 +37,6 @@ interface Props {
   defaultModel?: string;
   defaultSkipPermissions?: boolean;
   defaultProjectFolder?: string;
-  /** When true, show Gemini CLI toggle in new session form */
-  geminiEnabled?: boolean;
   /** Window directory (for switcher's "Sessions in other windows" group). */
   windowDirectory?: {
     leaderWindowId: number;
@@ -153,7 +151,6 @@ export default function SessionStrip({
   onCreateSession, onCloseSession, sessionStatuses, onResumeSession,
   onOpenResumeBrowser, onReorderSessions,
   defaultModel, defaultSkipPermissions, defaultProjectFolder,
-  geminiEnabled,
   windowDirectory, myWindowId,
 }: Props) {
   // Artifact dispatch — SessionStrip renders only in the main window, inside
@@ -168,8 +165,6 @@ export default function SessionStrip({
   const [newCwd, setNewCwd] = useState('');
   const [dangerous, setDangerous] = useState(false);
   const [newModel, setNewModel] = useState<string>('sonnet');
-  // Gemini CLI session toggle — only visible when enabled in settings
-  const [isGemini, setIsGemini] = useState(false);
   // Launch the new session in its own peer window instead of this one.
   // Hidden on platforms without multi-window support (Android / remote-shim).
   const [launchInNewWindow, setLaunchInNewWindow] = useState(false);
@@ -346,14 +341,13 @@ export default function SessionStrip({
   }, []);
 
   const handleCreate = useCallback(() => {
-    onCreateSession(newCwd, dangerous, newModel, isGemini ? 'gemini' : 'claude', launchInNewWindow);
+    onCreateSession(newCwd, dangerous, newModel, 'claude', launchInNewWindow);
     setMenuOpen(false);
     setShowNewForm(false);
     setDangerous(defaultSkipPermissions || false);
     setNewModel(defaultModel || 'sonnet');
-    setIsGemini(false);
     setLaunchInNewWindow(false);
-  }, [newCwd, dangerous, newModel, isGemini, launchInNewWindow, onCreateSession, defaultSkipPermissions, defaultModel]);
+  }, [newCwd, dangerous, newModel, launchInNewWindow, onCreateSession, defaultSkipPermissions, defaultModel]);
 
   /* ── Pointer-event drag handlers ───────────────────────── */
 
@@ -964,8 +958,8 @@ export default function SessionStrip({
                   onManageProjects={() => { setMenuOpen(false); artifactDispatch({ type: 'PROJECT_VIEW_OPENED' }); }}
                 />
               </div>
-              {/* Model selector — grayed out when Gemini is selected */}
-              <div style={{ opacity: isGemini ? 0.4 : 1, pointerEvents: isGemini ? 'none' : 'auto', transition: 'opacity 200ms' }}>
+              {/* Model selector */}
+              <div>
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
                 <div className="flex gap-1">
                   {MODELS.map((m) => (
@@ -984,8 +978,8 @@ export default function SessionStrip({
                   ))}
                 </div>
               </div>
-              {/* Skip Permissions — grayed out when Gemini is selected */}
-              <div className="flex items-center justify-between" style={{ opacity: isGemini ? 0.4 : 1, pointerEvents: isGemini ? 'none' : 'auto', transition: 'opacity 200ms' }}>
+              {/* Skip Permissions */}
+              <div className="flex items-center justify-between">
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted inline-flex items-center">
                   Skip Permissions
                   <SkipPermissionsInfoTooltip />
@@ -997,7 +991,7 @@ export default function SessionStrip({
                   <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${dangerous ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
                 </button>
               </div>
-              {dangerous && !isGemini && (
+              {dangerous && (
                 <p className="text-[10px] text-[#DD4444]">Claude will execute tools without asking for approval.</p>
               )}
               {/* Launch in new window — hidden on platforms without multi-window support */}
@@ -1012,36 +1006,15 @@ export default function SessionStrip({
                   </button>
                 </div>
               )}
-              {/* Gemini CLI toggle — only visible when enabled in settings */}
-              {geminiEnabled && (
-                <div className="flex items-center justify-between">
-                  <label className="text-[10px] uppercase tracking-wider text-fg-muted">Gemini CLI</label>
-                  <button
-                    onClick={() => {
-                      const next = !isGemini;
-                      setIsGemini(next);
-                      // Gemini sessions don't support skip-permissions
-                      if (next) setDangerous(false);
-                    }}
-                    className="w-8 h-4.5 rounded-full relative transition-colors"
-                    style={{ backgroundColor: isGemini ? '#4285F4' : 'var(--inset)' }}
-                  >
-                    <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${isGemini ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-                  </button>
-                </div>
-              )}
               <button
                 onClick={handleCreate}
                 className={`w-full text-sm font-medium rounded-md py-1.5 transition-colors ${
-                  isGemini
-                    ? 'text-white'
-                    : dangerous
-                      ? 'bg-[#DD4444] hover:bg-[#E55555] text-white'
-                      : 'bg-accent hover:bg-accent text-on-accent'
+                  dangerous
+                    ? 'bg-[#DD4444] hover:bg-[#E55555] text-white'
+                    : 'bg-accent hover:bg-accent text-on-accent'
                 }`}
-                style={isGemini ? { background: 'linear-gradient(135deg, #4285F4, #7B68EE)' } : undefined}
               >
-                {isGemini ? 'Create Gemini Session' : dangerous ? 'Create (Dangerous)' : 'Create Session'}
+                {dangerous ? 'Create (Dangerous)' : 'Create Session'}
               </button>
             </div>
           ) : (
@@ -1062,7 +1035,6 @@ export default function SessionStrip({
                   setNewCwd(defaultProjectFolder || '');
                   setDangerous(defaultSkipPermissions || false);
                   setNewModel(defaultModel || 'sonnet');
-                  setIsGemini(false);
                   setShowNewForm(true);
                 }}
                 className="flex-1 px-3 py-2 text-sm text-fg-dim hover:bg-inset hover:text-fg transition-colors flex items-center justify-center gap-1.5"

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1285,8 +1285,8 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
 }
 
 interface DefaultsButtonProps {
-  defaults: { skipPermissions: boolean; model: string; projectFolder: string; geminiEnabled?: boolean; permissionOverrides?: PermissionOverrides };
-  onDefaultsChange: (updates: Partial<{ skipPermissions: boolean; model: string; projectFolder: string; geminiEnabled: boolean; permissionOverrides: PermissionOverrides }>) => void;
+  defaults: { skipPermissions: boolean; model: string; projectFolder: string; permissionOverrides?: PermissionOverrides };
+  onDefaultsChange: (updates: Partial<{ skipPermissions: boolean; model: string; projectFolder: string; permissionOverrides: PermissionOverrides }>) => void;
 }
 
 function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
@@ -1318,7 +1318,6 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
   const summaryParts: string[] = [];
   summaryParts.push(MODEL_LABELS[defaults.model] || 'Sonnet');
   if (defaults.skipPermissions) summaryParts.push('Skip Perms');
-  if (defaults.geminiEnabled) summaryParts.push('Gemini');
 
   return (
     <>
@@ -1405,23 +1404,6 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
                       Reset to home directory
                     </button>
                   )}
-                </section>
-
-                {/* Gemini CLI — opt-in toggle to show Gemini as a session provider */}
-                <section>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">Gemini CLI</h3>
-                      <p className="text-[10px] text-fg-faint mt-0.5">Show Gemini option when creating sessions</p>
-                    </div>
-                    <button
-                      onClick={() => onDefaultsChange({ geminiEnabled: !defaults.geminiEnabled })}
-                      className="w-8 h-4.5 rounded-full relative transition-colors shrink-0"
-                      style={{ backgroundColor: defaults.geminiEnabled ? '#4285F4' : 'var(--inset)' }}
-                    >
-                      <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${defaults.geminiEnabled ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-                    </button>
-                  </div>
                 </section>
 
                 {/* Close-session prompt — toggle off to skip the tag-before-closing

--- a/desktop/src/renderer/components/buddy/BubbleFeed.tsx
+++ b/desktop/src/renderer/components/buddy/BubbleFeed.tsx
@@ -176,10 +176,24 @@ export function BubbleFeed({ sessionId }: Props) {
           });
           break;
         case 'assistant-thinking':
-          batchDispatch({
-            type: 'TRANSCRIPT_THINKING_HEARTBEAT',
-            sessionId: event.sessionId,
-          });
+          // Reasoning chunks carry a text payload (native harness / thinking
+          // models); the CC transcript path is heartbeat-only. See App.tsx
+          // for the same branch logic.
+          if (event.data && typeof (event.data as any).text === 'string') {
+            batchDispatch({
+              type: 'TRANSCRIPT_ASSISTANT_REASONING',
+              sessionId: event.sessionId,
+              uuid: event.uuid,
+              text: (event.data as any).text,
+              timestamp: event.timestamp,
+              partId: (event.data as any).partId,
+            });
+          } else {
+            batchDispatch({
+              type: 'TRANSCRIPT_THINKING_HEARTBEAT',
+              sessionId: event.sessionId,
+            });
+          }
           break;
         // compact-summary: buddy doesn't drive compaction UI (no /compact command),
         // but we still need to close any pending compaction spinner if it was opened

--- a/desktop/src/renderer/components/buddy/BubbleFeed.tsx
+++ b/desktop/src/renderer/components/buddy/BubbleFeed.tsx
@@ -177,16 +177,17 @@ export function BubbleFeed({ sessionId }: Props) {
           break;
         case 'assistant-thinking':
           // Reasoning chunks carry a text payload (native harness / thinking
-          // models); the CC transcript path is heartbeat-only. See App.tsx
-          // for the same branch logic.
-          if (event.data && typeof (event.data as any).text === 'string') {
+          // models); the CC transcript path is heartbeat-only. Truthiness
+          // check (not typeof) so an empty-string payload stays a heartbeat —
+          // MUST match App.tsx's predicate or the two windows diverge.
+          if (event.data?.text) {
             batchDispatch({
               type: 'TRANSCRIPT_ASSISTANT_REASONING',
               sessionId: event.sessionId,
               uuid: event.uuid,
-              text: (event.data as any).text,
+              text: event.data.text,
               timestamp: event.timestamp,
-              partId: (event.data as any).partId,
+              partId: event.data.partId,
             });
           } else {
             batchDispatch({

--- a/desktop/src/renderer/hooks/useAttentionClassifier.ts
+++ b/desktop/src/renderer/hooks/useAttentionClassifier.ts
@@ -34,6 +34,10 @@ interface HookArgs {
   visible: boolean;
   /** Current reducer attentionState — used for dispatch-suppression. */
   currentAttentionState: AttentionState;
+  /** Which runtime backend this session uses. The classifier reads the xterm
+   *  PTY buffer — only meaningful for PTY sessions ('claude'). Native harness
+   *  sessions have no buffer; the hook short-circuits for them. */
+  provider?: 'claude' | 'native';
 }
 
 function bufferClassToAttention(cls: BufferClass): AttentionState {
@@ -65,13 +69,16 @@ export function useAttentionClassifier(sessionId: string, args: HookArgs): void 
     hasAwaitingApproval,
     visible,
     currentAttentionState,
+    provider,
   } = args;
 
   // Mutable refs avoid restarting the interval when these change mid-run.
   const currentAttentionStateRef = useRef(currentAttentionState);
   currentAttentionStateRef.current = currentAttentionState;
 
-  const active = isThinking && !hasRunningTools && !hasAwaitingApproval && visible;
+  // Classifier reads the xterm PTY buffer — only PTY sessions have one.
+  const hasBuffer = provider === undefined || provider === 'claude';
+  const active = hasBuffer && isThinking && !hasRunningTools && !hasAwaitingApproval && visible;
 
   useEffect(() => {
     if (!active) {

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -240,6 +240,12 @@ declare global {
       app: {
         restart: () => Promise<void>;
       };
+      // Native runtime capability flag (platform roadmap Phase 0 seam). Plain
+      // boolean — no IPC round-trip. Hard-false everywhere except dev Electron
+      // builds launched with YOUCODED_NATIVE=1; the runtime selector gates on it.
+      native: {
+        supported: boolean;
+      };
       // Platform integration for hardware back button (Android). On desktop,
       // both methods are no-op stubs (preload.ts). On Android, notifyStackState
       // enables/disables OnBackPressedCallback and onBack subscribes to

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1338,5 +1338,10 @@ export function installShim(): void {
     app: {
       restart: () => invoke('app:restart'),
     },
+    // Native runtime — desktop Electron only. false on Android/remote-browser
+    // so the renderer gates the runtime selector without platform branching.
+    native: {
+      supported: false,
+    },
   };
 }

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -502,9 +502,10 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return next;
     }
 
-    // Streaming reasoning chunk with text payload. Mirrors the
-    // TRANSCRIPT_ASSISTANT_TEXT streaming path: same partId merges chunks
-    // into one segment instead of creating a new bubble per token.
+    // Streaming reasoning chunk with text payload. Reasoning arrives as
+    // per-token deltas merged into one segment by partId — UNLIKE the
+    // TRANSCRIPT_ASSISTANT_TEXT path, which appends each event as a whole
+    // block in its own new segment.
     case 'TRANSCRIPT_ASSISTANT_REASONING': {
       const session = next.get(action.sessionId);
       if (!session) return state;

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -502,6 +502,43 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return next;
     }
 
+    // Streaming reasoning chunk with text payload. Mirrors the
+    // TRANSCRIPT_ASSISTANT_TEXT streaming path: same partId merges chunks
+    // into one segment instead of creating a new bubble per token.
+    case 'TRANSCRIPT_ASSISTANT_REASONING': {
+      const session = next.get(action.sessionId);
+      if (!session) return state;
+
+      const { assistantTurns, timeline, currentTurnId } = getOrCreateTurn(session);
+      const turn = assistantTurns.get(currentTurnId)!;
+      let segments = turn.segments;
+      const lastIdx = segments.length - 1;
+      const last = lastIdx >= 0 ? segments[lastIdx] : null;
+      if (
+        action.partId
+        && last
+        && last.type === 'reasoning'
+        && last.partId === action.partId
+      ) {
+        const merged = { ...last, content: last.content + action.text };
+        segments = [...segments.slice(0, lastIdx), merged];
+      } else {
+        segments = [
+          ...segments,
+          { type: 'reasoning', content: action.text, messageId: nextMessageId(), partId: action.partId },
+        ];
+      }
+      assistantTurns.set(currentTurnId, { ...turn, segments });
+
+      next.set(action.sessionId, {
+        ...session, assistantTurns, timeline, currentTurnId,
+        currentGroupId: null,
+        lastActivityAt: Date.now(),
+        attentionState: 'ok',
+      });
+      return next;
+    }
+
     case 'TRANSCRIPT_TOOL_USE': {
       // Subagent event: route into the parent Agent tool's nested timeline.
       if (action.parentAgentToolUseId) return applySubagentEvent(state, action);

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -15,6 +15,12 @@ export interface InteractivePrompt {
 
 export type AssistantTurnSegment =
   | { type: 'text'; content: string; messageId: string }
+  // Reasoning / extended-thinking content with a text payload. The native
+  // harness (Phase 2) streams these for thinking models; CC's transcript
+  // path may also carry thinking text in future. Rendered as a collapsible
+  // disclosure attached to the next text bubble. partId merges streaming
+  // chunks into one segment, mirroring the text streaming path.
+  | { type: 'reasoning'; content: string; messageId: string; partId?: string }
   | { type: 'tool-group'; groupId: string }
   // Plan mode: ExitPlanMode tool's `input.plan` surfaced as its own bubble so
   // users see the full plan markdown in chat, not just the approval buttons.
@@ -216,10 +222,22 @@ export type ChatAction =
     }
   | {
       // Heartbeat fired when the transcript watcher sees an assistant
-      // thinking block (extended-thinking models). No UI; just bumps
-      // lastActivityAt and clears attentionState back to 'ok'.
+      // thinking block (extended-thinking models) WITHOUT a text payload —
+      // a lifecycle marker only. No UI; just bumps lastActivityAt and
+      // clears attentionState back to 'ok'.
       type: 'TRANSCRIPT_THINKING_HEARTBEAT';
       sessionId: string;
+    }
+  | {
+      // Streaming reasoning chunk WITH text payload. Merged into a single
+      // reasoning segment by partId, rendered as a collapsible disclosure
+      // in AssistantTurnBubble. Bumps lastActivityAt + clears attentionState.
+      type: 'TRANSCRIPT_ASSISTANT_REASONING';
+      sessionId: string;
+      uuid: string;
+      text: string;
+      timestamp: number;
+      partId?: string;
     }
   | {
       type: 'PERMISSION_REQUEST';

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -18,8 +18,9 @@ export type AssistantTurnSegment =
   // Reasoning / extended-thinking content with a text payload. The native
   // harness (Phase 2) streams these for thinking models; CC's transcript
   // path may also carry thinking text in future. Rendered as a collapsible
-  // disclosure attached to the next text bubble. partId merges streaming
-  // chunks into one segment, mirroring the text streaming path.
+  // disclosure attached to the next text bubble. Reasoning streams as
+  // per-token deltas merged into one segment by partId — UNLIKE the text
+  // path, which appends each whole block as its own segment.
   | { type: 'reasoning'; content: string; messageId: string; partId?: string }
   | { type: 'tool-group'; groupId: string }
   // Plan mode: ExitPlanMode tool's `input.plan` surfaced as its own bubble so
@@ -229,9 +230,11 @@ export type ChatAction =
       sessionId: string;
     }
   | {
-      // Streaming reasoning chunk WITH text payload. Merged into a single
-      // reasoning segment by partId, rendered as a collapsible disclosure
-      // in AssistantTurnBubble. Bumps lastActivityAt + clears attentionState.
+      // Streaming reasoning chunk WITH text payload. Per-token deltas are
+      // merged into a single reasoning segment by partId (UNLIKE the text
+      // path, which appends whole blocks), rendered as a collapsible
+      // disclosure in AssistantTurnBubble. Bumps lastActivityAt + clears
+      // attentionState.
       type: 'TRANSCRIPT_ASSISTANT_REASONING';
       sessionId: string;
       uuid: string;

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -120,6 +120,8 @@ export interface TranscriptEvent {
     parentAgentToolUseId?: string;
     /** Stable subagent ID — matches the filename agent-<agentId>.jsonl on disk. */
     agentId?: string;
+    /** Streaming-part id used to merge reasoning chunks; emitted by the native harness, not CC's watcher. */
+    partId?: string;
     /**
      * Populated only on `user-interrupt` events. Distinguishes the two exact
      * marker strings Claude Code writes: `[Request interrupted by user]`

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -25,8 +25,14 @@ export const PERMISSION_OVERRIDES_DEFAULT: PermissionOverrides = {
   compoundCdGit: false,
 };
 
-// Which CLI backend powers a session — defaults to 'claude' for backwards compat
-export type SessionProvider = 'claude' | 'gemini';
+// Which runtime backend powers a session — defaults to 'claude'.
+// 'claude'  = Claude Code CLI over PTY (the original path).
+// 'native'  = YouCoded's first-party harness (Phase 1+ of the platform
+//             roadmap; dormant until window.claude.native.supported is true).
+// 'gemini' was removed 2026-07-10 — Google discontinued the Gemini CLI
+// (June 2026); Gemini models are reachable through the native runtime via
+// OpenRouter or a direct Google key instead.
+export type SessionProvider = 'claude' | 'native';
 
 export interface SessionInfo {
   id: string;
@@ -36,7 +42,7 @@ export interface SessionInfo {
   skipPermissions: boolean;
   status: 'active' | 'idle' | 'destroyed';
   createdAt: number;
-  /** Which CLI backend this session runs — 'claude' (default) or 'gemini' */
+  /** Which runtime backend this session runs — 'claude' (default) or 'native' */
   provider: SessionProvider;
   /** Model alias the session was started with (e.g. 'claude-sonnet-4-6') */
   model?: string;
@@ -848,6 +854,9 @@ export const IPC = {
   // System namespace — hardware back button bridge (Android only)
   SYSTEM_NOTIFY_STACK_STATE: 'system:notify-stack-state',
   SYSTEM_BACK: 'system:back',
+  // ---- Native runtime (YouCoded first-party harness — platform roadmap Phase 1+) ----
+  // Capability probe: false everywhere until Phase 1 ships the engine.
+  NATIVE_SUPPORTED: 'native:supported',
 } as const;
 
 // Performance / GPU configuration snapshot — returned by performance:get-config.

--- a/desktop/tests/chat-reducer.test.ts
+++ b/desktop/tests/chat-reducer.test.ts
@@ -142,16 +142,40 @@ describe('TRANSCRIPT_TURN_COMPLETE metadata', () => {
   });
 
   it('reasoning: consecutive REASONING events with same partId merge into one segment', () => {
-    // Thinking models (native harness) stream reasoning as chunks carrying a
-    // text payload + partId. Same partId → append to one segment, mirroring
-    // the text streaming path. Without this, the collapsible reasoning block
-    // would render dozens of tiny disclosures per turn.
+    // Thinking models (native harness) stream reasoning as per-token deltas
+    // carrying a text payload + partId. Same partId → append to one segment
+    // (unlike the text path, which appends whole blocks as new segments).
+    // Without this, the collapsible reasoning block would render dozens of
+    // tiny disclosures per turn.
     state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r1', text: 'Let me ', timestamp: 1, partId: 'rprt_1' });
     state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r2', text: 'think...', timestamp: 2, partId: 'rprt_1' });
 
     const turn = [...state.get(SESSION)!.assistantTurns.values()][0];
     expect(turn.segments.length).toBe(1);
     expect(turn.segments[0]).toMatchObject({ type: 'reasoning', content: 'Let me think...', partId: 'rprt_1' });
+  });
+
+  it('reasoning: different or missing partIds do NOT merge — each starts a new segment', () => {
+    // The don't-over-merge half of the contract: merging is keyed strictly
+    // on a matching partId. A new partId means a new reasoning part; an
+    // undefined partId can never match, so those events always append.
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r1', text: 'first part', timestamp: 1, partId: 'rprt_1' });
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r2', text: 'second part', timestamp: 2, partId: 'rprt_2' });
+
+    let turn = [...state.get(SESSION)!.assistantTurns.values()][0];
+    expect(turn.segments.length).toBe(2);
+    expect(turn.segments[0]).toMatchObject({ type: 'reasoning', content: 'first part', partId: 'rprt_1' });
+    expect(turn.segments[1]).toMatchObject({ type: 'reasoning', content: 'second part', partId: 'rprt_2' });
+
+    // Events with undefined partId each start a new segment — even
+    // back-to-back (undefined never satisfies the merge predicate).
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r3', text: 'no id A', timestamp: 3 });
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r4', text: 'no id B', timestamp: 4 });
+
+    turn = [...state.get(SESSION)!.assistantTurns.values()][0];
+    expect(turn.segments.length).toBe(4);
+    expect(turn.segments[2]).toMatchObject({ type: 'reasoning', content: 'no id A' });
+    expect(turn.segments[3]).toMatchObject({ type: 'reasoning', content: 'no id B' });
   });
 
   it('reasoning: REASONING followed by TEXT produces two segments (reasoning then text)', () => {

--- a/desktop/tests/chat-reducer.test.ts
+++ b/desktop/tests/chat-reducer.test.ts
@@ -140,4 +140,41 @@ describe('TRANSCRIPT_TURN_COMPLETE metadata', () => {
     expect(session.currentTurnId).toBeNull();
     expect(session.assistantTurns.size).toBe(0);
   });
+
+  it('reasoning: consecutive REASONING events with same partId merge into one segment', () => {
+    // Thinking models (native harness) stream reasoning as chunks carrying a
+    // text payload + partId. Same partId → append to one segment, mirroring
+    // the text streaming path. Without this, the collapsible reasoning block
+    // would render dozens of tiny disclosures per turn.
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r1', text: 'Let me ', timestamp: 1, partId: 'rprt_1' });
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r2', text: 'think...', timestamp: 2, partId: 'rprt_1' });
+
+    const turn = [...state.get(SESSION)!.assistantTurns.values()][0];
+    expect(turn.segments.length).toBe(1);
+    expect(turn.segments[0]).toMatchObject({ type: 'reasoning', content: 'Let me think...', partId: 'rprt_1' });
+  });
+
+  it('reasoning: REASONING followed by TEXT produces two segments (reasoning then text)', () => {
+    // The bubble splitter then attaches the reasoning to the following text
+    // bubble as a collapsible disclosure. Reducer just keeps them as
+    // distinct segments in order. (TEXT carries no partId on master.)
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r1', text: 'thinking', timestamp: 1, partId: 'rprt_1' });
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_TEXT', sessionId: SESSION, uuid: 't1', text: 'answer', timestamp: 2 });
+
+    const turn = [...state.get(SESSION)!.assistantTurns.values()][0];
+    expect(turn.segments.length).toBe(2);
+    expect(turn.segments[0].type).toBe('reasoning');
+    expect(turn.segments[1].type).toBe('text');
+  });
+
+  it('reasoning: REASONING action clears stale attentionState back to ok', () => {
+    // Reasoning is genuine activity — bumps lastActivityAt and clears the
+    // 'stuck' banner. Mirrors the existing TRANSCRIPT_THINKING_HEARTBEAT
+    // behavior so thinking models don't surface false-positive stuck banners
+    // while reasoning is streaming.
+    state = dispatch(state, { type: 'ATTENTION_STATE_CHANGED', sessionId: SESSION, state: 'stuck' });
+    expect(state.get(SESSION)!.attentionState).toBe('stuck');
+    state = dispatch(state, { type: 'TRANSCRIPT_ASSISTANT_REASONING', sessionId: SESSION, uuid: 'r1', text: 'x', timestamp: 1, partId: 'rprt_1' });
+    expect(state.get(SESSION)!.attentionState).toBe('ok');
+  });
 });

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -556,3 +556,21 @@ describe('syncspaces:* channel parity (desktop surfaces)', () => {
     expect(shim).toContain('syncspaces:event');
   });
 });
+
+// Native runtime capability flag (platform roadmap Phase 0 seam).
+// preload and remote-shim must both expose window.claude.native.supported —
+// the renderer gates the runtime selector on it without platform branching.
+// It is a plain boolean (no IPC round-trip), so there is no ipc-handlers or
+// SessionService.kt row — this describe pins shape parity only.
+describe('native runtime capability parity', () => {
+  it('preload.ts exposes native.supported', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../src/main/preload.ts'), 'utf8');
+    expect(src).toMatch(/native:\s*\{/);
+    expect(src).toMatch(/supported:/);
+  });
+  it('remote-shim.ts exposes native.supported: false', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../src/renderer/remote-shim.ts'), 'utf8');
+    expect(src).toMatch(/native:\s*\{/);
+    expect(src).toMatch(/supported:\s*false/);
+  });
+});

--- a/docs/cc-dependencies.md
+++ b/docs/cc-dependencies.md
@@ -2,6 +2,11 @@
 
 This doc tracks every place YouCoded couples to Claude Code's behavior — every silent point of failure when CC changes. It's both a navigational hub for humans and the input to the `review-cc-changes` release agent that maps CC CHANGELOG entries to code that might break.
 
+> **Sibling registries:** `engine-dependencies.md` (bundled llama.cpp) and
+> `provider-dependencies.md` (cloud provider APIs + AI SDK) track the
+> non-Claude backends introduced by the platform roadmap (Phase 0 seam:
+> `SessionProvider = 'claude' | 'native'`).
+
 ## When to update
 
 When you add code that parses CC output, consumes a CC file, depends on CLI behavior, or matches a CC text pattern, add an entry below. An omitted touchpoint silently downgrades the release agent to free-reasoning-only mode for that area — don't rely on the agent to notice a coupling that isn't documented here.

--- a/docs/engine-dependencies.md
+++ b/docs/engine-dependencies.md
@@ -1,0 +1,25 @@
+# Engine Coupling Registry (llama.cpp)
+
+Tracks every YouCoded touchpoint to the bundled llama.cpp engine
+(`llama-server`), mirroring the `cc-dependencies.md` discipline. Populated
+starting Phase 1 of the platform roadmap (see youcoded-dev
+`docs/superpowers/specs/2026-07-09-platform-vision-roadmap.md` and ADR 007).
+
+## Pinned version
+
+_None yet — Phase 1 pins the first engine build here. Bump together with a
+full coupling re-check + smoke probes._
+
+## Touchpoints (to be filled as built)
+
+- **`llama-server` CLI flags** — router mode, `--host/--port/--no-webui/--jinja`. (engine-supervisor)
+- **Health/readiness endpoint** — poll target for spawn supervision. (engine-supervisor)
+- **`/models`, `/models/load`, `/models/unload`** — router-mode model management. (model-catalog, engine-supervisor)
+- **`/v1/chat/completions`** — OpenAI-compat surface incl. `tools`, `json_schema`. (provider layer via @ai-sdk/openai-compatible)
+- **GGUF cache directory layout** — router auto-discovery contract. (model manager)
+- **`-hf user/repo:QUANT` download semantics.** (model manager)
+
+## Verification
+
+_Phase 1 adds smoke probes analogous to `test-conpty/` (spawn real engine,
+assert health + tool-call round-trip). Re-run on every engine bump._

--- a/docs/provider-dependencies.md
+++ b/docs/provider-dependencies.md
@@ -1,0 +1,20 @@
+# Provider Coupling Registry (cloud APIs + AI SDK)
+
+Tracks YouCoded's couplings to external model-provider APIs and the Vercel
+AI SDK, mirroring `cc-dependencies.md`. Populated starting Phase 1 (ADR 006
+in the youcoded-dev workspace).
+
+## Pinned versions
+
+_None yet — Phase 1 pins the AI SDK major/minor here._
+
+## Touchpoints (to be filled as built)
+
+- **Vercel AI SDK surface** — `streamText` stream-part shapes, tool-approval
+  mechanism (`needsApproval` vs `toolApproval` — version-sensitive), provider
+  factory signatures. (harness, provider-registry)
+- **models.dev `api.json` schema** — model/provider metadata. (model-catalog)
+- **OpenRouter** — `/api/v1/models` shape, attribution headers
+  (`HTTP-Referer`, `X-OpenRouter-Title`), BYOK behavior. (provider-registry)
+- **Per-vendor quirks** — reasoning blocks, prompt caching, rate-limit
+  headers; one entry per adopted `@ai-sdk/*` provider. (provider-registry)


### PR DESCRIPTION
Lands the dormant multi-model provider seam from the platform roadmap (youcoded-dev `docs/superpowers/specs/2026-07-09-platform-vision-roadmap.md`, Phase 0 spec `2026-07-10-phase0-foundations-design.md`, ADRs 006-010):

- `SessionProvider = 'claude' | 'native'`; `native:supported` IPC constant reserved
- **Gemini provider removed entirely** (CLI discontinued June 2026; Gemini models return via the native runtime in Phase 1 through OpenRouter/direct key) — the only user-visible change with default flags
- Two-way runtime selector (`Claude Code | YouCoded`), rendered only when `window.claude.native.supported` (hard-false until Phase 1; `YOUCODED_NATIVE=1` dev override); YouCoded option disabled
- Runtime-aware gating: attention classifier short-circuit, header view toggle, StatusBar permission badge + cycle, model picker guard; plus removal of HeaderBar's dead `permissionMode`/`onCyclePermission` props (badge lives in StatusBar)
- Collapsible reasoning segments salvaged from `feat/opencode-mvp` — `assistant-thinking` events with a text payload become merged `reasoning` segments with a collapsed "Show reasoning" disclosure; payload-less events stay heartbeats (CC path unchanged today: the watcher emits `data: {}`)
- `engine-dependencies.md` + `provider-dependencies.md` coupling-registry skeletons; `desktop/CLAUDE.md` preload/`process.env` claim corrected (verified empirically against the built preload in a sandboxed window)

**Verification:** tsc clean; full suite 1432 passed / 34 skipped; production build green; preload env probe confirms `supported` flips with `YOUCODED_NATIVE=1`; dev instance booted clean with the flag on. Every task passed independent spec-compliance + code-quality review.

**Phase 1 follow-ups noted by review** (all dormant today — native sessions cannot be created):
- Shift+Tab permission-cycle keyboard handler is ungated for native sessions
- Chat-view PTY send paths need harness routing: `InputBar` send, `guardedPtySend`, ESC interrupt, `useSubmitConfirmation` retry, ChatView Ink-menu keys, ToolCard permission keys, TrustGate, BubbleFeed send
- Subagent reasoning events would need `parentAgentToolUseId` routing in the reasoning reducer case

🤖 Generated with [Claude Code](https://claude.com/claude-code)