### PR TITLE
Fix: reconciler dedups same session id across slugs (CC home-dir duplication)

### DIFF
--- a/desktop/src/main/conversations/reconciler.ts
+++ b/desktop/src/main/conversations/reconciler.ts
@@ -114,15 +114,43 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
     for (const r of await opts.store.list('claude')) existingById.set(r.id, r);
   } catch { /* degraded: treat everything as new; upsert merges safely */ }
 
+  // COLLECT PASS — map each session id to its MOST-SPECIFIC (longest) slug, and
+  // cache the per-slug file lists so the process pass doesn't re-readdir.
+  // WHY: Claude Code writes a session's transcript into the HOME-dir project too,
+  // not only its real cwd project — verified on a real machine: the same id lives
+  // under BOTH `C--Users-desti` and its actual cwd slug `C--Users-desti-<proj>`.
+  // Because readdir hands back the shorter home slug first (it's a prefix), a
+  // naive first-seen scan tagged EVERY duplicated conversation with the home
+  // basename ('desti') and mirrored them all into one bucket. The longest slug is
+  // the deepest/real cwd, so it wins — the exact heuristic session-browser.ts
+  // uses to dedup (`projectSlug.length > existing.projectSlug.length`). A session
+  // that appears ONLY under the home slug is a genuine home session and keeps it.
+  const authoritativeSlug = new Map<string, string>(); // sessionId → longest slug
+  const slugFiles = new Map<string, string[]>();
   for (const slug of slugs) {
     const dir = path.join(opts.projectsDir, slug);
     let files: string[] = [];
     // A non-directory entry (or an unreadable dir) just yields no files.
     try { files = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl')); } catch { continue; }
+    slugFiles.set(slug, files);
+    for (const file of files) {
+      const sessionId = file.replace(/\.jsonl$/, '');
+      if (!SESSION_UUID_RE.test(sessionId)) continue;
+      const prev = authoritativeSlug.get(sessionId);
+      if (!prev || slug.length > prev.length) authoritativeSlug.set(sessionId, slug);
+    }
+  }
+
+  // PROCESS PASS — each id is handled once, under its authoritative slug only.
+  for (const slug of slugs) {
+    const dir = path.join(opts.projectsDir, slug);
+    const files = slugFiles.get(slug) ?? [];
     for (const file of files) {
       const sessionId = file.replace(/\.jsonl$/, '');
       // Malformed ids never become records (phantom-id guard).
       if (!SESSION_UUID_RE.test(sessionId)) continue;
+      // Skip a less-specific duplicate — a longer slug owns this id (see above).
+      if (authoritativeSlug.get(sessionId) !== slug) continue;
       const jsonlPath = path.join(dir, file);
       // Per-file isolation (review carry-forward): a store lock-timeout throw,
       // an unreadable transcript, or a meta-read error on ONE file must never

--- a/desktop/tests/conversation-reconciler.test.ts
+++ b/desktop/tests/conversation-reconciler.test.ts
@@ -295,3 +295,51 @@ describe('reconcile — exact projectKey from known folders', () => {
     expect(rec!.projectName).toBe('proj'); // last '-' segment, as before
   });
 });
+
+describe('reconcile — same id under multiple slugs (CC home-dir duplication)', () => {
+  // Found by the single-machine dev smoke test: Claude Code writes a session's
+  // transcript into the HOME-dir project too, so the same id lives under BOTH
+  // 'C--Users-desti' (home) and its real cwd slug 'C--Users-desti-<proj>'.
+  // readdir hands back the shorter home slug first (it's a prefix), so first-seen
+  // tagged EVERY duplicated conversation with the home basename ('desti') and
+  // bucketed them together. The MOST-SPECIFIC (longest) slug must win.
+
+  it('uses the longest (most-specific) slug, not the home slug, for a duplicated id', async () => {
+    // Same id in BOTH the home project AND the real youcoded-dev project.
+    writeTranscript(projectsDir, 'C--Users-desti', SID_A);                 // home dup (shorter)
+    writeTranscript(projectsDir, 'C--Users-desti-youcoded-dev', SID_A);    // real cwd (longer)
+
+    const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+
+    // Exactly one record (processed once, under the authoritative slug).
+    expect(n).toBe(1);
+    const rec = await store.get('claude', SID_A);
+    // 'youcoded-dev' slug's last segment 'dev' — NOT the home basename 'desti'
+    // (red before the fix, which yielded 'desti' and bucketed the mirror there).
+    expect(rec!.projectName).toBe('dev');
+    expect(rec!.transcriptRef).toBe(`claude/transcripts/dev/${SID_A}.jsonl`);
+    // Mirrored exactly once, from the youcoded-dev slug dir, to the 'dev' bucket.
+    expect(mirrorCalls).toHaveLength(1);
+    expect(mirrorCalls[0].key).toBe('dev');
+    expect(mirrorCalls[0].p).toBe(
+      path.join(projectsDir, 'C--Users-desti-youcoded-dev', `${SID_A}.jsonl`),
+    );
+  });
+
+  it('a session ONLY under the home slug keeps the home basename (genuine home session)', async () => {
+    writeTranscript(projectsDir, 'C--Users-desti', SID_A);
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.projectName).toBe('desti'); // legitimately a home-dir conversation
+  });
+
+  it('the longest slug wins even when the home (shorter) copy is NEWER', async () => {
+    // Freshness must not let the home dup re-tag the record: the process pass
+    // never touches the home copy at all (authoritative-slug skip).
+    writeTranscript(projectsDir, 'C--Users-desti-youcoded-dev', SID_A, { lastTimestamp: '2026-06-01T10:00:00Z' });
+    writeTranscript(projectsDir, 'C--Users-desti', SID_A, { lastTimestamp: '2026-09-01T10:00:00Z' }); // newer home dup
+    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
+    const rec = await store.get('claude', SID_A);
+    expect(rec!.projectName).toBe('dev'); // still the real cwd, not 'desti'
+  });
+});


### PR DESCRIPTION
## The bug (found by the single-machine dev smoke test)

Follow-up to #116. Running the conversation store against a real `~/.claude/projects` immediately surfaced a bug the synthetic single-slug unit tests couldn't: **Claude Code duplicates a session's transcript into the home-dir project** (`C--Users-desti`) in addition to its real cwd project (`C--Users-desti-youcoded-dev`). The same session id lives under both.

The reconciler scanned slugs in `readdir` order. The home slug is a **prefix** of every project slug under the home dir, so it comes first — the record got created with `projectName` derived from the home basename (`desti`), and `resolveProjectName`'s `existing?.projectName` preference then locked it in when the real project slug was scanned later.

**Impact on a real machine: 921/921 records mis-keyed to `desti`**, every transcript mirrored into one `transcripts/desti/` bucket. Cross-device sync would have propagated a single giant wrong bucket — a serious correctness bug for the exact scenario this feature exists for.

## The fix

Two-phase scan:
1. **Collect pass** — map each session id to its **longest (most-specific / deepest cwd) slug**, caching per-slug file lists.
2. **Process pass** — skip any less-specific duplicate; each id is handled once, under its authoritative slug.

This is the same heuristic `session-browser.ts` already uses to dedup (`projectSlug.length > existing.projectSlug.length`). A session that appears **only** under the home slug is a genuine home conversation and keeps `desti`.

## Tests

Three new reconciler tests (the first was red-before: `expected 'desti' to be 'dev'`):
- duplicated id → longest slug wins (record + transcriptRef + single mirror all keyed to the real project, not home);
- home-only id → keeps the home basename;
- longest slug wins even when the home copy is newer (the process pass never touches the home dup).

104 conversation-suite tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)