### PR TITLE
Fix: reconciler skips legacy foreign-slug symlinks (correct root cause)

### DIFF
--- a/desktop/src/main/conversations/reconciler.ts
+++ b/desktop/src/main/conversations/reconciler.ts
@@ -114,51 +114,34 @@ export async function reconcile(opts: ReconcileOpts): Promise<number> {
     for (const r of await opts.store.list('claude')) existingById.set(r.id, r);
   } catch { /* degraded: treat everything as new; upsert merges safely */ }
 
-  // COLLECT PASS — map each session id to its MOST-SPECIFIC (longest) slug, and
-  // cache the per-slug file lists so the process pass doesn't re-readdir.
-  // WHY: Claude Code writes a session's transcript into the HOME-dir project too,
-  // not only its real cwd project — verified on a real machine: the same id lives
-  // under BOTH `C--Users-desti` and its actual cwd slug `C--Users-desti-<proj>`.
-  // Because readdir hands back the shorter home slug first (it's a prefix), a
-  // naive first-seen scan tagged EVERY duplicated conversation with the home
-  // basename ('desti') and mirrored them all into one bucket. The longest slug is
-  // the deepest/real cwd, so it wins — the exact heuristic session-browser.ts
-  // uses to dedup (`projectSlug.length > existing.projectSlug.length`). A session
-  // that appears ONLY under the home slug is a genuine home session and keeps it.
-  const authoritativeSlug = new Map<string, string>(); // sessionId → longest slug
-  const slugFiles = new Map<string, string[]>();
   for (const slug of slugs) {
     const dir = path.join(opts.projectsDir, slug);
     let files: string[] = [];
     // A non-directory entry (or an unreadable dir) just yields no files.
     try { files = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl')); } catch { continue; }
-    slugFiles.set(slug, files);
-    for (const file of files) {
-      const sessionId = file.replace(/\.jsonl$/, '');
-      if (!SESSION_UUID_RE.test(sessionId)) continue;
-      const prev = authoritativeSlug.get(sessionId);
-      if (!prev || slug.length > prev.length) authoritativeSlug.set(sessionId, slug);
-    }
-  }
-
-  // PROCESS PASS — each id is handled once, under its authoritative slug only.
-  for (const slug of slugs) {
-    const dir = path.join(opts.projectsDir, slug);
-    const files = slugFiles.get(slug) ?? [];
     for (const file of files) {
       const sessionId = file.replace(/\.jsonl$/, '');
       // Malformed ids never become records (phantom-id guard).
       if (!SESSION_UUID_RE.test(sessionId)) continue;
-      // Skip a less-specific duplicate — a longer slug owns this id (see above).
-      if (authoritativeSlug.get(sessionId) !== slug) continue;
       const jsonlPath = path.join(dir, file);
       // Per-file isolation (review carry-forward): a store lock-timeout throw,
       // an unreadable transcript, or a meta-read error on ONE file must never
       // abort the whole catch-up scan — skip the file, keep scanning.
       try {
-        let size = 0;
-        try { size = fs.statSync(jsonlPath).size; } catch { continue; }
-        if (size < MIN_TRANSCRIPT_BYTES) continue;
+        // Skip FOREIGN-SLUG SYMLINKS. The LEGACY sync / resume-browser machinery
+        // (slug rewriting + foreign-slug symlinks — deleted in Plan 2c, NOT a
+        // Claude Code behavior) symlinks a session's real transcript into the
+        // HOME-dir project slug:
+        //   C--Users-desti/<id>.jsonl  ->  ../C--Users-desti-<proj>/<id>.jsonl
+        // Verified on a real machine: 687 such symlinks, ALL in the home slug.
+        // Following them tags every linked conversation with the home basename
+        // ('desti') and buckets all transcripts together. lstat does NOT follow
+        // the link, so the symlink is detected here and skipped; the real
+        // transcript is processed normally in its true cwd slug. A genuine
+        // home-dir session is a REAL file and is kept.
+        const st = fs.lstatSync(jsonlPath);
+        if (st.isSymbolicLink()) continue;
+        if (st.size < MIN_TRANSCRIPT_BYTES) continue;
 
         const existing = existingById.get(sessionId) ?? null;
         // Gate read: tail timestamp only (wantTitle=false). Computing the title

--- a/desktop/tests/conversation-reconciler.test.ts
+++ b/desktop/tests/conversation-reconciler.test.ts
@@ -296,50 +296,65 @@ describe('reconcile — exact projectKey from known folders', () => {
   });
 });
 
-describe('reconcile — same id under multiple slugs (CC home-dir duplication)', () => {
-  // Found by the single-machine dev smoke test: Claude Code writes a session's
-  // transcript into the HOME-dir project too, so the same id lives under BOTH
-  // 'C--Users-desti' (home) and its real cwd slug 'C--Users-desti-<proj>'.
-  // readdir hands back the shorter home slug first (it's a prefix), so first-seen
-  // tagged EVERY duplicated conversation with the home basename ('desti') and
-  // bucketed them together. The MOST-SPECIFIC (longest) slug must win.
+describe('reconcile — foreign-slug symlinks (legacy machinery) are skipped', () => {
+  // Found by the single-machine dev smoke test on a real ~/.claude/projects: the
+  // LEGACY sync / resume-browser machinery symlinks a session's real transcript
+  // into the HOME-dir project slug ('C--Users-desti/<id>.jsonl' ->
+  // '../C--Users-desti-<proj>/<id>.jsonl'; 687 such symlinks observed, all in the
+  // home slug). Following them tagged EVERY linked conversation with the home
+  // basename ('desti') and bucketed all transcripts together. The reconciler must
+  // detect the symlink (via lstat, which does NOT follow) and skip it, processing
+  // the REAL transcript in its true cwd slug instead. NOT a Claude Code behavior.
 
-  it('uses the longest (most-specific) slug, not the home slug, for a duplicated id', async () => {
-    // Same id in BOTH the home project AND the real youcoded-dev project.
-    writeTranscript(projectsDir, 'C--Users-desti', SID_A);                 // home dup (shorter)
-    writeTranscript(projectsDir, 'C--Users-desti-youcoded-dev', SID_A);    // real cwd (longer)
+  // Windows file symlinks need Developer Mode / admin; skip these tests where the
+  // OS forbids symlink creation (they run on CI/POSIX and on dev machines with it
+  // enabled — the legacy app created 687 here, so it's enabled on the real one).
+  const canSymlink = (() => {
+    const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-symlink-probe-'));
+    try {
+      fs.writeFileSync(path.join(probeDir, 'target'), 'x');
+      fs.symlinkSync('target', path.join(probeDir, 'link'), 'file');
+      return true;
+    } catch { return false; }
+    finally { try { fs.rmSync(probeDir, { recursive: true, force: true }); } catch {} }
+  })();
 
+  it.skipIf(!canSymlink)('skips a home-slug symlink and processes the real transcript in its true slug', () => {
+    // Real transcript in its true cwd slug.
+    writeTranscript(projectsDir, 'C--Users-desti-youcoded-dev', SID_A);
+    // Legacy foreign-slug symlink in the HOME slug pointing at it.
+    const homeDir = path.join(projectsDir, 'C--Users-desti');
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.symlinkSync(
+      path.join('..', 'C--Users-desti-youcoded-dev', `${SID_A}.jsonl`),
+      path.join(homeDir, `${SID_A}.jsonl`),
+      'file',
+    );
+
+    return reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror }).then(async (n) => {
+      // Exactly one record — the symlink was skipped, the real file processed once.
+      expect(n).toBe(1);
+      const rec = await store.get('claude', SID_A);
+      // 'youcoded-dev' slug last segment 'dev' — NOT the home basename 'desti'
+      // (red before the fix, which followed the symlink and yielded 'desti').
+      expect(rec!.projectName).toBe('dev');
+      expect(rec!.transcriptRef).toBe(`claude/transcripts/dev/${SID_A}.jsonl`);
+      // Mirrored once, from the REAL file in the youcoded-dev slug (not the link).
+      expect(mirrorCalls).toHaveLength(1);
+      expect(mirrorCalls[0].key).toBe('dev');
+      expect(mirrorCalls[0].p).toBe(
+        path.join(projectsDir, 'C--Users-desti-youcoded-dev', `${SID_A}.jsonl`),
+      );
+    });
+  });
+
+  it('a REAL file in the home slug (genuine home-dir session) is kept as the home basename', async () => {
+    // No symlink — a session actually run from the home dir. lstat says regular
+    // file, so it is processed and legitimately keyed 'desti'.
+    writeTranscript(projectsDir, 'C--Users-desti', SID_A);
     const n = await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
-
-    // Exactly one record (processed once, under the authoritative slug).
     expect(n).toBe(1);
     const rec = await store.get('claude', SID_A);
-    // 'youcoded-dev' slug's last segment 'dev' — NOT the home basename 'desti'
-    // (red before the fix, which yielded 'desti' and bucketed the mirror there).
-    expect(rec!.projectName).toBe('dev');
-    expect(rec!.transcriptRef).toBe(`claude/transcripts/dev/${SID_A}.jsonl`);
-    // Mirrored exactly once, from the youcoded-dev slug dir, to the 'dev' bucket.
-    expect(mirrorCalls).toHaveLength(1);
-    expect(mirrorCalls[0].key).toBe('dev');
-    expect(mirrorCalls[0].p).toBe(
-      path.join(projectsDir, 'C--Users-desti-youcoded-dev', `${SID_A}.jsonl`),
-    );
-  });
-
-  it('a session ONLY under the home slug keeps the home basename (genuine home session)', async () => {
-    writeTranscript(projectsDir, 'C--Users-desti', SID_A);
-    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
-    const rec = await store.get('claude', SID_A);
-    expect(rec!.projectName).toBe('desti'); // legitimately a home-dir conversation
-  });
-
-  it('the longest slug wins even when the home (shorter) copy is NEWER', async () => {
-    // Freshness must not let the home dup re-tag the record: the process pass
-    // never touches the home copy at all (authoritative-slug skip).
-    writeTranscript(projectsDir, 'C--Users-desti-youcoded-dev', SID_A, { lastTimestamp: '2026-06-01T10:00:00Z' });
-    writeTranscript(projectsDir, 'C--Users-desti', SID_A, { lastTimestamp: '2026-09-01T10:00:00Z' }); // newer home dup
-    await reconcile({ projectsDir, topicsDir, store, device: 'Dev1', mirror });
-    const rec = await store.get('claude', SID_A);
-    expect(rec!.projectName).toBe('dev'); // still the real cwd, not 'desti'
+    expect(rec!.projectName).toBe('desti');
   });
 });


### PR DESCRIPTION
## Corrects #117's diagnosis

#117 attributed the home-slug conversation duplication to Claude Code and fixed it with a longest-slug heuristic. **That attribution was wrong.** Filesystem forensics + a code trace found the real cause: the **legacy sync system**.

`SyncService.aggregateConversations()` (`sync-service.ts:2062`, run from `pull()` on every app launch/restore) symlinks each non-home slug's transcripts into the home slug — "for /resume from ~":

```
C--Users-desti/<id>.jsonl  ->  ../C--Users-desti-<proj>/<id>.jsonl
```

687 such 73-byte symlinks on a real machine, all in the home slug. The reconciler's `statSync` **followed** them (symlink → real target size passes the gate), tagging every linked conversation with the home basename `desti` and bucketing all transcripts into `transcripts/desti/`.

## The fix

Replace #117's two-phase longest-slug scan with the cause-based fix: `lstatSync` (does **not** follow the link) + `isSymbolicLink()` skip. The real transcript is processed in its true cwd slug; a genuine home-dir session is a real file and is kept as `desti`. Simpler and cheaper than the heuristic.

## Why not just stop creating the symlinks?

That's the right end-state, but it's `sync-service.ts` (frozen until Plan 2c — the live app's `/resume from ~` and legacy backup still rely on the aggregation), and it's **already on the 2c demolition list** (design §4, now naming the exact functions). The built app keeps creating these symlinks until the next release ships 2c anyway, so this reconciler-side skip is the necessary-and-sufficient defense until then.

## Tests

Two reconciler tests (real symlinks, guarded with `skipIf` where the OS forbids symlink creation): a home-slug symlink is skipped and the real transcript is processed under its true slug (`dev`, not `desti`); a real home-dir file is kept as `desti`. 50 conversation/browser/service tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)