### PR TITLE
Conversation Store + CC transcript sync (Plan 2a)

### DIFF
--- a/desktop/src/main/conversations/conversation-store.ts
+++ b/desktop/src/main/conversations/conversation-store.ts
@@ -64,8 +64,12 @@ const HEALING_MARKER = '.healing-';
 // rejected exactly. CC ids are UUIDs, which pass untouched. Same house pattern
 // as the artifacts GET/SAVE root-escape refusal.
 const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+// Windows reserved device names pass the charset check but map to DEVICES on
+// older Windows ('con.json' → the console). Mirrors the module-private
+// WINDOWS_RESERVED in sync-spaces/guards.ts:5 — keep the two in sync.
+const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
 const isSafeSegment = (s: string) =>
-  SAFE_SEGMENT_RE.test(s) && s !== '.' && s !== '..';
+  SAFE_SEGMENT_RE.test(s) && s !== '.' && s !== '..' && !WINDOWS_RESERVED.test(s);
 
 export function createConversationStore(conversationsRoot: string): ConversationStore {
   const rootResolved = path.resolve(conversationsRoot);
@@ -268,14 +272,17 @@ export function createConversationStore(conversationsRoot: string): Conversation
         // provided field would silently vanish. Re-apply the caller's explicit
         // metadata POST-merge: these fields are facts the caller just observed,
         // not cross-device claims to arbitrate. lastActive/device deliberately
-        // stay merge-decided (activity-coupled); title lands only when
-        // non-empty (never blank a real name with '').
+        // stay merge-decided (activity-coupled); title lands only when it's a
+        // REAL name — non-empty AND not the literal 'Untitled' placeholder
+        // (same rule as store-core's realTitle). Callers normally normalize
+        // placeholders away, but the store is self-defending: a placeholder
+        // must never clobber a real title.
         return {
           ...merged,
           ...(partial.projectName !== undefined && { projectName: partial.projectName }),
           ...(partial.originalPath !== undefined && { originalPath: partial.originalPath }),
           ...(partial.transcriptRef !== undefined && { transcriptRef: partial.transcriptRef }),
-          ...(partial.title ? { title: partial.title } : null),
+          ...(partial.title && partial.title !== 'Untitled' ? { title: partial.title } : null),
         };
       });
     },

--- a/desktop/src/main/conversations/conversation-store.ts
+++ b/desktop/src/main/conversations/conversation-store.ts
@@ -1,0 +1,248 @@
+// IO shell for Conversation Store records (Phase 2a design §1). All disk access
+// for records lives HERE; every DECISION (what a merge resolves to, what a
+// conflict copy folds to) lives in store-core.ts (pure). This is the same
+// pure-core / IO-shell split used by local-theme-synthesizer.ts.
+//
+// Records are one-file-per-conversation so the sync engine's generic
+// conflict-copy policy stays out of our way (design decision 6) — and the
+// healer below cleans up the rare record-level conflict copies it does produce.
+import fs from 'node:fs';
+import path from 'node:path';
+import { mutateFileUnderLock } from '../artifacts/cas-write';
+import {
+  ConversationRecord,
+  RECORD_SCHEMA_VERSION,
+  parseRecord,
+  mergeRecords,
+  isConflictCopyName,
+  extractConflictBase,
+  foldConflictCopies,
+  FlagState,
+} from './store-core';
+
+export interface ConversationStore {
+  upsert(partial: UpsertInput): Promise<ConversationRecord>;
+  get(provider: string, id: string): Promise<ConversationRecord | null>;
+  list(provider: string): Promise<ConversationRecord[]>;
+  setFlag(provider: string, id: string, flag: string, value: boolean): Promise<void>;
+  setTitle(provider: string, id: string, title: string): Promise<void>;
+  root(): string;
+}
+
+// The activity/metadata fields a caller can supply. `lastActive` is the ONLY
+// field that drives merge outcome — omit it for metadata-only upserts (flag /
+// title seeds) so they never masquerade as fresh activity.
+export interface UpsertInput {
+  id: string;
+  provider: string;
+  projectName?: string;
+  originalPath?: string;
+  title?: string;
+  lastActive?: string;   // ISO — REQUIRED for activity updates; omitted for metadata-only
+  device?: string;
+  transcriptRef?: string;
+}
+
+// Epoch sentinel for lastActive on metadata-only seeds. Date.parse maps it to 0,
+// so a seed always LOSES a "newest wins" merge against any real turn — a flag
+// set before the first turn can never fabricate activity that outranks it.
+const EPOCH = '1970-01-01T00:00:00.000Z';
+
+export function createConversationStore(conversationsRoot: string): ConversationStore {
+  // <root>/<provider>/<id>.json — one file per conversation, grouped by provider.
+  const recordPath = (provider: string, id: string) =>
+    path.join(conversationsRoot, provider, `${id}.json`);
+
+  // Build a full record from a partial. Missing string fields default to '' so
+  // a record on disk never carries undefined. `lastActive` defaults to EPOCH
+  // (see above) so metadata-only partials don't outrank real activity, and
+  // `createdAt` is anchored to the supplied activity when present, else "now"
+  // (a fresh conversation is born when we first see it).
+  function toRecord(p: UpsertInput): ConversationRecord {
+    const la = p.lastActive ?? EPOCH;
+    return {
+      schema: RECORD_SCHEMA_VERSION,
+      id: p.id,
+      provider: p.provider,
+      projectName: p.projectName ?? '',
+      originalPath: p.originalPath ?? '',
+      title: p.title ?? '',
+      lastActive: la,
+      device: p.device ?? '',
+      flags: {},
+      transcriptRef: p.transcriptRef ?? '',
+      createdAt: p.lastActive ?? new Date().toISOString(),
+    };
+  }
+
+  // Read-modify-write one record file atomically. The callback sees the parsed
+  // on-disk record (null when absent) and returns the record to persist.
+  //
+  // mutateFileUnderLock gives read-modify-write atomicity under a mkdir lock:
+  // the dev instance and the built app both point at the same ~/YouCoded, so
+  // cross-process interleaving is a NORMAL state (same reasoning as the artifact
+  // central index — a read-outside-then-write loses updates).
+  async function mutateRecord(
+    provider: string,
+    id: string,
+    fn: (onDisk: ConversationRecord | null) => ConversationRecord,
+  ): Promise<ConversationRecord> {
+    const target = recordPath(provider, id);
+    // mutateFileUnderLock also mkdirs the parent, but doing it here keeps the
+    // "provider dir created on demand" guarantee obvious at the call site.
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    let result: ConversationRecord | undefined;
+    // The mutate callback is SYNCHRONOUS (see cas-write.ts) — we compute the
+    // next record and stringify it in one shot; the lock is held across the
+    // whole read+compute+write.
+    const committed = await mutateFileUnderLock(target, (onDisk) => {
+      const existing = onDisk ? parseRecord(onDisk) : null;
+      result = fn(existing);
+      return JSON.stringify(result, null, 2);
+    });
+    // Deviation from the plan: guard the lock-timeout case. mutateFileUnderLock
+    // returns false (and skips the write) when it can't acquire the lock within
+    // its timeout; the plan's `result!` would then hand back `undefined` typed
+    // as a record. Throwing surfaces the rare contention failure instead of
+    // silently returning a bogus record.
+    if (!committed || !result) {
+      throw new Error(`conversation-store: could not write ${provider}/${id} (lock timeout)`);
+    }
+    return result;
+  }
+
+  // Heal engine conflict copies for ONE record id: fold them field-level into
+  // the canonical record, rewrite the canonical, delete the copies. Runs
+  // opportunistically on the read paths (get/list) and before an upsert.
+  async function heal(provider: string, id: string): Promise<void> {
+    const dir = path.join(conversationsRoot, provider);
+    let names: string[];
+    // The provider dir may not exist yet — nothing to heal.
+    try { names = fs.readdirSync(dir); } catch { return; }
+    // Only conflict copies whose canonical base is exactly this id's file.
+    // extractConflictBase runs to the LAST ')' before .json (device names may
+    // contain ')'), so this correctly scopes to <id>.json copies only.
+    const copies = names.filter(
+      (n) => isConflictCopyName(n) && extractConflictBase(n) === `${id}.json`,
+    );
+    if (copies.length === 0) return;
+    // Parse the copies; a copy that won't parse (or whose id doesn't match) is
+    // dropped from the fold but STILL deleted below — it carries nothing and
+    // would otherwise re-trigger healing on every read forever.
+    const parsed = copies
+      .map((n) => {
+        try { return parseRecord(fs.readFileSync(path.join(dir, n), 'utf8')); }
+        catch { return null; }
+      })
+      .filter((r): r is ConversationRecord => !!r && r.id === id);
+    if (parsed.length > 0) {
+      await mutateRecord(provider, id, (existing) =>
+        // With a canonical on disk: fold ALL copies into it. Without one (only
+        // conflict copies exist): seed from the first copy and fold the rest.
+        // foldConflictCopies picks each field over its ORIGINAL inputs, so the
+        // result is independent of directory enumeration order.
+        foldConflictCopies(existing ?? parsed[0], existing ? parsed : parsed.slice(1)));
+    }
+    // Delete every copy we scanned (parseable or not). The try/catch tolerates a
+    // concurrent list()/heal() in another window having already unlinked it.
+    for (const n of copies) {
+      try { fs.unlinkSync(path.join(dir, n)); } catch { /* already gone */ }
+    }
+  }
+
+  return {
+    root: () => conversationsRoot,
+
+    async upsert(partial) {
+      // Fold away any conflict copies first so we merge into the true canonical.
+      await heal(partial.provider, partial.id);
+      const incoming = toRecord(partial);
+      return mutateRecord(partial.provider, partial.id, (existing) => {
+        if (!existing) return incoming;
+        // Metadata-only partials must NOT blank real fields: overlay ONLY the
+        // fields the caller actually provided onto the existing record, then
+        // field-merge. lastActive always comes from `incoming` (EPOCH when the
+        // caller omitted it) so mergeRecords ranks activity correctly.
+        const overlay: ConversationRecord = {
+          ...existing,
+          ...(partial.projectName !== undefined && { projectName: partial.projectName }),
+          ...(partial.originalPath !== undefined && { originalPath: partial.originalPath }),
+          ...(partial.title !== undefined && { title: partial.title }),
+          ...(partial.device !== undefined && { device: partial.device }),
+          ...(partial.transcriptRef !== undefined && { transcriptRef: partial.transcriptRef }),
+          lastActive: incoming.lastActive,
+        };
+        return mergeRecords(existing, overlay);
+      });
+    },
+
+    async get(provider, id) {
+      // Heal-on-read: any conflict copies for this id are folded in before we
+      // return, so callers always see the converged record.
+      await heal(provider, id);
+      try {
+        return parseRecord(fs.readFileSync(recordPath(provider, id), 'utf8'));
+      } catch {
+        // Missing file → null. (A corrupt file is handled by parseRecord
+        // returning null above; either way we never delete on a read.)
+        return null;
+      }
+    },
+
+    async list(provider) {
+      const dir = path.join(conversationsRoot, provider);
+      let names: string[];
+      // No provider dir → no conversations.
+      try { names = fs.readdirSync(dir); } catch { return []; }
+      // Heal any conflict copies found in this listing pass, then read clean.
+      for (const n of names) {
+        if (isConflictCopyName(n)) {
+          const base = extractConflictBase(n);
+          // Only .json conflict copies map back to a record id; a non-record
+          // copy ('notes (from X).txt') yields a base that isn't ours and heal
+          // finds no matching copies, so it's a no-op — but we still gate on the
+          // .json base to avoid pointless heal calls.
+          if (base && base.endsWith('.json')) {
+            await heal(provider, base.replace(/\.json$/, ''));
+          }
+        }
+      }
+      const out: ConversationRecord[] = [];
+      // Re-read the dir: heal may have deleted conflict copies above.
+      for (const n of fs.readdirSync(dir)) {
+        if (!n.endsWith('.json') || isConflictCopyName(n)) continue;
+        try {
+          const r = parseRecord(fs.readFileSync(path.join(dir, n), 'utf8'));
+          // A corrupt record damages exactly ONE conversation, never the list.
+          if (r) out.push(r);
+        } catch { /* unreadable file — skip */ }
+      }
+      return out;
+    },
+
+    async setFlag(provider, id, flag, value) {
+      await mutateRecord(provider, id, (existing) => {
+        // Seed a flag-only record when the conversation isn't on disk yet — a
+        // flag can legitimately be set before the first turn is recorded.
+        const base = existing ?? toRecord({ id, provider });
+        const flags: Record<string, FlagState> = {
+          ...base.flags,
+          // Fresh updatedAt so this flag wins any future merge against an older
+          // value for the same key.
+          [flag]: { value, updatedAt: new Date().toISOString() },
+        };
+        return { ...base, flags };
+      });
+    },
+
+    async setTitle(provider, id, title) {
+      // Empty title is a no-op — never overwrite a real name with nothing, and
+      // never seed an empty-titled record just to store "".
+      if (!title) return;
+      await mutateRecord(provider, id, (existing) => {
+        const base = existing ?? toRecord({ id, provider });
+        return { ...base, title };
+      });
+    },
+  };
+}

--- a/desktop/src/main/conversations/conversation-store.ts
+++ b/desktop/src/main/conversations/conversation-store.ts
@@ -29,9 +29,14 @@ export interface ConversationStore {
   root(): string;
 }
 
-// The activity/metadata fields a caller can supply. `lastActive` is the ONLY
-// field that drives merge outcome — omit it for metadata-only upserts (flag /
-// title seeds) so they never masquerade as fresh activity.
+// The activity/metadata fields a caller can supply. `lastActive` decides how
+// the merge RANKS the two sides (omit it for metadata-only upserts so they
+// never masquerade as fresh activity) — but caller-provided metadata fields
+// (projectName / originalPath / title / transcriptRef) are LOCAL TRUTH and
+// always land regardless of merge ranking: the merge exists for cross-device
+// convergence, not for arguing with the caller. `lastActive`/`device` are
+// activity-coupled and stay merge-decided (a caller with newer activity lands
+// them via the merge anyway).
 export interface UpsertInput {
   id: string;
   provider: string;
@@ -48,10 +53,43 @@ export interface UpsertInput {
 // set before the first turn can never fabricate activity that outranks it.
 const EPOCH = '1970-01-01T00:00:00.000Z';
 
+// Quarantine marker the healer appends when it atomically CLAIMS a conflict
+// copy (see heal()). Files carrying it are healer-private intermediates.
+const HEALING_MARKER = '.healing-';
+
+// SECURITY (review fix 1): `provider` and `id` become path segments, and this
+// store sits near IPC/remote surfaces, so raw strings could traverse out of the
+// store root ('../../escape'). Allowlist charset — letters, digits, dot,
+// underscore, hyphen — contains no separators and no NUL; '.' and '..' are
+// rejected exactly. CC ids are UUIDs, which pass untouched. Same house pattern
+// as the artifacts GET/SAVE root-escape refusal.
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+const isSafeSegment = (s: string) =>
+  SAFE_SEGMENT_RE.test(s) && s !== '.' && s !== '..';
+
 export function createConversationStore(conversationsRoot: string): ConversationStore {
-  // <root>/<provider>/<id>.json — one file per conversation, grouped by provider.
-  const recordPath = (provider: string, id: string) =>
-    path.join(conversationsRoot, provider, `${id}.json`);
+  const rootResolved = path.resolve(conversationsRoot);
+
+  // Resolve <root>/<provider>, refusing anything that escapes the root.
+  // The resolve+startsWith check is defense-in-depth behind the charset guard —
+  // both must hold for a path to be used.
+  function providerDir(provider: string): string {
+    const dir = path.resolve(rootResolved, provider);
+    if (!isSafeSegment(provider) || !dir.startsWith(rootResolved + path.sep)) {
+      throw new Error(`conversation-store: invalid provider '${provider}'`);
+    }
+    return dir;
+  }
+
+  // Resolve <root>/<provider>/<id>.json with the same escape refusal for id.
+  function recordPath(provider: string, id: string): string {
+    const dir = providerDir(provider);
+    const target = path.resolve(dir, `${id}.json`);
+    if (!isSafeSegment(id) || !target.startsWith(dir + path.sep)) {
+      throw new Error(`conversation-store: invalid conversation id '${id}'`);
+    }
+    return target;
+  }
 
   // Build a full record from a partial. Missing string fields default to '' so
   // a record on disk never carries undefined. `lastActive` defaults to EPOCH
@@ -87,6 +125,8 @@ export function createConversationStore(conversationsRoot: string): Conversation
     id: string,
     fn: (onDisk: ConversationRecord | null) => ConversationRecord,
   ): Promise<ConversationRecord> {
+    // recordPath validates provider + id and THROWS on traversal — this is the
+    // single chokepoint every write path funnels through (review fix 1).
     const target = recordPath(provider, id);
     // mutateFileUnderLock also mkdirs the parent, but doing it here keeps the
     // "provider dir created on demand" guarantee obvious at the call site.
@@ -100,41 +140,87 @@ export function createConversationStore(conversationsRoot: string): Conversation
       result = fn(existing);
       return JSON.stringify(result, null, 2);
     });
-    // Deviation from the plan: guard the lock-timeout case. mutateFileUnderLock
-    // returns false (and skips the write) when it can't acquire the lock within
-    // its timeout; the plan's `result!` would then hand back `undefined` typed
-    // as a record. Throwing surfaces the rare contention failure instead of
-    // silently returning a bogus record.
+    // mutateFileUnderLock returns false (and skips the write) when it can't
+    // acquire the lock within its timeout. Throwing surfaces the rare
+    // contention failure instead of silently returning a bogus record.
     if (!committed || !result) {
       throw new Error(`conversation-store: could not write ${provider}/${id} (lock timeout)`);
     }
     return result;
   }
 
-  // Heal engine conflict copies for ONE record id: fold them field-level into
-  // the canonical record, rewrite the canonical, delete the copies. Runs
-  // opportunistically on the read paths (get/list) and before an upsert.
+  // Heal engine conflict copies for ONE record id: atomically CLAIM each copy
+  // via quarantine-rename, fold the claimed content field-level into the
+  // canonical record, then delete the quarantine files. Runs opportunistically
+  // on the read paths (get/list) and before an upsert.
+  //
+  // WHY quarantine-rename (review fix 2): deleting a copy by its ORIGINAL name
+  // races the sync engine — between our read and our unlink, another process's
+  // heal can remove the copy and the engine can write NEW conflict content at
+  // the very same name (its free-name probe sees the name free; the date suffix
+  // is day-granular). Our unlink would then destroy unfolded data. Renaming to
+  // '<copy>.healing-<pid>' atomically claims the EXACT content we read: the
+  // engine can never collide with a claimed name, and everything we later
+  // delete is a name only we created.
   async function heal(provider: string, id: string): Promise<void> {
-    const dir = path.join(conversationsRoot, provider);
+    const dir = providerDir(provider);
     let names: string[];
     // The provider dir may not exist yet — nothing to heal.
     try { names = fs.readdirSync(dir); } catch { return; }
-    // Only conflict copies whose canonical base is exactly this id's file.
+    const baseName = `${id}.json`;
+
+    // CRASH RECOVERY: a healer that died after claiming left
+    // '<copy>.healing-<pid>' behind — junk that would otherwise sync forever.
+    // Adopt such files into this fold. Refolding content a previous healer
+    // already folded is harmless (the fold is idempotent), and if the file
+    // belongs to a LIVE concurrent healer, both of us fold the same bytes and
+    // the ENOENT guards below absorb whichever deletion lands second.
+    const claimed: string[] = names
+      .filter((n) => {
+        const h = n.indexOf(HEALING_MARKER);
+        if (h < 0) return false;
+        const original = n.slice(0, h);
+        return isConflictCopyName(original) && extractConflictBase(original) === baseName;
+      })
+      .map((n) => path.join(dir, n));
+
+    // Live conflict copies whose canonical base is exactly this id's file.
     // extractConflictBase runs to the LAST ')' before .json (device names may
     // contain ')'), so this correctly scopes to <id>.json copies only.
     const copies = names.filter(
-      (n) => isConflictCopyName(n) && extractConflictBase(n) === `${id}.json`,
+      (n) => isConflictCopyName(n) && extractConflictBase(n) === baseName,
     );
-    if (copies.length === 0) return;
-    // Parse the copies; a copy that won't parse (or whose id doesn't match) is
-    // dropped from the fold but STILL deleted below — it carries nothing and
-    // would otherwise re-trigger healing on every read forever.
-    const parsed = copies
-      .map((n) => {
-        try { return parseRecord(fs.readFileSync(path.join(dir, n), 'utf8')); }
+
+    for (const n of copies) {
+      const full = path.join(dir, n);
+      // Review fix 5b: a copy that parses to a VALID record with a DIFFERENT id
+      // is someone's data under a misleading filename — leave it in place for
+      // investigation; never fold it, never delete it. (Unreadable/corrupt
+      // copies fall through to claiming: unparseable content carries nothing
+      // usable as a record and would re-trigger healing forever if kept.)
+      let peek: ConversationRecord | null = null;
+      try { peek = parseRecord(fs.readFileSync(full, 'utf8')); } catch { /* vanished — claim attempt below sorts it out */ }
+      if (peek && peek.id !== id) continue;
+      // Atomic claim. ENOENT (or any rename failure) means another healer
+      // claimed or removed this copy first — skip it; their fold covers it.
+      const quarantine = full + HEALING_MARKER + process.pid;
+      try {
+        fs.renameSync(full, quarantine);
+        claimed.push(quarantine);
+      } catch { /* lost the claim race — not ours to heal */ }
+    }
+    if (claimed.length === 0) return;
+
+    // Read the claimed content. A quarantine file can still vanish under a
+    // concurrent adopter (see crash-recovery note) — per-file try/catch keeps
+    // one loss from aborting the fold of the rest.
+    const parsed = claimed
+      .map((q) => {
+        try { return parseRecord(fs.readFileSync(q, 'utf8')); }
         catch { return null; }
       })
       .filter((r): r is ConversationRecord => !!r && r.id === id);
+
     if (parsed.length > 0) {
       await mutateRecord(provider, id, (existing) =>
         // With a canonical on disk: fold ALL copies into it. Without one (only
@@ -143,10 +229,12 @@ export function createConversationStore(conversationsRoot: string): Conversation
         // result is independent of directory enumeration order.
         foldConflictCopies(existing ?? parsed[0], existing ? parsed : parsed.slice(1)));
     }
-    // Delete every copy we scanned (parseable or not). The try/catch tolerates a
-    // concurrent list()/heal() in another window having already unlinked it.
-    for (const n of copies) {
-      try { fs.unlinkSync(path.join(dir, n)); } catch { /* already gone */ }
+    // Delete the quarantine files ONLY after the fold landed — if mutateRecord
+    // threw above, they stay on disk and the next heal adopts them (no data
+    // loss on a failed fold). Unparseable claims are deleted too: they carry
+    // nothing usable as a record. ENOENT tolerated (concurrent adopter).
+    for (const q of claimed) {
+      try { fs.unlinkSync(q); } catch { /* already gone */ }
     }
   }
 
@@ -154,15 +242,17 @@ export function createConversationStore(conversationsRoot: string): Conversation
     root: () => conversationsRoot,
 
     async upsert(partial) {
+      // Validate FIRST so a traversal id/provider throws before any disk work
+      // (heal would otherwise silently no-op on a bad provider).
+      recordPath(partial.provider, partial.id);
       // Fold away any conflict copies first so we merge into the true canonical.
       await heal(partial.provider, partial.id);
       const incoming = toRecord(partial);
       return mutateRecord(partial.provider, partial.id, (existing) => {
         if (!existing) return incoming;
-        // Metadata-only partials must NOT blank real fields: overlay ONLY the
-        // fields the caller actually provided onto the existing record, then
-        // field-merge. lastActive always comes from `incoming` (EPOCH when the
-        // caller omitted it) so mergeRecords ranks activity correctly.
+        // Overlay the provided fields onto the existing record so mergeRecords
+        // can rank the two sides by activity (lastActive is `incoming`'s —
+        // EPOCH when the caller omitted it, so metadata-only never outranks).
         const overlay: ConversationRecord = {
           ...existing,
           ...(partial.projectName !== undefined && { projectName: partial.projectName }),
@@ -172,14 +262,33 @@ export function createConversationStore(conversationsRoot: string): Conversation
           ...(partial.transcriptRef !== undefined && { transcriptRef: partial.transcriptRef }),
           lastActive: incoming.lastActive,
         };
-        return mergeRecords(existing, overlay);
+        const merged = mergeRecords(existing, overlay);
+        // Review fix 3 — LOCAL TRUTH: the merge ranks by activity, so a
+        // metadata-only upsert (EPOCH lastActive) loses wholesale and every
+        // provided field would silently vanish. Re-apply the caller's explicit
+        // metadata POST-merge: these fields are facts the caller just observed,
+        // not cross-device claims to arbitrate. lastActive/device deliberately
+        // stay merge-decided (activity-coupled); title lands only when
+        // non-empty (never blank a real name with '').
+        return {
+          ...merged,
+          ...(partial.projectName !== undefined && { projectName: partial.projectName }),
+          ...(partial.originalPath !== undefined && { originalPath: partial.originalPath }),
+          ...(partial.transcriptRef !== undefined && { transcriptRef: partial.transcriptRef }),
+          ...(partial.title ? { title: partial.title } : null),
+        };
       });
     },
 
     async get(provider, id) {
-      // Heal-on-read: any conflict copies for this id are folded in before we
-      // return, so callers always see the converged record.
-      await heal(provider, id);
+      // Fail-soft reads (review fix 1): an invalid name can't address a record
+      // — answer "not found", don't throw (reads promise to degrade, not break).
+      if (!isSafeSegment(provider) || !isSafeSegment(id)) return null;
+      // Heal-on-read is OPPORTUNISTIC (review fix 4): a contended/stale lock on
+      // the canonical must not reject the read — serve the un-healed canonical
+      // and let the next read retry (claimed quarantine files survive a failed
+      // fold, so nothing is lost).
+      try { await heal(provider, id); } catch { /* heal retries on next read */ }
       try {
         return parseRecord(fs.readFileSync(recordPath(provider, id), 'utf8'));
       } catch {
@@ -190,26 +299,34 @@ export function createConversationStore(conversationsRoot: string): Conversation
     },
 
     async list(provider) {
-      const dir = path.join(conversationsRoot, provider);
+      // Fail-soft reads: invalid provider → empty listing, never a throw.
+      if (!isSafeSegment(provider)) return [];
+      let dir: string;
+      try { dir = providerDir(provider); } catch { return []; }
       let names: string[];
       // No provider dir → no conversations.
       try { names = fs.readdirSync(dir); } catch { return []; }
-      // Heal any conflict copies found in this listing pass, then read clean.
+      // Heal any conflict copies (and stale quarantine files) found in this
+      // listing pass, then read clean. Heal failures are swallowed per fix 4 —
+      // a stuck lock on ONE record must not empty the whole list.
       for (const n of names) {
-        if (isConflictCopyName(n)) {
-          const base = extractConflictBase(n);
-          // Only .json conflict copies map back to a record id; a non-record
-          // copy ('notes (from X).txt') yields a base that isn't ours and heal
-          // finds no matching copies, so it's a no-op — but we still gate on the
-          // .json base to avoid pointless heal calls.
-          if (base && base.endsWith('.json')) {
-            await heal(provider, base.replace(/\.json$/, ''));
+        // A stale quarantine name maps back to its original conflict-copy name.
+        const h = n.indexOf(HEALING_MARKER);
+        const original = h >= 0 ? n.slice(0, h) : n;
+        if (isConflictCopyName(original)) {
+          const base = extractConflictBase(original);
+          if (base) {
+            try { await heal(provider, base.replace(/\.json$/, '')); }
+            catch { /* opportunistic — next list retries */ }
           }
         }
       }
       const out: ConversationRecord[] = [];
-      // Re-read the dir: heal may have deleted conflict copies above.
-      for (const n of fs.readdirSync(dir)) {
+      // Re-read the dir (heal may have deleted copies) — guarded like the
+      // first read: a dir that vanished mid-list yields [] not a crash.
+      let finalNames: string[];
+      try { finalNames = fs.readdirSync(dir); } catch { return []; }
+      for (const n of finalNames) {
         if (!n.endsWith('.json') || isConflictCopyName(n)) continue;
         try {
           const r = parseRecord(fs.readFileSync(path.join(dir, n), 'utf8'));

--- a/desktop/src/main/conversations/reconciler.ts
+++ b/desktop/src/main/conversations/reconciler.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { readSessionTranscriptMeta } from '../session-browser';
 import type { ConversationStore } from './conversation-store';
+import type { ConversationRecord } from './store-core';
 
 // Same UUID gate as the legacy index (sync-service.ts SESSION_UUID_RE — COPIED,
 // not imported: sync-service is legacy/untouchable). The phantom-id lesson from
@@ -26,10 +27,13 @@ export interface ReconcileOpts {
 }
 
 // A CC slug is the cwd with separators flattened to '-' (cwdToProjectSlug).
-// The original path is NOT recoverable in general; the basename approximation
-// (last '-' segment) is good enough for projectName matching, and the record's
-// originalPath is corrected by the live path the next time the session runs in
-// the app. Deliberately no attempt to reverse the slug encoding.
+// The original path is NOT recoverable in general, so this takes the LAST slug
+// segment — which for a hyphenated folder name is a TRUNCATION, not the
+// basename ('youcoded-dev' slugs to '...-youcoded-dev' and yields 'dev').
+// That's acceptable because the value is internally consistent (transcriptRef
+// and the mirror key use the same string) and the live path corrects it the
+// next time the session runs in the app. Deliberately no attempt to reverse
+// the slug encoding.
 function projectNameFromSlug(slug: string): string {
   const parts = slug.split('-').filter(Boolean);
   return parts.length ? parts[parts.length - 1] : slug;
@@ -60,6 +64,19 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
   let slugs: string[] = [];
   // No projects dir → nothing to reconcile.
   try { slugs = fs.readdirSync(opts.projectsDir); } catch { return 0; }
+
+  // PERF (review fix): preload ALL existing records in ONE list() pass instead
+  // of store.get() per transcript. get() runs heal(), which readdirs the whole
+  // provider dir — per-file gets made the scan O(n²) in dirents (measured 2.8s
+  // steady-state at 600 records, every startup + 30-min tick). list() heals
+  // once in a single pass. On list failure the map stays empty and the scan
+  // degrades to create-everything upserts, which the store's merge absorbs
+  // safely (newest data wins).
+  const existingById = new Map<string, ConversationRecord>();
+  try {
+    for (const r of await opts.store.list('claude')) existingById.set(r.id, r);
+  } catch { /* degraded: treat everything as new; upsert merges safely */ }
+
   for (const slug of slugs) {
     const dir = path.join(opts.projectsDir, slug);
     let files: string[] = [];
@@ -78,13 +95,14 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
         try { size = fs.statSync(jsonlPath).size; } catch { continue; }
         if (size < MIN_TRANSCRIPT_BYTES) continue;
 
-        const existing = await opts.store.get('claude', sessionId);
-        // wantTitle only when we don't already have a title — skips the head
-        // read for records that are already named.
-        const meta = await readSessionTranscriptMeta(jsonlPath, !existing?.title);
+        const existing = existingById.get(sessionId) ?? null;
+        // Gate read: tail timestamp only (wantTitle=false). Computing the title
+        // here wasted a 256KB head read on every fresh-but-untitled record each
+        // scan — the title is only needed on the upsert branch below.
+        const gateMeta = await readSessionTranscriptMeta(jsonlPath, false);
         // lastActive from the transcript's own content timestamp — mtimes lie
         // after any sync/restore (the 627-file rebump incident).
-        const lastActive = meta.lastTimestampMs ? new Date(meta.lastTimestampMs).toISOString() : null;
+        const lastActive = gateMeta.lastTimestampMs ? new Date(gateMeta.lastTimestampMs).toISOString() : null;
 
         if (existing && lastActive && Date.parse(existing.lastActive) >= Date.parse(lastActive)) {
           // Record already as fresh as the file — leave it, but still mirror
@@ -92,18 +110,39 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
           safeMirror(opts, jsonlPath, existing.projectName || projectNameFromSlug(slug), sessionId);
           continue;
         }
+        // Corrupt-transcript guard (review fix): a >500-byte file with NO
+        // parseable tail timestamp is corrupt (the UUID/junk gates set the
+        // precedent for refusing bad inputs). Creating a record would stamp
+        // EPOCH lastActive and re-upsert on EVERY scan forever (the freshness
+        // gate never passes for EPOCH), and an EXISTING record must not be
+        // touched on the say-so of a corrupt file. Skip entirely — no record,
+        // and no mirroring of corrupt bytes into the durable space copy.
+        if (!lastActive) continue;
+
         const projectName = existing?.projectName || projectNameFromSlug(slug);
-        const title = readTopicTitle(opts.topicsDir, sessionId) || meta.fallbackTitle || '';
-        await opts.store.upsert({
+        // Title resolution only when needed: topic file first (cheap), then the
+        // derived first-user-message title via a second meta read with
+        // wantTitle=true. The double tail-read on this branch is acceptable —
+        // it only happens for records that actually upsert.
+        let title = readTopicTitle(opts.topicsDir, sessionId);
+        if (!title && !existing?.title) {
+          title = (await readSessionTranscriptMeta(jsonlPath, true)).fallbackTitle || '';
+        }
+        const upserted = await opts.store.upsert({
           id: sessionId,
           provider: 'claude',
           projectName,
           title: title || undefined,
-          lastActive: lastActive ?? undefined,
+          lastActive, // non-null here — the corrupt-guard above filtered null
           device: opts.device,
           // transcriptRef uses projectName (the portable projectKey), NOT the CC slug.
           transcriptRef: `claude/transcripts/${projectName}/${sessionId}.jsonl`,
         });
+        // Keep the preload map current: the SAME session id can appear under a
+        // second slug dir later in the scan (session-browser dedups by longest
+        // slug for the same reason) — the second sighting must see this upsert,
+        // not the stale preload.
+        existingById.set(sessionId, upserted);
         // Count only AFTER the upsert lands, and BEFORE the best-effort mirror,
         // so a mirror throw never un-counts a successful record write.
         upserts++;

--- a/desktop/src/main/conversations/reconciler.ts
+++ b/desktop/src/main/conversations/reconciler.ts
@@ -6,6 +6,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { readSessionTranscriptMeta } from '../session-browser';
+import { ccProjectSlug } from '../project-conversations';
 import type { ConversationStore } from './conversation-store';
 import type { ConversationRecord } from './store-core';
 
@@ -24,16 +25,49 @@ export interface ReconcileOpts {
   // transcript-mirror + the Conversations root. Best-effort — a throw here must
   // not abort the scan (see safeMirror).
   mirror: (localJsonlPath: string, projectKey: string, sessionId: string) => void;
+  // Absolute paths of folders this device knows about (managed projects + saved
+  // folders). Used to recover the EXACT folder name for a CC slug instead of the
+  // lossy last-segment truncation — see resolveProjectName.
+  knownFolders?: string[];
 }
 
-// A CC slug is the cwd with separators flattened to '-' (cwdToProjectSlug).
-// The original path is NOT recoverable in general, so this takes the LAST slug
-// segment — which for a hyphenated folder name is a TRUNCATION, not the
-// basename ('youcoded-dev' slugs to '...-youcoded-dev' and yields 'dev').
-// That's acceptable because the value is internally consistent (transcriptRef
-// and the mirror key use the same string) and the live path corrects it the
-// next time the session runs in the app. Deliberately no attempt to reverse
-// the slug encoding.
+// Build a slug → exact-basename lookup from the device's known folders. The CC
+// slug encodes the whole cwd with separators flattened, so the last segment
+// TRUNCATES hyphenated names ('youcoded-dev' slug → last segment 'dev'). But if
+// this device actually has that folder, ccProjectSlug(folder) reproduces CC's
+// on-disk slug exactly, letting us recover the true basename. WHY it matters:
+// the live/service path keys transcripts by basename(cwd); a mismatched
+// reconciler key produces an ORPHAN duplicate space transcript and a
+// cross-device materialize gap (the record's projectKey never matches the peer's
+// managed project). Keys are lowercased so Windows case drift between a saved
+// folder path and CC's cwd can't miss the match.
+function buildSlugToName(knownFolders: string[] | undefined): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const folder of knownFolders ?? []) {
+    try { m.set(ccProjectSlug(folder).toLowerCase(), path.basename(folder)); }
+    catch { /* unslugifiable path — skip */ }
+  }
+  return m;
+}
+
+// Exact folder name when this device knows the folder; else an existing record's
+// name; else the lossy truncation (corrected by the live path next in-app run).
+function resolveProjectName(
+  existing: ConversationRecord | null,
+  slug: string,
+  slugToName: Map<string, string>,
+): string {
+  return existing?.projectName || slugToName.get(slug.toLowerCase()) || projectNameFromSlug(slug);
+}
+
+// LAST-RESORT fallback used only when the folder is NOT among this device's
+// known folders (see buildSlugToName/resolveProjectName, which recover the exact
+// basename first). A CC slug is the cwd with separators flattened to '-'
+// (cwdToProjectSlug); the original path is not recoverable from the slug alone,
+// so this takes the LAST slug segment — a TRUNCATION for hyphenated names
+// ('...-youcoded-dev' → 'dev'). Acceptable as a fallback because it's internally
+// consistent (transcriptRef and the mirror key use the same string) and the live
+// path corrects it the next time the session runs in the app.
 function projectNameFromSlug(slug: string): string {
   const parts = slug.split('-').filter(Boolean);
   return parts.length ? parts[parts.length - 1] : slug;
@@ -64,6 +98,9 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
   let slugs: string[] = [];
   // No projects dir → nothing to reconcile.
   try { slugs = fs.readdirSync(opts.projectsDir); } catch { return 0; }
+
+  // Recover exact folder names for this device's known folders (see the helper).
+  const slugToName = buildSlugToName(opts.knownFolders);
 
   // PERF (review fix): preload ALL existing records in ONE list() pass instead
   // of store.get() per transcript. get() runs heal(), which readdirs the whole
@@ -107,7 +144,7 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
         if (existing && lastActive && Date.parse(existing.lastActive) >= Date.parse(lastActive)) {
           // Record already as fresh as the file — leave it, but still mirror
           // (cheap size check inside mirror makes a no-op copy when unchanged).
-          safeMirror(opts, jsonlPath, existing.projectName || projectNameFromSlug(slug), sessionId);
+          safeMirror(opts, jsonlPath, resolveProjectName(existing, slug, slugToName), sessionId);
           continue;
         }
         // Corrupt-transcript guard (review fix): a >500-byte file with NO
@@ -119,7 +156,7 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
         // and no mirroring of corrupt bytes into the durable space copy.
         if (!lastActive) continue;
 
-        const projectName = existing?.projectName || projectNameFromSlug(slug);
+        const projectName = resolveProjectName(existing, slug, slugToName);
         // Title resolution only when needed: topic file first (cheap), then the
         // derived first-user-message title via a second meta read with
         // wantTitle=true. The double tail-read on this branch is acceptable —

--- a/desktop/src/main/conversations/reconciler.ts
+++ b/desktop/src/main/conversations/reconciler.ts
@@ -1,0 +1,117 @@
+// Catch-up scan (design §1): sessions run OUTSIDE the app (bare `claude` in a
+// terminal) never fire the live transcript-event path, so on startup (and a
+// slow periodic tick) we walk ~/.claude/projects and upsert records for what
+// we find. The live path remains authoritative — the upsert merge keeps the
+// newest data, so re-scanning is always safe.
+import fs from 'node:fs';
+import path from 'node:path';
+import { readSessionTranscriptMeta } from '../session-browser';
+import type { ConversationStore } from './conversation-store';
+
+// Same UUID gate as the legacy index (sync-service.ts SESSION_UUID_RE — COPIED,
+// not imported: sync-service is legacy/untouchable). The phantom-id lesson from
+// the Resume Browser incident: never create records from malformed ids.
+const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MIN_TRANSCRIPT_BYTES = 500; // junk threshold, same as listPastSessions
+
+export interface ReconcileOpts {
+  projectsDir: string;   // ~/.claude/projects
+  topicsDir: string;     // ~/.claude/topics
+  store: ConversationStore;
+  device: string;
+  // Injected so tests don't need a real space; production passes a closure over
+  // transcript-mirror + the Conversations root. Best-effort — a throw here must
+  // not abort the scan (see safeMirror).
+  mirror: (localJsonlPath: string, projectKey: string, sessionId: string) => void;
+}
+
+// A CC slug is the cwd with separators flattened to '-' (cwdToProjectSlug).
+// The original path is NOT recoverable in general; the basename approximation
+// (last '-' segment) is good enough for projectName matching, and the record's
+// originalPath is corrected by the live path the next time the session runs in
+// the app. Deliberately no attempt to reverse the slug encoding.
+function projectNameFromSlug(slug: string): string {
+  const parts = slug.split('-').filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : slug;
+}
+
+// Topic-file title wins over the derived fallback (matches session-browser
+// precedence). Placeholders ('New Session' / 'Untitled') are treated as absent
+// so the derived fallback still applies.
+function readTopicTitle(topicsDir: string, sessionId: string): string {
+  try {
+    const t = fs.readFileSync(path.join(topicsDir, `topic-${sessionId}`), 'utf8').trim();
+    if (t && t !== 'New Session' && t !== 'Untitled') return t;
+  } catch { /* no topic file */ }
+  return '';
+}
+
+// Mirror is best-effort housekeeping — a throw (space dir unwritable, disk full)
+// must never kill the catch-up scan. Isolated so the loop continues.
+function safeMirror(opts: ReconcileOpts, localJsonlPath: string, projectKey: string, sessionId: string): void {
+  try { opts.mirror(localJsonlPath, projectKey, sessionId); }
+  catch { /* mirror is best-effort; the record write already landed */ }
+}
+
+// Returns the number of records that were actually upserted (not counting
+// files that were skipped, already-fresh, or failed).
+export async function reconcile(opts: ReconcileOpts): Promise<number> {
+  let upserts = 0;
+  let slugs: string[] = [];
+  // No projects dir → nothing to reconcile.
+  try { slugs = fs.readdirSync(opts.projectsDir); } catch { return 0; }
+  for (const slug of slugs) {
+    const dir = path.join(opts.projectsDir, slug);
+    let files: string[] = [];
+    // A non-directory entry (or an unreadable dir) just yields no files.
+    try { files = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl')); } catch { continue; }
+    for (const file of files) {
+      const sessionId = file.replace(/\.jsonl$/, '');
+      // Malformed ids never become records (phantom-id guard).
+      if (!SESSION_UUID_RE.test(sessionId)) continue;
+      const jsonlPath = path.join(dir, file);
+      // Per-file isolation (review carry-forward): a store lock-timeout throw,
+      // an unreadable transcript, or a meta-read error on ONE file must never
+      // abort the whole catch-up scan — skip the file, keep scanning.
+      try {
+        let size = 0;
+        try { size = fs.statSync(jsonlPath).size; } catch { continue; }
+        if (size < MIN_TRANSCRIPT_BYTES) continue;
+
+        const existing = await opts.store.get('claude', sessionId);
+        // wantTitle only when we don't already have a title — skips the head
+        // read for records that are already named.
+        const meta = await readSessionTranscriptMeta(jsonlPath, !existing?.title);
+        // lastActive from the transcript's own content timestamp — mtimes lie
+        // after any sync/restore (the 627-file rebump incident).
+        const lastActive = meta.lastTimestampMs ? new Date(meta.lastTimestampMs).toISOString() : null;
+
+        if (existing && lastActive && Date.parse(existing.lastActive) >= Date.parse(lastActive)) {
+          // Record already as fresh as the file — leave it, but still mirror
+          // (cheap size check inside mirror makes a no-op copy when unchanged).
+          safeMirror(opts, jsonlPath, existing.projectName || projectNameFromSlug(slug), sessionId);
+          continue;
+        }
+        const projectName = existing?.projectName || projectNameFromSlug(slug);
+        const title = readTopicTitle(opts.topicsDir, sessionId) || meta.fallbackTitle || '';
+        await opts.store.upsert({
+          id: sessionId,
+          provider: 'claude',
+          projectName,
+          title: title || undefined,
+          lastActive: lastActive ?? undefined,
+          device: opts.device,
+          // transcriptRef uses projectName (the portable projectKey), NOT the CC slug.
+          transcriptRef: `claude/transcripts/${projectName}/${sessionId}.jsonl`,
+        });
+        // Count only AFTER the upsert lands, and BEFORE the best-effort mirror,
+        // so a mirror throw never un-counts a successful record write.
+        upserts++;
+        safeMirror(opts, jsonlPath, projectName, sessionId);
+      } catch {
+        // One bad file skipped — the scan continues.
+      }
+    }
+  }
+  return upserts;
+}

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -39,6 +39,11 @@ export function getConversationStore(): ConversationStore | null { return store;
 export async function startConversationStore(opts?: {
   conversationsRoot?: string; projectsDir?: string; topicsDir?: string; device?: string;
 }): Promise<void> {
+  // Idempotent start (review fix 4): a second start without a stop would leak
+  // the first onSyncSpacesEvent subscription (duplicate materialize sweeps
+  // forever) and the first periodic interval. Tearing down first keeps the
+  // module a true singleton regardless of how callers sequence start/stop.
+  stopConversationStore();
   const personalRoot = getManagedRoots()?.personalRoot;
   const root = opts?.conversationsRoot
     ?? (personalRoot ? path.join(personalRoot, 'Conversations') : null);
@@ -168,32 +173,55 @@ export function noteFlagChanged(claudeSessionId: string, flag: string, value: bo
 // device that recorded it), then a managed project by name, then a saved folder
 // by basename. null when nothing local matches — that record just isn't
 // materialized on this device (the record itself already synced).
-function resolveLocalProject(rec: { projectName: string; originalPath: string }): string | null {
+// The managed/saved lookups are HOISTED by the caller (review fix 2): on a
+// secondary device where originalPath never exists, per-record readdir + JSON
+// reads made the sweep O(records × disk-reads) on EVERY remote turn.
+function resolveLocalProject(
+  rec: { projectName: string; originalPath: string },
+  managed: Map<string, string>,
+  saved: Array<{ path: string }>,
+): string | null {
   if (rec.originalPath && fs.existsSync(rec.originalPath)) return rec.originalPath;
-  const roots = getManagedRoots();
-  if (roots) {
-    for (const p of roots.listProjects()) {
-      if (p.name === rec.projectName) return p.path;
-    }
-  }
-  try {
-    const hit = readFolders().find((f) => path.basename(f.path) === rec.projectName);
-    if (hit && fs.existsSync(hit.path)) return hit.path;
-  } catch { /* saved folders unreadable */ }
+  const managedHit = managed.get(rec.projectName);
+  if (managedHit) return managedHit;
+  const hit = saved.find((f) => path.basename(f.path) === rec.projectName);
+  if (hit && fs.existsSync(hit.path)) return hit.path;
   return null;
 }
 
 async function materializeSweep(): Promise<void> {
-  if (!store) return;
+  // Capture the store (review fix 3): stop() mid-sweep nulls the module field,
+  // and every use below an await would otherwise become a swallowed TypeError.
+  const s = store;
+  if (!s) return;
   let records;
-  try { records = await store.list('claude'); } catch { return; }
+  try { records = await s.list('claude'); } catch { return; }
+  // Hoist the project lookups once per sweep (review fix 2) — see
+  // resolveLocalProject's comment for why per-record IO was a real cost.
+  const managed = new Map<string, string>(
+    (getManagedRoots()?.listProjects() ?? []).map((p) => [p.name, p.path]),
+  );
+  let saved: Array<{ path: string }> = [];
+  try { saved = readFolders(); } catch { /* saved folders unreadable */ }
   for (const rec of records) {
     if (!rec.transcriptRef) continue; // no durable copy to materialize from
-    const local = resolveLocalProject(rec);
+    // Review fix 1: NEVER materialize over a LIVE session's transcript. Without
+    // leases (Plan 2b), a same-conversation-on-two-devices pull would replace
+    // the JSONL Claude Code is actively appending to — Windows EPERM containment
+    // is unreliable (libuv opens with FILE_SHARE_DELETE), and on POSIX the
+    // rename always succeeds: CC keeps appending to the unlinked inode, the
+    // TranscriptWatcher's path-read never grows, chat view freezes, and local
+    // turns are lost when the handle closes. Accepted caveat: nothing removes
+    // entries from `sessions` on session exit, so an ended session stays
+    // guarded until restart — fine for 2a because mirrorIn keeps the space
+    // current from the fresher local side; a noteSessionEnded refinement lands
+    // with leases in 2b.
+    if (sessions.has(rec.id)) continue;
+    const local = resolveLocalProject(rec, managed, saved);
     if (!local) continue;
     try {
       materializeOut({
-        spaceTranscriptPath: path.join(store.root(), rec.transcriptRef),
+        spaceTranscriptPath: path.join(s.root(), rec.transcriptRef),
         localJsonlPath: localJsonlPath(local, rec.id),
       });
     } catch { /* per-record isolation — one bad copy must not abort the sweep */ }

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -231,8 +231,18 @@ async function materializeSweep(): Promise<void> {
 function runReconcile(): void {
   if (!store) return;
   const s = store;
+  // Known folders let the reconciler recover the EXACT project name for a CC slug
+  // instead of the lossy last-segment truncation, so a bare-`claude` session in a
+  // hyphenated folder ('youcoded-dev') gets the same projectKey the live path
+  // uses — no orphan duplicate transcript, no cross-device materialize gap. Built
+  // fresh per run (one readdir + one JSON read every 30 min — cheap).
+  const knownFolders: string[] = [
+    ...(getManagedRoots()?.listProjects() ?? []).map((p) => p.path),
+  ];
+  try { knownFolders.push(...readFolders().map((f) => f.path)); }
+  catch { /* saved folders unreadable — managed projects still cover most cases */ }
   reconcile({
-    projectsDir, topicsDir, store: s, device,
+    projectsDir, topicsDir, store: s, device, knownFolders,
     // Production mirror closure: the reconciler stays free of transcript-mirror
     // + the Conversations root. Best-effort — a throw here must not abort the scan.
     mirror: (localPath: string, projectKey: string, sessionId: string) => {

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -1,0 +1,216 @@
+// desktop/src/main/conversations/service.ts
+// Composition root for the Conversation Store (design §1–§2). Module singleton
+// like sync-spaces/service.ts. Owns: the store instance, live transcript-event
+// intake (debounced activity upserts; prompt mirror+push on turn-complete),
+// title/flag write-through, the startup + periodic reconciler, and the
+// materialize-on-synced subscription.
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createConversationStore, ConversationStore } from './conversation-store';
+import { mirrorIn, materializeOut } from './transcript-mirror';
+import { reconcile } from './reconciler';
+import { ccProjectSlug } from '../project-conversations';
+import { onSyncSpacesEvent, syncSpacesSyncNow, getManagedRoots } from '../sync-spaces/service';
+import { readFolders } from '../saved-folders';
+import type { TranscriptEvent } from '../../shared/types';
+import type { SpaceSyncEvent } from '../sync-spaces/types';
+
+const ACTIVITY_DEBOUNCE_MS = 5_000;
+const RECONCILE_INTERVAL_MS = 30 * 60_000; // slow tick; the startup scan is the load-bearing one
+
+interface SessionCtx { cwd: string }
+
+let store: ConversationStore | null = null;
+let projectsDir = '';
+let topicsDir = '';
+let device = '';
+let unsubscribe: (() => void) | null = null;
+let reconcileTimer: NodeJS.Timeout | null = null;
+// Desktop hook wiring resolves the CLAUDE session id before calling in, so the
+// map is keyed by claude id (matches the store's record id). cwd is learned via
+// noteSessionStarted; events for never-announced sessions still upsert (the live
+// path corrects projectName/originalPath the next time the session runs here).
+const sessions = new Map<string, SessionCtx>();
+const pendingActivity = new Map<string, NodeJS.Timeout>();
+
+export function getConversationStore(): ConversationStore | null { return store; }
+
+export async function startConversationStore(opts?: {
+  conversationsRoot?: string; projectsDir?: string; topicsDir?: string; device?: string;
+}): Promise<void> {
+  const personalRoot = getManagedRoots()?.personalRoot;
+  const root = opts?.conversationsRoot
+    ?? (personalRoot ? path.join(personalRoot, 'Conversations') : null);
+  if (!root) return; // managed roots unavailable — the store stays off this launch
+  projectsDir = opts?.projectsDir ?? path.join(os.homedir(), '.claude', 'projects');
+  topicsDir = opts?.topicsDir ?? path.join(os.homedir(), '.claude', 'topics');
+  device = opts?.device ?? os.hostname();
+  store = createConversationStore(root);
+
+  // Carry-forward 3: subscribe ONCE and hold the unsubscribe. The listener Set
+  // dedups identical fn refs, but a fresh closure each start would still leak.
+  unsubscribe = onSyncSpacesEvent((e: SpaceSyncEvent) => {
+    // Personal-space updates carry new/updated transcripts — sweep them out to
+    // the CC projects dir so a session that ran on another device is resumable
+    // here. Non-personal / non-updated events are ignored (the 'hub' sentinel
+    // and project spaces never materialize conversations).
+    if (e.type === 'synced' && e.spaceId === 'personal' && e.updated) void materializeSweep();
+  });
+
+  // Carry-forward 2: kick the reconciler DETACHED. The first-ever run mirrors
+  // potentially GBs of transcripts (serial copies); awaiting it here would block
+  // app startup. runReconcile swallows its own failures.
+  runReconcile();
+  reconcileTimer = setInterval(() => { runReconcile(); }, RECONCILE_INTERVAL_MS);
+  reconcileTimer.unref?.();
+}
+
+export function stopConversationStore(): void {
+  unsubscribe?.(); unsubscribe = null;
+  if (reconcileTimer) { clearInterval(reconcileTimer); reconcileTimer = null; }
+  for (const t of pendingActivity.values()) clearTimeout(t);
+  pendingActivity.clear();
+  sessions.clear();
+  store = null;
+}
+
+export function noteSessionStarted(claudeSessionId: string, cwd: string): void {
+  sessions.set(claudeSessionId, { cwd });
+}
+
+// <root>/claude/transcripts/<projectKey>/<id>.jsonl — the durable space copy.
+// projectKey is the portable project name (basename of cwd), matching the
+// reconciler's transcriptRef convention (NOT the CC slug).
+function spaceTranscriptPath(projectKey: string, sessionId: string): string {
+  return path.join(store!.root(), 'claude', 'transcripts', projectKey, `${sessionId}.jsonl`);
+}
+// The CC on-disk transcript path for this session — projects dir + CC slug.
+function localJsonlPath(cwd: string, sessionId: string): string {
+  return path.join(projectsDir, ccProjectSlug(cwd), `${sessionId}.jsonl`);
+}
+
+// Fire-and-forget store write with carry-forward 1 baked in: upsert can reject
+// on lock timeout, and an uncaught rejection in Electron main is fatal-ish noise.
+// The reconciler catches up whatever a dropped write missed.
+function safeUpsert(input: Parameters<ConversationStore['upsert']>[0]): void {
+  store?.upsert(input).catch(() => { /* lock contention — reconciler catches up */ });
+}
+
+export function noteTranscriptEvent(claudeSessionId: string, ev: TranscriptEvent): void {
+  if (!store) return;
+  const ctx = sessions.get(claudeSessionId);
+  const upsertNow = () => {
+    // Carry-forward 4: clear any pending debounce for this session before the
+    // immediate write, so a stale timer can't fire a redundant older upsert 5s
+    // later.
+    const t = pendingActivity.get(claudeSessionId);
+    if (t) { clearTimeout(t); pendingActivity.delete(claudeSessionId); }
+    safeUpsert({
+      id: claudeSessionId,
+      provider: 'claude',
+      // Metadata fields are LOCAL TRUTH in the store's merge; omit them (leave
+      // undefined) when no cwd is known so we never overwrite a real value with ''.
+      projectName: ctx ? path.basename(ctx.cwd) : undefined,
+      originalPath: ctx?.cwd,
+      // ev.timestamp is a Date.now() ms number stamped by the watcher (NOT the
+      // JSONL time), so new Date(...) is safe.
+      lastActive: new Date(ev.timestamp).toISOString(),
+      device,
+      transcriptRef: ctx
+        ? `claude/transcripts/${path.basename(ctx.cwd)}/${claudeSessionId}.jsonl`
+        : undefined,
+    });
+  };
+
+  if (ev.type === 'turn-complete') {
+    upsertNow();
+    if (ctx) {
+      const key = path.basename(ctx.cwd);
+      try {
+        // Mirror the fresh local transcript into the durable space copy so it
+        // rides the personal-space sync. Best-effort — the reconciler re-mirrors.
+        mirrorIn({
+          localJsonlPath: localJsonlPath(ctx.cwd, claudeSessionId),
+          spaceTranscriptPath: spaceTranscriptPath(key, claudeSessionId),
+        });
+      } catch { /* best-effort; the reconciler catches up */ }
+      // Prompt push (design §2): conversations move faster than the engine's
+      // quiet-window debounce, so nudge a sync now. syncSpace is single-flight —
+      // bursts coalesce. Wrapped in Promise.resolve so a sync/throwing stub
+      // can't produce an unhandled rejection either.
+      Promise.resolve(syncSpacesSyncNow('personal')).catch(() => { /* the poll covers a miss */ });
+    }
+    return;
+  }
+
+  // Chatty events (assistant-text / tool-use / thinking / …) debounce to one
+  // activity upsert per quiet window — a turn can emit dozens.
+  if (!pendingActivity.has(claudeSessionId)) {
+    const t = setTimeout(upsertNow, ACTIVITY_DEBOUNCE_MS);
+    t.unref?.();
+    pendingActivity.set(claudeSessionId, t);
+  }
+}
+
+// Carry-forward 5: only the auto-title flow (topic-watcher) calls this. setTitle
+// is timestamp-less — it never fabricates activity. No user-rename path exists
+// for conversations yet (Plan 2b/2c scope).
+export function noteTitleChanged(claudeSessionId: string, title: string): void {
+  store?.setTitle('claude', claudeSessionId, title).catch(() => { /* carry-forward 1 */ });
+}
+
+export function noteFlagChanged(claudeSessionId: string, flag: string, value: boolean): void {
+  store?.setFlag('claude', claudeSessionId, flag, value).catch(() => { /* carry-forward 1 */ });
+}
+
+// Resolve a record's project to a live on-disk folder. originalPath first (the
+// device that recorded it), then a managed project by name, then a saved folder
+// by basename. null when nothing local matches — that record just isn't
+// materialized on this device (the record itself already synced).
+function resolveLocalProject(rec: { projectName: string; originalPath: string }): string | null {
+  if (rec.originalPath && fs.existsSync(rec.originalPath)) return rec.originalPath;
+  const roots = getManagedRoots();
+  if (roots) {
+    for (const p of roots.listProjects()) {
+      if (p.name === rec.projectName) return p.path;
+    }
+  }
+  try {
+    const hit = readFolders().find((f) => path.basename(f.path) === rec.projectName);
+    if (hit && fs.existsSync(hit.path)) return hit.path;
+  } catch { /* saved folders unreadable */ }
+  return null;
+}
+
+async function materializeSweep(): Promise<void> {
+  if (!store) return;
+  let records;
+  try { records = await store.list('claude'); } catch { return; }
+  for (const rec of records) {
+    if (!rec.transcriptRef) continue; // no durable copy to materialize from
+    const local = resolveLocalProject(rec);
+    if (!local) continue;
+    try {
+      materializeOut({
+        spaceTranscriptPath: path.join(store.root(), rec.transcriptRef),
+        localJsonlPath: localJsonlPath(local, rec.id),
+      });
+    } catch { /* per-record isolation — one bad copy must not abort the sweep */ }
+  }
+}
+
+function runReconcile(): void {
+  if (!store) return;
+  const s = store;
+  reconcile({
+    projectsDir, topicsDir, store: s, device,
+    // Production mirror closure: the reconciler stays free of transcript-mirror
+    // + the Conversations root. Best-effort — a throw here must not abort the scan.
+    mirror: (localPath: string, projectKey: string, sessionId: string) => {
+      try {
+        mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spaceTranscriptPath(projectKey, sessionId) });
+      } catch { /* best-effort */ }
+    },
+  }).catch(() => { /* reconciler failure must never break startup (carry-forward 2) */ });
+}

--- a/desktop/src/main/conversations/store-core.ts
+++ b/desktop/src/main/conversations/store-core.ts
@@ -26,6 +26,23 @@ export interface ConversationRecord {
   createdAt: string;             // ISO-8601
 }
 
+// Keep only well-formed FlagState entries. A malformed flag (string value,
+// missing updatedAt) would corrupt mergeRecords' per-flag newest-wins
+// comparison downstream, so it's dropped at the door instead of round-tripped
+// — "flags migrate losslessly" only holds for flags that ARE FlagStates.
+// Arrays are typeof 'object' too, so they're explicitly normalized to {}.
+function sanitizeFlags(raw: unknown): Record<string, FlagState> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out: Record<string, FlagState> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    const f = v as FlagState | null;
+    if (f && typeof f === 'object' && typeof f.value === 'boolean' && typeof f.updatedAt === 'string') {
+      out[k] = { value: f.value, updatedAt: f.updatedAt };
+    }
+  }
+  return out;
+}
+
 // Parse + validate a record file's content. Returns null on anything invalid —
 // a corrupt record must damage exactly one conversation, never the whole list
 // (same "one bad record can't break the browser" guarantee as parseRecord's
@@ -49,10 +66,16 @@ export function parseRecord(json: string): ConversationRecord | null {
     title: typeof raw.title === 'string' ? raw.title : '',
     lastActive: raw.lastActive,
     device: typeof raw.device === 'string' ? raw.device : '',
-    flags: raw.flags && typeof raw.flags === 'object' ? raw.flags : {},
+    flags: sanitizeFlags(raw.flags),
     transcriptRef: typeof raw.transcriptRef === 'string' ? raw.transcriptRef : '',
-    // A record with no createdAt is treated as born when it was last active.
-    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : raw.lastActive,
+    // A record with a missing OR unparseable createdAt is treated as born when
+    // it was last active. Corrupt strings must not survive: Date.parse(garbage)
+    // is NaN → ts() maps it to 0 → it would WIN every "earliest claim wins"
+    // comparison in mergeRecords and poison the merged createdAt forever.
+    createdAt:
+      typeof raw.createdAt === 'string' && !Number.isNaN(Date.parse(raw.createdAt))
+        ? raw.createdAt
+        : raw.lastActive,
   };
 }
 
@@ -60,27 +83,52 @@ export function parseRecord(json: string): ConversationRecord | null {
 // "newest wins" comparison rather than throwing.
 const ts = (iso: string) => Date.parse(iso) || 0;
 
+// Pick the "later" of two values under a TOTAL order: primary by timestamp,
+// exact ties broken by comparing the two values' JSON text lexicographically.
+// WHY: convergence requires merge(a,b) === merge(b,a). A positional tiebreak
+// ("second argument wins") makes the healer fold depend on directory
+// enumeration order — two devices folding the same tied copies would pick
+// DIFFERENT winners and ping-pong forever instead of converging. The JSON
+// comparison is arbitrary but symmetric and stable across devices, which is
+// all a lattice join needs. Max under a total order is commutative AND
+// associative, so folds converge regardless of copy order.
+function laterOf<T>(x: T, y: T, tx: number, ty: number): T {
+  if (tx !== ty) return tx > ty ? x : y;
+  return JSON.stringify(x) >= JSON.stringify(y) ? x : y;
+}
+
+// Earliest-claim pick for createdAt, with the same content tiebreak: two
+// different spellings of the same instant must resolve identically on every
+// device, or merged records never byte-converge.
+function earliestOf(x: string, y: string): string {
+  const tx = ts(x);
+  const ty = ts(y);
+  if (tx !== ty) return tx < ty ? x : y;
+  return x <= y ? x : y;
+}
+
 // Field-level merge, newest-wins per field group (design §1 healer rule).
 // Used by BOTH the live upsert (base=on-disk, incoming=new event data) and the
 // conflict-copy healer — one merge function so the two paths can't drift.
 export function mergeRecords(a: ConversationRecord, b: ConversationRecord): ConversationRecord {
   // Activity fields travel together: whichever side saw the later turn knows
   // the true lastActive/device (and, for two real titles, the true title).
-  const newer = ts(b.lastActive) >= ts(a.lastActive) ? b : a;
+  // Exact lastActive ties break on record CONTENT via laterOf — never on
+  // argument position — so merge(a,b) === merge(b,a).
+  const newer = laterOf(a, b, ts(a.lastActive), ts(b.lastActive));
   const older = newer === a ? b : a;
   // Flags merge per-key by each flag's own updatedAt — a flag set on an idle
-  // device must survive a merge with a busier device's record. We seed from
-  // the older side, then let the newer side's flags win ties, then give the
-  // older side a second pass so a flag it updated MORE RECENTLY still lands
-  // (field-level, not record-level — this is contract item 4).
-  const flags: Record<string, FlagState> = { ...older.flags };
-  for (const [k, v] of Object.entries(newer.flags)) {
-    const prev = flags[k];
-    if (!prev || ts(v.updatedAt) >= ts(prev.updatedAt)) flags[k] = v;
-  }
-  for (const [k, v] of Object.entries(older.flags)) {
-    const cur = flags[k];
-    if (cur && ts(v.updatedAt) > ts(cur.updatedAt)) flags[k] = v;
+  // device must survive a merge with a busier device's record (field-level,
+  // not record-level — this is contract item 4). Equal-updatedAt ties break
+  // by flag content, same convergence reason as above. Keys are sorted so the
+  // merged object's key order is identical no matter which argument came
+  // first — downstream serialization then byte-converges too.
+  const flags: Record<string, FlagState> = {};
+  const flagKeys = [...new Set([...Object.keys(a.flags), ...Object.keys(b.flags)])].sort();
+  for (const k of flagKeys) {
+    const fa = a.flags[k];
+    const fb = b.flags[k];
+    flags[k] = fa && fb ? laterOf(fa, fb, ts(fa.updatedAt), ts(fb.updatedAt)) : (fa ?? fb);
   }
   // A real title always beats an empty one (auto-title can lag a turn behind,
   // so the newer side may not yet have a title). Literal 'Untitled' is a
@@ -95,17 +143,20 @@ export function mergeRecords(a: ConversationRecord, b: ConversationRecord): Conv
     ...newer,
     title,
     flags,
-    // createdAt is the conversation's birth — keep the earliest claim.
-    createdAt: ts(a.createdAt) <= ts(b.createdAt) ? a.createdAt : b.createdAt,
+    // createdAt is the conversation's birth — keep the earliest claim
+    // (content-tiebroken on equal instants, see earliestOf).
+    createdAt: earliestOf(a.createdAt, b.createdAt),
   };
 }
 
 // Engine conflict copies look like '<base> (from <device>, <date>).json'
 // (git-transport.ts → guards.ts conflictCopyName inserts the suffix BEFORE the
-// extension). The healer folds them back into the canonical record and deletes
-// them. `[^)]+` in the middle matches both the real ISO date ('2026-07-03') and
-// any other device/date shape, so the regex tracks the real producer.
-const CONFLICT_RE = /^(.+) \(from [^)]+\)\.json$/;
+// extension; the date is ISO, e.g. '2026-07-03'). The healer folds them back
+// into the canonical record and deletes them. The inner matcher is a GREEDY
+// `.+` — it runs to the LAST ')' before '.json' — because the producer's name
+// validation permits ')' inside device names; a first-')' stop ([^)]+) would
+// fail to match such names and the copy would silently never be healed.
+const CONFLICT_RE = /^(.+) \(from .+\)\.json$/;
 
 export function isConflictCopyName(fileName: string): boolean {
   return CONFLICT_RE.test(fileName);
@@ -119,8 +170,12 @@ export function extractConflictBase(fileName: string): string | null {
 }
 
 // Fold every conflict copy of a conversation back into its canonical record.
-// Because mergeRecords is field-level newest-wins (associative for these
-// fields), the result is independent of the order the copies are folded in.
+// The result is independent of the order the copies are folded in BECAUSE
+// mergeRecords picks each field group as the max/min under a total order
+// (timestamp primary, JSON-content tiebreak — see laterOf). Without the
+// content tiebreak, exact-timestamp ties would resolve by fold position and
+// two devices enumerating the same copies in different directory orders would
+// heal to different records.
 export function foldConflictCopies(
   canonical: ConversationRecord,
   copies: ConversationRecord[],

--- a/desktop/src/main/conversations/store-core.ts
+++ b/desktop/src/main/conversations/store-core.ts
@@ -83,9 +83,14 @@ export function mergeRecords(a: ConversationRecord, b: ConversationRecord): Conv
     if (cur && ts(v.updatedAt) > ts(cur.updatedAt)) flags[k] = v;
   }
   // A real title always beats an empty one (auto-title can lag a turn behind,
-  // so the newer side may not yet have a title). Two real titles → newer wins,
-  // which falls out naturally because `newer.title` is checked first.
-  const title = newer.title || older.title;
+  // so the newer side may not yet have a title). Literal 'Untitled' is a
+  // legacy placeholder some older clients wrote (see PITFALLS → Resume
+  // Browser) — it must never shadow a real title either. Two real titles →
+  // newer wins, which falls out naturally because `newer` is checked first.
+  // The trailing fallbacks keep *something* when both sides are placeholders
+  // (harmless — the renderer treats '' and 'Untitled' alike as untitled).
+  const real = (t: string) => (t && t !== 'Untitled' ? t : '');
+  const title = real(newer.title) || real(older.title) || newer.title || older.title;
   return {
     ...newer,
     title,

--- a/desktop/src/main/conversations/store-core.ts
+++ b/desktop/src/main/conversations/store-core.ts
@@ -1,0 +1,124 @@
+// PURE record logic for the Conversation Store (Phase 2a design §1).
+// No fs/path/os imports — the IO shell (conversation-store.ts) does disk work.
+// This is the same pure-core/IO-shell split as local-theme-synthesizer.ts:
+// keeping this file free of side effects is what lets us unit-test every merge
+// and parse rule with plain objects and no mocks.
+import type { SessionProvider } from '../../shared/types';
+
+export const RECORD_SCHEMA_VERSION = 1;
+
+// One flag's state — matches the legacy conversation-index v2 shape so flags
+// (pinned, archived, etc.) migrate losslessly in Plan 2c. `updatedAt` is what
+// lets us merge a single flag independently of the whole record.
+export interface FlagState { value: boolean; updatedAt: string }
+
+export interface ConversationRecord {
+  schema: number;
+  id: string;                    // provider-stable conversation id (CC: session UUID)
+  provider: SessionProvider | string; // 'claude' today; string-open for future providers
+  projectName: string;           // portable cross-device key (folder basename)
+  originalPath: string;          // path on the device that created it
+  title: string;                 // '' means untitled
+  lastActive: string;            // ISO-8601 — set at EVENT time, never from file mtime
+  device: string;                // last device that ran a turn
+  flags: Record<string, FlagState>;
+  transcriptRef: string;         // space-relative, e.g. 'claude/transcripts/<key>/<id>.jsonl'
+  createdAt: string;             // ISO-8601
+}
+
+// Parse + validate a record file's content. Returns null on anything invalid —
+// a corrupt record must damage exactly one conversation, never the whole list
+// (same "one bad record can't break the browser" guarantee as parseRecord's
+// siblings across the codebase).
+export function parseRecord(json: string): ConversationRecord | null {
+  let raw: any;
+  try { raw = JSON.parse(json); } catch { return null; }
+  if (!raw || typeof raw !== 'object') return null;
+  if (raw.schema !== RECORD_SCHEMA_VERSION) return null;
+  if (typeof raw.id !== 'string' || !raw.id) return null;
+  if (typeof raw.provider !== 'string' || !raw.provider) return null;
+  // lastActive must be a real, parseable date — it drives every merge decision.
+  if (typeof raw.lastActive !== 'string' || Number.isNaN(Date.parse(raw.lastActive))) return null;
+  return {
+    schema: RECORD_SCHEMA_VERSION,
+    id: raw.id,
+    provider: raw.provider,
+    // Optional string fields default to '' so downstream code never sees undefined.
+    projectName: typeof raw.projectName === 'string' ? raw.projectName : '',
+    originalPath: typeof raw.originalPath === 'string' ? raw.originalPath : '',
+    title: typeof raw.title === 'string' ? raw.title : '',
+    lastActive: raw.lastActive,
+    device: typeof raw.device === 'string' ? raw.device : '',
+    flags: raw.flags && typeof raw.flags === 'object' ? raw.flags : {},
+    transcriptRef: typeof raw.transcriptRef === 'string' ? raw.transcriptRef : '',
+    // A record with no createdAt is treated as born when it was last active.
+    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : raw.lastActive,
+  };
+}
+
+// Parse an ISO string to epoch ms; unparseable → 0 so it always loses a
+// "newest wins" comparison rather than throwing.
+const ts = (iso: string) => Date.parse(iso) || 0;
+
+// Field-level merge, newest-wins per field group (design §1 healer rule).
+// Used by BOTH the live upsert (base=on-disk, incoming=new event data) and the
+// conflict-copy healer — one merge function so the two paths can't drift.
+export function mergeRecords(a: ConversationRecord, b: ConversationRecord): ConversationRecord {
+  // Activity fields travel together: whichever side saw the later turn knows
+  // the true lastActive/device (and, for two real titles, the true title).
+  const newer = ts(b.lastActive) >= ts(a.lastActive) ? b : a;
+  const older = newer === a ? b : a;
+  // Flags merge per-key by each flag's own updatedAt — a flag set on an idle
+  // device must survive a merge with a busier device's record. We seed from
+  // the older side, then let the newer side's flags win ties, then give the
+  // older side a second pass so a flag it updated MORE RECENTLY still lands
+  // (field-level, not record-level — this is contract item 4).
+  const flags: Record<string, FlagState> = { ...older.flags };
+  for (const [k, v] of Object.entries(newer.flags)) {
+    const prev = flags[k];
+    if (!prev || ts(v.updatedAt) >= ts(prev.updatedAt)) flags[k] = v;
+  }
+  for (const [k, v] of Object.entries(older.flags)) {
+    const cur = flags[k];
+    if (cur && ts(v.updatedAt) > ts(cur.updatedAt)) flags[k] = v;
+  }
+  // A real title always beats an empty one (auto-title can lag a turn behind,
+  // so the newer side may not yet have a title). Two real titles → newer wins,
+  // which falls out naturally because `newer.title` is checked first.
+  const title = newer.title || older.title;
+  return {
+    ...newer,
+    title,
+    flags,
+    // createdAt is the conversation's birth — keep the earliest claim.
+    createdAt: ts(a.createdAt) <= ts(b.createdAt) ? a.createdAt : b.createdAt,
+  };
+}
+
+// Engine conflict copies look like '<base> (from <device>, <date>).json'
+// (git-transport.ts → guards.ts conflictCopyName inserts the suffix BEFORE the
+// extension). The healer folds them back into the canonical record and deletes
+// them. `[^)]+` in the middle matches both the real ISO date ('2026-07-03') and
+// any other device/date shape, so the regex tracks the real producer.
+const CONFLICT_RE = /^(.+) \(from [^)]+\)\.json$/;
+
+export function isConflictCopyName(fileName: string): boolean {
+  return CONFLICT_RE.test(fileName);
+}
+
+// Recover the canonical filename a conflict copy belongs to, or null if the
+// name isn't a conflict copy at all.
+export function extractConflictBase(fileName: string): string | null {
+  const m = CONFLICT_RE.exec(fileName);
+  return m ? `${m[1]}.json` : null;
+}
+
+// Fold every conflict copy of a conversation back into its canonical record.
+// Because mergeRecords is field-level newest-wins (associative for these
+// fields), the result is independent of the order the copies are folded in.
+export function foldConflictCopies(
+  canonical: ConversationRecord,
+  copies: ConversationRecord[],
+): ConversationRecord {
+  return copies.reduce((acc, c) => mergeRecords(acc, c), canonical);
+}

--- a/desktop/src/main/conversations/store-core.ts
+++ b/desktop/src/main/conversations/store-core.ts
@@ -176,25 +176,38 @@ export function extractConflictBase(fileName: string): string | null {
 }
 
 // Fold every conflict copy of a conversation back into its canonical record.
-// Order-independence, field by field: lastActive/device/flags/createdAt
-// converge because the pairwise merge picks each of them as max/min under a
-// TOTAL order (timestamp primary, JSON-content tiebreak — see laterOf), and
-// max/min are associative + commutative. TITLE does NOT get that for free:
-// the pairwise title rule is a heuristic that isn't associative — once the
-// accumulator adopts a title from its first merge partner, that title rides
-// the accumulator's newest lastActive and beats a NEWER real title arriving
-// in a later fold step, so enumeration order changed the healed title. The
-// fold therefore OVERRIDES title with a pick computed over the original input
-// SET (order can't matter when the inputs are considered together): among
-// inputs with a real title, the one that is max under the same total order
-// wins; if none has a real title, the reduce's placeholder result stands.
+// Order-independence strategy: every field group is picked over the ORIGINAL
+// inputs, never over mutated intermediates — that's what makes directory
+// enumeration order unable to change the healed record.
+//  - flags/createdAt: accumulated through the pairwise reduce, which is safe
+//    for THEM because those picks are per-key max / earliest-min over values
+//    that pass through merges UNCHANGED (max/min under a total order are
+//    associative and commutative).
+//  - activity/spread fields (lastActive, device, transcriptRef, ...): picked
+//    directly as the total-order max of the original inputs. Taking them from
+//    the reduce accumulator was subtly order-dependent: the accumulator's
+//    title override can shrink its JSON and flip a later exact-lastActive tie
+//    comparison inside mergeRecords, healing e.g. a different device per
+//    enumeration order.
+//  - title: picked over the original inputs that have a REAL (non-placeholder)
+//    title — the pairwise title rule is a heuristic that isn't associative
+//    (an adopted title rides the accumulator's newest lastActive and beats a
+//    newer real title from a later fold step). If no input has a real title,
+//    the reduce's placeholder result stands (either placeholder is fine — the
+//    renderer treats '' and 'Untitled' alike as untitled).
 export function foldConflictCopies(
   canonical: ConversationRecord,
   copies: ConversationRecord[],
 ): ConversationRecord {
+  const inputs = [canonical, ...copies];
   const folded = copies.reduce((acc, c) => mergeRecords(acc, c), canonical);
-  const titled = [canonical, ...copies].filter((r) => realTitle(r.title));
-  if (titled.length === 0) return folded;
-  const winner = titled.reduce((x, y) => laterOf(x, y, ts(x.lastActive), ts(y.lastActive)));
-  return { ...folded, title: winner.title };
+  // Spread-source: the total-order-max ORIGINAL record supplies every field
+  // the pairwise merge would take from its "newer" side.
+  const base = inputs.reduce((x, y) => laterOf(x, y, ts(x.lastActive), ts(y.lastActive)));
+  const titled = inputs.filter((r) => realTitle(r.title));
+  const title =
+    titled.length > 0
+      ? titled.reduce((x, y) => laterOf(x, y, ts(x.lastActive), ts(y.lastActive))).title
+      : folded.title;
+  return { ...base, title, flags: folded.flags, createdAt: folded.createdAt };
 }

--- a/desktop/src/main/conversations/store-core.ts
+++ b/desktop/src/main/conversations/store-core.ts
@@ -97,6 +97,12 @@ function laterOf<T>(x: T, y: T, tx: number, ty: number): T {
   return JSON.stringify(x) >= JSON.stringify(y) ? x : y;
 }
 
+// A "real" title is non-empty and not the literal 'Untitled' — that literal
+// is a legacy placeholder some older clients wrote (see PITFALLS → Resume
+// Browser) and must never shadow an actual name. Shared by the pairwise merge
+// and the fold's set-based title pick so the two definitions can't drift.
+const realTitle = (t: string) => (t && t !== 'Untitled' ? t : '');
+
 // Earliest-claim pick for createdAt, with the same content tiebreak: two
 // different spellings of the same instant must resolve identically on every
 // device, or merged records never byte-converge.
@@ -130,15 +136,15 @@ export function mergeRecords(a: ConversationRecord, b: ConversationRecord): Conv
     const fb = b.flags[k];
     flags[k] = fa && fb ? laterOf(fa, fb, ts(fa.updatedAt), ts(fb.updatedAt)) : (fa ?? fb);
   }
-  // A real title always beats an empty one (auto-title can lag a turn behind,
-  // so the newer side may not yet have a title). Literal 'Untitled' is a
-  // legacy placeholder some older clients wrote (see PITFALLS → Resume
-  // Browser) — it must never shadow a real title either. Two real titles →
-  // newer wins, which falls out naturally because `newer` is checked first.
-  // The trailing fallbacks keep *something* when both sides are placeholders
-  // (harmless — the renderer treats '' and 'Untitled' alike as untitled).
-  const real = (t: string) => (t && t !== 'Untitled' ? t : '');
-  const title = real(newer.title) || real(older.title) || newer.title || older.title;
+  // A real title always beats a placeholder (empty / literal 'Untitled' —
+  // see realTitle): auto-title can lag a turn behind, so the newer side may
+  // not have a name yet. Two real titles → newer wins, which falls out
+  // naturally because `newer` is checked first. The trailing fallbacks keep
+  // *something* when both sides are placeholders (harmless — the renderer
+  // treats '' and 'Untitled' alike as untitled). NOTE: this pairwise rule is
+  // a heuristic and is NOT associative — foldConflictCopies compensates with
+  // a set-based title pick over its original inputs.
+  const title = realTitle(newer.title) || realTitle(older.title) || newer.title || older.title;
   return {
     ...newer,
     title,
@@ -170,15 +176,25 @@ export function extractConflictBase(fileName: string): string | null {
 }
 
 // Fold every conflict copy of a conversation back into its canonical record.
-// The result is independent of the order the copies are folded in BECAUSE
-// mergeRecords picks each field group as the max/min under a total order
-// (timestamp primary, JSON-content tiebreak — see laterOf). Without the
-// content tiebreak, exact-timestamp ties would resolve by fold position and
-// two devices enumerating the same copies in different directory orders would
-// heal to different records.
+// Order-independence, field by field: lastActive/device/flags/createdAt
+// converge because the pairwise merge picks each of them as max/min under a
+// TOTAL order (timestamp primary, JSON-content tiebreak — see laterOf), and
+// max/min are associative + commutative. TITLE does NOT get that for free:
+// the pairwise title rule is a heuristic that isn't associative — once the
+// accumulator adopts a title from its first merge partner, that title rides
+// the accumulator's newest lastActive and beats a NEWER real title arriving
+// in a later fold step, so enumeration order changed the healed title. The
+// fold therefore OVERRIDES title with a pick computed over the original input
+// SET (order can't matter when the inputs are considered together): among
+// inputs with a real title, the one that is max under the same total order
+// wins; if none has a real title, the reduce's placeholder result stands.
 export function foldConflictCopies(
   canonical: ConversationRecord,
   copies: ConversationRecord[],
 ): ConversationRecord {
-  return copies.reduce((acc, c) => mergeRecords(acc, c), canonical);
+  const folded = copies.reduce((acc, c) => mergeRecords(acc, c), canonical);
+  const titled = [canonical, ...copies].filter((r) => realTitle(r.title));
+  if (titled.length === 0) return folded;
+  const winner = titled.reduce((x, y) => laterOf(x, y, ts(x.lastActive), ts(y.lastActive)));
+  return { ...folded, title: winner.title };
 }

--- a/desktop/src/main/conversations/transcript-mirror.ts
+++ b/desktop/src/main/conversations/transcript-mirror.ts
@@ -1,0 +1,94 @@
+// CC transcript movement between the device and the personal space (design §2).
+// BOTH directions are add/update-only and size-gated:
+//  - mirror-in: the space copy is the DURABLE one. CC's cleanupPeriodDays
+//    deleting a local transcript must never delete the synced copy, and a
+//    local rewrite that SHRANK the file (e.g. /clear) must not clobber the
+//    fuller durable history.
+//  - materialize-out: local files are only ever created or grown, never
+//    deleted, and never overwritten by a smaller/equal space copy.
+// Size comparison (not content hash) is sufficient: CC transcripts are
+// append-only JSONL between rewrites, and a same-size-different-content case
+// resolves on the next turn's growth.
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface MirrorResult { copied: boolean; shrunk?: boolean }
+
+// A crashed copy can orphan a '<dest>.<pid>.<ts>.tmp' file in the SPACE dir.
+// '.tmp' is NOT in the sync engine's DEFAULT_IGNORES (sync-spaces/guards.ts), so
+// an orphan would sync forever as junk. copyInto sweeps orphans for the SAME
+// dest older than this before writing a fresh one. An hour is comfortably longer
+// than any real copy, so a live copy in flight is never swept.
+const STALE_TMP_MS = 60 * 60 * 1000;
+
+function sizeOf(p: string): number | null {
+  // stat throws for a missing file; null is the "not present" signal every
+  // caller below branches on. A missing LOCAL file must never mutate the space,
+  // so this null is load-bearing, not just convenience.
+  try { return fs.statSync(p).size; } catch { return null; }
+}
+
+// Best-effort sweep of crash-orphaned tmp files for one dest. Isolated in its
+// own try/catch so a cleanup hiccup (permissions, dir race) can never abort the
+// copy it precedes — cleanup is opportunistic housekeeping, not correctness.
+function sweepStaleTmp(dir: string, destBase: string): void {
+  try {
+    const prefix = `${destBase}.`;
+    const now = Date.now();
+    for (const name of fs.readdirSync(dir)) {
+      // Match only OUR tmp shape for THIS dest: '<destBase>.<something>.tmp'.
+      // A foreign dest's tmp (different basename) is left alone.
+      if (!name.startsWith(prefix) || !name.endsWith('.tmp')) continue;
+      const full = path.join(dir, name);
+      try {
+        if (now - fs.statSync(full).mtimeMs > STALE_TMP_MS) fs.unlinkSync(full);
+      } catch { /* vanished or unreadable — nothing to sweep */ }
+    }
+  } catch { /* dir unreadable — skip the sweep entirely */ }
+}
+
+// Copy src OVER dest via a unique tmp + rename so a mid-copy crash never leaves
+// a torn (half-written) file for the sync engine to push. rename replaces an
+// existing dest atomically (POSIX rename(2); Windows MoveFileEx REPLACE_EXISTING
+// via Node's fs.renameSync).
+function copyInto(src: string, dest: string): void {
+  const dir = path.dirname(dest);
+  fs.mkdirSync(dir, { recursive: true });
+  sweepStaleTmp(dir, path.basename(dest));
+  const tmp = `${dest}.${process.pid}.${Date.now()}.tmp`;
+  fs.copyFileSync(src, tmp);
+  fs.renameSync(tmp, dest);
+}
+
+// Local → space. Copies only when the local file is STRICTLY LARGER than the
+// space copy (append-only growth) or when no space copy exists yet.
+export function mirrorIn(opts: { localJsonlPath: string; spaceTranscriptPath: string }): MirrorResult {
+  const localSize = sizeOf(opts.localJsonlPath);
+  // Local gone (CC cleanup) — NEVER propagate deletion into the durable copy.
+  if (localSize === null) return { copied: false };
+  const spaceSize = sizeOf(opts.spaceTranscriptPath);
+  // Local shrank below the durable copy (/clear rewrite or foreign truncation).
+  // Preserve the fuller history; signal `shrunk` so the caller knows the record
+  // still legitimately points at the longer space copy.
+  if (spaceSize !== null && localSize < spaceSize) return { copied: false, shrunk: true };
+  // Identical size ⇒ already mirrored (append-only means same size = same file
+  // in the normal case); skip the write so mtime/sync stay quiet.
+  if (spaceSize !== null && localSize === spaceSize) return { copied: false };
+  copyInto(opts.localJsonlPath, opts.spaceTranscriptPath);
+  return { copied: true };
+}
+
+// Space → local. Copies only when the space copy is STRICTLY LARGER than the
+// local file (or local is missing). Never deletes; never clobbers newer/equal
+// local work.
+export function materializeOut(opts: { spaceTranscriptPath: string; localJsonlPath: string }): MirrorResult {
+  const spaceSize = sizeOf(opts.spaceTranscriptPath);
+  // No space copy — nothing to materialize (and we never delete the local one).
+  if (spaceSize === null) return { copied: false };
+  const localSize = sizeOf(opts.localJsonlPath);
+  // Local is present and already as long as (or longer than) the space copy —
+  // leave the newer/equal local work untouched.
+  if (localSize !== null && localSize >= spaceSize) return { copied: false };
+  copyInto(opts.spaceTranscriptPath, opts.localJsonlPath);
+  return { copied: true };
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -1912,7 +1912,20 @@ export function registerIpcHandlers(
       // Dual-write into the Conversation Store (Phase 2a). The legacy index
       // above is removed in Plan 2c; until then both carry flags so a rollback
       // never loses them. safeWrite semantics live inside noteFlagChanged.
-      noteFlagChanged(resolved, flag, !!value);
+      //
+      // Phantom-record gate (review fix 5): only write when `resolved` is
+      // actually a CLAUDE id. Either the mapping is known (sessionId was a
+      // desktop id → resolved is the mapped claude id), or sessionId is NOT a
+      // live desktop session (Resume Browser rows pass claude ids for past
+      // sessions — safe to write as-is). Without this gate, flagging a LIVE
+      // session before its SessionStart hook establishes the mapping would
+      // seed a flag-only record keyed by the desktop randomUUID — UUID-shaped
+      // (passes the store's id guard), synced to every device, and never
+      // pruned (flagged records are deliberately kept). The legacy index above
+      // keeps the flag either way, so nothing is lost while gated.
+      if (sessionIdMap.has(sessionId) || !sessionManager.getSession(sessionId)) {
+        noteFlagChanged(resolved, flag, !!value);
+      }
       const payload = { flag, value: !!value };
       sendForSession(resolved, IPC.SESSION_META_CHANGED, resolved, payload);
       remoteServer?.broadcast({

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -55,6 +55,10 @@ import { evaluateBinaryRead } from './artifacts/read-binary-access';
 import { trackedArtifacts } from './artifacts/visible-artifacts';
 import { PROJECT_IPC } from './project/ipc-channels';
 import { listProjectConversations, projectConversationHistory } from './project-conversations';
+// Conversation Store (Phase 2a): live intake of transcript activity, session
+// cwd, title and flag changes. Keyed by CLAUDE session id (resolved from the
+// desktop id via sessionIdMap below), matching the store's record id.
+import { noteTranscriptEvent, noteSessionStarted, noteTitleChanged, noteFlagChanged } from './conversations/service';
 import { getRepoInfo } from './project-repo';
 import { listContext, readContextFile, writeContextFile } from './project-context';
 
@@ -1690,6 +1694,12 @@ export function registerIpcHandlers(
     if (remoteServer) {
       remoteServer.broadcast({ type: 'transcript:event', payload: event });
     }
+    // Conversation Store (Phase 2a): feed live activity into the record store.
+    // event.sessionId is the DESKTOP id; the store keys by CLAUDE id, so resolve
+    // via sessionIdMap and skip if we haven't seen the mapping yet (a hook event
+    // establishes it — the reconciler backfills anything missed before then).
+    const claudeId = sessionIdMap.get(event.sessionId);
+    if (claudeId) noteTranscriptEvent(claudeId, event);
   });
 
   // Transcript replay: a window that just acquired a session asks for every
@@ -1752,6 +1762,10 @@ export function registerIpcHandlers(
       lastTopics.set(desktopId, initial);
       sendForSession(desktopId, IPC.SESSION_RENAMED, desktopId, initial);
       broadcastRename(desktopId, initial);
+      // Conversation Store (Phase 2a): mirror the auto-title into the record.
+      // Keyed by claudeId (the store's record id). This is the only sanctioned
+      // title writer (carry-forward 5) — no user-rename path exists yet.
+      noteTitleChanged(claudeId, initial);
     }
 
     const topicFilePath = path.join(topicDir, `topic-${claudeId}`);
@@ -1765,6 +1779,7 @@ export function registerIpcHandlers(
           lastTopics.set(desktopId, topic);
           sendForSession(desktopId, IPC.SESSION_RENAMED, desktopId, topic);
           broadcastRename(desktopId, topic);
+          noteTitleChanged(claudeId, topic); // Conversation Store (Phase 2a) title write-through
         }
       });
       watcher.on('error', () => {
@@ -1789,6 +1804,7 @@ export function registerIpcHandlers(
         lastTopics.set(desktopId, topic);
         sendForSession(desktopId, IPC.SESSION_RENAMED, desktopId, topic);
         broadcastRename(desktopId, topic);
+        noteTitleChanged(claudeId, topic); // Conversation Store (Phase 2a) title write-through
       }
     }, 2000);
     topicWatchers.set(desktopId, interval);
@@ -1852,6 +1868,9 @@ export function registerIpcHandlers(
       const sessionInfo = sessionManager.getSession(desktopId);
       if (sessionInfo) {
         transcriptWatcher.startWatching(desktopId, claudeId, sessionInfo.cwd);
+        // Conversation Store (Phase 2a): tell the store this claude session's cwd
+        // so its activity upserts carry projectName/originalPath (local truth).
+        noteSessionStarted(claudeId, sessionInfo.cwd);
       }
     });
   }
@@ -1890,6 +1909,10 @@ export function registerIpcHandlers(
     const resolved = sessionIdMap.get(sessionId) || sessionId;
     try {
       svc.setSessionFlag(resolved, flag, !!value);
+      // Dual-write into the Conversation Store (Phase 2a). The legacy index
+      // above is removed in Plan 2c; until then both carry flags so a rollback
+      // never loses them. safeWrite semantics live inside noteFlagChanged.
+      noteFlagChanged(resolved, flag, !!value);
       const payload = { flag, value: !!value };
       sendForSession(resolved, IPC.SESSION_META_CHANGED, resolved, payload);
       remoteServer?.broadcast({

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -19,6 +19,10 @@ import { SyncService } from './sync-service';
 import { setSyncService, getSyncConfig } from './sync-state';
 // Cross-device sync spaces (spec 2026-07-03) — folder-based sync engine.
 import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore } from './sync-spaces/service';
+// Conversation Store (Phase 2a): records + transcript sync ride the personal
+// space. Imported statically like the sync-spaces stop so the non-async quit
+// handler can call stopConversationStore() directly.
+import { startConversationStore, stopConversationStore } from './conversations/service';
 import { initRestoreService } from './restore-service';
 import { createAuthStore } from './marketplace-auth-store';
 import { registerMarketplaceApiHandlers } from './marketplace-api-handlers';
@@ -1458,6 +1462,13 @@ app.whenReady().then(async () => {
     (m) => log('INFO', 'SyncSpaces', m),
   ).catch(e => log('ERROR', 'Main', 'SyncSpaces start failed', { error: String(e) }));
 
+  // Conversation Store (Phase 2a): records + transcript sync ride the personal
+  // space. Started after startSyncSpaces because getManagedRoots() must be
+  // populated (its synchronous prologue creates the roots before its first
+  // await, so the roots exist by the time this line runs). startConversationStore
+  // resolves fast — the first-run reconcile inside is detached (may mirror GBs).
+  startConversationStore().catch(e => log('ERROR', 'Main', 'ConversationStore start failed', { error: String(e) }));
+
   // Push session JSONL on session close (replaces session-end-sync.sh)
   sessionManager.on('session-exit', (sessionId: string) => {
     syncService.pushSession(sessionId).catch(e =>
@@ -1476,6 +1487,9 @@ app.on('window-all-closed', () => {
   // .catch, not try/catch: it's an async fn, so a failure arrives as a rejected
   // promise — the old `void` call left that rejection unhandled at quit.
   stopSyncSpaces().catch(() => {});
+  // Stop the Conversation Store (Phase 2a) — unsubscribes the sync-spaces
+  // listener, clears the periodic reconciler + pending debounce timers. Sync fn.
+  try { stopConversationStore(); } catch {}
   // Stop sync service — clears timer, releases locks, removes .app-sync-active marker
   try { setSyncService(null); } catch {}
   app.quit();

--- a/desktop/src/main/session-browser.ts
+++ b/desktop/src/main/session-browser.ts
@@ -335,8 +335,9 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
   // conversation named on another device reads right here; legacy rows WIN on
   // projectSlug/projectPath because resume needs the LOCAL slug, which the store
   // doesn't know for a conversation that never ran on this device. A store
-  // record with no local transcript becomes a NEW row flagged missingProject
-  // (visible everywhere, resume disabled) when its project folder isn't here.
+  // record with no local transcript becomes a NEW row (visible everywhere)
+  // flagged missingProject (folder not on this device) or notSyncedYet
+  // (folder here, transcript not materialized yet) — resume disabled either way.
   // `deduped` is already keyed by sessionId, so it doubles as the merge index;
   // mutating a legacy value mutates the same object already in `result`.
   try {
@@ -345,6 +346,12 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
     if (store) {
       const records = await store.list('claude');
       for (const rec of records) {
+        // LIVE sessions are excluded for the same reason the legacy scan
+        // excludes them: every live session gains a store record within
+        // seconds (live intake upserts on transcript events), and offering
+        // resume on one would spawn a SECOND `claude --resume` against the
+        // transcript the live session is actively appending to.
+        if (activeSessionIds?.has(rec.id)) continue;
         const legacy = deduped.get(rec.id);
         // Store flags are { value, updatedAt }; keep only the ON, known flags.
         const flags: Partial<Record<SessionFlagName, boolean>> = {};
@@ -352,16 +359,25 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
           if (v.value && (k === 'complete' || k === 'priority' || k === 'helpful')) flags[k] = true;
         }
         if (legacy) {
-          // Overlay store metadata onto the local row (resume slug/path untouched).
-          legacy.name = rec.title || legacy.name;
+          // Overlay store metadata onto the local row (resume slug/path
+          // untouched). A literal 'Untitled' title is a PLACEHOLDER, not a
+          // name — older clients synced such topic files (see docs/PITFALLS.md
+          // → Resume Browser) — so it must never clobber a real derived name.
+          legacy.name = rec.title && rec.title !== 'Untitled' ? rec.title : legacy.name;
           legacy.lastModified = Math.max(legacy.lastModified, Date.parse(rec.lastActive) || 0);
           if (Object.keys(flags).length) legacy.flags = flags;
           legacy.device = rec.device || undefined;
           legacy.provider = rec.provider;
         } else {
-          // Store-only conversation: resolve its project locally. When the folder
-          // isn't on this device, there's no cwd to resume into — flag it.
+          // Store-only conversation: resolve its project locally. Resume needs
+          // BOTH the project folder AND a materialized transcript in
+          // ~/.claude/projects — a store-only row has no legacy-scanned
+          // transcript by construction, so check the JSONL explicitly;
+          // `claude --resume` on a missing transcript just errors out.
           const localPath = rec.originalPath && fs.existsSync(rec.originalPath) ? rec.originalPath : null;
+          const transcriptHere = localPath
+            ? fs.existsSync(path.join(PROJECTS_DIR, ccProjectSlug(localPath), `${rec.id}.jsonl`))
+            : false;
           result.push({
             sessionId: rec.id,
             name: rec.title || 'Untitled',
@@ -372,7 +388,10 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
             ...(Object.keys(flags).length ? { flags } : {}),
             device: rec.device || undefined,
             provider: rec.provider,
+            // Two distinct resume-blocked sub-cases so the renderer can word
+            // the note accurately: folder absent vs. transcript not synced yet.
             ...(localPath ? {} : { missingProject: true }),
+            ...(localPath && !transcriptHere ? { notSyncedYet: true } : {}),
           });
         }
       }

--- a/desktop/src/main/session-browser.ts
+++ b/desktop/src/main/session-browser.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { PastSession, HistoryMessage } from '../shared/types';
+import { PastSession, HistoryMessage, SessionFlagName } from '../shared/types';
+// ccProjectSlug drive-normalizes before slugifying, so a store originalPath with
+// a lowercase Windows drive still maps to CC's uppercase-drive project dir. Used
+// lazily inside listPastSessions, so the session-browser ↔ project-conversations
+// import cycle is harmless (neither uses the other at module-eval time).
+import { ccProjectSlug } from './project-conversations';
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const PROJECTS_DIR = path.join(CLAUDE_DIR, 'projects');
@@ -249,8 +254,12 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
     );
     slugs = statResults.filter((s): s is string => s !== null);
   } catch (err) {
+    // A missing/unreadable projects dir is NORMAL on a fresh secondary device
+    // (store synced, but no local CC transcripts written here yet). Degrade to
+    // an empty legacy scan and fall through to the store union below — remote
+    // conversations must still appear so they're visible "everywhere". (Phase 2a)
     console.warn('[session-browser] Failed to read projects directory:', err);
-    return [];
+    slugs = [];
   }
 
   // Join flag + topic metadata from the synced conversation index
@@ -319,6 +328,57 @@ export async function listPastSessions(activeSessionIds?: Set<string>): Promise<
   }
 
   const result = Array.from(deduped.values());
+
+  // Store union (Phase 2a): the Conversation Store is the canonical record;
+  // legacy transcript scanning stays as the fallback until Plan 2c deletes it.
+  // Store rows WIN on display metadata (title/lastActive/flags/device) so a
+  // conversation named on another device reads right here; legacy rows WIN on
+  // projectSlug/projectPath because resume needs the LOCAL slug, which the store
+  // doesn't know for a conversation that never ran on this device. A store
+  // record with no local transcript becomes a NEW row flagged missingProject
+  // (visible everywhere, resume disabled) when its project folder isn't here.
+  // `deduped` is already keyed by sessionId, so it doubles as the merge index;
+  // mutating a legacy value mutates the same object already in `result`.
+  try {
+    const { getConversationStore } = await import('./conversations/service');
+    const store = getConversationStore();
+    if (store) {
+      const records = await store.list('claude');
+      for (const rec of records) {
+        const legacy = deduped.get(rec.id);
+        // Store flags are { value, updatedAt }; keep only the ON, known flags.
+        const flags: Partial<Record<SessionFlagName, boolean>> = {};
+        for (const [k, v] of Object.entries(rec.flags)) {
+          if (v.value && (k === 'complete' || k === 'priority' || k === 'helpful')) flags[k] = true;
+        }
+        if (legacy) {
+          // Overlay store metadata onto the local row (resume slug/path untouched).
+          legacy.name = rec.title || legacy.name;
+          legacy.lastModified = Math.max(legacy.lastModified, Date.parse(rec.lastActive) || 0);
+          if (Object.keys(flags).length) legacy.flags = flags;
+          legacy.device = rec.device || undefined;
+          legacy.provider = rec.provider;
+        } else {
+          // Store-only conversation: resolve its project locally. When the folder
+          // isn't on this device, there's no cwd to resume into — flag it.
+          const localPath = rec.originalPath && fs.existsSync(rec.originalPath) ? rec.originalPath : null;
+          result.push({
+            sessionId: rec.id,
+            name: rec.title || 'Untitled',
+            projectSlug: localPath ? ccProjectSlug(localPath) : '',
+            projectPath: localPath ?? rec.originalPath,
+            lastModified: Date.parse(rec.lastActive) || 0,
+            size: 0,
+            ...(Object.keys(flags).length ? { flags } : {}),
+            device: rec.device || undefined,
+            provider: rec.provider,
+            ...(localPath ? {} : { missingProject: true }),
+          });
+        }
+      }
+    }
+  } catch { /* store unavailable — the legacy list stands alone */ }
+
   result.sort((a, b) => b.lastModified - a.lastModified);
   return result;
 }

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -52,6 +52,16 @@ export function setSyncSpacesRemoteBroadcaster(fn: ((e: SpaceSyncEvent) => void)
   remoteBroadcast = fn;
 }
 
+// Main-process subscribers (conversations service materializes on 'synced').
+// Renderer/remote consumers use the existing window/remote fan-outs; this hook
+// exists because main-process modules have no webContents to receive on.
+const localListeners = new Set<(e: SpaceSyncEvent) => void>();
+
+export function onSyncSpacesEvent(fn: (e: SpaceSyncEvent) => void): () => void {
+  localListeners.add(fn);
+  return () => localListeners.delete(fn);
+}
+
 function broadcast(e: SpaceSyncEvent): void {
   // Stamp at emit time — the renderer derives "Last synced N min ago" from it,
   // so every stored + fanned-out copy must carry the same timestamp.
@@ -62,6 +72,13 @@ function broadcast(e: SpaceSyncEvent): void {
   }
   // Fan out to remote clients too (see comment on remoteBroadcast above).
   try { remoteBroadcast?.(stamped); } catch { /* remote server not up / closing */ }
+  // Fan out to main-process subscribers (each isolated — same rationale as the
+  // window/remote blocks). Runs BEFORE the hub send so a bad listener can't
+  // strand the cross-device signal, and its own try/catch keeps one throwing
+  // listener from aborting the rest.
+  for (const fn of localListeners) {
+    try { fn(stamped); } catch { /* one bad listener must not strand the rest */ }
+  }
   // A local push means this account's OTHER devices should pull now — signal
   // the room LAST, isolated in its own try/catch like the fan-outs above:
   // broadcast() is the single fan-out chokepoint invoked from the engine's

--- a/desktop/src/renderer/components/ResumeBrowser.tsx
+++ b/desktop/src/renderer/components/ResumeBrowser.tsx
@@ -178,6 +178,10 @@ interface PastSession {
   // True when the conversation's project folder is not on THIS device (synced
   // in from elsewhere). Resume is disabled — there's no cwd to resume into.
   missingProject?: boolean;
+  // True when the folder IS here but the transcript hasn't been materialized
+  // into ~/.claude/projects yet (sync in flight). Resume is disabled too —
+  // distinct flag so the note can say so accurately.
+  notSyncedYet?: boolean;
 }
 
 interface Props {
@@ -527,12 +531,13 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
     <div key={s.sessionId}>
       <button
         // Resume is disabled for conversations whose project folder isn't on
-        // this device (synced in from elsewhere) — there's no cwd to resume
-        // into, so the row shows a plain-words note instead of expanding.
-        onClick={() => { if (!s.missingProject) handleSelectSession(s.sessionId); }}
-        aria-disabled={s.missingProject || undefined}
+        // this device (synced in from elsewhere) OR whose transcript hasn't
+        // synced here yet — either way there's nothing to resume into, so the
+        // row shows a plain-words note instead of expanding.
+        onClick={() => { if (!s.missingProject && !s.notSyncedYet) handleSelectSession(s.sessionId); }}
+        aria-disabled={s.missingProject || s.notSyncedYet || undefined}
         className={`w-full text-left px-4 py-2 flex items-center gap-3 transition-colors ${
-          s.missingProject
+          s.missingProject || s.notSyncedYet
             ? 'text-fg-dim cursor-default'
             : expandedId === s.sessionId
               ? 'bg-inset text-fg'
@@ -556,10 +561,13 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
               project label since there's no group header; size rides along so
               no info is lost vs. the grouped view. Grouped rows keep size only
               — the group header already names the project. */}
-          {s.missingProject ? (
+          {s.missingProject || s.notSyncedYet ? (
             // Plain words, no glyphs (house rule). The conversation is visible
-            // everywhere; resume needs the project folder present on this device.
-            <div className="text-[10px] text-fg-muted truncate">Project folder not on this device</div>
+            // everywhere; resume needs the project folder AND its transcript
+            // present on this device — the two notes say which one is missing.
+            <div className="text-[10px] text-fg-muted truncate">
+              {s.notSyncedYet ? 'Not synced to this device yet' : 'Project folder not on this device'}
+            </div>
           ) : (
             <div className="text-[10px] text-fg-faint truncate">
               {showPath

--- a/desktop/src/renderer/components/ResumeBrowser.tsx
+++ b/desktop/src/renderer/components/ResumeBrowser.tsx
@@ -172,6 +172,12 @@ interface PastSession {
   // is on; `priority` pins the session to the top of its project group;
   // `helpful` is informational only.
   flags?: Partial<Record<FlagName, boolean>>;
+  // Conversation Store (Phase 2a) fields, present on store-fed rows only.
+  device?: string;   // last device that ran a turn
+  provider?: string; // 'claude' | 'native'
+  // True when the conversation's project folder is not on THIS device (synced
+  // in from elsewhere). Resume is disabled — there's no cwd to resume into.
+  missingProject?: boolean;
 }
 
 interface Props {
@@ -520,11 +526,17 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
   const renderSessionRow = (s: PastSession, showPath?: boolean) => (
     <div key={s.sessionId}>
       <button
-        onClick={() => handleSelectSession(s.sessionId)}
+        // Resume is disabled for conversations whose project folder isn't on
+        // this device (synced in from elsewhere) — there's no cwd to resume
+        // into, so the row shows a plain-words note instead of expanding.
+        onClick={() => { if (!s.missingProject) handleSelectSession(s.sessionId); }}
+        aria-disabled={s.missingProject || undefined}
         className={`w-full text-left px-4 py-2 flex items-center gap-3 transition-colors ${
-          expandedId === s.sessionId
-            ? 'bg-inset text-fg'
-            : 'text-fg-dim hover:bg-inset hover:text-fg'
+          s.missingProject
+            ? 'text-fg-dim cursor-default'
+            : expandedId === s.sessionId
+              ? 'bg-inset text-fg'
+              : 'text-fg-dim hover:bg-inset hover:text-fg'
         }`}
       >
         <div className="flex-1 min-w-0">
@@ -544,11 +556,17 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
               project label since there's no group header; size rides along so
               no info is lost vs. the grouped view. Grouped rows keep size only
               — the group header already names the project. */}
-          <div className="text-[10px] text-fg-faint truncate">
-            {showPath
-              ? `${s.projectPath.replace(/\\/g, '/').split('/').pop()} · ${formatSize(s.size)}`
-              : formatSize(s.size)}
-          </div>
+          {s.missingProject ? (
+            // Plain words, no glyphs (house rule). The conversation is visible
+            // everywhere; resume needs the project folder present on this device.
+            <div className="text-[10px] text-fg-muted truncate">Project folder not on this device</div>
+          ) : (
+            <div className="text-[10px] text-fg-faint truncate">
+              {showPath
+                ? `${s.projectPath.replace(/\\/g, '/').split('/').pop()} · ${formatSize(s.size)}`
+                : formatSize(s.size)}
+            </div>
+          )}
         </div>
         <span className="text-[10px] text-fg-faint shrink-0">
           {formatRelativeTime(s.lastModified)}

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -570,6 +570,15 @@ export interface PastSession {
   /** User-set flags. `complete` hides from resume menu; `priority` pins to top;
    *  `helpful` is informational only. Multiple flags per session are allowed. */
   flags?: Partial<Record<SessionFlagName, boolean>>;
+  /** Last device that ran a turn. Populated on store-fed rows (Conversation
+   *  Store, Phase 2a) so the Resume Browser can show where a conversation ran. */
+  device?: string;
+  /** Provider that owns the conversation: 'claude' | 'native'. Store-fed rows only. */
+  provider?: string;
+  /** True when the conversation's project folder is not present on THIS device
+   *  (a conversation synced in from another device). Resume is disabled for
+   *  these rows — the working directory to resume into doesn't exist here. */
+  missingProject?: boolean;
 }
 
 export interface HistoryMessage {

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -579,6 +579,11 @@ export interface PastSession {
    *  (a conversation synced in from another device). Resume is disabled for
    *  these rows — the working directory to resume into doesn't exist here. */
   missingProject?: boolean;
+  /** True when the project folder IS on this device but the transcript hasn't
+   *  been materialized into ~/.claude/projects yet (sync in flight). Resume is
+   *  disabled — `claude --resume` would error on the missing JSONL. Distinct
+   *  from missingProject so the renderer can word the note accurately. */
+  notSyncedYet?: boolean;
 }
 
 export interface HistoryMessage {

--- a/desktop/tests/conversation-reconciler.test.ts
+++ b/desktop/tests/conversation-reconciler.test.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { reconcile } from '../src/main/conversations/reconciler';
+import { ccProjectSlug } from '../src/main/project-conversations';
 import {
   createConversationStore,
   type ConversationStore,
@@ -236,5 +237,61 @@ describe('reconcile — per-file isolation', () => {
     expect(calls).toBe(2);
     expect(await store.get('claude', SID_A)).not.toBeNull();
     expect(await store.get('claude', SID_B)).not.toBeNull();
+  });
+});
+
+describe('reconcile — exact projectKey from known folders', () => {
+  // The whole-branch review's Finding 1: the slug-last-segment truncation
+  // ('...-youcoded-dev' → 'dev') disagrees with the live path's basename(cwd)
+  // key ('youcoded-dev'), producing an orphan duplicate space transcript and a
+  // cross-device materialize gap. When this device KNOWS the folder, the exact
+  // basename is recovered from its slug.
+
+  it('recovers the exact folder name (not the truncation) for a known hyphenated folder', async () => {
+    // A realistic hyphenated project path; slug is derived the same way CC would
+    // name the on-disk dir, so the test is platform-encoding-agnostic.
+    const folder = path.join('C:', 'Users', 'desti', 'youcoded-dev');
+    const slug = ccProjectSlug(folder); // e.g. 'C--Users-desti-youcoded-dev'
+    writeTranscript(projectsDir, slug, SID_A);
+
+    const n = await reconcile({
+      projectsDir, topicsDir, store, device: 'Dev1', mirror,
+      knownFolders: [folder],
+    });
+
+    expect(n).toBe(1);
+    const rec = await store.get('claude', SID_A);
+    // Exact basename — NOT the last-segment truncation 'dev' (red before the fix).
+    expect(rec!.projectName).toBe('youcoded-dev');
+    expect(rec!.transcriptRef).toBe(`claude/transcripts/youcoded-dev/${SID_A}.jsonl`);
+    // The mirror (space) key matches too — no orphan under 'dev/'.
+    expect(mirrorCalls[0].key).toBe('youcoded-dev');
+  });
+
+  it('matches case-insensitively so folder-path case drift still recovers the name', async () => {
+    // Saved-folder path recorded with different case than CC's on-disk slug —
+    // Windows paths are case-insensitive, so the lowercased map lookup must match.
+    const folder = path.join('C:', 'Users', 'Desti', 'MyApp-Client');
+    const onDiskSlug = ccProjectSlug(folder).toLowerCase(); // CC dir written lowercased
+    writeTranscript(projectsDir, onDiskSlug, SID_A);
+
+    await reconcile({
+      projectsDir, topicsDir, store, device: 'Dev1', mirror,
+      knownFolders: [folder],
+    });
+
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.projectName).toBe('MyApp-Client');
+  });
+
+  it('falls back to the last-segment truncation for an UNKNOWN folder', async () => {
+    // No knownFolders match → the documented truncation fallback is unchanged.
+    writeTranscript(projectsDir, 'C--Users-someone-else-secret-proj', SID_A);
+    await reconcile({
+      projectsDir, topicsDir, store, device: 'Dev1', mirror,
+      knownFolders: [path.join('C:', 'Users', 'desti', 'youcoded-dev')],
+    });
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.projectName).toBe('proj'); // last '-' segment, as before
   });
 });

--- a/desktop/tests/conversation-reconciler.test.ts
+++ b/desktop/tests/conversation-reconciler.test.ts
@@ -105,6 +105,24 @@ describe('reconcile — UUID gate', () => {
 });
 
 describe('reconcile — freshness merge', () => {
+  it('UPDATES an existing STALE record from a newer transcript (the catch-up core purpose)', async () => {
+    // Seed a record OLDER than the transcript — e.g. the session last ran in
+    // the app a week ago, then the user ran bare `claude` in a terminal since.
+    await store.upsert({
+      id: SID_A, provider: 'claude', projectName: 'alpha',
+      device: 'OldDevice', lastActive: '2026-06-01T00:00:00.000Z', title: 'Existing',
+    });
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A, { lastTimestamp: '2026-06-20T12:00:00Z' });
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'NewDevice', mirror });
+    expect(n).toBe(1);
+    const rec = await store.get('claude', SID_A);
+    // lastActive advanced to the transcript tail; device flipped (merge-decided,
+    // and this side carries the newer activity so it wins).
+    expect(rec!.lastActive).toBe('2026-06-20T12:00:00.000Z');
+    expect(rec!.device).toBe('NewDevice');
+    expect(rec!.title).toBe('Existing'); // real title survives the refresh
+  });
+
   it('does not touch an existing record whose lastActive >= the transcript tail', async () => {
     // Seed a record FRESHER than the transcript we are about to scan.
     await store.upsert({
@@ -172,6 +190,20 @@ describe('reconcile — junk threshold', () => {
     const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
     expect(n).toBe(0);
     expect(await store.list('claude')).toHaveLength(0);
+  });
+
+  it('skips a corrupt transcript (no parseable tail timestamp) instead of creating an EPOCH record', async () => {
+    // >500 bytes but NO line carries a parseable timestamp — a corrupt file.
+    // Creating a record would stamp EPOCH lastActive and re-upsert every scan.
+    const dir = path.join(projectsDir, 'C--proj-alpha');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${SID_A}.jsonl`), 'not json at all '.repeat(50) + '\n');
+    // A GOOD transcript alongside proves the scan continues past the corrupt one.
+    writeTranscript(projectsDir, 'C--proj-beta', SID_B);
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    expect(n).toBe(1);
+    expect(await store.get('claude', SID_A)).toBeNull();
+    expect(await store.get('claude', SID_B)).not.toBeNull();
   });
 });
 

--- a/desktop/tests/conversation-reconciler.test.ts
+++ b/desktop/tests/conversation-reconciler.test.ts
@@ -1,0 +1,208 @@
+// Tests for the catch-up RECONCILER (Phase 2a design §1, Task 4). Sessions run
+// OUTSIDE the app (bare `claude` in a terminal) never fire the live transcript-
+// event path, so on startup + a slow periodic tick we scan ~/.claude/projects
+// and upsert records for whatever we find. REAL temp dirs (fs.mkdtempSync) — no
+// fs mocking — because the whole point is real transcript reads + the real store
+// (locked read-modify-write on disk). Fixture style mirrors session-browser.test.ts.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { reconcile } from '../src/main/conversations/reconciler';
+import {
+  createConversationStore,
+  type ConversationStore,
+} from '../src/main/conversations/conversation-store';
+
+const SID_A = '11111111-1111-4111-8111-111111111111';
+const SID_B = '22222222-2222-4222-8222-222222222222';
+
+function jsonlLine(obj: Record<string, unknown>): string {
+  return JSON.stringify(obj) + '\n';
+}
+
+/**
+ * Write a realistic minimal transcript (meta + user prompt + long assistant
+ * reply, >500 bytes) into <projectsDir>/<slug>/<sid>.jsonl. Returns the path so
+ * a test can clobber its mtime (the load-bearing mtime-vs-content assertion).
+ */
+function writeTranscript(projectsDir: string, slug: string, sid: string, opts: {
+  firstUserText?: string;
+  lastTimestamp?: string;
+} = {}): string {
+  const dir = path.join(projectsDir, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${sid}.jsonl`);
+  let content = '';
+  content += jsonlLine({ type: 'user', isMeta: true, uuid: 'm1', timestamp: '2026-06-01T10:00:00Z', message: { content: 'meta noise' } });
+  content += jsonlLine({
+    type: 'user', uuid: 'u1', promptId: 'p1', timestamp: '2026-06-01T10:00:01Z',
+    message: { content: opts.firstUserText ?? 'fix the reconciler please' },
+  });
+  content += jsonlLine({
+    type: 'assistant', uuid: 'a1', timestamp: opts.lastTimestamp ?? '2026-06-01T10:05:00Z',
+    message: { stop_reason: 'end_turn', content: [{ type: 'text', text: 'done. '.repeat(40) }] },
+  });
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+let tmp: string;
+let projectsDir: string;
+let topicsDir: string;
+let store: ConversationStore;
+let mirrorCalls: Array<{ p: string; key: string; sid: string }>;
+const mirror = (p: string, key: string, sid: string) => { mirrorCalls.push({ p, key, sid }); };
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-reconcile-'));
+  projectsDir = path.join(tmp, '.claude', 'projects');
+  topicsDir = path.join(tmp, '.claude', 'topics');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  fs.mkdirSync(topicsDir, { recursive: true });
+  store = createConversationStore(path.join(tmp, 'conversations'));
+  mirrorCalls = [];
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+});
+
+describe('reconcile — record creation', () => {
+  it('creates a record per valid-UUID transcript, with projectName from the slug last segment', async () => {
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A);
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    expect(n).toBe(1);
+    const rec = await store.get('claude', SID_A);
+    expect(rec).not.toBeNull();
+    // 'C--proj-alpha' → last '-' segment → 'alpha' (documented approximation).
+    expect(rec!.projectName).toBe('alpha');
+    expect(rec!.device).toBe('Dev1');
+    expect(rec!.transcriptRef).toBe(`claude/transcripts/alpha/${SID_A}.jsonl`);
+  });
+
+  it('sets lastActive from the transcript TAIL timestamp, NEVER the file mtime', async () => {
+    // The load-bearing test: the 627-file mtime-rebump incident is why
+    // lastActive must come from transcript CONTENT, not the (sync-clobbered) mtime.
+    const file = writeTranscript(projectsDir, 'C--proj-alpha', SID_A, { lastTimestamp: '2026-06-10T12:00:00Z' });
+    // Clobber the mtime to a wildly different time — reconcile must ignore it.
+    fs.utimesSync(file, new Date('2020-01-01'), new Date('2020-01-01'));
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.lastActive).toBe('2026-06-10T12:00:00.000Z');
+  });
+});
+
+describe('reconcile — UUID gate', () => {
+  it('skips files whose name is not a valid session UUID (no record created)', async () => {
+    // >500 bytes so the ONLY reason to skip is the UUID gate.
+    writeTranscript(projectsDir, 'C--proj-alpha', 'not-a-valid-uuid');
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    expect(n).toBe(0);
+    expect(await store.list('claude')).toHaveLength(0);
+    expect(mirrorCalls).toHaveLength(0);
+  });
+});
+
+describe('reconcile — freshness merge', () => {
+  it('does not touch an existing record whose lastActive >= the transcript tail', async () => {
+    // Seed a record FRESHER than the transcript we are about to scan.
+    await store.upsert({
+      id: SID_A, provider: 'claude', projectName: 'alpha',
+      device: 'OldDevice', lastActive: '2026-07-10T00:00:00.000Z', title: 'Existing',
+    });
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A, { lastTimestamp: '2026-06-01T12:00:00Z' });
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'NewDevice', mirror });
+    // No upsert happened (record already as fresh as the file).
+    expect(n).toBe(0);
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.device).toBe('OldDevice'); // untouched — the merge-decided device field did not flip
+    // Still mirrored (cheap, idempotent) even when the record was left alone.
+    expect(mirrorCalls).toHaveLength(1);
+    expect(mirrorCalls[0].key).toBe('alpha');
+  });
+});
+
+describe('reconcile — title precedence', () => {
+  it('prefers the topic file title', async () => {
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A);
+    fs.writeFileSync(path.join(topicsDir, `topic-${SID_A}`), 'Reconciler Work');
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.title).toBe('Reconciler Work');
+  });
+
+  it('falls back to the derived first-user-message title when no topic file exists', async () => {
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A, { firstUserText: 'fix the reconciler please' });
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.title).toBe('fix the reconciler please');
+  });
+
+  it('leaves the record untitled ("") when neither a topic nor a derivable prompt exists', async () => {
+    // >500 bytes, has a timestamp, but the only line is meta (no qualifying
+    // user prompt) → no derivable title.
+    const dir = path.join(projectsDir, 'C--proj-alpha');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `${SID_A}.jsonl`),
+      jsonlLine({ type: 'user', isMeta: true, uuid: 'm1', timestamp: '2026-06-01T10:05:00Z', message: { content: 'z'.repeat(600) } }),
+    );
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    const rec = await store.get('claude', SID_A);
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toBe('');
+  });
+});
+
+describe('reconcile — mirroring', () => {
+  it('mirrors each scanned transcript with its projectKey + sessionId', async () => {
+    const file = writeTranscript(projectsDir, 'C--proj-alpha', SID_A);
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    expect(mirrorCalls).toHaveLength(1);
+    expect(mirrorCalls[0]).toMatchObject({ p: file, key: 'alpha', sid: SID_A });
+  });
+});
+
+describe('reconcile — junk threshold', () => {
+  it('skips transcripts under 500 bytes', async () => {
+    const dir = path.join(projectsDir, 'C--proj-alpha');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${SID_A}.jsonl`), 'tiny');
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    expect(n).toBe(0);
+    expect(await store.list('claude')).toHaveLength(0);
+  });
+});
+
+describe('reconcile — per-file isolation', () => {
+  it('a store.upsert throw on ONE file does not abort the scan', async () => {
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A); // upsert will throw
+    writeTranscript(projectsDir, 'C--proj-beta', SID_B);  // upsert succeeds
+    // Wrap the store so upsert throws for SID_A only; get/list delegate to the real store.
+    const throwing: ConversationStore = {
+      ...store,
+      upsert: async (input) => {
+        if (input.id === SID_A) throw new Error('boom (simulated lock timeout / invalid id)');
+        return store.upsert(input);
+      },
+    };
+    const n = await reconcile({ projectsDir, topicsDir, store: throwing, device: 'Dev1', mirror });
+    expect(n).toBe(1); // only SID_B counted
+    expect(await store.get('claude', SID_A)).toBeNull();      // failed file left no record
+    expect(await store.get('claude', SID_B)).not.toBeNull();  // scan continued past the failure
+  });
+
+  it('a mirror throw does not abort the scan or lose the upsert', async () => {
+    writeTranscript(projectsDir, 'C--proj-alpha', SID_A);
+    writeTranscript(projectsDir, 'C--proj-beta', SID_B);
+    let calls = 0;
+    const throwingMirror = () => { calls++; throw new Error('mirror boom'); };
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror: throwingMirror });
+    // Both upserts landed despite both mirror calls throwing.
+    expect(n).toBe(2);
+    expect(calls).toBe(2);
+    expect(await store.get('claude', SID_A)).not.toBeNull();
+    expect(await store.get('claude', SID_B)).not.toBeNull();
+  });
+});

--- a/desktop/tests/conversation-store-core.test.ts
+++ b/desktop/tests/conversation-store-core.test.ts
@@ -74,6 +74,46 @@ describe('parseRecord', () => {
     expect(() => parseRecord('  ')).not.toThrow();
     expect(() => parseRecord('[1,2,3')).not.toThrow();
   });
+
+  // Flags must round-trip LOSSLESSLY or not at all — a malformed FlagState
+  // reaching mergeRecords would corrupt the per-flag updatedAt comparison.
+  it('drops malformed flag entries but keeps well-formed ones', () => {
+    const parsed = parseRecord(JSON.stringify({
+      ...rec(),
+      flags: {
+        good: { value: true, updatedAt: '2026-07-01T00:00:00.000Z' },
+        stringValue: 'yes',                    // not an object
+        emptyObject: {},                       // missing both fields
+        badValue: { value: 'yes', updatedAt: '2026-07-01T00:00:00.000Z' }, // non-boolean
+        badUpdatedAt: { value: true, updatedAt: 42 },                      // non-string
+      },
+    }));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.flags).toEqual({
+      good: { value: true, updatedAt: '2026-07-01T00:00:00.000Z' },
+    });
+  });
+
+  it('normalizes a non-record flags shape (array) to {}', () => {
+    // Arrays are typeof 'object' — a naive object check would let one through.
+    const parsed = parseRecord(JSON.stringify({ ...rec(), flags: [1, 2, 3] }));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.flags).toEqual({});
+  });
+
+  // createdAt hygiene: garbage would parse to epoch 0 and then win every
+  // "earliest claim" comparison in mergeRecords — so it must never survive parse.
+  it('falls back to lastActive when createdAt is corrupt', () => {
+    const parsed = parseRecord(JSON.stringify({ ...rec(), createdAt: 'not-a-date' }));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.createdAt).toBe(rec().lastActive);
+  });
+
+  it('defaults createdAt to lastActive when absent', () => {
+    const parsed = parseRecord(JSON.stringify({ ...rec(), createdAt: undefined }));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.createdAt).toBe(rec().lastActive);
+  });
 });
 
 describe('mergeRecords', () => {
@@ -184,6 +224,38 @@ describe('mergeRecords', () => {
     expect(mergeRecords(older, newer).title).toBe('Newer title');
     expect(mergeRecords(newer, older).title).toBe('Newer title');
   });
+
+  // LOAD-BEARING convergence test: two devices merging the same pair must get
+  // the SAME result even on an exact lastActive tie. Positional tie-breaking
+  // ("second argument wins") makes merge(a,b) !== merge(b,a), and the healer
+  // fold becomes directory-enumeration-order dependent — devices ping-pong
+  // instead of converging. Ties must break on CONTENT (total order), never on
+  // argument position.
+  it('is commutative on an exact lastActive tie (content tiebreak)', () => {
+    const same = '2026-07-05T12:00:00.000Z';
+    const x = rec({
+      lastActive: same,
+      device: 'Laptop',
+      title: 'Title from laptop',
+      flags: { pinned: flag(true, same) },
+    });
+    const y = rec({
+      lastActive: same,
+      device: 'Desktop',
+      title: 'Title from desktop',
+      flags: { pinned: flag(false, same) }, // same updatedAt, different value
+    });
+    expect(mergeRecords(x, y)).toEqual(mergeRecords(y, x));
+  });
+
+  it('flag ties on equal updatedAt break by content, not argument order', () => {
+    const same = '2026-07-05T12:00:00.000Z';
+    const a = rec({ flags: { starred: flag(true, same) } });
+    const b = rec({ flags: { starred: flag(false, same) } });
+    const ab = mergeRecords(a, b).flags.starred;
+    const ba = mergeRecords(b, a).flags.starred;
+    expect(ab).toEqual(ba);
+  });
 });
 
 describe('isConflictCopyName / extractConflictBase', () => {
@@ -206,11 +278,21 @@ describe('isConflictCopyName / extractConflictBase', () => {
     expect(isConflictCopyName('abc123.json')).toBe(false);
     expect(extractConflictBase('abc123.json')).toBeNull();
   });
+
+  // The producer (guards.ts) permits ')' inside device names, so the matcher
+  // must run greedily to the LAST ')' before '.json' — a first-')' stop would
+  // truncate on such names and miss the copy entirely.
+  it("matches device names containing ')'", () => {
+    const tricky = 'abc123 (from foo)bar, 2026-07-03).json';
+    expect(isConflictCopyName(tricky)).toBe(true);
+    expect(extractConflictBase(tricky)).toBe('abc123.json');
+  });
 });
 
 describe('foldConflictCopies', () => {
-  // Contract 8: folding == successive mergeRecords, and is order-independent for
-  // these fields (associative merge) — both orderings must yield the same record.
+  // Contract 8: folding == successive mergeRecords, and is order-independent —
+  // true because each field group is picked as max/min under a TOTAL order
+  // (timestamp primary, JSON-content tiebreak). Both orderings must match.
   it('folds copies into the canonical record, order-independently', () => {
     const canonical = rec({
       id: 'sess-1',
@@ -251,5 +333,17 @@ describe('foldConflictCopies', () => {
   it('returns the canonical record unchanged when there are no copies', () => {
     const canonical = rec();
     expect(foldConflictCopies(canonical, [])).toEqual(canonical);
+  });
+
+  // Convergence under ties: when canonical and every copy share ONE lastActive
+  // (a real shape — two devices ran the same last turn's clock second), the
+  // fold must still be enumeration-order independent, which requires the
+  // content-based total-order tiebreak inside mergeRecords.
+  it('is order-independent even when all records tie on lastActive', () => {
+    const same = '2026-07-05T12:00:00.000Z';
+    const canon = rec({ lastActive: same, device: 'Laptop', title: 'Canon' });
+    const x = rec({ lastActive: same, device: 'Desktop', title: 'From desktop' });
+    const y = rec({ lastActive: same, device: 'Phone', title: 'From phone' });
+    expect(foldConflictCopies(canon, [x, y])).toEqual(foldConflictCopies(canon, [y, x]));
   });
 });

--- a/desktop/tests/conversation-store-core.test.ts
+++ b/desktop/tests/conversation-store-core.test.ts
@@ -148,6 +148,36 @@ describe('mergeRecords', () => {
     expect(mergeRecords(incoming, base).title).toBe('Real title');
   });
 
+  // Contract 5 (continued): the literal 'Untitled' is a legacy placeholder
+  // (PITFALLS → Resume Browser: older clients wrote it into topic files) — it
+  // must never shadow a real title, in either direction, regardless of age.
+  it("lets a real title beat a literal 'Untitled' even when the placeholder side is newer", () => {
+    const older = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'Real title' });
+    const newer = rec({ lastActive: '2026-07-09T00:00:00.000Z', title: 'Untitled' });
+    // (a) older side's real title beats newer side's 'Untitled'.
+    expect(mergeRecords(older, newer).title).toBe('Real title');
+    expect(mergeRecords(newer, older).title).toBe('Real title');
+  });
+
+  it("lets a newer real title beat an older 'Untitled'", () => {
+    const older = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'Untitled' });
+    const newer = rec({ lastActive: '2026-07-09T00:00:00.000Z', title: 'Real title' });
+    // (b) newer real title beats older 'Untitled'.
+    expect(mergeRecords(older, newer).title).toBe('Real title');
+    expect(mergeRecords(newer, older).title).toBe('Real title');
+  });
+
+  it('degrades gracefully when both sides are placeholders', () => {
+    // (c) both placeholder/empty → no crash; result is one of the placeholders
+    // (the renderer treats '' and 'Untitled' alike as untitled, so either is fine).
+    const a = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'Untitled' });
+    const b = rec({ lastActive: '2026-07-09T00:00:00.000Z', title: '' });
+    expect(['', 'Untitled']).toContain(mergeRecords(a, b).title);
+    expect(['', 'Untitled']).toContain(mergeRecords(b, a).title);
+    const c = rec({ title: 'Untitled' });
+    expect(['', 'Untitled']).toContain(mergeRecords(c, c).title);
+  });
+
   it('picks the newest side when both titles are non-empty', () => {
     const older = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'Older title' });
     const newer = rec({ lastActive: '2026-07-09T00:00:00.000Z', title: 'Newer title' });

--- a/desktop/tests/conversation-store-core.test.ts
+++ b/desktop/tests/conversation-store-core.test.ts
@@ -1,0 +1,225 @@
+// Tests for the PURE Conversation Store record logic (Phase 2a design §1).
+// Plain vitest, no mocks — store-core.ts is a pure module (no fs/path/os), so
+// every behavior is exercised directly on plain objects/strings.
+import { describe, it, expect } from 'vitest';
+import {
+  RECORD_SCHEMA_VERSION,
+  parseRecord,
+  mergeRecords,
+  isConflictCopyName,
+  extractConflictBase,
+  foldConflictCopies,
+  type ConversationRecord,
+  type FlagState,
+} from '../src/main/conversations/store-core';
+
+// Small factory so each test states only the fields it cares about — the rest
+// default to a valid baseline record.
+function rec(over: Partial<ConversationRecord> = {}): ConversationRecord {
+  return {
+    schema: RECORD_SCHEMA_VERSION,
+    id: 'sess-1',
+    provider: 'claude',
+    projectName: 'my-app',
+    originalPath: '/home/a/my-app',
+    title: 'Hello',
+    lastActive: '2026-07-03T10:00:00.000Z',
+    device: 'Laptop',
+    flags: {},
+    transcriptRef: 'claude/transcripts/my-app/sess-1.jsonl',
+    createdAt: '2026-07-01T09:00:00.000Z',
+    ...over,
+  };
+}
+
+function flag(value: boolean, updatedAt: string): FlagState {
+  return { value, updatedAt };
+}
+
+describe('parseRecord', () => {
+  // Contract 1: a well-formed schema:1 record with all required fields round-trips.
+  it('parses valid JSON with schema:1 and all required fields', () => {
+    const source = rec();
+    const parsed = parseRecord(JSON.stringify(source));
+    expect(parsed).not.toBeNull();
+    expect(parsed).toEqual(source);
+  });
+
+  // Contract 2 (three ways to be invalid → null, never throw):
+  it('returns null on malformed JSON', () => {
+    expect(parseRecord('{ not json')).toBeNull();
+    expect(parseRecord('')).toBeNull();
+    expect(parseRecord('null')).toBeNull();
+    expect(parseRecord('42')).toBeNull();
+  });
+
+  it('returns null on wrong schema version', () => {
+    const wrong = JSON.stringify({ ...rec(), schema: 2 });
+    expect(parseRecord(wrong)).toBeNull();
+  });
+
+  it('returns null when id/provider/lastActive is missing or invalid', () => {
+    // Missing id
+    expect(parseRecord(JSON.stringify({ ...rec(), id: undefined }))).toBeNull();
+    expect(parseRecord(JSON.stringify({ ...rec(), id: '' }))).toBeNull();
+    // Missing provider
+    expect(parseRecord(JSON.stringify({ ...rec(), provider: undefined }))).toBeNull();
+    expect(parseRecord(JSON.stringify({ ...rec(), provider: '' }))).toBeNull();
+    // Missing / unparseable lastActive
+    expect(parseRecord(JSON.stringify({ ...rec(), lastActive: undefined }))).toBeNull();
+    expect(parseRecord(JSON.stringify({ ...rec(), lastActive: 'not-a-date' }))).toBeNull();
+  });
+
+  it('never throws on arbitrary garbage input', () => {
+    expect(() => parseRecord('  ')).not.toThrow();
+    expect(() => parseRecord('[1,2,3')).not.toThrow();
+  });
+});
+
+describe('mergeRecords', () => {
+  // Contract 3: incoming NEWER → activity fields (lastActive/device/title) from
+  // incoming; createdAt keeps the OLDER of the two; flags merge per-flag newest-wins.
+  it('takes activity fields from the newer side and keeps the older createdAt', () => {
+    const base = rec({
+      lastActive: '2026-07-03T10:00:00.000Z',
+      device: 'Laptop',
+      title: 'Old title',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      flags: { pinned: flag(true, '2026-07-02T00:00:00.000Z') },
+    });
+    const incoming = rec({
+      lastActive: '2026-07-04T10:00:00.000Z', // newer
+      device: 'Desktop',
+      title: 'New title',
+      createdAt: '2026-07-05T00:00:00.000Z', // later birth claim — should NOT win
+      flags: { pinned: flag(false, '2026-07-06T00:00:00.000Z') }, // newer flag
+    });
+    const merged = mergeRecords(base, incoming);
+    expect(merged.lastActive).toBe('2026-07-04T10:00:00.000Z');
+    expect(merged.device).toBe('Desktop');
+    expect(merged.title).toBe('New title');
+    // createdAt keeps the EARLIER of the two, not the newer side's value.
+    expect(merged.createdAt).toBe('2026-07-01T00:00:00.000Z');
+    // Flag merged per-flag by updatedAt (incoming's is newer).
+    expect(merged.flags.pinned).toEqual(flag(false, '2026-07-06T00:00:00.000Z'));
+  });
+
+  // Contract 4: incoming OLDER → base's activity fields win, but incoming's
+  // newer individual flags STILL land (field-level, not record-level).
+  it('lets an older record still contribute its newer individual flags', () => {
+    const base = rec({
+      lastActive: '2026-07-10T10:00:00.000Z', // newer overall
+      device: 'Laptop',
+      title: 'Base title',
+      flags: { archived: flag(false, '2026-07-01T00:00:00.000Z') },
+    });
+    const incoming = rec({
+      lastActive: '2026-07-02T10:00:00.000Z', // older overall
+      device: 'Phone',
+      title: 'Incoming title',
+      // This flag was updated AFTER base's copy of it — must survive the merge.
+      flags: { archived: flag(true, '2026-07-09T00:00:00.000Z') },
+    });
+    const merged = mergeRecords(base, incoming);
+    // Activity fields come from the newer (base) side.
+    expect(merged.lastActive).toBe('2026-07-10T10:00:00.000Z');
+    expect(merged.device).toBe('Laptop');
+    expect(merged.title).toBe('Base title');
+    // But the older record's newer flag still lands.
+    expect(merged.flags.archived).toEqual(flag(true, '2026-07-09T00:00:00.000Z'));
+  });
+
+  it('merges disjoint flag keys from both sides', () => {
+    const base = rec({ flags: { a: flag(true, '2026-07-01T00:00:00.000Z') } });
+    const incoming = rec({ flags: { b: flag(true, '2026-07-02T00:00:00.000Z') } });
+    const merged = mergeRecords(base, incoming);
+    expect(merged.flags.a).toEqual(flag(true, '2026-07-01T00:00:00.000Z'));
+    expect(merged.flags.b).toEqual(flag(true, '2026-07-02T00:00:00.000Z'));
+  });
+
+  // Contract 5: title precedence — non-empty always beats empty/'Untitled'
+  // regardless of age; two non-empty → newest lastActive side wins.
+  it('lets a real title beat an empty title even when the empty side is newer', () => {
+    const base = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'Real title' });
+    const incoming = rec({ lastActive: '2026-07-09T00:00:00.000Z', title: '' });
+    // incoming is newer but has no title — the real title must survive.
+    expect(mergeRecords(base, incoming).title).toBe('Real title');
+    // Order-independent.
+    expect(mergeRecords(incoming, base).title).toBe('Real title');
+  });
+
+  it('picks the newest side when both titles are non-empty', () => {
+    const older = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'Older title' });
+    const newer = rec({ lastActive: '2026-07-09T00:00:00.000Z', title: 'Newer title' });
+    expect(mergeRecords(older, newer).title).toBe('Newer title');
+    expect(mergeRecords(newer, older).title).toBe('Newer title');
+  });
+});
+
+describe('isConflictCopyName / extractConflictBase', () => {
+  // Contract 6: real conflict-copy filenames are detected and the base recovered.
+  // The REAL format (git-transport.ts conflictCopyName) uses an ISO date.
+  it('detects a real conflict-copy name and extracts its canonical base', () => {
+    const real = 'abc123 (from Laptop, 2026-07-03).json';
+    expect(isConflictCopyName(real)).toBe(true);
+    expect(extractConflictBase(real)).toBe('abc123.json');
+  });
+
+  it('also matches the task example date shape', () => {
+    const name = 'abc123 (from Laptop, Jul 3).json';
+    expect(isConflictCopyName(name)).toBe(true);
+    expect(extractConflictBase(name)).toBe('abc123.json');
+  });
+
+  // Contract 7: a plain canonical name is NOT a conflict copy.
+  it('rejects a plain canonical filename', () => {
+    expect(isConflictCopyName('abc123.json')).toBe(false);
+    expect(extractConflictBase('abc123.json')).toBeNull();
+  });
+});
+
+describe('foldConflictCopies', () => {
+  // Contract 8: folding == successive mergeRecords, and is order-independent for
+  // these fields (associative merge) — both orderings must yield the same record.
+  it('folds copies into the canonical record, order-independently', () => {
+    const canonical = rec({
+      id: 'sess-1',
+      lastActive: '2026-07-03T00:00:00.000Z',
+      title: 'Canonical',
+      flags: { pinned: flag(true, '2026-07-03T00:00:00.000Z') },
+    });
+    const copy1 = rec({
+      id: 'sess-1',
+      lastActive: '2026-07-05T00:00:00.000Z', // newest activity
+      device: 'Desktop',
+      title: 'Copy One',
+      flags: { archived: flag(true, '2026-07-05T00:00:00.000Z') },
+    });
+    const copy2 = rec({
+      id: 'sess-1',
+      lastActive: '2026-07-04T00:00:00.000Z',
+      device: 'Phone',
+      title: 'Copy Two',
+      flags: { pinned: flag(false, '2026-07-06T00:00:00.000Z') }, // newest pinned flag
+    });
+
+    const forward = foldConflictCopies(canonical, [copy1, copy2]);
+    const reversed = foldConflictCopies(canonical, [copy2, copy1]);
+
+    // Both orders converge to the same record (associativity for these fields).
+    expect(forward).toEqual(reversed);
+    // And the fold matches successive pairwise merges.
+    const manual = mergeRecords(mergeRecords(canonical, copy1), copy2);
+    expect(forward).toEqual(manual);
+    // Sanity on the winning fields: newest activity from copy1, newest flags win.
+    expect(forward.lastActive).toBe('2026-07-05T00:00:00.000Z');
+    expect(forward.device).toBe('Desktop');
+    expect(forward.flags.pinned).toEqual(flag(false, '2026-07-06T00:00:00.000Z'));
+    expect(forward.flags.archived).toEqual(flag(true, '2026-07-05T00:00:00.000Z'));
+  });
+
+  it('returns the canonical record unchanged when there are no copies', () => {
+    const canonical = rec();
+    expect(foldConflictCopies(canonical, [])).toEqual(canonical);
+  });
+});

--- a/desktop/tests/conversation-store-core.test.ts
+++ b/desktop/tests/conversation-store-core.test.ts
@@ -379,4 +379,26 @@ describe('foldConflictCopies', () => {
     const y = rec({ lastActive: same, device: 'Phone', title: 'From phone' });
     expect(foldConflictCopies(canon, [x, y])).toEqual(foldConflictCopies(canon, [y, x]));
   });
+
+  // Residual-corner probe: 3-way exact tie + 'Untitled' placeholder canonical +
+  // real-titled copies straddling it in JSON order. When the record-level pick
+  // ran over the MUTATED reduce accumulator, the fold's title override shrank
+  // the accumulator's JSON and flipped a later tie comparison — device healed
+  // differently per enumeration order. The fix picks the spread-source record
+  // over the ORIGINAL inputs, same as the title pick.
+  it('picks activity fields over the original inputs, not the mutated accumulator', () => {
+    const same = '2026-07-05T12:00:00.000Z';
+    const canon = rec({ lastActive: same, title: 'Untitled', device: 'C-dev' });
+    const alpha = rec({ lastActive: same, title: 'Alpha', device: 'B-dev' });
+    const delta = rec({ lastActive: same, title: 'Delta', device: 'A-dev' });
+    const fwd = foldConflictCopies(canon, [alpha, delta]);
+    const rev = foldConflictCopies(canon, [delta, alpha]);
+    expect(fwd).toEqual(rev);
+    // Concrete winners under the total order (records' JSON first differs at
+    // `title`): 'Untitled' > 'Delta' > 'Alpha', so the canonical is the
+    // spread-source max → device 'C-dev'; the title pick considers only the
+    // REAL-titled inputs, where 'Delta' beats 'Alpha' on the same tiebreak.
+    expect(fwd.device).toBe('C-dev');
+    expect(fwd.title).toBe('Delta');
+  });
 });

--- a/desktop/tests/conversation-store-core.test.ts
+++ b/desktop/tests/conversation-store-core.test.ts
@@ -245,7 +245,16 @@ describe('mergeRecords', () => {
       title: 'Title from desktop',
       flags: { pinned: flag(false, same) }, // same updatedAt, different value
     });
-    expect(mergeRecords(x, y)).toEqual(mergeRecords(y, x));
+    const xy = mergeRecords(x, y);
+    expect(xy).toEqual(mergeRecords(y, x));
+    // Pin the CONCRETE winner, not just symmetry: the two records' JSON text
+    // first differs at `title` ('Title from laptop' vs 'Title from desktop',
+    // 'l' > 'd'), so x sorts higher and wins the tiebreak. If a future
+    // comparator change silently flips historical tie resolutions, this catches it.
+    expect(xy.device).toBe('Laptop');
+    expect(xy.title).toBe('Title from laptop');
+    // Flag tie: '{"value":true,...}' sorts above '{"value":false,...}' ('t' > 'f').
+    expect(xy.flags.pinned).toEqual(flag(true, same));
   });
 
   it('flag ties on equal updatedAt break by content, not argument order', () => {
@@ -255,6 +264,9 @@ describe('mergeRecords', () => {
     const ab = mergeRecords(a, b).flags.starred;
     const ba = mergeRecords(b, a).flags.starred;
     expect(ab).toEqual(ba);
+    // Concrete winner: '{"value":true,...}' sorts above '{"value":false,...}'
+    // ('t' > 'f'), so the true-valued FlagState deterministically wins this tie.
+    expect(ab).toEqual(flag(true, same));
   });
 });
 
@@ -290,9 +302,10 @@ describe('isConflictCopyName / extractConflictBase', () => {
 });
 
 describe('foldConflictCopies', () => {
-  // Contract 8: folding == successive mergeRecords, and is order-independent —
-  // true because each field group is picked as max/min under a TOTAL order
-  // (timestamp primary, JSON-content tiebreak). Both orderings must match.
+  // Contract 8: folding is order-independent. lastActive/device/flags/createdAt
+  // converge via the pairwise merge's total-order picks (timestamp primary,
+  // JSON-content tiebreak); title converges via the fold's SET-BASED pick over
+  // the original inputs (the pairwise title heuristic is not associative).
   it('folds copies into the canonical record, order-independently', () => {
     const canonical = rec({
       id: 'sess-1',
@@ -333,6 +346,26 @@ describe('foldConflictCopies', () => {
   it('returns the canonical record unchanged when there are no copies', () => {
     const canonical = rec();
     expect(foldConflictCopies(canonical, [])).toEqual(canonical);
+  });
+
+  // The reviewer's counterexample — NO tie needed: once the accumulator adopts
+  // a title from its first merge partner, that title rides the accumulator's
+  // newest lastActive and beats a NEWER real title arriving in a later fold
+  // step. Pairwise: fold [B,C] healed to 'M-title' while fold [C,B] healed to
+  // 'Q-title' — two devices enumerating the same copies in different directory
+  // orders would heal to different titles and re-conflict forever. The fix is
+  // the fold's set-based title pick: newest REAL title among the inputs wins.
+  it('heals to the newest real title regardless of copy enumeration order', () => {
+    const canon = rec({ lastActive: '2026-07-05T00:00:00.000Z', title: '' });
+    const b = rec({ lastActive: '2026-07-01T00:00:00.000Z', title: 'M-title' });
+    const c = rec({ lastActive: '2026-07-03T00:00:00.000Z', title: 'Q-title' });
+    const bc = foldConflictCopies(canon, [b, c]);
+    const cb = foldConflictCopies(canon, [c, b]);
+    expect(bc).toEqual(cb);
+    // Specifically: the newest REAL title (C at 07-03 beats B at 07-01; the
+    // canonical's newer-but-empty title doesn't count).
+    expect(bc.title).toBe('Q-title');
+    expect(cb.title).toBe('Q-title');
   });
 
   // Convergence under ties: when canonical and every copy share ONE lastActive

--- a/desktop/tests/conversation-store.test.ts
+++ b/desktop/tests/conversation-store.test.ts
@@ -4,7 +4,7 @@
 // locked read-modify-write, and heal-on-read that DELETES conflict-copy files.
 // The pure record logic it sits on top of is tested separately in
 // conversation-store-core.test.ts.
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -46,6 +46,12 @@ function stage(root: string, provider: string, fileName: string, content: string
   fs.writeFileSync(path.join(dir, fileName), content);
 }
 
+// No file in `dir` still carries the healer's quarantine marker — proves heal
+// cleaned up after itself.
+function noHealingLeftovers(dir: string): boolean {
+  return fs.readdirSync(dir).every((n) => !n.includes('.healing-'));
+}
+
 const EPOCH = '1970-01-01T00:00:00.000Z';
 
 let tmp: string;
@@ -55,6 +61,7 @@ beforeEach(() => {
   store = createConversationStore(tmp);
 });
 afterEach(() => {
+  vi.restoreAllMocks();
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -110,6 +117,41 @@ describe('createConversationStore', () => {
     expect(merged.title).toBe('Old title');
   });
 
+  // Review fix 3: caller-provided fields are LOCAL TRUTH — a metadata-only
+  // upsert (no lastActive) must land every provided field even though the merge
+  // ranks the existing record as "newer". lastActive/device stay merge-decided.
+  it('metadata-only upsert lands all provided fields without touching activity', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({
+      id: 'sess-1',
+      title: 'Old',
+      projectName: 'old-proj',
+      originalPath: '/old',
+      transcriptRef: 'old-ref',
+      lastActive: '2026-07-03T10:00:00.000Z',
+      device: 'Laptop',
+    }));
+
+    const rec = await store.upsert({
+      id: 'sess-1',
+      provider: 'claude',
+      // NO lastActive — metadata-only
+      projectName: 'new-proj',
+      originalPath: '/new',
+      title: 'New',
+      transcriptRef: 'new-ref',
+    });
+
+    // Every provided field landed (this was the red case — all four were
+    // silently dropped before the local-truth overlay)...
+    expect(rec.projectName).toBe('new-proj');
+    expect(rec.originalPath).toBe('/new');
+    expect(rec.title).toBe('New');
+    expect(rec.transcriptRef).toBe('new-ref');
+    // ...but activity fields stayed merge-decided (EPOCH loses to real activity).
+    expect(rec.lastActive).toBe('2026-07-03T10:00:00.000Z');
+    expect(rec.device).toBe('Laptop');
+  });
+
   // Contract 3: get returns null for missing AND corrupt files, and a read must
   // NEVER delete the corrupt file (data isn't ours to throw away).
   it('get returns null for missing files', async () => {
@@ -141,7 +183,7 @@ describe('createConversationStore', () => {
 
   // Contract 5: HEALER — a canonical file plus a conflict copy carrying a newer
   // flag. get() returns the FOLDED record, rewrites the canonical file with the
-  // fold, and DELETES the conflict copy.
+  // fold, and DELETES the conflict copy (leaving no quarantine leftovers).
   it('heal folds a conflict copy into the canonical record and deletes the copy', async () => {
     stage(tmp, 'claude', 'sess-1.json', recJson({
       id: 'sess-1',
@@ -164,8 +206,10 @@ describe('createConversationStore', () => {
     // The canonical file on disk now contains the fold...
     const onDisk = JSON.parse(fs.readFileSync(path.join(tmp, 'claude', 'sess-1.json'), 'utf8'));
     expect(onDisk.flags.complete).toEqual({ value: true, updatedAt: '2026-07-03T13:00:00.000Z' });
-    // ...and the conflict copy is gone.
+    // ...the conflict copy is gone...
     expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json'))).toBe(false);
+    // ...and the quarantine mechanism left zero .healing- files behind.
+    expect(noHealingLeftovers(path.join(tmp, 'claude'))).toBe(true);
   });
 
   // Contract 6: the healer only touches RECORD conflict copies (.json), never a
@@ -193,6 +237,110 @@ describe('createConversationStore', () => {
     const claudeRec = JSON.parse(fs.readFileSync(path.join(tmp, 'claude', 'sess-1.json'), 'utf8'));
     expect(claudeRec.flags.complete).toBeUndefined();
   });
+
+  // Review fix 5d: copies-only heal — no canonical exists yet, only conflict
+  // copies. get() must seed the canonical from the fold and delete the copies.
+  it('heal seeds the canonical from copies when no canonical exists', async () => {
+    stage(tmp, 'claude', 'sess-2 (from Laptop, 2026-07-03).json', recJson({
+      id: 'sess-2',
+      title: 'Only copy',
+      flags: { pinned: { value: true, updatedAt: '2026-07-03T09:00:00.000Z' } },
+    }));
+
+    const rec = await store.get('claude', 'sess-2');
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toBe('Only copy');
+    expect(rec!.flags.pinned.value).toBe(true);
+    // Canonical materialized; copy gone; no quarantine leftovers.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-2.json'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-2 (from Laptop, 2026-07-03).json'))).toBe(false);
+    expect(noHealingLeftovers(path.join(tmp, 'claude'))).toBe(true);
+  });
+
+  // Review fix 5d: a corrupt copy is deleted (unparseable junk) while valid
+  // copies in the same pass still fold in.
+  it('heal deletes a corrupt copy while folding valid copies', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1', flags: {} }));
+    stage(tmp, 'claude', 'sess-1 (from A, 2026-07-03).json', 'corrupt garbage {{{');
+    stage(tmp, 'claude', 'sess-1 (from B, 2026-07-03).json', recJson({
+      id: 'sess-1',
+      flags: { complete: { value: true, updatedAt: '2026-07-03T13:00:00.000Z' } },
+    }));
+
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec!.flags.complete.value).toBe(true); // valid copy folded
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from A, 2026-07-03).json'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from B, 2026-07-03).json'))).toBe(false);
+    expect(noHealingLeftovers(path.join(tmp, 'claude'))).toBe(true);
+  });
+
+  // Review fix 5b: a conflict copy that parses to a VALID record with a
+  // DIFFERENT id is someone's data (misnamed) — it is left in place, never
+  // folded and never deleted.
+  it('heal leaves a valid copy with a mismatched id in place', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1', flags: {} }));
+    stage(tmp, 'claude', 'sess-1 (from C, 2026-07-03).json', recJson({
+      id: 'other-id', // valid record, wrong id for this filename
+      flags: { complete: { value: true, updatedAt: '2026-07-03T13:00:00.000Z' } },
+    }));
+
+    const rec = await store.get('claude', 'sess-1');
+    // Nothing folded in from the foreign record...
+    expect(rec!.flags.complete).toBeUndefined();
+    // ...and the file is preserved for investigation.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from C, 2026-07-03).json'))).toBe(true);
+    expect(noHealingLeftovers(path.join(tmp, 'claude'))).toBe(true);
+  });
+
+  // Review fix 2 (crash recovery): a stale quarantine file left by a crashed
+  // healer ('<copy>.healing-<pid>') is folded in and deleted on the next heal.
+  it('heal adopts a stale quarantine file: folds it and deletes it', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1', flags: {} }));
+    stage(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json.healing-424242', recJson({
+      id: 'sess-1',
+      flags: { complete: { value: true, updatedAt: '2026-07-03T13:00:00.000Z' } },
+    }));
+
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec!.flags.complete.value).toBe(true); // stale quarantine folded in
+    expect(noHealingLeftovers(path.join(tmp, 'claude'))).toBe(true); // and deleted
+  });
+
+  // Review fix 2: a copy that vanishes between detection and the quarantine
+  // rename (another process claimed it first) must be skipped, not crash the read.
+  it('heal skips a copy that vanishes mid-heal (rename ENOENT)', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1', title: 'Canonical' }));
+    stage(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json', recJson({ id: 'sess-1' }));
+    // Simulate the copy vanishing at claim time: the quarantine rename throws
+    // ENOENT exactly once (as if another healer renamed it away first).
+    vi.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+      const e: any = new Error('ENOENT: no such file');
+      e.code = 'ENOENT';
+      throw e;
+    });
+
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec).not.toBeNull(); // read survived the lost claim
+    expect(rec!.title).toBe('Canonical');
+  });
+
+  // Review fix 4: heal failure (a live/contended lock on the canonical) must
+  // NOT reject reads — get/list serve the un-healed canonical and the next read
+  // retries healing. A fresh lock dir makes mutateFileUnderLock wait its 3s max
+  // and give up, hence the long test timeout.
+  it('get and list still return data when heal cannot acquire the lock', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1', title: 'Survivor' }));
+    stage(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json', recJson({ id: 'sess-1' }));
+    // A fresh lock dir on the canonical simulates another process mid-write.
+    fs.mkdirSync(path.join(tmp, 'claude', 'sess-1.json.lock'));
+
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec).not.toBeNull(); // un-healed canonical served, not a rejection
+    expect(rec!.title).toBe('Survivor');
+
+    const list = await store.list('claude');
+    expect(list.map((r) => r.id)).toEqual(['sess-1']);
+  }, 20_000);
 
   // Contract 7: setFlag on a MISSING record seeds a flag-only record — empty
   // title, lastActive = EPOCH sentinel (so it never outranks real activity in a
@@ -227,6 +375,33 @@ describe('createConversationStore', () => {
     expect(rec!.lastActive).toBe('2026-07-03T10:00:00.000Z'); // untouched
   });
 
+  // Review fix 5d: setTitle behaviors.
+  it('setTitle with an empty title is a no-op (never seeds or blanks)', async () => {
+    await store.setTitle('claude', 'sess-9', '');
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-9.json'))).toBe(false);
+  });
+
+  it('setTitle seeds a title-only record when missing (EPOCH activity)', async () => {
+    await store.setTitle('claude', 'sess-9', 'Fresh name');
+    const rec = await store.get('claude', 'sess-9');
+    expect(rec!.title).toBe('Fresh name');
+    expect(rec!.lastActive).toBe(EPOCH); // seed never outranks real activity
+  });
+
+  it('setTitle overwrites the title on an existing record, keeping the rest', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({
+      id: 'sess-1',
+      title: 'Old name',
+      lastActive: '2026-07-03T10:00:00.000Z',
+      device: 'Laptop',
+    }));
+    await store.setTitle('claude', 'sess-1', 'New name');
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec!.title).toBe('New name');
+    expect(rec!.lastActive).toBe('2026-07-03T10:00:00.000Z'); // untouched
+    expect(rec!.device).toBe('Laptop');                       // untouched
+  });
+
   // Contract 8: two concurrent upserts to the SAME id both land — the final
   // record contains the union of both. Without the lock, both would read a
   // missing file, both create, and the second rename would clobber the first
@@ -253,5 +428,62 @@ describe('createConversationStore', () => {
     // regardless of which write won the lock first.
     expect(rec!.title).toBe('Titled');
     expect(rec!.device).toBe('DeviceB');
+  });
+});
+
+// Review fix 1 (CRITICAL): id/provider become path segments — traversal
+// attempts must never escape the store root. Writes throw; reads fail soft
+// (null / []). Uses a NESTED store root so "escaped outside the root" is
+// observable inside the test's own temp dir.
+describe('path traversal guard', () => {
+  let base: string;
+  let root: string;
+  let s: ConversationStore;
+  beforeEach(() => {
+    base = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-trav-'));
+    root = path.join(base, 'nested', 'store');
+    fs.mkdirSync(root, { recursive: true });
+    s = createConversationStore(root);
+  });
+  afterEach(() => {
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+
+  it('setFlag with a traversal id throws and writes nothing outside the root', async () => {
+    await expect(s.setFlag('claude', '../../escape', 'complete', true)).rejects.toThrow(/invalid/i);
+    // Nothing landed at any of the escape targets.
+    expect(fs.existsSync(path.join(base, 'escape.json'))).toBe(false);
+    expect(fs.existsSync(path.join(base, 'nested', 'escape.json'))).toBe(false);
+  });
+
+  it('upsert with a traversal id or provider throws', async () => {
+    await expect(
+      s.upsert({ id: '../../escape', provider: 'claude', lastActive: '2026-07-03T10:00:00.000Z' }),
+    ).rejects.toThrow(/invalid/i);
+    await expect(
+      s.upsert({ id: 'ok-id', provider: '..\\..', lastActive: '2026-07-03T10:00:00.000Z' }),
+    ).rejects.toThrow(/invalid/i);
+    expect(fs.existsSync(path.join(base, 'escape.json'))).toBe(false);
+  });
+
+  it('setTitle with a traversal id throws', async () => {
+    await expect(s.setTitle('claude', '..', 'Evil')).rejects.toThrow(/invalid/i);
+  });
+
+  it('get with a traversal id/provider fails soft (null)', async () => {
+    // Plant a file OUTSIDE the store root that a traversal would reach.
+    fs.writeFileSync(path.join(base, 'nested', 'secret.json'), recJson({ id: 'secret' }));
+    expect(await s.get('claude', '../secret')).toBeNull();
+    expect(await s.get('..', 'secret')).toBeNull();
+    expect(await s.get('claude', '.')).toBeNull();
+  });
+
+  it('list with a traversal provider fails soft ([])', async () => {
+    // '../outside' from the store root resolves to base/nested/outside — stage
+    // real records THERE so an unguarded list would actually return them.
+    fs.mkdirSync(path.join(base, 'nested', 'outside'), { recursive: true });
+    fs.writeFileSync(path.join(base, 'nested', 'outside', 'x.json'), recJson({ id: 'x' }));
+    expect(await s.list('../outside')).toEqual([]);
+    expect(await s.list('..')).toEqual([]);
   });
 });

--- a/desktop/tests/conversation-store.test.ts
+++ b/desktop/tests/conversation-store.test.ts
@@ -1,0 +1,257 @@
+// Tests for the IO SHELL of the Conversation Store (Phase 2a design §1).
+// Uses REAL temp dirs (fs.mkdtempSync) — no memfs, no fs mocking — because the
+// whole point of this module is real disk behavior: on-demand dir creation,
+// locked read-modify-write, and heal-on-read that DELETES conflict-copy files.
+// The pure record logic it sits on top of is tested separately in
+// conversation-store-core.test.ts.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  createConversationStore,
+  type ConversationStore,
+} from '../src/main/conversations/conversation-store';
+import {
+  RECORD_SCHEMA_VERSION,
+  type ConversationRecord,
+} from '../src/main/conversations/store-core';
+
+// Build a valid record JSON string, overriding only the fields a test cares
+// about. Keeps each test focused on the one behavior it pins.
+function recJson(over: Partial<ConversationRecord> = {}): string {
+  const base: ConversationRecord = {
+    schema: RECORD_SCHEMA_VERSION,
+    id: 'sess-1',
+    provider: 'claude',
+    projectName: 'my-app',
+    originalPath: '/home/a/my-app',
+    title: 'Hello',
+    lastActive: '2026-07-03T10:00:00.000Z',
+    device: 'Laptop',
+    flags: {},
+    transcriptRef: 'claude/transcripts/my-app/sess-1.jsonl',
+    createdAt: '2026-07-01T09:00:00.000Z',
+    ...over,
+  };
+  return JSON.stringify(base, null, 2);
+}
+
+// Write a raw file directly into a provider dir, bypassing the store — used to
+// stage on-disk state (canonical records, conflict copies, garbage) before a
+// read/heal path runs.
+function stage(root: string, provider: string, fileName: string, content: string): void {
+  const dir = path.join(root, provider);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, fileName), content);
+}
+
+const EPOCH = '1970-01-01T00:00:00.000Z';
+
+let tmp: string;
+let store: ConversationStore;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-conv-'));
+  store = createConversationStore(tmp);
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('createConversationStore', () => {
+  // Contract 1: upsert on a MISSING record creates <root>/claude/<id>.json with
+  // schema 1, returns the written record, and creates the provider dir on demand.
+  it('upsert creates the record file (and provider dir) on demand', async () => {
+    const written = await store.upsert({
+      id: 'sess-1',
+      provider: 'claude',
+      title: 'First',
+      lastActive: '2026-07-03T10:00:00.000Z',
+      device: 'Laptop',
+    });
+
+    const file = path.join(tmp, 'claude', 'sess-1.json');
+    expect(fs.existsSync(file)).toBe(true); // dir + file created on demand
+    expect(written.schema).toBe(RECORD_SCHEMA_VERSION);
+    expect(written.id).toBe('sess-1');
+    expect(written.title).toBe('First');
+    expect(written.lastActive).toBe('2026-07-03T10:00:00.000Z');
+
+    // The returned record matches what actually landed on disk.
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(onDisk).toEqual(written);
+  });
+
+  // Contract 2: upsert on an EXISTING record merges via mergeRecords — a partial
+  // with a newer lastActive updates activity fields while preserving flags.
+  it('upsert merges into an existing record (newer activity wins, flags kept)', async () => {
+    // Seed a base record that already carries a flag.
+    stage(tmp, 'claude', 'sess-1.json', recJson({
+      id: 'sess-1',
+      title: 'Old title',
+      lastActive: '2026-07-03T10:00:00.000Z',
+      device: 'Laptop',
+      flags: { pinned: { value: true, updatedAt: '2026-07-03T09:00:00.000Z' } },
+    }));
+
+    const merged = await store.upsert({
+      id: 'sess-1',
+      provider: 'claude',
+      lastActive: '2026-07-03T12:00:00.000Z', // newer turn
+      device: 'Phone',
+    });
+
+    // Activity fields advanced to the newer turn...
+    expect(merged.lastActive).toBe('2026-07-03T12:00:00.000Z');
+    expect(merged.device).toBe('Phone');
+    // ...the flag set on the older record survived the merge...
+    expect(merged.flags.pinned).toEqual({ value: true, updatedAt: '2026-07-03T09:00:00.000Z' });
+    // ...and the metadata-only partial did NOT blank the existing title.
+    expect(merged.title).toBe('Old title');
+  });
+
+  // Contract 3: get returns null for missing AND corrupt files, and a read must
+  // NEVER delete the corrupt file (data isn't ours to throw away).
+  it('get returns null for missing files', async () => {
+    expect(await store.get('claude', 'nope')).toBeNull();
+  });
+
+  it('get returns null for a corrupt file and leaves it in place', async () => {
+    stage(tmp, 'claude', 'sess-1.json', 'this is not json at all {{{');
+    expect(await store.get('claude', 'sess-1')).toBeNull();
+    // The garbage file is untouched — a read never deletes.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1.json'))).toBe(true);
+  });
+
+  // Contract 4: list returns every VALID record; corrupt files are skipped
+  // silently so one bad record can't break the whole listing.
+  it('list returns valid records and skips corrupt ones', async () => {
+    stage(tmp, 'claude', 'a.json', recJson({ id: 'a' }));
+    stage(tmp, 'claude', 'b.json', recJson({ id: 'b' }));
+    stage(tmp, 'claude', 'c.json', 'garbage-not-json');
+
+    const list = await store.list('claude');
+    const ids = list.map((r) => r.id).sort();
+    expect(ids).toEqual(['a', 'b']); // 'c' skipped, but a+b still returned
+  });
+
+  it('list returns [] for a provider dir that does not exist', async () => {
+    expect(await store.list('gemini')).toEqual([]);
+  });
+
+  // Contract 5: HEALER — a canonical file plus a conflict copy carrying a newer
+  // flag. get() returns the FOLDED record, rewrites the canonical file with the
+  // fold, and DELETES the conflict copy.
+  it('heal folds a conflict copy into the canonical record and deletes the copy', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({
+      id: 'sess-1',
+      lastActive: '2026-07-03T12:00:00.000Z', // canonical has the later turn
+      flags: {},
+    }));
+    // A valid record conflict copy with a NEWER flag than the canonical (none).
+    stage(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json', recJson({
+      id: 'sess-1',
+      lastActive: '2026-07-03T08:00:00.000Z', // older activity, must lose
+      flags: { complete: { value: true, updatedAt: '2026-07-03T13:00:00.000Z' } },
+    }));
+
+    const folded = await store.get('claude', 'sess-1');
+    expect(folded).not.toBeNull();
+    // The fold picked the flag from the copy AND kept the canonical's later turn.
+    expect(folded!.flags.complete).toEqual({ value: true, updatedAt: '2026-07-03T13:00:00.000Z' });
+    expect(folded!.lastActive).toBe('2026-07-03T12:00:00.000Z');
+
+    // The canonical file on disk now contains the fold...
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmp, 'claude', 'sess-1.json'), 'utf8'));
+    expect(onDisk.flags.complete).toEqual({ value: true, updatedAt: '2026-07-03T13:00:00.000Z' });
+    // ...and the conflict copy is gone.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json'))).toBe(false);
+  });
+
+  // Contract 6: the healer only touches RECORD conflict copies (.json), never a
+  // non-record conflict copy, and never reaches into another provider's dir.
+  it('heal ignores non-record conflict copies and never crosses providers', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1', flags: {} }));
+    // A conflict copy that is NOT a record file (different extension) — must be
+    // left alone.
+    stage(tmp, 'claude', 'notes (from Laptop, 2026-07-03).txt', 'just some notes');
+    // A same-named conflict copy under a DIFFERENT provider — must not be
+    // pulled into claude's heal.
+    stage(tmp, 'gemini', 'sess-1 (from Laptop, 2026-07-03).json', recJson({
+      id: 'sess-1',
+      provider: 'gemini',
+      flags: { complete: { value: true, updatedAt: '2026-07-03T13:00:00.000Z' } },
+    }));
+
+    await store.get('claude', 'sess-1');
+
+    // The .txt conflict copy is untouched.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'notes (from Laptop, 2026-07-03).txt'))).toBe(true);
+    // The gemini conflict copy was never healed away (different provider dir).
+    expect(fs.existsSync(path.join(tmp, 'gemini', 'sess-1 (from Laptop, 2026-07-03).json'))).toBe(true);
+    // claude's canonical picked up NOTHING from gemini's copy.
+    const claudeRec = JSON.parse(fs.readFileSync(path.join(tmp, 'claude', 'sess-1.json'), 'utf8'));
+    expect(claudeRec.flags.complete).toBeUndefined();
+  });
+
+  // Contract 7: setFlag on a MISSING record seeds a flag-only record — empty
+  // title, lastActive = EPOCH sentinel (so it never outranks real activity in a
+  // later merge) — and sets the flag with a fresh updatedAt.
+  it('setFlag creates a flag-only seed record when missing', async () => {
+    const before = Date.now();
+    await store.setFlag('claude', 'sess-9', 'complete', true);
+    const after = Date.now();
+
+    const rec = await store.get('claude', 'sess-9');
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toBe('');            // flag-only seed: no title
+    expect(rec!.lastActive).toBe(EPOCH);    // epoch sentinel: loses every real-activity merge
+    expect(rec!.flags.complete.value).toBe(true);
+    // updatedAt is a fresh timestamp captured at setFlag time.
+    const stampedAt = Date.parse(rec!.flags.complete.updatedAt);
+    expect(stampedAt).toBeGreaterThanOrEqual(before);
+    expect(stampedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('setFlag updates a flag on an existing record without touching activity', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({
+      id: 'sess-1',
+      title: 'Keep me',
+      lastActive: '2026-07-03T10:00:00.000Z',
+    }));
+    await store.setFlag('claude', 'sess-1', 'archived', true);
+
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec!.flags.archived.value).toBe(true);
+    expect(rec!.title).toBe('Keep me');                       // untouched
+    expect(rec!.lastActive).toBe('2026-07-03T10:00:00.000Z'); // untouched
+  });
+
+  // Contract 8: two concurrent upserts to the SAME id both land — the final
+  // record contains the union of both. Without the lock, both would read a
+  // missing file, both create, and the second rename would clobber the first
+  // (lost update). The union proves mutateFileUnderLock serialized them.
+  it('concurrent upserts to the same id both land (no lost update)', async () => {
+    await Promise.all([
+      store.upsert({
+        id: 'sess-1',
+        provider: 'claude',
+        title: 'Titled',
+        lastActive: '2026-07-03T10:00:00.000Z',
+      }),
+      store.upsert({
+        id: 'sess-1',
+        provider: 'claude',
+        device: 'DeviceB',
+        lastActive: '2026-07-03T11:00:00.000Z',
+      }),
+    ]);
+
+    const rec = await store.get('claude', 'sess-1');
+    expect(rec).not.toBeNull();
+    // Both the title from one upsert AND the device from the other survived,
+    // regardless of which write won the lock first.
+    expect(rec!.title).toBe('Titled');
+    expect(rec!.device).toBe('DeviceB');
+  });
+});

--- a/desktop/tests/conversation-store.test.ts
+++ b/desktop/tests/conversation-store.test.ts
@@ -152,6 +152,25 @@ describe('createConversationStore', () => {
     expect(rec.device).toBe('Laptop');
   });
 
+  // Review follow-up: a provided title of literal 'Untitled' is a legacy
+  // placeholder (see store-core realTitle), not a name — the local-truth
+  // re-apply must not let it clobber a real title.
+  it("upsert with title 'Untitled' never overwrites a real title", async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({
+      id: 'sess-1',
+      title: 'Real name',
+      lastActive: '2026-07-03T10:00:00.000Z',
+    }));
+
+    const rec = await store.upsert({
+      id: 'sess-1',
+      provider: 'claude',
+      title: 'Untitled', // placeholder from a non-normalizing caller
+    });
+
+    expect(rec.title).toBe('Real name'); // placeholder lost, real title survived
+  });
+
   // Contract 3: get returns null for missing AND corrupt files, and a read must
   // NEVER delete the corrupt file (data isn't ours to throw away).
   it('get returns null for missing files', async () => {
@@ -468,6 +487,16 @@ describe('path traversal guard', () => {
 
   it('setTitle with a traversal id throws', async () => {
     await expect(s.setTitle('claude', '..', 'Evil')).rejects.toThrow(/invalid/i);
+  });
+
+  // Review follow-up: Windows reserved device names ('con', 'nul', 'com1', …)
+  // pass a pure charset check but map to DEVICES on older Windows — writing
+  // 'con.json' can target the console device. Refuse them like traversal names.
+  it('write with a Windows reserved device name throws', async () => {
+    await expect(s.setFlag('claude', 'con', 'complete', true)).rejects.toThrow(/invalid/i);
+    await expect(s.setFlag('claude', 'NUL', 'complete', true)).rejects.toThrow(/invalid/i);
+    await expect(s.setFlag('claude', 'com1', 'complete', true)).rejects.toThrow(/invalid/i);
+    await expect(s.setFlag('con', 'sess-1', 'complete', true)).rejects.toThrow(/invalid/i);
   });
 
   it('get with a traversal id/provider fails soft (null)', async () => {

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -179,6 +179,58 @@ describe('conversations service composition root', () => {
     void svc;
   });
 
+  // Review fix 1: the sweep must NEVER touch a LIVE session's transcript. A
+  // same-conversation-on-two-devices pull would otherwise materializeOut over
+  // the JSONL Claude Code is actively appending to (Windows EPERM containment
+  // is unreliable — libuv opens with FILE_SHARE_DELETE; on POSIX the rename
+  // always succeeds and CC keeps appending to the unlinked inode → chat view
+  // freezes, local turns lost on handle close).
+  it('the sweep SKIPS records whose id is a live session; others still materialize', async () => {
+    const liveDir = path.join(tmpRoot, 'live-proj');
+    const idleDir = path.join(tmpRoot, 'idle-proj');
+    fs.mkdirSync(liveDir, { recursive: true });
+    fs.mkdirSync(idleDir, { recursive: true });
+    const liveRec = {
+      id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', provider: 'claude',
+      projectName: 'live-proj', originalPath: liveDir,
+      transcriptRef: 'claude/transcripts/live-proj/cccccccc-cccc-cccc-cccc-cccccccccccc.jsonl',
+    };
+    const idleRec = {
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', provider: 'claude',
+      projectName: 'idle-proj', originalPath: idleDir,
+      transcriptRef: 'claude/transcripts/idle-proj/dddddddd-dddd-dddd-dddd-dddddddddddd.jsonl',
+    };
+    h.store.list.mockResolvedValue([liveRec, idleRec] as any);
+    const svc = await freshService(startOpts());
+    svc.noteSessionStarted(liveRec.id, liveDir); // liveRec is a LIVE session here
+    fireSync({ type: 'synced', spaceId: 'personal', updated: true, pushed: false });
+    await vi.waitFor(() => expect(h.materializeOut).toHaveBeenCalled());
+    expect(h.materializeOut).toHaveBeenCalledTimes(1);
+    expect(h.materializeOut.mock.calls[0][0].localJsonlPath).toContain(`${idleRec.id}.jsonl`);
+  });
+
+  // Review fix 4: start must be idempotent — a second start without stop must
+  // not leak the first sync-spaces subscription (duplicate sweeps forever) or
+  // the first periodic interval.
+  it('a second start without stop leaves exactly ONE subscription and ONE interval', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    await svc.startConversationStore(startOpts()); // double start — no stop between
+    // Exactly one sweep per synced event ⇒ store.list called once.
+    h.store.list.mockClear();
+    fireSync({ type: 'synced', spaceId: 'personal', updated: true, pushed: false });
+    await vi.waitFor(() => expect(h.store.list).toHaveBeenCalled());
+    expect(h.store.list).toHaveBeenCalledTimes(1);
+    // Exactly one periodic interval ⇒ one reconcile per 30-min tick.
+    h.reconcile.mockClear();
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+    expect(h.reconcile).toHaveBeenCalledTimes(1);
+    svc.stopConversationStore();
+    vi.useRealTimers();
+  });
+
   it('a non-personal or non-updated synced event does NOT materialize', async () => {
     h.store.list.mockResolvedValue([{ id: 'x', provider: 'claude', projectName: 'a', originalPath: '/x', transcriptRef: 'claude/transcripts/a/x.jsonl' }] as any);
     await freshService(startOpts());

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -1,0 +1,292 @@
+// Pins the Conversation Store composition root (conversations/service.ts):
+// the startup + periodic reconciler kick, live transcript-event intake
+// (debounced activity upserts + prompt mirror/push on turn-end), title/flag
+// write-through, and the materialize-on-synced sweep. All collaborators
+// (store, mirror, reconciler, sync-spaces) are faked via vi.hoisted, mirroring
+// sync-spaces-service.test.ts — this tests ONLY the wiring, not the IO shells.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// vi.mock factories are hoisted above imports, so shared fake state must be
+// created via vi.hoisted for the factories to close over it.
+const h = vi.hoisted(() => {
+  return {
+    // Single fake store instance returned by createConversationStore(root).
+    // root() is (re)assigned per createConversationStore call to echo the root
+    // the service computed, so spaceTranscriptPath resolution is real.
+    store: {
+      upsert: vi.fn(async (_p: any) => ({ id: 'x' })),
+      get: vi.fn(async () => null),
+      list: vi.fn(async (_provider: string): Promise<any[]> => []),
+      setFlag: vi.fn(async () => {}),
+      setTitle: vi.fn(async () => {}),
+      root: vi.fn(() => ''),
+    },
+    // Default reconciler NEVER resolves — that's how the non-blocking-start test
+    // (carry-forward 2) proves startConversationStore doesn't await it. Callers
+    // attach .catch, so a never-resolving promise causes no unhandled rejection.
+    reconcile: vi.fn((_opts: any) => new Promise<number>(() => {})),
+    mirrorIn: vi.fn((_o: any) => ({ copied: true })),
+    materializeOut: vi.fn((_o: any) => ({ copied: true })),
+    syncSpacesSyncNow: vi.fn(async (_spaceId?: string) => ({ ok: true })),
+    // onSyncSpacesEvent subscribers — fireSync() drives them like the real
+    // broadcast() fan-out would.
+    syncListeners: new Set<(e: any) => void>(),
+    managedRoots: null as any,
+  };
+});
+
+vi.mock('../src/main/conversations/conversation-store', () => ({
+  createConversationStore: (root: string) => {
+    h.store.root = vi.fn(() => root);
+    return h.store;
+  },
+}));
+vi.mock('../src/main/conversations/transcript-mirror', () => ({
+  mirrorIn: (o: any) => h.mirrorIn(o),
+  materializeOut: (o: any) => h.materializeOut(o),
+}));
+vi.mock('../src/main/conversations/reconciler', () => ({
+  reconcile: (o: any) => h.reconcile(o),
+}));
+vi.mock('../src/main/sync-spaces/service', () => ({
+  onSyncSpacesEvent: (fn: (e: any) => void) => {
+    h.syncListeners.add(fn);
+    return () => h.syncListeners.delete(fn);
+  },
+  syncSpacesSyncNow: (spaceId?: string) => h.syncSpacesSyncNow(spaceId),
+  getManagedRoots: () => h.managedRoots,
+}));
+vi.mock('../src/main/saved-folders', () => ({
+  readFolders: () => [],
+}));
+// ccProjectSlug + shared/types are used REAL (pure / type-only).
+
+function fireSync(e: any): void {
+  for (const fn of h.syncListeners) fn(e);
+}
+
+async function freshService(opts?: {
+  conversationsRoot?: string; projectsDir?: string; topicsDir?: string; device?: string;
+}) {
+  vi.resetModules();
+  const svc = await import('../src/main/conversations/service');
+  await svc.startConversationStore(opts);
+  return svc;
+}
+
+function ev(over: Partial<any>): any {
+  return { type: 'user-message', sessionId: 'desktop-1', uuid: 'u', timestamp: 1_700_000_000_000, data: {}, ...over };
+}
+
+let tmpRoot = '';
+
+describe('conversations service composition root', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    h.syncListeners.clear();
+    h.store.upsert.mockReset().mockResolvedValue({ id: 'x' } as any);
+    h.store.list.mockReset().mockResolvedValue([]);
+    h.store.setFlag.mockReset().mockResolvedValue(undefined as any);
+    h.store.setTitle.mockReset().mockResolvedValue(undefined as any);
+    h.reconcile.mockReset().mockImplementation(() => new Promise<number>(() => {}));
+    h.mirrorIn.mockReset().mockReturnValue({ copied: true } as any);
+    h.materializeOut.mockReset().mockReturnValue({ copied: true } as any);
+    h.syncSpacesSyncNow.mockReset().mockResolvedValue({ ok: true } as any);
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-svc-'));
+    h.managedRoots = { personalRoot: path.join(tmpRoot, 'Personal'), listProjects: () => [] };
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  const startOpts = () => ({
+    conversationsRoot: path.join(tmpRoot, 'Conversations'),
+    projectsDir: path.join(tmpRoot, 'projects'),
+    topicsDir: path.join(tmpRoot, 'topics'),
+    device: 'test-device',
+  });
+
+  // 1 — kicks the reconciler at start, WITHOUT awaiting it (carry-forward 2).
+  it('kicks the reconciler at start and resolves even though reconcile never settles', async () => {
+    await freshService(startOpts()); // resolves despite the never-resolving reconcile mock
+    expect(h.reconcile).toHaveBeenCalledTimes(1);
+    const opts = h.reconcile.mock.calls[0][0];
+    expect(opts.projectsDir).toBe(startOpts().projectsDir);
+    expect(opts.topicsDir).toBe(startOpts().topicsDir);
+    expect(opts.device).toBe('test-device');
+    expect(typeof opts.mirror).toBe('function');
+  });
+
+  // 2 — an event upserts local-truth metadata keyed by the claude id. Asserted
+  // via turn-complete (non-debounced) so the exact payload lands synchronously.
+  it('an event upserts projectName/originalPath/lastActive/device', async () => {
+    const svc = await freshService(startOpts());
+    const cwd = path.join(tmpRoot, 'my-project');
+    svc.noteSessionStarted('claude-abc', cwd);
+    svc.noteTranscriptEvent('claude-abc', ev({ type: 'turn-complete', timestamp: 1_700_000_000_000 }));
+    await Promise.resolve();
+    expect(h.store.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'claude-abc',
+      provider: 'claude',
+      projectName: path.basename(cwd),
+      originalPath: cwd,
+      lastActive: new Date(1_700_000_000_000).toISOString(),
+      device: 'test-device',
+    }));
+  });
+
+  // 3 — turn-complete additionally mirrors the transcript and pushes 'personal'.
+  it('turn-complete mirrors the jsonl and syncs the personal space promptly', async () => {
+    const svc = await freshService(startOpts());
+    const cwd = path.join(tmpRoot, 'proj-x');
+    svc.noteSessionStarted('claude-xyz', cwd);
+    svc.noteTranscriptEvent('claude-xyz', ev({ type: 'turn-complete' }));
+    await Promise.resolve();
+    expect(h.mirrorIn).toHaveBeenCalledTimes(1);
+    const arg = h.mirrorIn.mock.calls[0][0];
+    expect(arg.localJsonlPath).toContain('claude-xyz.jsonl');
+    expect(arg.localJsonlPath).toContain(startOpts().projectsDir);
+    expect(h.syncSpacesSyncNow).toHaveBeenCalledWith('personal');
+  });
+
+  // 4 — a personal 'synced'/updated event materializes records that resolve
+  // locally; records with no local match are skipped.
+  it('synced(updated) event materializes only records whose project resolves locally', async () => {
+    const existingDir = path.join(tmpRoot, 'alpha');
+    fs.mkdirSync(existingDir, { recursive: true });
+    const recA = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', provider: 'claude',
+      projectName: 'alpha', originalPath: existingDir,
+      transcriptRef: 'claude/transcripts/alpha/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl',
+    };
+    const recB = {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', provider: 'claude',
+      projectName: 'ghost', originalPath: path.join(tmpRoot, 'nope-does-not-exist'),
+      transcriptRef: 'claude/transcripts/ghost/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl',
+    };
+    h.store.list.mockResolvedValue([recA, recB] as any);
+    const svc = await freshService(startOpts());
+    fireSync({ type: 'synced', spaceId: 'personal', updated: true, pushed: false });
+    await vi.waitFor(() => expect(h.materializeOut).toHaveBeenCalled());
+    expect(h.materializeOut).toHaveBeenCalledTimes(1);
+    const arg = h.materializeOut.mock.calls[0][0];
+    expect(arg.spaceTranscriptPath).toContain(recA.transcriptRef.replace(/\//g, path.sep));
+    expect(arg.localJsonlPath).toContain(`${recA.id}.jsonl`);
+    void svc;
+  });
+
+  it('a non-personal or non-updated synced event does NOT materialize', async () => {
+    h.store.list.mockResolvedValue([{ id: 'x', provider: 'claude', projectName: 'a', originalPath: '/x', transcriptRef: 'claude/transcripts/a/x.jsonl' }] as any);
+    await freshService(startOpts());
+    fireSync({ type: 'synced', spaceId: 'project:alpha', updated: true, pushed: false }); // wrong space
+    fireSync({ type: 'synced', spaceId: 'personal', updated: false, pushed: true });      // not updated
+    await new Promise((r) => setTimeout(r, 20));
+    expect(h.materializeOut).not.toHaveBeenCalled();
+  });
+
+  // 5 — title write-through.
+  it('noteTitleChanged writes through to store.setTitle', async () => {
+    const svc = await freshService(startOpts());
+    svc.noteTitleChanged('claude-t', 'My Title');
+    expect(h.store.setTitle).toHaveBeenCalledWith('claude', 'claude-t', 'My Title');
+  });
+
+  // 6 — flag write-through.
+  it('noteFlagChanged writes through to store.setFlag', async () => {
+    const svc = await freshService(startOpts());
+    svc.noteFlagChanged('claude-f', 'complete', true);
+    expect(h.store.setFlag).toHaveBeenCalledWith('claude', 'claude-f', 'complete', true);
+  });
+
+  // 7 — stop() unsubscribes, clears the periodic timer AND pending debounce timers.
+  it('stopConversationStore unsubscribes, stops the periodic reconciler and pending debounces', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    expect(h.reconcile).toHaveBeenCalledTimes(1); // start kick
+    // Advance one periodic interval — reconcile fires again.
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+    expect(h.reconcile).toHaveBeenCalledTimes(2);
+    // Arm a pending debounce for a chatty event, then stop BEFORE its 5s window.
+    svc.noteSessionStarted('claude-s', path.join(tmpRoot, 'p'));
+    svc.noteTranscriptEvent('claude-s', ev({ type: 'assistant-text' }));
+    svc.stopConversationStore();
+    // A synced event after stop does nothing (unsubscribed + store nulled).
+    fireSync({ type: 'synced', spaceId: 'personal', updated: true, pushed: false });
+    // Advance well past the periodic interval AND the debounce window.
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(h.reconcile).toHaveBeenCalledTimes(2);   // periodic timer cleared
+    expect(h.materializeOut).not.toHaveBeenCalled(); // unsubscribed
+    expect(h.store.upsert).not.toHaveBeenCalled();   // pending debounce cleared
+    vi.useRealTimers();
+  });
+
+  // 8 — events for sessions never announced still upsert (no cwd known).
+  it('an event for an unannounced session upserts with no originalPath', async () => {
+    const svc = await freshService(startOpts());
+    svc.noteTranscriptEvent('claude-unknown', ev({ type: 'turn-complete' }));
+    await Promise.resolve();
+    expect(h.store.upsert).toHaveBeenCalledTimes(1);
+    const arg = h.store.upsert.mock.calls[0][0];
+    expect(arg.id).toBe('claude-unknown');
+    expect(arg.provider).toBe('claude');
+    expect(arg.originalPath).toBeUndefined();
+    expect(arg.projectName).toBeUndefined();
+  });
+
+  // 9 — chatty events debounce to ONE upsert; turn-complete cancels the pending one.
+  it('two rapid chatty events coalesce into ONE upsert after the debounce window', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    svc.noteSessionStarted('claude-d', path.join(tmpRoot, 'd'));
+    svc.noteTranscriptEvent('claude-d', ev({ type: 'assistant-text', uuid: 'a1' }));
+    svc.noteTranscriptEvent('claude-d', ev({ type: 'assistant-text', uuid: 'a2' }));
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(h.store.upsert).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('turn-complete cancels a pending debounce timer (no extra upsert later)', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    svc.noteSessionStarted('claude-c', path.join(tmpRoot, 'c'));
+    svc.noteTranscriptEvent('claude-c', ev({ type: 'assistant-text' })); // arms debounce
+    svc.noteTranscriptEvent('claude-c', ev({ type: 'turn-complete' }));   // immediate upsert + cancel
+    await Promise.resolve();
+    expect(h.store.upsert).toHaveBeenCalledTimes(1);
+    // The stale debounce timer must NOT fire a second upsert 5s later.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(h.store.upsert).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  // 10 — a store.upsert rejection does not produce an unhandled rejection.
+  it('a rejecting store.upsert is swallowed (no unhandled rejection)', async () => {
+    h.store.upsert.mockRejectedValue(new Error('lock timeout'));
+    const svc = await freshService(startOpts());
+    svc.noteSessionStarted('claude-r', path.join(tmpRoot, 'r'));
+    svc.noteTranscriptEvent('claude-r', ev({ type: 'turn-complete' }));
+    await new Promise((r) => setTimeout(r, 10));
+    // World keeps turning: the prompt push still fired despite the upsert reject.
+    expect(h.syncSpacesSyncNow).toHaveBeenCalledWith('personal');
+  });
+
+  // Guard: no managed roots + no explicit root → store stays off (no reconcile).
+  it('stays off when neither an explicit root nor managed roots are available', async () => {
+    h.managedRoots = null;
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(); // no opts, no managed roots
+    expect(h.reconcile).not.toHaveBeenCalled();
+    svc.stopConversationStore();
+  });
+});

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -35,6 +35,9 @@ const h = vi.hoisted(() => {
     // broadcast() fan-out would.
     syncListeners: new Set<(e: any) => void>(),
     managedRoots: null as any,
+    // Saved folders returned by the mocked readFolders — configurable so the
+    // knownFolders-wiring test can exercise both sources.
+    savedFolders: [] as Array<{ path: string }>,
   };
 });
 
@@ -60,7 +63,7 @@ vi.mock('../src/main/sync-spaces/service', () => ({
   getManagedRoots: () => h.managedRoots,
 }));
 vi.mock('../src/main/saved-folders', () => ({
-  readFolders: () => [],
+  readFolders: () => h.savedFolders,
 }));
 // ccProjectSlug + shared/types are used REAL (pure / type-only).
 
@@ -95,6 +98,7 @@ describe('conversations service composition root', () => {
     h.mirrorIn.mockReset().mockReturnValue({ copied: true } as any);
     h.materializeOut.mockReset().mockReturnValue({ copied: true } as any);
     h.syncSpacesSyncNow.mockReset().mockResolvedValue({ ok: true } as any);
+    h.savedFolders = [];
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-svc-'));
     h.managedRoots = { personalRoot: path.join(tmpRoot, 'Personal'), listProjects: () => [] };
   });
@@ -119,6 +123,23 @@ describe('conversations service composition root', () => {
     expect(opts.topicsDir).toBe(startOpts().topicsDir);
     expect(opts.device).toBe('test-device');
     expect(typeof opts.mirror).toBe('function');
+  });
+
+  // 1b — the reconciler is handed this device's known folders (managed projects
+  // + saved folders) so it can recover exact projectKeys (whole-branch review
+  // Finding 1). Without this wiring the reconciler truncates hyphenated names.
+  it('passes managed + saved folder paths as knownFolders to the reconciler', async () => {
+    h.managedRoots = {
+      personalRoot: path.join(tmpRoot, 'Personal'),
+      listProjects: () => [{ name: 'youcoded-dev', path: 'C:/Users/desti/youcoded-dev' }],
+    };
+    h.savedFolders = [{ path: 'C:/Users/desti/notes' }];
+    await freshService(startOpts());
+    const opts = h.reconcile.mock.calls[0][0];
+    expect(opts.knownFolders).toEqual([
+      'C:/Users/desti/youcoded-dev', // managed project
+      'C:/Users/desti/notes',        // saved folder
+    ]);
   });
 
   // 2 — an event upserts local-truth metadata keyed by the claude id. Asserted

--- a/desktop/tests/session-browser.test.ts
+++ b/desktop/tests/session-browser.test.ts
@@ -290,6 +290,73 @@ describe('listPastSessions — Conversation Store union (Phase 2a)', () => {
     expect(sessions.map((s: any) => s.sessionId)).toEqual([SID_A, SID_B]);
   });
 
+  it('never resurfaces a LIVE session from the store (double-attach hazard)', async () => {
+    const store = seedStore();
+    // A live session gains a store record within seconds of starting (live
+    // intake upserts on transcript events). The union must honor the same
+    // activeSessionIds exclusion the legacy scan applies — otherwise the
+    // running session shows up as a resumable store-only row, and resuming it
+    // spawns a second `claude --resume` against the transcript the live
+    // session is appending to.
+    await store.upsert({
+      id: SID_A,
+      provider: 'claude',
+      projectName: 'proj-alpha',
+      originalPath: absentProject(),
+      title: 'Currently Running',
+      lastActive: '2026-06-28T00:00:00Z',
+      device: 'this-machine',
+    });
+    const sessions = await listSessions(new Set([SID_A]));
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('gates resume on a store-only row whose folder is local but transcript is not materialized yet', async () => {
+    const store = seedStore();
+    // Project folder EXISTS on this device, but the transcript hasn't been
+    // materialized into ~/.claude/projects yet — `claude --resume` would error.
+    const localProj = path.join(tmpHome, 'local-proj');
+    fs.mkdirSync(localProj, { recursive: true });
+    await store.upsert({
+      id: SID_A,
+      provider: 'claude',
+      projectName: 'local-proj',
+      originalPath: localProj,
+      title: 'Folder Here, Transcript Pending',
+      lastActive: '2026-06-22T00:00:00Z',
+      device: 'other-laptop',
+    });
+    const sessions = await listSessions();
+    expect(sessions).toHaveLength(1);
+    const row = sessions[0];
+    // Distinct sub-case: the folder is here, sync just hasn't delivered the
+    // transcript — renderer shows "Not synced to this device yet".
+    expect(row.notSyncedYet).toBe(true);
+    expect(row.missingProject).toBeUndefined();
+  });
+
+  it('ignores a literal Untitled store title when the legacy row has a real name', async () => {
+    const store = seedStore();
+    writeTranscript('C--proj-alpha', SID_A, {
+      firstUserText: 'derived name beats the placeholder',
+      lastTimestamp: '2026-06-01T10:05:00Z',
+    });
+    // Older clients synced literal 'Untitled' topic content; a record seeded
+    // fresh through upsert carries it verbatim (only the merge-override path
+    // rejects the placeholder, not first-write). The union must not let it
+    // clobber a real derived name.
+    await store.upsert({
+      id: SID_A,
+      provider: 'claude',
+      title: 'Untitled',
+      lastActive: '2026-06-26T00:00:00Z',
+      device: 'old-client',
+    });
+    const sessions = await listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].name).toBe('derived name beats the placeholder');
+  });
+
   it('degrades to the legacy list when store.list() throws', async () => {
     // A store whose list rejects — the union must swallow it, not fail the call.
     storeHolder.current = { list: () => Promise.reject(new Error('store dir unreadable')) };

--- a/desktop/tests/session-browser.test.ts
+++ b/desktop/tests/session-browser.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { createConversationStore } from '../src/main/conversations/conversation-store';
+
+// Task 7 (store union): session-browser reads the Conversation Store via a
+// dynamic import of './conversations/service' inside listPastSessions. The real
+// service singleton is only non-null after startConversationStore() runs (which
+// drags in the whole sync-spaces graph). We mock the service module to a thin
+// facade whose getConversationStore() reads a mutable holder — each store test
+// drops a REAL createConversationStore(tempRoot) into the holder, exercising the
+// genuine store read path without booting sync-spaces. resetModules re-applies
+// vi.mock automatically, so the harness's per-call reset still works.
+const storeHolder = vi.hoisted(() => ({ current: null as any }));
+vi.mock('../src/main/conversations/service', () => ({
+  getConversationStore: () => storeHolder.current,
+}));
 
 let tmpHome: string;
 let origHomedir: typeof os.homedir;
@@ -11,6 +25,9 @@ beforeEach(() => {
   origHomedir = os.homedir;
   (os as any).homedir = () => tmpHome;
   fs.mkdirSync(path.join(tmpHome, '.claude', 'topics'), { recursive: true });
+  // Isolation: a prior store test must not leak its store into the next test
+  // (existing legacy-only tests assert the store branch is dormant).
+  storeHolder.current = null;
 });
 
 afterEach(() => {
@@ -158,5 +175,132 @@ describe('listPastSessions — existing gates still hold', () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0].sessionId).toBe(SID_A);
     expect(sessions[0].projectSlug).toBe('C--home-project-deep');
+  });
+});
+
+describe('listPastSessions — Conversation Store union (Phase 2a)', () => {
+  // Build a real store rooted under the stubbed home and stash it in the holder
+  // the mocked service reads. Records live at <root>/claude/<id>.json.
+  function seedStore(): ReturnType<typeof createConversationStore> {
+    const root = path.join(tmpHome, 'YouCoded', 'Personal', 'Conversations');
+    const store = createConversationStore(root);
+    storeHolder.current = store;
+    return store;
+  }
+
+  // A path guaranteed NOT to exist on this device — stands in for the
+  // originalPath of a conversation that only ran on another machine.
+  const absentProject = () => path.join(tmpHome, 'not-on-this-device', 'remote-proj');
+
+  it('surfaces a remote-device conversation (no local transcript) with resume gated off', async () => {
+    const store = seedStore();
+    await store.upsert({
+      id: SID_A,
+      provider: 'claude',
+      projectName: 'remote-proj',
+      originalPath: absentProject(),
+      title: 'Remote Conversation',
+      lastActive: '2026-06-20T10:00:00Z',
+      device: 'other-laptop',
+    });
+    await store.setFlag('claude', SID_A, 'priority', true);
+
+    const sessions = await listSessions();
+    expect(sessions).toHaveLength(1);
+    const row = sessions[0];
+    expect(row.sessionId).toBe(SID_A);
+    expect(row.name).toBe('Remote Conversation');
+    expect(row.lastModified).toBe(Date.parse('2026-06-20T10:00:00Z'));
+    expect(row.flags).toEqual({ priority: true });
+    expect(row.device).toBe('other-laptop');
+    expect(row.provider).toBe('claude');
+    expect(row.missingProject).toBe(true);
+    // No local project → empty slug (resume has no cwd to resume into here).
+    expect(row.projectSlug).toBe('');
+  });
+
+  it('collapses a store record + local transcript into ONE row (store metadata wins, local slug kept)', async () => {
+    seedStore();
+    // Legacy transcript under a real slug, older content timestamp.
+    writeTranscript('C--proj-alpha', SID_A, {
+      firstUserText: 'the original local prompt for this session',
+      lastTimestamp: '2026-06-01T10:05:00Z',
+    });
+    const store = storeHolder.current;
+    await store.upsert({
+      id: SID_A,
+      provider: 'claude',
+      title: 'Store Title Wins',
+      lastActive: '2026-06-25T00:00:00Z',
+      device: 'phone',
+    });
+
+    const sessions = await listSessions();
+    expect(sessions).toHaveLength(1); // ONE row, not two
+    const row = sessions[0];
+    // Store wins on display metadata...
+    expect(row.name).toBe('Store Title Wins');
+    expect(row.lastModified).toBe(Date.parse('2026-06-25T00:00:00Z'));
+    expect(row.device).toBe('phone');
+    expect(row.provider).toBe('claude');
+    // ...but the LOCAL transcript keeps the resume slug/path working.
+    expect(row.projectSlug).toBe('C--proj-alpha');
+    // A both-sources row is resumable here, so it's not flagged missing.
+    expect(row.missingProject).toBeUndefined();
+  });
+
+  it('leaves a legacy row untouched when the store is off (regression guard)', async () => {
+    // storeHolder.current stays null (sync off / store unavailable).
+    const file = writeTranscript('C--proj-alpha', SID_A, {
+      firstUserText: 'legacy only conversation with no store record',
+      lastTimestamp: '2026-06-08T09:00:00Z',
+    });
+    const { size } = fs.statSync(file);
+
+    const sessions = await listSessions();
+    expect(sessions).toHaveLength(1);
+    const row = sessions[0];
+    expect(row.sessionId).toBe(SID_A);
+    expect(row.name).toBe('legacy only conversation with no store record');
+    expect(row.projectSlug).toBe('C--proj-alpha');
+    expect(row.lastModified).toBe(Date.parse('2026-06-08T09:00:00Z'));
+    expect(row.size).toBe(size);
+    // Store-only fields never set on a pure legacy row.
+    expect(row.device).toBeUndefined();
+    expect(row.provider).toBeUndefined();
+    expect(row.missingProject).toBeUndefined();
+  });
+
+  it('sorts by lastModified desc across BOTH sources', async () => {
+    const store = seedStore();
+    // Legacy transcript — OLDER.
+    writeTranscript('C--proj-beta', SID_B, { lastTimestamp: '2026-06-01T00:00:00Z' });
+    // Store-only remote conversation — NEWER.
+    await store.upsert({
+      id: SID_A,
+      provider: 'claude',
+      projectName: 'remote-proj',
+      originalPath: absentProject(),
+      title: 'Newer Remote',
+      lastActive: '2026-06-30T00:00:00Z',
+      device: 'other-laptop',
+    });
+
+    const sessions = await listSessions();
+    expect(sessions.map((s: any) => s.sessionId)).toEqual([SID_A, SID_B]);
+  });
+
+  it('degrades to the legacy list when store.list() throws', async () => {
+    // A store whose list rejects — the union must swallow it, not fail the call.
+    storeHolder.current = { list: () => Promise.reject(new Error('store dir unreadable')) };
+    writeTranscript('C--proj-alpha', SID_A, {
+      firstUserText: 'survives a broken store read',
+      lastTimestamp: '2026-06-05T00:00:00Z',
+    });
+
+    const sessions = await listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].sessionId).toBe(SID_A);
+    expect(sessions[0].name).toBe('survives a broken store read');
   });
 });

--- a/desktop/tests/sync-spaces-service.test.ts
+++ b/desktop/tests/sync-spaces-service.test.ts
@@ -312,4 +312,44 @@ describe('sync-spaces service transition serialization', () => {
     await bootP;
     expect((await svc.syncSpacesStatus()).syncHub).toBe('connected');
   });
+
+  // ---- Main-process listener hook (Task 5): onSyncSpacesEvent ----
+  // behavior contract:
+  // 1. onSyncSpacesEvent(fn) subscribes; an engine event reaches fn with the
+  //    stamped `at` field; the returned unsubscribe fn stops delivery.
+  // 2. a listener that THROWS does not break other listeners or the window/
+  //    remote/hub fan-outs (assert a second listener still fires and the event
+  //    still lands in recentEvents).
+
+  it('onSyncSpacesEvent delivers stamped events; unsubscribe stops delivery', async () => {
+    const svc = await enabledMultiSpaceService();
+    const received: any[] = [];
+    const unsub = svc.onSyncSpacesEvent((e: any) => received.push(e));
+    // Fire an engine event (= service.broadcast) the way the real engine would.
+    h.onEvent!({ type: 'synced', spaceId: 'project:beta', pushed: false, updated: true });
+    expect(received.length).toBe(1);
+    expect(received[0].spaceId).toBe('project:beta');
+    expect(typeof received[0].at).toBe('number'); // stamped by broadcast()
+    unsub();
+    h.onEvent!({ type: 'synced', spaceId: 'project:alpha', pushed: false, updated: true });
+    expect(received.length).toBe(1); // no delivery after unsubscribe
+  });
+
+  it('a throwing listener does not strand other listeners, the hub send, or recentEvents', async () => {
+    const svc = await enabledMultiSpaceService();
+    h.hub.sendSignal.mockClear();
+    const good: any[] = [];
+    // First listener throws; second must still fire (per-listener isolation).
+    svc.onSyncSpacesEvent(() => { throw new Error('bad listener'); });
+    svc.onSyncSpacesEvent((e: any) => good.push(e));
+    // pushed:true so the hub send (which runs AFTER the local fan-out) also fires.
+    h.onEvent!({ type: 'synced', spaceId: 'project:beta', pushed: true, updated: false });
+    expect(good.length).toBe(1); // second listener still delivered
+    // Hub send comes after the local listeners — a throwing listener must not
+    // strand it.
+    expect(h.hub.sendSignal).toHaveBeenCalledWith('space-updated', 'repo-project:beta');
+    // And the event still landed in recentEvents.
+    const st = await svc.syncSpacesStatus();
+    expect(st.recentEvents.some((x: any) => x.spaceId === 'project:beta')).toBe(true);
+  });
 });

--- a/desktop/tests/transcript-mirror.test.ts
+++ b/desktop/tests/transcript-mirror.test.ts
@@ -78,6 +78,21 @@ describe('mirrorIn (local → space, add/update-only)', () => {
     expect(fs.statSync(spacePath).mtimeMs).toBe(before); // never rewritten
   });
 
+  // Reviewer pin: same byte length but DIFFERENT content still skips — and the
+  // space copy's bytes stay untouched. This pins the module header's deliberate
+  // trade-off ("a same-size-different-content case resolves on the next turn's
+  // growth"): a future content-hash refactor that starts copying here must trip
+  // this red test and re-argue the design first.
+  it('same size but different content: no copy, space bytes unchanged', () => {
+    put(spacePath, 'space-bytes\n');
+    put(localPath, 'local-bytes\n'); // identical byte length, different content
+
+    const res = mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(res).toEqual({ copied: false });
+    expect(read(spacePath)).toBe('space-bytes\n'); // exact bytes preserved
+  });
+
   // Contract 4 (LOAD-BEARING): the local file is MISSING (CC's cleanupPeriodDays
   // deleted it). mirror-in must be a pure no-op — the durable space copy's BYTES
   // are untouched. Deletion must NEVER propagate into the space.
@@ -209,5 +224,30 @@ describe('stale tmp cleanup', () => {
     expect(fs.existsSync(freshTmp)).toBe(true);    // too new to sweep
     expect(fs.existsSync(foreignTmp)).toBe(true);  // belongs to another dest
     expect(read(spacePath)).toBe('trigger-a-copy\n'); // copy still succeeded
+  });
+
+  // Reviewer pin: the sweep also runs on the materialize-out side — its tmp
+  // lands in the LOCAL project-slug dir, and a crash-orphan there is disk junk
+  // (harmless to sync, but still junk). Same rules: stale same-dest swept,
+  // fresh and foreign-dest kept.
+  it('materializeOut sweeps a stale same-dest .tmp in the local dir, keeps fresh/foreign', () => {
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    const staleTmp = `${localPath}.77777.333.tmp`;      // matches <dest>.*.tmp
+    const freshTmp = `${localPath}.66666.444.tmp`;      // matches, but recent
+    const foreignTmp = path.join(path.dirname(localPath), 'other.jsonl.5.6.tmp'); // different dest
+    fs.writeFileSync(staleTmp, 'junk');
+    fs.writeFileSync(freshTmp, 'junk');
+    fs.writeFileSync(foreignTmp, 'junk');
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2h ago
+    fs.utimesSync(staleTmp, old, old);
+    fs.utimesSync(foreignTmp, old, old); // old too, but different dest ⇒ kept
+
+    put(spacePath, 'trigger-materialize\n');
+    materializeOut({ spaceTranscriptPath: spacePath, localJsonlPath: localPath });
+
+    expect(fs.existsSync(staleTmp)).toBe(false);   // swept
+    expect(fs.existsSync(freshTmp)).toBe(true);    // too new to sweep
+    expect(fs.existsSync(foreignTmp)).toBe(true);  // belongs to another dest
+    expect(read(localPath)).toBe('trigger-materialize\n'); // copy still succeeded
   });
 });

--- a/desktop/tests/transcript-mirror.test.ts
+++ b/desktop/tests/transcript-mirror.test.ts
@@ -1,0 +1,213 @@
+// Tests for the CC transcript MOVEMENT module (Phase 2a design §2).
+// Uses REAL temp dirs (fs.mkdtempSync) — no memfs — standing in for both
+// ~/.claude/projects/<slug>/ (the local side) and the personal space's
+// Conversations/ dir (the durable side). The whole point of this module is real
+// disk behavior: size-gated whole-file copy, on-demand dir creation, and the
+// LOAD-BEARING invariant that a missing/shrunk local file NEVER mutates the
+// durable space copy (CC's cleanupPeriodDays deletes local transcripts).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { mirrorIn, materializeOut } from '../src/main/conversations/transcript-mirror';
+
+let tmp: string;
+let localPath: string;   // stands in for ~/.claude/projects/<slug>/<id>.jsonl
+let spacePath: string;   // stands in for <space>/Conversations/claude/transcripts/<key>/<id>.jsonl
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-tmirror-'));
+  // Deliberately place both under directories that do NOT exist yet, so the
+  // "creates dirs on demand" contract is exercised on the first copy.
+  localPath = path.join(tmp, 'projects', 'home-a-my-app', 'sess-1.jsonl');
+  spacePath = path.join(tmp, 'space', 'Conversations', 'claude', 'transcripts', 'my-app', 'sess-1.jsonl');
+});
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// Write a file, creating parent dirs. Content length is what the size-gate
+// compares, so tests control the gate purely by string length.
+function put(p: string, content: string): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+const read = (p: string) => fs.readFileSync(p, 'utf8');
+
+describe('mirrorIn (local → space, add/update-only)', () => {
+  // Contract 1: a brand-new local transcript with no space copy yet is copied
+  // in (creating every parent dir) and reports {copied:true}.
+  it('copies a new local transcript into the space and creates dirs', () => {
+    put(localPath, 'line-1\nline-2\n');
+
+    const res = mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(res).toEqual({ copied: true });
+    expect(fs.existsSync(spacePath)).toBe(true);          // dir tree created on demand
+    expect(read(spacePath)).toBe('line-1\nline-2\n');     // byte-for-byte copy
+  });
+
+  // Contract 2: a local file LARGER than the space copy is the append-only
+  // growth case — it overwrites the (older, shorter) space copy.
+  it('overwrites the space copy when the local file is larger', () => {
+    put(spacePath, 'line-1\n');                 // 7 bytes — older, shorter
+    put(localPath, 'line-1\nline-2\nline-3\n'); // 21 bytes — grew via appends
+
+    const res = mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(res).toEqual({ copied: true });
+    // renameSync over an existing dest must atomically REPLACE it (Windows maps
+    // to MoveFileEx w/ REPLACE_EXISTING) — this assertion pins that behavior.
+    expect(read(spacePath)).toBe('line-1\nline-2\nline-3\n');
+  });
+
+  // Contract 3: identical size → NO write at all. Verified via mtime: we stamp
+  // the space copy to a fixed past time, mirror, and assert the mtime is
+  // unchanged (a rename would bump it to "now"). This is stronger than checking
+  // the return flag alone and immune to coarse Windows mtime resolution.
+  it('does not write when sizes are identical (mtime unchanged)', () => {
+    put(spacePath, 'same-size\n');
+    put(localPath, 'same-size\n'); // identical byte length
+    const past = new Date('2020-01-01T00:00:00.000Z');
+    fs.utimesSync(spacePath, past, past);
+    const before = fs.statSync(spacePath).mtimeMs;
+
+    const res = mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(res).toEqual({ copied: false });
+    expect(fs.statSync(spacePath).mtimeMs).toBe(before); // never rewritten
+  });
+
+  // Contract 4 (LOAD-BEARING): the local file is MISSING (CC's cleanupPeriodDays
+  // deleted it). mirror-in must be a pure no-op — the durable space copy's BYTES
+  // are untouched. Deletion must NEVER propagate into the space.
+  it('is a no-op when the local file is missing — space copy byte-identical', () => {
+    put(spacePath, 'durable-history\nkeep-me\n');
+    const before = read(spacePath);
+    // localPath is intentionally never created.
+
+    const res = mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(res).toEqual({ copied: false });
+    expect(fs.existsSync(spacePath)).toBe(true);   // still there
+    expect(read(spacePath)).toBe(before);          // exact same bytes — no truncation
+  });
+
+  // Contract 5: the local file SHRANK below the space copy (a /clear rewrite or
+  // foreign truncation). The fuller durable copy must NOT be clobbered; the call
+  // reports {copied:false, shrunk:true} so the caller knows the record's
+  // transcriptRef still points at the longer history.
+  it('never clobbers a fuller space copy when local shrank (reports shrunk)', () => {
+    put(spacePath, 'full-history-line-1\nfull-history-line-2\n'); // long, durable
+    const before = read(spacePath);
+    put(localPath, 'cleared\n');                                  // short, post-/clear
+
+    const res = mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(res).toEqual({ copied: false, shrunk: true });
+    expect(read(spacePath)).toBe(before); // fuller durable copy preserved exactly
+  });
+});
+
+describe('materializeOut (space → local, add/update-only)', () => {
+  // Contract 6a: local is MISSING — write the space copy out, creating the
+  // project slug dir on demand.
+  it('writes the space copy to local (creating the slug dir) when local missing', () => {
+    put(spacePath, 'from-other-device\n');
+    // localPath's parent dir does not exist yet.
+
+    const res = materializeOut({ spaceTranscriptPath: spacePath, localJsonlPath: localPath });
+
+    expect(res).toEqual({ copied: true });
+    expect(fs.existsSync(localPath)).toBe(true);
+    expect(read(localPath)).toBe('from-other-device\n');
+  });
+
+  // Contract 6b: local exists but is SMALLER than the space copy — the space
+  // copy (grown on another device) wins.
+  it('overwrites local when the space copy is larger', () => {
+    put(localPath, 'short\n');                          // 6 bytes
+    put(spacePath, 'grown-on-another-device-longer\n'); // longer
+
+    const res = materializeOut({ spaceTranscriptPath: spacePath, localJsonlPath: localPath });
+
+    expect(res).toEqual({ copied: true });
+    expect(read(localPath)).toBe('grown-on-another-device-longer\n');
+  });
+
+  // Contract 7: local is LARGER OR EQUAL — never clobber newer/equal local work
+  // with an older/equal space copy. Two sub-cases pinned in one test.
+  it('leaves local untouched when it is larger or equal to the space copy', () => {
+    // larger-local case
+    put(spacePath, 'space\n');                     // 6 bytes
+    put(localPath, 'local-is-longer-here\n');      // longer
+    const localerBefore = read(localPath);
+    let res = materializeOut({ spaceTranscriptPath: spacePath, localJsonlPath: localPath });
+    expect(res).toEqual({ copied: false });
+    expect(read(localPath)).toBe(localerBefore);   // untouched
+
+    // equal-size case (fresh paths so the two sub-cases don't interfere)
+    const eqLocal = path.join(tmp, 'projects', 'p2', 'eq.jsonl');
+    const eqSpace = path.join(tmp, 'space', 'p2', 'eq.jsonl');
+    put(eqSpace, 'abcdef\n');
+    put(eqLocal, 'ABCDEF\n'); // same length, different content
+    res = materializeOut({ spaceTranscriptPath: eqSpace, localJsonlPath: eqLocal });
+    expect(res).toEqual({ copied: false });
+    expect(read(eqLocal)).toBe('ABCDEF\n'); // equal size ⇒ local kept, not clobbered
+  });
+
+  // Contract 8 first half: space copy MISSING — materialize is a no-op that
+  // never creates or deletes anything locally.
+  it('is a no-op when the space copy is missing', () => {
+    // Neither file exists.
+    const res = materializeOut({ spaceTranscriptPath: spacePath, localJsonlPath: localPath });
+    expect(res).toEqual({ copied: false });
+    expect(fs.existsSync(localPath)).toBe(false); // nothing conjured
+  });
+});
+
+// Contract 8 (explicit): NEITHER direction ever deletes a file. After running
+// every path against a fully-populated pair, both originals still exist.
+describe('never deletes anything, ever', () => {
+  it('every operation leaves pre-existing files present', () => {
+    put(spacePath, 'space-content\n');
+    put(localPath, 'local-content-longer\n'); // larger than space
+
+    // mirror-in (local larger ⇒ writes) then materialize-out (local larger ⇒
+    // no-op): neither may remove the other side.
+    mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+    expect(fs.existsSync(localPath)).toBe(true);
+    expect(fs.existsSync(spacePath)).toBe(true);
+
+    materializeOut({ spaceTranscriptPath: spacePath, localJsonlPath: localPath });
+    expect(fs.existsSync(localPath)).toBe(true);
+    expect(fs.existsSync(spacePath)).toBe(true);
+  });
+});
+
+// DEVIATION from the plan's sketch (flagged in the report): the copy tmp file
+// lands in the SPACE dir, and '.tmp' is NOT in the sync engine's DEFAULT_IGNORES
+// (guards.ts) — a crash-orphaned tmp would sync forever as junk. copyInto sweeps
+// stale '<dest>.*.tmp' files (>1h old) in the destination dir on each copy.
+describe('stale tmp cleanup', () => {
+  it('removes a stale orphaned .tmp for the same dest, keeps fresh/foreign ones', () => {
+    fs.mkdirSync(path.dirname(spacePath), { recursive: true });
+    const staleTmp = `${spacePath}.99999.111.tmp`;      // matches <dest>.*.tmp
+    const freshTmp = `${spacePath}.88888.222.tmp`;      // matches, but recent
+    const foreignTmp = path.join(path.dirname(spacePath), 'other.jsonl.7.9.tmp'); // different dest
+    fs.writeFileSync(staleTmp, 'junk');
+    fs.writeFileSync(freshTmp, 'junk');
+    fs.writeFileSync(foreignTmp, 'junk');
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2h ago
+    fs.utimesSync(staleTmp, old, old);
+    fs.utimesSync(foreignTmp, old, old); // old too, but different dest ⇒ kept
+
+    put(localPath, 'trigger-a-copy\n');
+    mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spacePath });
+
+    expect(fs.existsSync(staleTmp)).toBe(false);   // swept
+    expect(fs.existsSync(freshTmp)).toBe(true);    // too new to sweep
+    expect(fs.existsSync(foreignTmp)).toBe(true);  // belongs to another dest
+    expect(read(spacePath)).toBe('trigger-a-copy\n'); // copy still succeeded
+  });
+});


### PR DESCRIPTION
## What this is

Plan 2a of Phase 2 conversation sync — the **Conversation Store**. Per-conversation JSON records that sync across devices through the existing Sync Spaces engine, plus Claude Code transcript mirroring, so your conversations (and the ability to resume them) travel between machines.

Spec: `docs/superpowers/specs/2026-07-10-phase2-conversation-sync-design.md` §1–§2.
Plan: `docs/superpowers/plans/2026-07-10-conversation-store-2a.md`.

## What it does

- **Records** at `~/YouCoded/Personal/Conversations/claude/<id>.json` — `{id, provider, projectName, originalPath, title, lastActive, device, flags, transcriptRef, createdAt}`. Born multi-provider (`provider` field; Claude is the only adapter in 2a). One file per conversation so the engine's generic conflict policy stays out of the way; a healer folds any conflict copies back with convergent, order-independent merges.
- **Transcript sync** — on turn-complete the local JSONL mirrors into the space (add/update-only, shrink-guarded: CC's `cleanupPeriodDays` deletion or a `/clear` rewrite can never shrink the durable copy), then a prompt `syncSpacesSyncNow('personal')` pushes it faster than the engine's 15s window. On pull, a materialize sweep writes transcripts back into `~/.claude/projects/<slug>/` so `claude --resume` works natively.
- **Reconciler** — startup + 30min catch-up scan of `~/.claude/projects` for sessions run outside the app (bare `claude`), UUID-gated, `lastActive` from transcript content (never file mtime).
- **Resume Browser** — unions store records over the legacy transcript scan. Store metadata wins; legacy keeps the local slug for resume. Conversations from other devices appear everywhere, with resume gated (plain-words note) when the project folder isn't here or the transcript hasn't materialized yet.

## What's deliberately NOT here

- **Leases + takeover** → Plan 2b. Consequence in 2a: the materialize sweep and the Resume Browser union both **skip live sessions** so a pull can never replace a transcript Claude Code is actively appending to (would freeze chat view / lose turns without lease protection).
- **Legacy demolition** → Plan 2c. `sync-service.ts` is **byte-untouched** (verified). Flags dual-write (legacy index + store) during the transition.

## Review process

Every task ran through spec-compliance + code-quality review loops. Notable defects caught and fixed before merge (not an exhaustive list): merge non-convergence on timestamp ties (fixed with a total-order tiebreak → true lattice join), a path-traversal write via a crafted id, a multi-process heal race that could delete an unfolded conflict copy (fixed with quarantine-rename), an O(n²) reconciler scan (measured ~2.8s at 600 records → list-preload, ~200× fewer dirent reads), two live-transcript-clobber hazards (sweep + browser union), a phantom synced-record from early flagging, and the reconciler/live projectKey mismatch that produced orphan duplicate transcripts for hyphenated folder names.

## Known limitations (documented, not blockers)

- **Transient cross-device wording**: a store-only Resume Browser row on a second device can briefly read "Not synced to this device yet" until the materialize sweep writes the transcript (same personal-space pull); self-corrects on the next browser open.
- **>50 MB transcripts**: the sync engine's pre-existing `MAX_SYNC_FILE_BYTES` cap means a transcript over 50 MB won't push to peers — it lists but never materializes on other devices. Pre-existing engine limit; revisit if conversation transcripts routinely approach it.

## Verification

- Full desktop suite green (**1573 passed**), `tsc --noEmit` clean, production build + installer succeeded.
- The **two-device dogfood** (handoff item D) is the designated real-world gate before building Plan 2b on top — the first live test of records + transcripts converging across two machines. A single-instance live smoke test was not run in this session; the dogfood supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
