### PR TITLE
Plan 2b: session leases, takeover, materialize-on-release + Bug 1, device registry

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3570,7 +3570,16 @@ class SessionService : Service() {
             // Cross-device project rename (display-name) + stop-syncing (2026-07-12)
             // are desktop-only (Phase 3 on Android).
             "syncspaces:rename-project",
-            "syncspaces:stop-project" -> {
+            "syncspaces:stop-project",
+            // Plan 2b — conversation leases/takeover + device registry are
+            // desktop-only (Android has no lease/takeover). The shared React UI
+            // degrades: these invokes reject fast with this stub instead of
+            // 30s-timing-out. (session:moved is a PUSH event — no request handler.)
+            "syncspaces:lease-query",
+            "syncspaces:lease-takeover",
+            "syncspaces:lease-force",
+            "syncspaces:list-devices",
+            "syncspaces:rename-device" -> {
                 msg.id?.let { bridgeServer.respond(ws, msg.type, it,
                     org.json.JSONObject().put("ok", false).put("error", "not-implemented-on-mobile")) }
             }

--- a/desktop/src/main/conversations/lease-client.ts
+++ b/desktop/src/main/conversations/lease-client.ts
@@ -41,6 +41,14 @@ export interface LeaseClientOpts {
 export interface LeaseQueryResult {
   held: boolean;
   device?: string;
+  // The per-install device id of the holder (NOT the label). `self` is derived
+  // from it — a caller MUST NOT infer self-identity from `device` (the hostname
+  // label), which collides when two installs share a hostname (the dev instance
+  // + built app, or two same-hostname machines). deviceId is unique per install.
+  deviceId?: string;
+  // True when the holder is THIS install (holder deviceId === our deviceId). This
+  // is the correct "is it me?" signal — see deviceId above for why the label isn't.
+  self?: boolean;
   expiresAt?: number;
   source: 'hub' | 'file' | 'none';
 }
@@ -220,18 +228,34 @@ export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
       catch { r = null; }
 
       if (r !== null) {
-        // Hub answered — authoritative.
-        if (r.holder) return { held: true, device: r.holder.device, expiresAt: r.holder.expiresAt, source: 'hub' };
-        return { held: false, source: 'hub' };
+        // Hub answered — authoritative. `self` keys on the per-install deviceId,
+        // never the hostname label (which collides across installs).
+        if (r.holder) return {
+          held: true,
+          device: r.holder.device,
+          deviceId: r.holder.deviceId,
+          expiresAt: r.holder.expiresAt,
+          self: r.holder.deviceId === opts.deviceId,
+          source: 'hub',
+        };
+        return { held: false, self: false, source: 'hub' };
       }
 
       // Hub down — consult the file fallback with the 300s stale rule (local clock).
+      // The lease file stores the holder's deviceId too, so self keys on it here as well.
       const file = readLeaseFile(sessionId);
       if (file && file.expiresAt > Date.now()) {
-        return { held: true, device: file.device, expiresAt: file.expiresAt, source: 'file' };
+        return {
+          held: true,
+          device: file.device,
+          deviceId: file.deviceId,
+          expiresAt: file.expiresAt,
+          self: file.deviceId === opts.deviceId,
+          source: 'file',
+        };
       }
       // Missing or expired file => free.
-      return { held: false, source: 'none' };
+      return { held: false, self: false, source: 'none' };
     },
 
     async takeover(sessionId) {

--- a/desktop/src/main/conversations/lease-client.ts
+++ b/desktop/src/main/conversations/lease-client.ts
@@ -63,6 +63,13 @@ interface LeaseFileContent { deviceId: string; device: string; expiresAt: number
 export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
   // sessionId -> renew timer. Membership IS "this device holds the lease".
   const held = new Map<string, NodeJS.Timeout>();
+  // sessionId -> monotonically-increasing generation. Bumped on every acquire /
+  // fresh renew loop. A renew tick captures the gen it was scheduled under and
+  // bails if the current gen has moved on — this is what makes a re-acquire
+  // genuinely idempotent even if a PRIOR tick for the same session is still
+  // awaiting hubRequest (its resumed schedule() would otherwise leak a second
+  // heartbeat loop, double-renewing).
+  const gen = new Map<string, number>();
 
   // ---- lease-file helpers (all best-effort, all try/caught) ----
 
@@ -102,12 +109,20 @@ export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
 
   // ---- renew timer ----
 
+  // Clears the renew TIMER only — it does NOT remove `held`/`gen` membership.
+  // Callers must pair it with `held.delete(sessionId)` (and let the gen bump on
+  // the next acquire) to fully release the session.
   function stopTimer(sessionId: string): void {
     const t = held.get(sessionId);
     if (t) clearTimeout(t);
   }
 
   function startRenewTimer(sessionId: string): void {
+    // Bump the generation so any in-flight tick from a prior loop becomes a
+    // no-op when it resumes. `myGen` is captured by this loop's schedule/tick.
+    const myGen = (gen.get(sessionId) ?? 0) + 1;
+    gen.set(sessionId, myGen);
+
     // Self-rescheduling setTimeout (not setInterval) so an async renew that runs
     // long can't stack overlapping renews. Each tick reschedules itself.
     const schedule = () => {
@@ -120,8 +135,13 @@ export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
       // The whole body is wrapped so an unexpected throw in a timer callback can
       // never become a fatal unhandled rejection in Electron main.
       try {
+        // Stale-generation guard: a re-acquire (or fresh renew loop) since this
+        // tick was scheduled means we're an orphaned loop — bail silently so we
+        // never leak a second heartbeat that double-renews.
+        if (gen.get(sessionId) !== myGen) return;
         if (!held.has(sessionId)) return; // released/destroyed between scheduling and firing
         const r = await opts.hubRequest('renew', sessionId, opts.deviceId);
+        if (gen.get(sessionId) !== myGen) return; // superseded while the renew was in flight
         if (!held.has(sessionId)) return; // released while the renew was in flight
 
         if (r && !r.ok) {
@@ -148,8 +168,9 @@ export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
         schedule(); // reschedule the next heartbeat only if we still hold it
       } catch {
         // Swallow — a renew failure must never crash main. Reschedule so a one-off
-        // error doesn't silently kill the heartbeat.
-        if (held.has(sessionId)) schedule();
+        // error doesn't silently kill the heartbeat, but only if we're still the
+        // live loop (gen unchanged) and still hold the session.
+        if (gen.get(sessionId) === myGen && held.has(sessionId)) schedule();
       }
     }
 
@@ -174,7 +195,10 @@ export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
       // OPTIMISTICALLY: sync must never block on the hub, so we take a local hold
       // and let the next renew reconcile once the hub is back.
       const expiresAt = res?.holder?.expiresAt ?? Date.now() + LEASE_TTL_MS;
-      stopTimer(sessionId); // idempotent: restart cleanly if re-acquiring the same session
+      // Genuinely idempotent re-acquire: stopTimer clears the old timer, and
+      // startRenewTimer bumps the generation so any PRIOR renew tick still
+      // awaiting hubRequest becomes a no-op when it resumes (no leaked 2nd loop).
+      stopTimer(sessionId);
       held.delete(sessionId);
       writeLeaseFile(sessionId, expiresAt);
       startRenewTimer(sessionId);
@@ -221,7 +245,10 @@ export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
       // Only act if THIS device currently holds the session — otherwise the
       // request isn't for us (the hub broadcasts to the whole account).
       if (!held.has(sessionId)) return;
-      opts.onTakeoverRequest(sessionId, from);
+      // The callback is caller-supplied (untrusted) and dispatched synchronously
+      // from the service's hub-event handler — a throw here would propagate to
+      // Electron main. Swallow so a bad handler can never crash the process.
+      try { opts.onTakeoverRequest(sessionId, from); } catch { /* never crash main */ }
     },
 
     isHeld(sessionId) { return held.has(sessionId); },

--- a/desktop/src/main/conversations/lease-client.ts
+++ b/desktop/src/main/conversations/lease-client.ts
@@ -1,0 +1,234 @@
+// Lease client (Plan 2b, Task 6). Owns the per-held-session heartbeat renew
+// timers, the acquire/release/query/takeover operations, and a best-effort
+// lease-FILE fallback so a device can still answer "who holds this session?"
+// while the SyncHub is transiently disconnected.
+//
+// Design notes (why this shape):
+//   - The HUB is the source of truth. The lease file at
+//     Personal/Leases/<sessionId>.json is a best-effort mirror consulted ONLY
+//     when the hub returns null (down). It uses the same 300s stale rule via the
+//     LOCAL clock — good enough because a wrong file answer just means one extra
+//     query round-trip, never data loss.
+//   - NEVER block the caller and NEVER throw from a fire-and-forget path. A hub
+//     request that returns null (disconnected) is treated as an optimistic local
+//     hold rather than a failure — sync must degrade gracefully, never wedge.
+//   - Every timer is unref()'d so a lingering renew timer can't keep the Electron
+//     main process alive on quit; all fs ops are try/caught (best-effort).
+import * as fs from 'fs';
+import * as path from 'path';
+import type { LeaseResult } from '../sync-hub-socket';
+
+// Match the worker's contract: 300s lease expiry, 30s heartbeat.
+const LEASE_TTL_MS = 300_000;
+const RENEW_MS = 30_000;
+
+export interface LeaseClientOpts {
+  deviceId: string;
+  deviceName: string;
+  // Returns the Personal sync-space root, or null when managed roots are
+  // unavailable (sync disabled / not yet initialized). Null => skip all file ops.
+  personalRoot: () => string | null;
+  // Injected transport (the SyncHub socket's request()). Resolves a LeaseResult,
+  // or null when the hub is disconnected / timed out — never rejects.
+  hubRequest: (op: string, sessionId: string, deviceId: string) => Promise<LeaseResult | null>;
+  // Upward callback the caller (Task 8 service) supplies to trigger holder-side
+  // teardown (interrupt -> mirror -> release -> destroy). `from` is OPTIONAL — a
+  // deliberate deviation from the plan's non-optional shape: the renew-failure
+  // path (we lost the lease to a force-acquire) has no `from` to supply.
+  onTakeoverRequest: (sessionId: string, from?: { deviceId: string; device: string }) => void;
+}
+
+export interface LeaseQueryResult {
+  held: boolean;
+  device?: string;
+  expiresAt?: number;
+  source: 'hub' | 'file' | 'none';
+}
+
+export interface LeaseClient {
+  acquire(sessionId: string): Promise<LeaseResult | null>;
+  release(sessionId: string): Promise<void>;
+  query(sessionId: string): Promise<LeaseQueryResult>;
+  takeover(sessionId: string): Promise<LeaseResult | null>;
+  // Inbound: the service calls this when the hub delivers a takeover-request
+  // lease-event. Filtered HERE because the client is the only thing that knows
+  // which sessions THIS device holds.
+  handleTakeoverRequest(sessionId: string, from?: { deviceId: string; device: string }): void;
+  isHeld(sessionId: string): boolean;
+  destroy(): void;
+}
+
+interface LeaseFileContent { deviceId: string; device: string; expiresAt: number }
+
+export function createLeaseClient(opts: LeaseClientOpts): LeaseClient {
+  // sessionId -> renew timer. Membership IS "this device holds the lease".
+  const held = new Map<string, NodeJS.Timeout>();
+
+  // ---- lease-file helpers (all best-effort, all try/caught) ----
+
+  function leaseFile(sessionId: string): string | null {
+    const root = opts.personalRoot();
+    if (!root) return null; // managed roots unavailable — hub is the primary path anyway
+    return path.join(root, 'Leases', `${sessionId}.json`);
+  }
+
+  function writeLeaseFile(sessionId: string, expiresAt: number): void {
+    const file = leaseFile(sessionId);
+    if (!file) return;
+    try {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      const body: LeaseFileContent = { deviceId: opts.deviceId, device: opts.deviceName, expiresAt };
+      fs.writeFileSync(file, JSON.stringify(body));
+    } catch { /* best-effort: file fallback is a nicety, not a correctness guarantee */ }
+  }
+
+  function deleteLeaseFile(sessionId: string): void {
+    const file = leaseFile(sessionId);
+    if (!file) return;
+    try { fs.rmSync(file, { force: true }); } catch { /* best-effort */ }
+  }
+
+  function readLeaseFile(sessionId: string): LeaseFileContent | null {
+    const file = leaseFile(sessionId);
+    if (!file) return null;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (parsed && typeof parsed.expiresAt === 'number' && Number.isFinite(parsed.expiresAt)) {
+        return { deviceId: String(parsed.deviceId ?? ''), device: String(parsed.device ?? ''), expiresAt: parsed.expiresAt };
+      }
+      return null;
+    } catch { return null; } // missing / malformed -> treat as no lease
+  }
+
+  // ---- renew timer ----
+
+  function stopTimer(sessionId: string): void {
+    const t = held.get(sessionId);
+    if (t) clearTimeout(t);
+  }
+
+  function startRenewTimer(sessionId: string): void {
+    // Self-rescheduling setTimeout (not setInterval) so an async renew that runs
+    // long can't stack overlapping renews. Each tick reschedules itself.
+    const schedule = () => {
+      const timer = setTimeout(() => { void renewTick(sessionId); }, RENEW_MS);
+      timer.unref?.(); // don't keep the Electron main process alive just for a renew
+      held.set(sessionId, timer);
+    };
+
+    async function renewTick(sessionId: string): Promise<void> {
+      // The whole body is wrapped so an unexpected throw in a timer callback can
+      // never become a fatal unhandled rejection in Electron main.
+      try {
+        if (!held.has(sessionId)) return; // released/destroyed between scheduling and firing
+        const r = await opts.hubRequest('renew', sessionId, opts.deviceId);
+        if (!held.has(sessionId)) return; // released while the renew was in flight
+
+        if (r && !r.ok) {
+          // WE LOST THE LEASE: another device force-acquired it (spec §3 step 5 —
+          // "A's client, whenever it wakes, sees it no longer holds the lease").
+          // Stop renewing, drop local state + file, and drive the upward teardown
+          // with NO `from` (the force-acquirer isn't carried on a renew reply).
+          stopTimer(sessionId);
+          held.delete(sessionId);
+          deleteLeaseFile(sessionId);
+          opts.onTakeoverRequest(sessionId);
+          return;
+        }
+
+        if (r && r.ok) {
+          // Still ours — extend the file fallback with the hub's fresh deadline.
+          writeLeaseFile(sessionId, r.holder?.expiresAt ?? Date.now() + LEASE_TTL_MS);
+        } else {
+          // r === null: hub transiently disconnected. Do NOT drop the lease on a
+          // blip — keep renewing and keep the file fallback fresh with a local
+          // deadline (never-block / tolerate transient hub loss).
+          writeLeaseFile(sessionId, Date.now() + LEASE_TTL_MS);
+        }
+        schedule(); // reschedule the next heartbeat only if we still hold it
+      } catch {
+        // Swallow — a renew failure must never crash main. Reschedule so a one-off
+        // error doesn't silently kill the heartbeat.
+        if (held.has(sessionId)) schedule();
+      }
+    }
+
+    schedule();
+  }
+
+  // ---- public ops ----
+
+  return {
+    async acquire(sessionId) {
+      let res: LeaseResult | null = null;
+      try { res = await opts.hubRequest('acquire', sessionId, opts.deviceId); }
+      catch { res = null; } // never throw from acquire
+
+      if (res && !res.ok) {
+        // Someone else holds it. Don't start a timer, don't write a file — the
+        // caller inspects res.holder to decide whether to request a takeover.
+        return res;
+      }
+
+      // res.ok OR res === null (hub down). On the disconnected path we hold
+      // OPTIMISTICALLY: sync must never block on the hub, so we take a local hold
+      // and let the next renew reconcile once the hub is back.
+      const expiresAt = res?.holder?.expiresAt ?? Date.now() + LEASE_TTL_MS;
+      stopTimer(sessionId); // idempotent: restart cleanly if re-acquiring the same session
+      held.delete(sessionId);
+      writeLeaseFile(sessionId, expiresAt);
+      startRenewTimer(sessionId);
+      return res ?? { ok: true, op: 'acquire', sessionId, holder: { deviceId: opts.deviceId, device: opts.deviceName, expiresAt } };
+    },
+
+    async release(sessionId) {
+      // Stop local state FIRST so a late renew can't re-arm anything, then tell
+      // the hub best-effort. Release must never throw.
+      stopTimer(sessionId);
+      held.delete(sessionId);
+      deleteLeaseFile(sessionId);
+      try { await opts.hubRequest('release', sessionId, opts.deviceId); } catch { /* best-effort */ }
+    },
+
+    async query(sessionId) {
+      let r: LeaseResult | null = null;
+      try { r = await opts.hubRequest('get', sessionId, opts.deviceId); }
+      catch { r = null; }
+
+      if (r !== null) {
+        // Hub answered — authoritative.
+        if (r.holder) return { held: true, device: r.holder.device, expiresAt: r.holder.expiresAt, source: 'hub' };
+        return { held: false, source: 'hub' };
+      }
+
+      // Hub down — consult the file fallback with the 300s stale rule (local clock).
+      const file = readLeaseFile(sessionId);
+      if (file && file.expiresAt > Date.now()) {
+        return { held: true, device: file.device, expiresAt: file.expiresAt, source: 'file' };
+      }
+      // Missing or expired file => free.
+      return { held: false, source: 'none' };
+    },
+
+    async takeover(sessionId) {
+      // Thin passthrough: the DO relays this as a takeover-request to the current
+      // holder, who answers by releasing. The requester (Task 9) then polls query.
+      try { return await opts.hubRequest('takeover', sessionId, opts.deviceId); }
+      catch { return null; }
+    },
+
+    handleTakeoverRequest(sessionId, from) {
+      // Only act if THIS device currently holds the session — otherwise the
+      // request isn't for us (the hub broadcasts to the whole account).
+      if (!held.has(sessionId)) return;
+      opts.onTakeoverRequest(sessionId, from);
+    },
+
+    isHeld(sessionId) { return held.has(sessionId); },
+
+    destroy() {
+      for (const timer of held.values()) clearTimeout(timer);
+      held.clear();
+    },
+  };
+}

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -252,15 +252,22 @@ export function noteSessionEnded(claudeSessionId: string): void {
   sessions.delete(claudeSessionId); // release the materialize guard FIRST — even if the rest bails
   if (!store) return;
   // The targeted materialize is gated on the local transcript being quiescent
-  // (CC may still be flushing) and never full-scans — see materializeEndedSession.
-  void materializeEndedSession(claudeSessionId, ctx?.cwd).catch(() => { /* never reject in main */ });
+  // (CC may still be flushing) and never full-scans — see materializeOne.
+  void materializeOne(claudeSessionId, ctx?.cwd).catch(() => { /* never reject in main */ });
 }
 
-// Targeted equivalent of materializeSweep for ONE just-ended session: resolve its
-// local project, wait for the local transcript to go quiescent, then pull a
-// larger peer version over it (grow-only, same as the sweep). Isolated so an
-// ended session applies a peer edit without waiting for the 30-min reconcile tick.
-async function materializeEndedSession(id: string, cwd?: string): Promise<void> {
+// Targeted equivalent of materializeSweep for ONE session: resolve its local
+// project, wait for the local transcript to go quiescent, then pull a larger peer
+// version over it (grow-only, same as the sweep). Isolated so an ended session
+// applies a peer edit without waiting for the 30-min reconcile tick.
+//
+// Plan 2b Task 9: EXPORTED and renamed from materializeEndedSession because the
+// REQUESTER-side takeover flow reuses it — after a holder releases a lease, the
+// requester pulls the peer's final turn into the local CC transcript with this.
+// For the requester there's no live local session (sessions.has(id) is false and
+// the local file is stale/absent), so it quiesces immediately; cwd is undefined
+// so it resolves the project via resolveLocalProject.
+export async function materializeOne(id: string, cwd?: string): Promise<void> {
   const s = store; if (!s) return;
   let rec; try { rec = await s.get('claude', id); } catch { return; }
   if (!rec?.transcriptRef) return;

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -264,24 +264,34 @@ async function materializeEndedSession(id: string, cwd?: string): Promise<void> 
   const s = store; if (!s) return;
   let rec; try { rec = await s.get('claude', id); } catch { return; }
   if (!rec?.transcriptRef) return;
-  // Hoist the project lookups once (same rationale as materializeSweep).
-  const managed = new Map<string, string>((getManagedRoots()?.listProjects() ?? []).map((p) => [p.name, p.path]));
-  let saved: Array<{ path: string }> = [];
-  try { saved = readFolders(); } catch { /* saved folders unreadable */ }
-  const local = cwd ?? resolveLocalProject(rec, managed, saved);
+  // Resolve the local project. On the common path cwd is known (learned via
+  // noteSessionStarted), so only pay for the managed/saved-folder reads on the
+  // cwd miss (a session that ended without ever being announced here).
+  let local = cwd;
+  if (!local) {
+    const managed = new Map<string, string>((getManagedRoots()?.listProjects() ?? []).map((p) => [p.name, p.path]));
+    let saved: Array<{ path: string }> = [];
+    try { saved = readFolders(); } catch { /* saved folders unreadable */ }
+    local = resolveLocalProject(rec, managed, saved) ?? undefined;
+  }
   if (!local) return;
   const localPath = localJsonlPath(local, id);
-  // Quiescence: poll size until it holds steady across one probe interval, or
-  // give up at QUIESCE_MAX_MS (the reconciler/startup sweep catch up later).
+  // Quiescence: poll size until it holds steady across one probe interval. If it
+  // never stabilizes before QUIESCE_MAX_MS, CC is still flushing — SKIP this
+  // round (never rename over a transcript CC still has open: POSIX detaches the
+  // inode and CC keeps appending to it → chat freeze + lost turns). The
+  // reconciler/startup sweep catch up once the local file is quiet.
   const started = Date.now();
+  let quiesced = false;
   let prev = -1;
   while (Date.now() - started < QUIESCE_MAX_MS) {
     let size = 0;
     try { size = fs.statSync(localPath).size; } catch { size = 0; } // absent local is quiescent (size 0 stable)
-    if (size === prev) break;
+    if (size === prev) { quiesced = true; break; }
     prev = size;
     await new Promise((r) => setTimeout(r, QUIESCE_PROBE_MS));
   }
+  if (!quiesced) return; // timed out still growing — skip, do NOT materialize
   // Re-opened during the wait — the live guard wins; do NOT touch the transcript
   // CC is now appending to (the sweep's live-session invariant).
   if (sessions.has(id)) return;

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -19,6 +19,12 @@ import type { SpaceSyncEvent } from '../sync-spaces/types';
 
 const ACTIVITY_DEBOUNCE_MS = 5_000;
 const RECONCILE_INTERVAL_MS = 30 * 60_000; // slow tick; the startup scan is the load-bearing one
+// Bug 2 Part 2 (Plan 2b): session-exit fires BEFORE the PTY worker actually dies,
+// so CC may still be flushing its final turn to the local transcript. Before the
+// targeted materialize copies a peer's version over the local file, wait for the
+// local file to stop growing — two equal-size stats this far apart = CC done.
+const QUIESCE_PROBE_MS = 750;   // gap between size probes
+const QUIESCE_MAX_MS = 6_000;   // give up waiting; skip this round (reconciler/startup sweep catch up)
 
 interface SessionCtx { cwd: string }
 
@@ -234,6 +240,54 @@ async function materializeSweep(): Promise<void> {
       });
     } catch { /* per-record isolation — one bad copy must not abort the sweep */ }
   }
+}
+
+// Bug 2 Part 2 (Plan 2b Task 7): called from the session-exit IPC handler when a
+// CLAUDE session ends. Releases the per-session materialize guard `sessions` sets
+// (so the record stops being skipped by materializeSweep) AND applies any peer
+// version immediately — no app restart needed, which was the Bug-2 symptom. The
+// companion lease release lands in Task 8.
+export function noteSessionEnded(claudeSessionId: string): void {
+  const ctx = sessions.get(claudeSessionId);
+  sessions.delete(claudeSessionId); // release the materialize guard FIRST — even if the rest bails
+  if (!store) return;
+  // The targeted materialize is gated on the local transcript being quiescent
+  // (CC may still be flushing) and never full-scans — see materializeEndedSession.
+  void materializeEndedSession(claudeSessionId, ctx?.cwd).catch(() => { /* never reject in main */ });
+}
+
+// Targeted equivalent of materializeSweep for ONE just-ended session: resolve its
+// local project, wait for the local transcript to go quiescent, then pull a
+// larger peer version over it (grow-only, same as the sweep). Isolated so an
+// ended session applies a peer edit without waiting for the 30-min reconcile tick.
+async function materializeEndedSession(id: string, cwd?: string): Promise<void> {
+  const s = store; if (!s) return;
+  let rec; try { rec = await s.get('claude', id); } catch { return; }
+  if (!rec?.transcriptRef) return;
+  // Hoist the project lookups once (same rationale as materializeSweep).
+  const managed = new Map<string, string>((getManagedRoots()?.listProjects() ?? []).map((p) => [p.name, p.path]));
+  let saved: Array<{ path: string }> = [];
+  try { saved = readFolders(); } catch { /* saved folders unreadable */ }
+  const local = cwd ?? resolveLocalProject(rec, managed, saved);
+  if (!local) return;
+  const localPath = localJsonlPath(local, id);
+  // Quiescence: poll size until it holds steady across one probe interval, or
+  // give up at QUIESCE_MAX_MS (the reconciler/startup sweep catch up later).
+  const started = Date.now();
+  let prev = -1;
+  while (Date.now() - started < QUIESCE_MAX_MS) {
+    let size = 0;
+    try { size = fs.statSync(localPath).size; } catch { size = 0; } // absent local is quiescent (size 0 stable)
+    if (size === prev) break;
+    prev = size;
+    await new Promise((r) => setTimeout(r, QUIESCE_PROBE_MS));
+  }
+  // Re-opened during the wait — the live guard wins; do NOT touch the transcript
+  // CC is now appending to (the sweep's live-session invariant).
+  if (sessions.has(id)) return;
+  try {
+    materializeOut({ spaceTranscriptPath: path.join(s.root(), rec.transcriptRef), localJsonlPath: localPath });
+  } catch { /* grow-only copy failed — startup sweep catches up */ }
 }
 
 function runReconcile(): void {

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -276,28 +276,53 @@ async function materializeEndedSession(id: string, cwd?: string): Promise<void> 
   }
   if (!local) return;
   const localPath = localJsonlPath(local, id);
-  // Quiescence: poll size until it holds steady across one probe interval. If it
-  // never stabilizes before QUIESCE_MAX_MS, CC is still flushing — SKIP this
-  // round (never rename over a transcript CC still has open: POSIX detaches the
-  // inode and CC keeps appending to it → chat freeze + lost turns). The
-  // reconciler/startup sweep catch up once the local file is quiet.
-  const started = Date.now();
-  let quiesced = false;
-  let prev = -1;
-  while (Date.now() - started < QUIESCE_MAX_MS) {
-    let size = 0;
-    try { size = fs.statSync(localPath).size; } catch { size = 0; } // absent local is quiescent (size 0 stable)
-    if (size === prev) { quiesced = true; break; }
-    prev = size;
-    await new Promise((r) => setTimeout(r, QUIESCE_PROBE_MS));
-  }
-  if (!quiesced) return; // timed out still growing — skip, do NOT materialize
+  // Quiescence: if it never stabilizes before QUIESCE_MAX_MS, CC is still
+  // flushing — SKIP this round (never rename over a transcript CC still has open:
+  // POSIX detaches the inode and CC keeps appending to it → chat freeze + lost
+  // turns). The reconciler/startup sweep catch up once the local file is quiet.
+  if (!(await waitForQuiescence(localPath))) return; // timed out still growing — skip, do NOT materialize
   // Re-opened during the wait — the live guard wins; do NOT touch the transcript
   // CC is now appending to (the sweep's live-session invariant).
   if (sessions.has(id)) return;
   try {
     materializeOut({ spaceTranscriptPath: path.join(s.root(), rec.transcriptRef), localJsonlPath: localPath });
   } catch { /* grow-only copy failed — startup sweep catches up */ }
+}
+
+// Poll the local transcript size until it holds steady across one probe interval.
+// Returns true if it went quiescent, false on timeout (still growing at
+// QUIESCE_MAX_MS). Shared by materializeEndedSession (space->local direction:
+// skip on timeout) and flushSessionToSpace (local->space direction: push anyway).
+async function waitForQuiescence(localPath: string): Promise<boolean> {
+  const started = Date.now();
+  let prev = -1;
+  while (Date.now() - started < QUIESCE_MAX_MS) {
+    let size = 0;
+    try { size = fs.statSync(localPath).size; } catch { size = 0; } // absent local is quiescent (size 0 stable)
+    if (size === prev) return true;
+    prev = size;
+    await new Promise((r) => setTimeout(r, QUIESCE_PROBE_MS));
+  }
+  return false;
+}
+
+// Holder-side takeover step 4-5 (Plan 2b Task 8): after the holder interrupts,
+// wait for CC to finish flushing the interrupted turn, then push the local
+// transcript into the space so the REQUESTER pulls the FINAL turn. mirrorIn
+// (local->space) is grow-only and never touches CC's open local file, so pushing
+// even on a quiescence TIMEOUT is safe (unlike materializeEndedSession's
+// space->local direction, which must skip on timeout to avoid clobbering the file
+// CC still has open).
+export async function flushSessionToSpace(claudeSessionId: string): Promise<void> {
+  const s = store; if (!s) return;
+  const ctx = sessions.get(claudeSessionId);
+  if (!ctx) return; // no cwd known — can't locate the transcript
+  const key = path.basename(ctx.cwd);
+  const localPath = localJsonlPath(ctx.cwd, claudeSessionId);
+  await waitForQuiescence(localPath); // best-effort wait; push regardless of the result
+  try { mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spaceTranscriptPath(key, claudeSessionId) }); }
+  catch { /* best-effort; the reconciler re-mirrors */ }
+  try { await Promise.resolve(syncSpacesSyncNow('personal')); } catch { /* the poll covers a miss */ }
 }
 
 function runReconcile(): void {

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -298,7 +298,7 @@ export async function materializeOne(id: string, cwd?: string): Promise<void> {
 
 // Poll the local transcript size until it holds steady across one probe interval.
 // Returns true if it went quiescent, false on timeout (still growing at
-// QUIESCE_MAX_MS). Shared by materializeEndedSession (space->local direction:
+// QUIESCE_MAX_MS). Shared by materializeOne (space->local direction:
 // skip on timeout) and flushSessionToSpace (local->space direction: push anyway).
 async function waitForQuiescence(localPath: string): Promise<boolean> {
   const started = Date.now();
@@ -317,7 +317,7 @@ async function waitForQuiescence(localPath: string): Promise<boolean> {
 // wait for CC to finish flushing the interrupted turn, then push the local
 // transcript into the space so the REQUESTER pulls the FINAL turn. mirrorIn
 // (local->space) is grow-only and never touches CC's open local file, so pushing
-// even on a quiescence TIMEOUT is safe (unlike materializeEndedSession's
+// even on a quiescence TIMEOUT is safe (unlike materializeOne's
 // space->local direction, which must skip on timeout to avoid clobbering the file
 // CC still has open).
 export async function flushSessionToSpace(claudeSessionId: string): Promise<void> {

--- a/desktop/src/main/conversations/takeover.ts
+++ b/desktop/src/main/conversations/takeover.ts
@@ -32,41 +32,54 @@ export interface HolderTakeoverDeps {
 export function createHolderTakeover(deps: HolderTakeoverDeps):
   (claudeId: string, from?: { deviceId: string; device: string }) => Promise<void> {
   return async (claudeId, from) => {
-    // 1. Reverse-map the claude id to the LIVE desktop session(s) holding it. A
-    //    stale map entry (missed exit) is filtered out by the getSession check.
-    const liveDesktopIds = [...deps.sessionIdMap.entries()]
-      .filter(([, cid]) => cid === claudeId)
-      .map(([did]) => did)
-      .filter((did) => deps.sessionManager.getSession(did) !== undefined);
+    // Outer backstop (belt-and-suspenders): every step below is ALSO individually
+    // try/caught, but this guarantees the never-throw contract even if step 1's
+    // sessionIdMap/getSession lookup itself throws — the handler is invoked
+    // fire-and-forget (`void holderTakeover(...)`), so any escape would become an
+    // unhandled rejection in Electron main.
+    try {
+      // 1. Reverse-map the claude id to the LIVE desktop session(s) holding it. A
+      //    stale map entry (missed exit) is filtered out by the getSession check.
+      const liveDesktopIds = [...deps.sessionIdMap.entries()]
+        .filter(([, cid]) => cid === claudeId)
+        .map(([did]) => did)
+        .filter((did) => deps.sessionManager.getSession(did) !== undefined);
 
-    // 2. We don't actually hold it live — just release the lease (idempotent) and
-    //    stop. Nothing to interrupt / flush / move.
-    if (liveDesktopIds.length === 0) {
+      // 2. We don't actually hold it live — just release the lease (idempotent) and
+      //    stop. Nothing to interrupt / flush / move.
+      if (liveDesktopIds.length === 0) {
+        try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
+        return;
+      }
+      // Pick-first is deliberate: the rare same-claudeId-in-two-live-windows case
+      // hands off only the first holder (the others' leases drop on their own exit).
+      const desktopId = liveDesktopIds[0];
+
+      // 3. Interrupt the in-flight turn. Single ESC byte — safe to write directly
+      //    per PITFALLS "Keyboard Routing" (single-byte writes reach Ink as a fresh
+      //    keystroke regardless of timing; no paste-classification applies).
+      try { deps.sessionManager.sendInput(desktopId, '\x1b'); } catch { /* best-effort */ }
+
+      // 4-5. Wait for CC to finish flushing the interrupted turn, mirror local->space,
+      //      and nudge a personal-space sync. MIRROR-BEFORE-RELEASE is load-bearing:
+      //      the requester pulls the moment it sees the release, so the final turn
+      //      must already be in the space (flushSessionToSpace does both steps).
+      try { await deps.flushSessionToSpace(claudeId); } catch { /* best-effort */ }
+
+      // 6. Release the lease so the requester can acquire. Idempotent + best-effort.
       try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
-      return;
-    }
-    const desktopId = liveDesktopIds[0];
 
-    // 3. Interrupt the in-flight turn. Single ESC byte — safe to write directly
-    //    per PITFALLS "Keyboard Routing" (single-byte writes reach Ink as a fresh
-    //    keystroke regardless of timing; no paste-classification applies).
-    try { deps.sessionManager.sendInput(desktopId, '\x1b'); } catch { /* best-effort */ }
+      // 7. Tell the renderer + remote this conversation moved. BEFORE destroy, while
+      //    the session still exists so the "moved to <device>" banner can attach.
+      //    Guarded: pushMoved fans out to remoteServer.broadcast -> ws.send in a
+      //    loop, which can THROW synchronously if a remote socket is mid-teardown
+      //    (readyState checked, then transitions to CLOSING). An escape here would
+      //    skip step 8 (leaving the local CC session alive → half-done handoff).
+      try { deps.pushMoved(desktopId, from?.device); } catch { /* best-effort */ }
 
-    // 4-5. Wait for CC to finish flushing the interrupted turn, mirror local->space,
-    //      and nudge a personal-space sync. MIRROR-BEFORE-RELEASE is load-bearing:
-    //      the requester pulls the moment it sees the release, so the final turn
-    //      must already be in the space (flushSessionToSpace does both steps).
-    try { await deps.flushSessionToSpace(claudeId); } catch { /* best-effort */ }
-
-    // 6. Release the lease so the requester can acquire. Idempotent + best-effort.
-    try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
-
-    // 7. Tell the renderer + remote this conversation moved. BEFORE destroy, while
-    //    the session still exists so the "moved to <device>" banner can attach.
-    deps.pushMoved(desktopId, from?.device);
-
-    // 8. End the holder's session — fires session-exit -> Task 7 cleanup +
-    //    idempotent lease release.
-    try { deps.sessionManager.destroySession(desktopId); } catch { /* best-effort */ }
+      // 8. End the holder's session — fires session-exit -> Task 7 cleanup +
+      //    idempotent lease release.
+      try { deps.sessionManager.destroySession(desktopId); } catch { /* best-effort */ }
+    } catch { /* never surface out of a fire-and-forget hub-event handler */ }
   };
 }

--- a/desktop/src/main/conversations/takeover.ts
+++ b/desktop/src/main/conversations/takeover.ts
@@ -83,3 +83,74 @@ export function createHolderTakeover(deps: HolderTakeoverDeps):
     } catch { /* never surface out of a fire-and-forget hub-event handler */ }
   };
 }
+
+// Requester-side takeover flow (Plan 2b Task 9). When the user clicks "resume" on
+// a conversation another device holds, THIS device asks the holder to hand off,
+// waits for the lease to free, then pulls the peer's final turn and acquires the
+// lease itself. Extracted as an injected-deps factory (same shape as the holder
+// flow) so the poll loop is unit-testable with fake timers.
+//
+// spec §3 NEVER-BLOCK: this must NEVER throw. On any error the caller degrades to
+// a warning dialog and proceeds with the resume anyway — a lease hiccup must not
+// stop a user from opening their conversation.
+export interface RequesterTakeoverDeps {
+  leaseClient: {
+    takeover(sessionId: string): Promise<unknown>;
+    query(sessionId: string): Promise<{ held: boolean; device?: string }>;
+    acquire(sessionId: string): Promise<unknown>;
+  };
+  syncNow: () => Promise<unknown> | unknown;            // syncSpacesSyncNow('personal')
+  materializeOne: (sessionId: string) => Promise<void>; // pull the peer's final turn into the local CC transcript
+  forceAcquire: (sessionId: string) => Promise<unknown>;// hub op 'force-acquire' — overwrite a stale lease
+  delay: (ms: number) => Promise<void>;                 // injectable so tests drive the poll with fake timers
+  selfDevice: string;                                   // this device's label — a query holder === self counts as free
+}
+
+export interface RequesterOutcome { outcome: 'acquired' | 'timeout' | 'error' }
+
+// The requester object's type — referenced by ipc-handlers' leaseWiring param so
+// main.ts can build the flow and pass it through without a circular import.
+export type RequesterTakeoverType = ReturnType<typeof createRequesterTakeover>;
+
+export function createRequesterTakeover(deps: RequesterTakeoverDeps) {
+  const POLL_MS = 1_000, MAX_MS = 10_000;
+  return {
+    async takeover(sessionId: string): Promise<RequesterOutcome> {
+      try {
+        // Broadcast the request; the holder answers by releasing its lease.
+        await deps.leaseClient.takeover(sessionId);
+        const started = Date.now();
+        // Poll until the lease frees (held:false, or the holder is now us) or we
+        // hit the 10s budget. Checking free BEFORE the first sleep means an
+        // already-free lease returns fast without a wasted poll interval.
+        while (Date.now() - started < MAX_MS) {
+          const q = await deps.leaseClient.query(sessionId);
+          if (!q.held || q.device === deps.selfDevice) {
+            // Free: nudge a personal-space sync so the holder's final turn is in
+            // the space, pull it into the local CC transcript, then claim the
+            // lease. Each downstream step is best-effort — a miss self-heals via
+            // the startup sweep / next renew; we still report 'acquired'.
+            await Promise.resolve(deps.syncNow()).catch(() => {});
+            try { await deps.materializeOne(sessionId); } catch { /* best-effort; startup sweep catches up */ }
+            await deps.leaseClient.acquire(sessionId).catch(() => {});
+            return { outcome: 'acquired' };
+          }
+          await deps.delay(POLL_MS);
+        }
+        // Holder never released within the budget — the caller offers a force.
+        return { outcome: 'timeout' };
+      } catch { return { outcome: 'error' }; }
+    },
+    async force(sessionId: string): Promise<{ ok: boolean }> {
+      try {
+        // Overwrite the stale lease outright (the holder is presumed unresponsive),
+        // then pull the latest we have. force-acquire goes through the hub directly
+        // (the reviewed lease-client has no force method — see main.ts wiring).
+        await deps.forceAcquire(sessionId);
+        await Promise.resolve(deps.syncNow()).catch(() => {});
+        try { await deps.materializeOne(sessionId); } catch { /* best-effort */ }
+        return { ok: true };
+      } catch { return { ok: false }; }
+    },
+  };
+}

--- a/desktop/src/main/conversations/takeover.ts
+++ b/desktop/src/main/conversations/takeover.ts
@@ -1,0 +1,72 @@
+// Holder-side takeover sequence (Plan 2b Task 8). When another device asks to
+// take over a conversation THIS device currently holds, the lease client's
+// onTakeoverRequest fires this handler. It cleanly hands the session off:
+//   1. reverse-map the claude id -> the LIVE desktop session(s) holding it
+//   2. if none live: just release the lease and stop (nothing to hand off)
+//   3. interrupt the in-flight turn (single ESC byte to the PTY)
+//   4-5. wait for CC to flush the interrupted turn, then push local->space
+//   6. release the lease so the requester can acquire
+//   7. tell the renderer + remote the conversation moved (BEFORE destroy)
+//   8. end the local session (fires session-exit -> Task 7 cleanup)
+//
+// Extracted into an injected-deps factory (not inlined in ipc-handlers) so it's
+// unit-testable — the real handler needs sessionIdMap, which is local to
+// registerIpcHandlers. NEVER throws: it's invoked fire-and-forget from a hub
+// event, so every step is independently try/caught (a mid-step failure must not
+// abort the rest of the handoff, and must never surface as an unhandled rejection
+// in Electron main).
+
+export interface HolderTakeoverDeps {
+  sessionManager: {
+    getSession(id: string): unknown | undefined;
+    sendInput(id: string, text: string): boolean;
+    destroySession(id: string): boolean;
+  };
+  sessionIdMap: Map<string, string>;                    // desktopId -> claudeId
+  leaseClient: { release(sessionId: string): Promise<void> };
+  flushSessionToSpace: (claudeSessionId: string) => Promise<void>;
+  pushMoved: (desktopId: string, device?: string) => void;  // dual-path push (renderer + remote)
+}
+
+// Returns the async handler wired to the lease client's onTakeoverRequest.
+export function createHolderTakeover(deps: HolderTakeoverDeps):
+  (claudeId: string, from?: { deviceId: string; device: string }) => Promise<void> {
+  return async (claudeId, from) => {
+    // 1. Reverse-map the claude id to the LIVE desktop session(s) holding it. A
+    //    stale map entry (missed exit) is filtered out by the getSession check.
+    const liveDesktopIds = [...deps.sessionIdMap.entries()]
+      .filter(([, cid]) => cid === claudeId)
+      .map(([did]) => did)
+      .filter((did) => deps.sessionManager.getSession(did) !== undefined);
+
+    // 2. We don't actually hold it live — just release the lease (idempotent) and
+    //    stop. Nothing to interrupt / flush / move.
+    if (liveDesktopIds.length === 0) {
+      try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
+      return;
+    }
+    const desktopId = liveDesktopIds[0];
+
+    // 3. Interrupt the in-flight turn. Single ESC byte — safe to write directly
+    //    per PITFALLS "Keyboard Routing" (single-byte writes reach Ink as a fresh
+    //    keystroke regardless of timing; no paste-classification applies).
+    try { deps.sessionManager.sendInput(desktopId, '\x1b'); } catch { /* best-effort */ }
+
+    // 4-5. Wait for CC to finish flushing the interrupted turn, mirror local->space,
+    //      and nudge a personal-space sync. MIRROR-BEFORE-RELEASE is load-bearing:
+    //      the requester pulls the moment it sees the release, so the final turn
+    //      must already be in the space (flushSessionToSpace does both steps).
+    try { await deps.flushSessionToSpace(claudeId); } catch { /* best-effort */ }
+
+    // 6. Release the lease so the requester can acquire. Idempotent + best-effort.
+    try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
+
+    // 7. Tell the renderer + remote this conversation moved. BEFORE destroy, while
+    //    the session still exists so the "moved to <device>" banner can attach.
+    deps.pushMoved(desktopId, from?.device);
+
+    // 8. End the holder's session — fires session-exit -> Task 7 cleanup +
+    //    idempotent lease release.
+    try { deps.sessionManager.destroySession(desktopId); } catch { /* best-effort */ }
+  };
+}

--- a/desktop/src/main/conversations/takeover.ts
+++ b/desktop/src/main/conversations/takeover.ts
@@ -96,14 +96,18 @@ export function createHolderTakeover(deps: HolderTakeoverDeps):
 export interface RequesterTakeoverDeps {
   leaseClient: {
     takeover(sessionId: string): Promise<unknown>;
-    query(sessionId: string): Promise<{ held: boolean; device?: string }>;
+    // `self` (deviceId-derived, from the lease client) is the correct "held by
+    // US" signal — NOT `device`, which is the hostname label and collides when
+    // two installs share a hostname (dev instance + built app is this plan's own
+    // dogfood gate). Keying self-identity on the label would make one install
+    // treat the OTHER's lease as its own and skip the real handoff.
+    query(sessionId: string): Promise<{ held: boolean; device?: string; self?: boolean }>;
     acquire(sessionId: string): Promise<unknown>;
   };
   syncNow: () => Promise<unknown> | unknown;            // syncSpacesSyncNow('personal')
   materializeOne: (sessionId: string) => Promise<void>; // pull the peer's final turn into the local CC transcript
   forceAcquire: (sessionId: string) => Promise<unknown>;// hub op 'force-acquire' — overwrite a stale lease
   delay: (ms: number) => Promise<void>;                 // injectable so tests drive the poll with fake timers
-  selfDevice: string;                                   // this device's label — a query holder === self counts as free
 }
 
 export interface RequesterOutcome { outcome: 'acquired' | 'timeout' | 'error' }
@@ -125,7 +129,11 @@ export function createRequesterTakeover(deps: RequesterTakeoverDeps) {
         // already-free lease returns fast without a wasted poll interval.
         while (Date.now() - started < MAX_MS) {
           const q = await deps.leaseClient.query(sessionId);
-          if (!q.held || q.device === deps.selfDevice) {
+          // Free (nobody holds it) OR the holder is US (self, keyed on deviceId —
+          // see RequesterTakeoverDeps.query for why not the label). Two installs
+          // sharing a hostname now serialize correctly: each recognizes only its
+          // OWN deviceId as self, so the requester waits for a genuine release.
+          if (!q.held || q.self) {
             // Free: nudge a personal-space sync so the holder's final turn is in
             // the space, pull it into the local CC transcript, then claim the
             // lease. Each downstream step is best-effort — a miss self-heals via

--- a/desktop/src/main/device-identity.ts
+++ b/desktop/src/main/device-identity.ts
@@ -1,0 +1,18 @@
+// Per-INSTALL identity for lease coordination. userData-scoped ON PURPOSE:
+// the dev instance and built app share ~/.claude but have separate userData,
+// so they get distinct ids and leases coordinate them cross-process (spec §3.4).
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export function getDeviceIdentity(userDataDir: string): { id: string } {
+  const p = path.join(userDataDir, 'device-id.json');
+  try {
+    // Reuse the existing id so this install keeps ONE stable identity across launches.
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (typeof parsed?.id === 'string' && parsed.id) return { id: parsed.id };
+  } catch { /* absent or corrupt — regenerate below */ }
+  const fresh = { id: randomUUID() };
+  try { fs.writeFileSync(p, JSON.stringify(fresh)); } catch { /* read-only disk: ephemeral id this launch */ }
+  return fresh;
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -39,6 +39,7 @@ import {
   syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject,
   syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots,
 } from './sync-spaces/service';
+import { readDevices, renameDevice } from './sync-spaces/device-registry';
 import { getConfig as getMarketplaceConfig, setConfig as setMarketplaceConfig } from './marketplace-config-store';
 import { readComponent, type ComponentKind } from './marketplace-file-reader';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
@@ -110,6 +111,9 @@ export function registerIpcHandlers(
     // deviceId + hubLeaseRequest + materializeOne + syncSpacesSyncNow are all
     // reachable). The three lease IPC handlers below are thin passthroughs to it.
     requester: import('./conversations/takeover').RequesterTakeoverType;
+    // Plan 2b Task 11: this machine's device id, so the list-devices handler can
+    // mark the current device with self:true.
+    deviceId: string;
   },
 ) {
   // Broadcast a non-session-scoped event to every renderer. Status data, UI
@@ -1861,6 +1865,13 @@ export function registerIpcHandlers(
   // ipc-handler-owned state into remoteServer — no global needed).
   remoteServer?.setNativeRuntime({ nativeHost, providerRegistry, modelCatalog, engineManager });
 
+  // Plan 2b Task 11: give the remote server the SAME lease client/requester +
+  // deviceId so its WS clients reach the identical lease/device state the
+  // Electron IPC handlers use (mirrors setNativeRuntime). Absent when sync is off.
+  if (leaseWiring && remoteServer) {
+    remoteServer.setLeaseWiring({ client: leaseWiring.client, requester: leaseWiring.requester, deviceId: leaseWiring.deviceId });
+  }
+
   // Transcript replay: a window that just acquired a session asks for every
   // historical event so its reducer can hydrate. Events stream back on the
   // normal TRANSCRIPT_EVENT channel (uuid dedup handles overlap with live).
@@ -2288,6 +2299,21 @@ export function registerIpcHandlers(
     leaseWiring?.requester.takeover(String(p?.claudeSessionId ?? '')) ?? { outcome: 'error' });
   ipcMain.handle(IPC.SYNC_SPACES_LEASE_FORCE, (_e, p: { claudeSessionId: string }) =>
     leaseWiring?.requester.force(String(p?.claudeSessionId ?? '')) ?? { ok: false });
+
+  // Device registry (Plan 2b spec §10a): the "Your devices" list (Task 12 UI
+  // consumes these). self:true marks the current machine so the UI can label it.
+  ipcMain.handle(IPC.SYNC_SPACES_LIST_DEVICES, () => {
+    const pr = getManagedRoots()?.personalRoot;
+    if (!pr) return [];
+    const selfId = leaseWiring?.deviceId ?? '';
+    return readDevices(pr).map((d) => ({ ...d, self: d.id === selfId }));
+  });
+  ipcMain.handle(IPC.SYNC_SPACES_RENAME_DEVICE, async (_e, p: { id: string; name: string }) => {
+    const pr = getManagedRoots()?.personalRoot;
+    if (!pr) return { ok: false };
+    try { await renameDevice(pr, String(p?.id ?? ''), String(p?.name ?? '')); return { ok: true }; }
+    catch { return { ok: false }; }
+  });
 
   // V2: Per-instance backend management (storage backends + multi-instance support)
   ipcMain.handle('sync:add-backend', (_e, instance) => addBackend(instance));

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -71,7 +71,10 @@ import { listProjectConversations, projectConversationHistory } from './project-
 // Conversation Store (Phase 2a): live intake of transcript activity, session
 // cwd, title and flag changes. Keyed by CLAUDE session id (resolved from the
 // desktop id via sessionIdMap below), matching the store's record id.
-import { noteTranscriptEvent, noteSessionStarted, noteSessionEnded, noteTitleChanged, noteFlagChanged, noteSessionNote, getConversationStore } from './conversations/service';
+import { noteTranscriptEvent, noteSessionStarted, noteSessionEnded, noteTitleChanged, noteFlagChanged, noteSessionNote, getConversationStore, flushSessionToSpace } from './conversations/service';
+// Plan 2b Task 8: holder-side takeover — when another device requests a session
+// this device holds, cleanly interrupt/flush/release/move/destroy it.
+import { createHolderTakeover } from './conversations/takeover';
 import { getTagRegistry } from './conversations/tag-registry-service';
 import { tagFlagKey, isTagColor, TagColor } from '../shared/tags';
 import { getRepoInfo } from './project-repo';
@@ -96,6 +99,14 @@ export function registerIpcHandlers(
   // Multi-window ownership: when a session is created via IPC, assign it to
   // the calling renderer's window so subsequent per-session events route there.
   windowRegistry?: import('./window-registry').WindowRegistry,
+  // Plan 2b Task 8 (optional): the lease client + a setter main.ts uses to
+  // receive the holder-side takeover handler (which needs the local sessionIdMap,
+  // built inside this function). Absent → lease lifecycle wiring is skipped
+  // entirely (nothing breaks — acquire/release/takeover simply don't run).
+  leaseWiring?: {
+    client: import('./conversations/lease-client').LeaseClient;
+    setHolderTakeover: (fn: (sessionId: string, from?: { deviceId: string; device: string }) => void) => void;
+  },
 ) {
   // Broadcast a non-session-scoped event to every renderer. Status data, UI
   // actions, and similar globals must reach every window — not just window 1.
@@ -1759,6 +1770,26 @@ export function registerIpcHandlers(
   // Maps desktop session ID → Claude Code session ID
   const sessionIdMap = new Map<string, string>();
 
+  // Holder-side takeover (Plan 2b Task 8): when another device requests this
+  // session, cleanly interrupt, flush the final turn to the space, release the
+  // lease, tell the UI it moved, and end the local session. Wired here because
+  // the reverse-map (claude id → desktop id) needs sessionIdMap; sendForSession is
+  // in scope for the dual-path renderer + remote push.
+  if (leaseWiring) {
+    const pushMoved = (desktopId: string, device?: string) => {
+      const payload = { sessionId: desktopId, device };
+      sendForSession(desktopId, IPC.SESSION_MOVED, payload);          // owning renderer window
+      remoteServer?.broadcast({ type: IPC.SESSION_MOVED, payload }); // remote clients
+    };
+    const holderTakeover = createHolderTakeover({
+      sessionManager, sessionIdMap, leaseClient: leaseWiring.client,
+      flushSessionToSpace, pushMoved,
+    });
+    // Fire-and-forget from a hub event — the handler never throws (each step is
+    // try/caught inside createHolderTakeover), so void is safe.
+    leaseWiring.setHolderTakeover((sid, from) => { void holderTakeover(sid, from); });
+  }
+
   // `lastAttentionBySession` is declared alongside the other status-value
   // caches above buildStatusData(); the listener that writes into it is
   // registered here where the handler block begins.
@@ -2033,6 +2064,12 @@ export function registerIpcHandlers(
         // Conversation Store (Phase 2a): tell the store this claude session's cwd
         // so its activity upserts carry projectName/originalPath (local truth).
         noteSessionStarted(claudeId, sessionInfo.cwd);
+        // 2b Task 8: this device now owns the session — take the lease.
+        // Fire-and-forget: a denied (ok:false) result would only mean another
+        // device holds it, but the sanctioned resume path already ran takeover
+        // BEFORE spawn, so we never block session start on the lease. acquire()
+        // never rejects, but the .catch keeps a future change from leaking one.
+        void leaseWiring?.client.acquire(claudeId).catch(() => { /* never-block */ });
       }
     });
   }
@@ -2049,6 +2086,9 @@ export function registerIpcHandlers(
       // apply any peer version now that this session ended — no restart needed.
       // Resolved from the map BEFORE the delete below, so the claude id is known.
       noteSessionEnded(claudeId);
+      // 2b Task 8: drop our lease so another device can acquire. Idempotent +
+      // best-effort; release() never rejects, .catch guards a future change.
+      void leaseWiring?.client.release(claudeId).catch(() => { /* best-effort */ });
     }
     sessionIdMap.delete(sessionId);
     lastAttentionBySession.delete(sessionId);

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -37,7 +37,7 @@ import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dis
 // Cross-device sync spaces (spec 2026-07-03) — the folder-based sync engine.
 import {
   syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject,
-  syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots,
+  syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots, isSyncSpacesEnabled,
 } from './sync-spaces/service';
 import { readDevices, renameDevice } from './sync-spaces/device-registry';
 import { getConfig as getMarketplaceConfig, setConfig as setMarketplaceConfig } from './marketplace-config-store';
@@ -2067,6 +2067,11 @@ export function registerIpcHandlers(
       // coupled to the remap.
       if (current) {
         teardownSessionWatchers(desktopId);
+        // 2b: /clear rotates the CC session id WITHOUT firing session-exit, so the
+        // pre-rotation claudeId's lease + its 30s renew timer would otherwise leak
+        // (renewing a dead id every 30s until app quit). Release it here.
+        // Idempotent + best-effort; release() never rejects, .catch guards a future change.
+        void leaseWiring?.client.release(current).catch(() => { /* best-effort */ });
       }
 
       sessionIdMap.set(desktopId, claudeId);
@@ -2084,7 +2089,15 @@ export function registerIpcHandlers(
         // device holds it, but the sanctioned resume path already ran takeover
         // BEFORE spawn, so we never block session start on the lease. acquire()
         // never rejects, but the .catch keeps a future change from leaking one.
-        void leaseWiring?.client.acquire(claudeId).catch(() => { /* never-block */ });
+        //
+        // Gate on sync being ENABLED: leases coordinate CROSS-DEVICE writers, which
+        // only exist for a synced conversation. Without this, every CC SessionStart
+        // (even for users who never enabled sync) took an optimistic local hold with
+        // a 30s renew timer writing Personal/Leases/*.json — wasteful and creates a
+        // Leases/ dir for no reason. Release on session-exit stays UNCONDITIONAL
+        // (idempotent — harmless if never acquired) so a session that acquired while
+        // sync was on still releases if sync later flips off.
+        if (isSyncSpacesEnabled()) void leaseWiring?.client.acquire(claudeId).catch(() => { /* never-block */ });
       }
     });
   }

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -71,7 +71,7 @@ import { listProjectConversations, projectConversationHistory } from './project-
 // Conversation Store (Phase 2a): live intake of transcript activity, session
 // cwd, title and flag changes. Keyed by CLAUDE session id (resolved from the
 // desktop id via sessionIdMap below), matching the store's record id.
-import { noteTranscriptEvent, noteSessionStarted, noteTitleChanged, noteFlagChanged, noteSessionNote, getConversationStore } from './conversations/service';
+import { noteTranscriptEvent, noteSessionStarted, noteSessionEnded, noteTitleChanged, noteFlagChanged, noteSessionNote, getConversationStore } from './conversations/service';
 import { getTagRegistry } from './conversations/tag-registry-service';
 import { tagFlagKey, isTagColor, TagColor } from '../shared/tags';
 import { getRepoInfo } from './project-repo';
@@ -1248,11 +1248,14 @@ export function registerIpcHandlers(
 
   // --- Session browser (resume) ---
   ipcMain.handle(IPC.SESSION_BROWSE, async () => {
-    // Collect active Claude Code session IDs so we can exclude them
+    // Collect active Claude Code session IDs so we can exclude them.
+    // Bug 1 (2026-07-13 dogfood): a stale sessionIdMap entry (missed exit event,
+    // or a create+resume pair leaving two desktop ids on one claude id) hid a
+    // CLOSED session from the browser until restart. Filter to mappings whose
+    // desktop session actually still exists — the map is a cache, not truth.
     const activeIds = new Set<string>();
-    // sessionIdMap is already defined in this scope — maps desktop ID → Claude ID
-    for (const claudeId of sessionIdMap.values()) {
-      activeIds.add(claudeId);
+    for (const [desktopId, claudeId] of sessionIdMap.entries()) {
+      if (sessionManager.getSession(desktopId)) activeIds.add(claudeId);
     }
     // CC (Claude Code) transcript rows.
     const ccRows = await listPastSessions(activeIds);
@@ -2042,6 +2045,10 @@ export function registerIpcHandlers(
     if (claudeId) {
       fs.unlink(path.join(os.homedir(), '.claude', `.context-${claudeId}`), () => {});
       fs.unlink(path.join(os.homedir(), '.claude', `.session-stats-${claudeId}.json`), () => {});
+      // 2b (Bug 2 Part 2): release the conversation-store materialize guard +
+      // apply any peer version now that this session ended — no restart needed.
+      // Resolved from the map BEFORE the delete below, so the claude id is known.
+      noteSessionEnded(claudeId);
     }
     sessionIdMap.delete(sessionId);
     lastAttentionBySession.delete(sessionId);

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -68,7 +68,7 @@ import { canonicalize } from '../shared/artifacts/canonicalize';
 import { evaluateBinaryRead } from './artifacts/read-binary-access';
 import { trackedArtifacts } from './artifacts/visible-artifacts';
 import { PROJECT_IPC } from './project/ipc-channels';
-import { listProjectConversations, projectConversationHistory } from './project-conversations';
+import { listProjectConversations, projectConversationHistory, ccProjectSlug } from './project-conversations';
 // Conversation Store (Phase 2a): live intake of transcript activity, session
 // cwd, title and flag changes. Keyed by CLAUDE session id (resolved from the
 // desktop id via sessionIdMap below), matching the store's record id.
@@ -1785,7 +1785,17 @@ export function registerIpcHandlers(
   // in scope for the dual-path renderer + remote push.
   if (leaseWiring) {
     const pushMoved = (desktopId: string, device?: string) => {
-      const payload = { sessionId: desktopId, device };
+      // Enrich the push so the renderer's MovedGate can offer "Resume on this
+      // device" without a second lookup. At push time (step 7) the holder session
+      // still exists — destroy is step 8 — so both the claude id and the live
+      // session's cwd are available. projectSlug mirrors how the Resume Browser
+      // derives it (ccProjectSlug of the cwd) so handleResumeSession's history
+      // load + resumeInfo land on the right CC project dir.
+      const claudeSessionId = sessionIdMap.get(desktopId);
+      const info = sessionManager.getSession(desktopId);
+      const projectPath = info?.cwd;
+      const projectSlug = projectPath ? ccProjectSlug(projectPath) : undefined;
+      const payload = { sessionId: desktopId, device, claudeSessionId, projectSlug, projectPath };
       sendForSession(desktopId, IPC.SESSION_MOVED, payload);          // owning renderer window
       remoteServer?.broadcast({ type: IPC.SESSION_MOVED, payload }); // remote clients
     };

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -106,6 +106,10 @@ export function registerIpcHandlers(
   leaseWiring?: {
     client: import('./conversations/lease-client').LeaseClient;
     setHolderTakeover: (fn: (sessionId: string, from?: { deviceId: string; device: string }) => void) => void;
+    // Plan 2b Task 9: the requester-side takeover flow, built in main.ts (where
+    // deviceId + hubLeaseRequest + materializeOne + syncSpacesSyncNow are all
+    // reachable). The three lease IPC handlers below are thin passthroughs to it.
+    requester: import('./conversations/takeover').RequesterTakeoverType;
   },
 ) {
   // Broadcast a non-session-scoped event to every renderer. Status data, UI
@@ -2272,6 +2276,18 @@ export function registerIpcHandlers(
     syncSpacesRenameProject(String(p?.name ?? ''), String(p?.displayName ?? '')));
   ipcMain.handle(IPC.SYNC_SPACES_STOP_PROJECT, (_e, p: { name: string }) =>
     syncSpacesStopProject(String(p?.name ?? '')));
+
+  // Conversation-lease takeover (Plan 2b Task 9). Thin passthroughs to the lease
+  // client (query) and the requester flow (takeover/force) built in main.ts.
+  // When lease wiring is absent (sync disabled), every handler degrades to a
+  // "free / error" answer so the renderer's resume gate proceeds unblocked
+  // (spec §3 never-block).
+  ipcMain.handle(IPC.SYNC_SPACES_LEASE_QUERY, (_e, p: { claudeSessionId: string }) =>
+    leaseWiring?.client.query(String(p?.claudeSessionId ?? '')) ?? { held: false, source: 'none' });
+  ipcMain.handle(IPC.SYNC_SPACES_LEASE_TAKEOVER, (_e, p: { claudeSessionId: string }) =>
+    leaseWiring?.requester.takeover(String(p?.claudeSessionId ?? '')) ?? { outcome: 'error' });
+  ipcMain.handle(IPC.SYNC_SPACES_LEASE_FORCE, (_e, p: { claudeSessionId: string }) =>
+    leaseWiring?.requester.force(String(p?.claudeSessionId ?? '')) ?? { ok: false });
 
   // V2: Per-instance backend management (storage backends + multi-instance support)
   ipcMain.handle('sync:add-backend', (_e, instance) => addBackend(instance));

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -650,7 +650,7 @@ function createWindow(firstRunManager?: FirstRunManager) {
   });
 
   cleanupIpcHandlers = registerIpcHandlers(ipcMain, sessionManager, mainWindow, skillProvider, commandProvider, hookRelay, remoteConfig, remoteServer, windowRegistry,
-    { client: leaseClient, setHolderTakeover: (fn) => { holderTakeoverRef.fn = fn; }, requester });
+    { client: leaseClient, setHolderTakeover: (fn) => { holderTakeoverRef.fn = fn; }, requester, deviceId: deviceIdentity.id });
 
   if (firstRunManager) {
     registerFirstRunIpc(mainWindow, firstRunManager);

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -18,17 +18,21 @@ import { FirstRunManager } from './first-run';
 import { SyncService } from './sync-service';
 import { setSyncService, getSyncConfig } from './sync-state';
 // Cross-device sync spaces (spec 2026-07-03) — folder-based sync engine.
-import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore, hubLeaseRequest, setSyncSpacesLeaseEventListener, getManagedRoots } from './sync-spaces/service';
+import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore, hubLeaseRequest, setSyncSpacesLeaseEventListener, getManagedRoots, syncSpacesSyncNow } from './sync-spaces/service';
 // Plan 2b Task 8: conversation-lease lifecycle. The lease client coordinates
 // which device "holds" a conversation so two devices don't append to the same
 // transcript. Constructed in the main process (needs userData-scoped device id).
 import { getDeviceIdentity } from './device-identity';
 import { createLeaseClient, type LeaseClient } from './conversations/lease-client';
+// Plan 2b Task 9: the requester-side takeover flow (ask-hand-off, poll, pull,
+// acquire). Built here where deviceId + hubLeaseRequest + materializeOne +
+// syncSpacesSyncNow are all reachable, then passed to registerIpcHandlers.
+import { createRequesterTakeover } from './conversations/takeover';
 import { upsertSelf } from './sync-spaces/device-registry';
 // Conversation Store (Phase 2a): records + transcript sync ride the personal
 // space. Imported statically like the sync-spaces stop so the non-async quit
 // handler can call stopConversationStore() directly.
-import { startConversationStore, stopConversationStore } from './conversations/service';
+import { startConversationStore, stopConversationStore, materializeOne } from './conversations/service';
 import { startTagRegistry } from './conversations/tag-registry-service';
 import { initRestoreService } from './restore-service';
 import { createAuthStore } from './marketplace-auth-store';
@@ -631,8 +635,22 @@ function createWindow(firstRunManager?: FirstRunManager) {
     onTakeoverRequest: (sid, from) => holderTakeoverRef.fn(sid, from),
   });
 
+  // Plan 2b Task 9: build the requester-side takeover flow. It reuses the SAME
+  // lease client (takeover/query/acquire), nudges a personal-space sync, pulls the
+  // peer's final turn via materializeOne, and force-acquires through the hub
+  // directly (the reviewed lease client has no force method). selfDevice matches
+  // the lease client's deviceName so a lease held by US counts as free.
+  const requester = createRequesterTakeover({
+    leaseClient,
+    syncNow: () => syncSpacesSyncNow('personal'),
+    materializeOne: (id) => materializeOne(id),
+    forceAcquire: (id) => hubLeaseRequest('force-acquire', id, deviceIdentity!.id),
+    delay: (ms) => new Promise((r) => setTimeout(r, ms)),
+    selfDevice: os.hostname(),
+  });
+
   cleanupIpcHandlers = registerIpcHandlers(ipcMain, sessionManager, mainWindow, skillProvider, commandProvider, hookRelay, remoteConfig, remoteServer, windowRegistry,
-    { client: leaseClient, setHolderTakeover: (fn) => { holderTakeoverRef.fn = fn; } });
+    { client: leaseClient, setHolderTakeover: (fn) => { holderTakeoverRef.fn = fn; }, requester });
 
   if (firstRunManager) {
     registerFirstRunIpc(mainWindow, firstRunManager);

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -638,15 +638,16 @@ function createWindow(firstRunManager?: FirstRunManager) {
   // Plan 2b Task 9: build the requester-side takeover flow. It reuses the SAME
   // lease client (takeover/query/acquire), nudges a personal-space sync, pulls the
   // peer's final turn via materializeOne, and force-acquires through the hub
-  // directly (the reviewed lease client has no force method). selfDevice matches
-  // the lease client's deviceName so a lease held by US counts as free.
+  // directly (the reviewed lease client has no force method). "Held by US" is now
+  // decided inside query() via the per-install deviceId (self flag), so no
+  // selfDevice label is threaded here — a hostname label would collide when two
+  // installs share a hostname (the dev instance + built app dogfood gate).
   const requester = createRequesterTakeover({
     leaseClient,
     syncNow: () => syncSpacesSyncNow('personal'),
     materializeOne: (id) => materializeOne(id),
     forceAcquire: (id) => hubLeaseRequest('force-acquire', id, deviceIdentity!.id),
     delay: (ms) => new Promise((r) => setTimeout(r, ms)),
-    selfDevice: os.hostname(),
   });
 
   cleanupIpcHandlers = registerIpcHandlers(ipcMain, sessionManager, mainWindow, skillProvider, commandProvider, hookRelay, remoteConfig, remoteServer, windowRegistry,

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1537,6 +1537,9 @@ app.on('window-all-closed', () => {
   // Stop the Conversation Store (Phase 2a) — unsubscribes the sync-spaces
   // listener, clears the periodic reconciler + pending debounce timers. Sync fn.
   try { stopConversationStore(); } catch {}
+  // Plan 2b Task 8: tear down the lease client so its per-session renew timers
+  // don't linger past a hard quit (destroy clears all held timers). Sync fn.
+  try { leaseClient?.destroy(); } catch {}
   // Stop sync service — clears timer, releases locks, removes .app-sync-active marker
   try { setSyncService(null); } catch {}
   app.quit();

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -18,7 +18,13 @@ import { FirstRunManager } from './first-run';
 import { SyncService } from './sync-service';
 import { setSyncService, getSyncConfig } from './sync-state';
 // Cross-device sync spaces (spec 2026-07-03) — folder-based sync engine.
-import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore } from './sync-spaces/service';
+import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore, hubLeaseRequest, setSyncSpacesLeaseEventListener, getManagedRoots } from './sync-spaces/service';
+// Plan 2b Task 8: conversation-lease lifecycle. The lease client coordinates
+// which device "holds" a conversation so two devices don't append to the same
+// transcript. Constructed in the main process (needs userData-scoped device id).
+import { getDeviceIdentity } from './device-identity';
+import { createLeaseClient, type LeaseClient } from './conversations/lease-client';
+import { upsertSelf } from './sync-spaces/device-registry';
 // Conversation Store (Phase 2a): records + transcript sync ride the personal
 // space. Imported statically like the sync-spaces stop so the non-async quit
 // handler can call stopConversationStore() directly.
@@ -82,6 +88,14 @@ let mainWindow: BrowserWindow | null = null;
 // when the last main window closes (spec §7.6).
 let buddyManagerRef: BuddyWindowManager | null = null;
 let cleanupIpcHandlers: (() => void) | null = null;
+// Plan 2b Task 8: the conversation-lease client + this install's device identity.
+// Constructed inside createWindow (before registerIpcHandlers) but referenced
+// again in the app-ready sync block, so they live at module scope. The holder
+// takeover handler is routed through a mutable ref that ipc-handlers fills in
+// (it needs sessionIdMap, which is local to registerIpcHandlers).
+let leaseClient: LeaseClient | null = null;
+let deviceIdentity: { id: string } | null = null;
+const holderTakeoverRef: { fn: (sessionId: string, from?: { deviceId: string; device: string }) => void } = { fn: () => {} };
 const sessionManager = new SessionManager();
 
 // Multi-window ownership: maps sessionId -> windowId and tracks leader for
@@ -603,7 +617,22 @@ function createAppWindow(opts?: { x?: number; y?: number; width?: number; height
 function createWindow(firstRunManager?: FirstRunManager) {
   mainWindow = createAppWindow({ maximize: true });
 
-  cleanupIpcHandlers = registerIpcHandlers(ipcMain, sessionManager, mainWindow, skillProvider, commandProvider, hookRelay, remoteConfig, remoteServer, windowRegistry);
+  // Plan 2b Task 8: construct the conversation-lease client. Lazy accessors —
+  // the hub socket + managed roots don't exist yet at this point (they're wired
+  // in the app-ready sync block below), so hubRequest/personalRoot read them
+  // lazily. onTakeoverRequest routes through holderTakeoverRef, which
+  // registerIpcHandlers fills in (it owns sessionIdMap).
+  deviceIdentity = getDeviceIdentity(app.getPath('userData'));
+  leaseClient = createLeaseClient({
+    deviceId: deviceIdentity.id,
+    deviceName: os.hostname(),
+    personalRoot: () => getManagedRoots()?.personalRoot ?? null,
+    hubRequest: hubLeaseRequest,
+    onTakeoverRequest: (sid, from) => holderTakeoverRef.fn(sid, from),
+  });
+
+  cleanupIpcHandlers = registerIpcHandlers(ipcMain, sessionManager, mainWindow, skillProvider, commandProvider, hookRelay, remoteConfig, remoteServer, windowRegistry,
+    { client: leaseClient, setHolderTakeover: (fn) => { holderTakeoverRef.fn = fn; } });
 
   if (firstRunManager) {
     registerFirstRunIpc(mainWindow, firstRunManager);
@@ -1445,6 +1474,11 @@ app.whenReady().then(async () => {
   // lazily per-connect so sign-in/out mid-session is picked up without a restart.
   // Must be set before startSyncSpaces so a sync enabled at boot can connect.
   setSyncSpacesAuthStore(marketplaceAuthStore);
+  // Plan 2b Task 8: route hub takeover-requests to the lease client, which
+  // filters to sessions THIS device actually holds before driving the handoff.
+  setSyncSpacesLeaseEventListener((ev) => {
+    if (ev.kind === 'takeover-request') leaseClient?.handleTakeoverRequest(ev.sessionId, ev.from);
+  });
   startSyncSpaces(
     async () => {
       // Daily dated backup targets come from the SAME backend config the legacy
@@ -1462,6 +1496,14 @@ app.whenReady().then(async () => {
     },
     (m) => log('INFO', 'SyncSpaces', m),
   ).catch(e => log('ERROR', 'Main', 'SyncSpaces start failed', { error: String(e) }));
+
+  // Device registry (spec §10a, Plan 2b): stamp this device's own record
+  // (friendly name + lastSeen) on launch so Task 12's "Your devices" list is
+  // never empty. No-op when sync is off (no personal root yet).
+  try {
+    const pr = getManagedRoots()?.personalRoot;
+    if (pr && deviceIdentity) void upsertSelf(pr, { id: deviceIdentity.id, platform: process.platform }).catch(() => { /* best-effort */ });
+  } catch { /* sync not configured */ }
 
   // Conversation Store (Phase 2a): records + transcript sync ride the personal
   // space. Started after startSyncSpaces because getManagedRoots() must be

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -187,6 +187,9 @@ const IPC = {
   SYNC_SPACES_LEASE_QUERY: 'syncspaces:lease-query',
   SYNC_SPACES_LEASE_TAKEOVER: 'syncspaces:lease-takeover',
   SYNC_SPACES_LEASE_FORCE: 'syncspaces:lease-force',
+  // Device registry (Plan 2b spec §10a) — inlined literals (preload can't import).
+  SYNC_SPACES_LIST_DEVICES: 'syncspaces:list-devices',
+  SYNC_SPACES_RENAME_DEVICE: 'syncspaces:rename-device',
   SYNC_SPACES_EVENT: 'syncspaces:event',
   // Restore from backup (directional pull — see restore-service.ts)
   SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
@@ -827,6 +830,11 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.invoke(IPC.SYNC_SPACES_LEASE_TAKEOVER, { claudeSessionId }),
     leaseForce: (claudeSessionId: string) =>
       ipcRenderer.invoke(IPC.SYNC_SPACES_LEASE_FORCE, { claudeSessionId }),
+    // Device registry (Plan 2b spec §10a): the "Your devices" list marks the
+    // current machine with self:true; renameDevice sets a friendly label.
+    listDevices: () => ipcRenderer.invoke(IPC.SYNC_SPACES_LIST_DEVICES),
+    renameDevice: (id: string, name: string) =>
+      ipcRenderer.invoke(IPC.SYNC_SPACES_RENAME_DEVICE, { id, name }),
     // Returns an unsubscribe function — callers MUST invoke it on unmount to
     // avoid leaking listeners across mounts (matches restore.onProgress above).
     onEvent: (cb: (e: unknown) => void) => {

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -26,6 +26,8 @@ const IPC = {
   PTY_RAW_BYTES: 'pty:raw-bytes',
   HOOK_EVENT: 'hook:event',
   SESSION_RENAMED: 'session:renamed',
+  // Plan 2b Task 10 — pushed when another device takes over a session's lease.
+  SESSION_MOVED: 'session:moved',
   DIALOG_OPEN_FILE: 'dialog:open-file',
   DIALOG_OPEN_FOLDER: 'dialog:open-folder',
   DIALOG_OPEN_SOUND: 'dialog:open-sound',
@@ -400,6 +402,16 @@ contextBridge.exposeInMainWorld('claude', {
     sessionRenamed: (cb: (sessionId: string, name: string) => void) => {
       const handler = (_e: IpcRendererEvent, sid: string, name: string) => cb(sid, name);
       ipcRenderer.on(IPC.SESSION_RENAMED, handler);
+      return handler;
+    },
+    // Plan 2b Task 10 — another device took over this session's lease. Payload
+    // is { sessionId, device? }; App.tsx dispatches SESSION_MOVED to drop the
+    // "this conversation moved to <device>" marker. Returns the raw handler so
+    // callers unsubscribe via off('session:moved', handler) — mirrors
+    // sessionRenamed and stays parity with remote-shim.
+    sessionMoved: (cb: (payload: { sessionId: string; device?: string }) => void) => {
+      const handler = (_e: IpcRendererEvent, payload: any) => cb(payload);
+      ipcRenderer.on(IPC.SESSION_MOVED, handler);
       return handler;
     },
     // Pushed when a session's metadata changes (flags, applied tags, or note).

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -181,6 +181,10 @@ const IPC = {
   SYNC_SPACES_IMPORT_PROJECT: 'syncspaces:import-project',
   SYNC_SPACES_RENAME_PROJECT: 'syncspaces:rename-project',
   SYNC_SPACES_STOP_PROJECT: 'syncspaces:stop-project',
+  // Conversation-lease takeover (Plan 2b Task 9) — inlined literals (preload can't import).
+  SYNC_SPACES_LEASE_QUERY: 'syncspaces:lease-query',
+  SYNC_SPACES_LEASE_TAKEOVER: 'syncspaces:lease-takeover',
+  SYNC_SPACES_LEASE_FORCE: 'syncspaces:lease-force',
   SYNC_SPACES_EVENT: 'syncspaces:event',
   // Restore from backup (directional pull — see restore-service.ts)
   SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
@@ -802,6 +806,15 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.invoke(IPC.SYNC_SPACES_RENAME_PROJECT, { name, displayName }),
     stopProject: (name: string) =>
       ipcRenderer.invoke(IPC.SYNC_SPACES_STOP_PROJECT, { name }),
+    // Conversation-lease takeover (Plan 2b Task 9). The Resume Browser calls
+    // leaseQuery before resuming a store-backed row; if held elsewhere it offers
+    // leaseTakeover (ask-hand-off), falling back to leaseForce on timeout.
+    leaseQuery: (claudeSessionId: string) =>
+      ipcRenderer.invoke(IPC.SYNC_SPACES_LEASE_QUERY, { claudeSessionId }),
+    leaseTakeover: (claudeSessionId: string) =>
+      ipcRenderer.invoke(IPC.SYNC_SPACES_LEASE_TAKEOVER, { claudeSessionId }),
+    leaseForce: (claudeSessionId: string) =>
+      ipcRenderer.invoke(IPC.SYNC_SPACES_LEASE_FORCE, { claudeSessionId }),
     // Returns an unsubscribe function — callers MUST invoke it on unmount to
     // avoid leaking listeners across mounts (matches restore.onProgress above).
     onEvent: (cb: (e: unknown) => void) => {

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -407,12 +407,13 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.on(IPC.SESSION_RENAMED, handler);
       return handler;
     },
-    // Plan 2b Task 10 — another device took over this session's lease. Payload
-    // is { sessionId, device? }; App.tsx dispatches SESSION_MOVED to drop the
-    // "this conversation moved to <device>" marker. Returns the raw handler so
+    // Plan 2b — another device took over this session's lease. Payload carries
+    // the desktop sessionId + the new holder's device label, PLUS the resume
+    // params (claudeSessionId / projectSlug / projectPath) so App.tsx's MovedGate
+    // can offer "Resume on this device" directly. Returns the raw handler so
     // callers unsubscribe via off('session:moved', handler) — mirrors
     // sessionRenamed and stays parity with remote-shim.
-    sessionMoved: (cb: (payload: { sessionId: string; device?: string }) => void) => {
+    sessionMoved: (cb: (payload: { sessionId: string; device?: string; claudeSessionId?: string; projectSlug?: string; projectPath?: string }) => void) => {
       const handler = (_e: IpcRendererEvent, payload: any) => cb(payload);
       ipcRenderer.on(IPC.SESSION_MOVED, handler);
       return handler;

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -21,7 +21,8 @@ import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dis
 import { getRestoreService } from './restore-service';
 // Cross-device sync spaces (spec 2026-07-03) — same service functions the
 // Electron IPC handlers call, so remote browsers get identical behavior.
-import { syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject, syncSpacesRenameProject, syncSpacesStopProject } from './sync-spaces/service';
+import { syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject, syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots } from './sync-spaces/service';
+import { readDevices, renameDevice } from './sync-spaces/device-registry';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
 
 const PTY_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB per session — enough for full conversation replay
@@ -66,6 +67,16 @@ export class RemoteServer {
   // time because they live in the ipc-handlers scope). Null until wired; the
   // native:* / provider:* WS cases no-op until then.
   private nativeRuntime: { nativeHost: NativeSessionHost; providerRegistry: ProviderRegistry; modelCatalog: ModelCatalog; engineManager: EngineManager } | null = null;
+  // Plan 2b Task 11: conversation-lease + device wiring, injected by ipc-handlers
+  // via setLeaseWiring() AFTER main.ts builds the lease client/requester (they
+  // live in the whenReady scope, not reachable at RemoteServer construction).
+  // Null until wired; the syncspaces:lease-*/device WS cases degrade the same
+  // way the desktop handlers do (free/error) so a remote resume never hard-blocks.
+  private leaseWiring: {
+    client: import('./conversations/lease-client').LeaseClient;
+    requester: import('./conversations/takeover').RequesterTakeoverType;
+    deviceId: string;
+  } | null = null;
 
   constructor(
     private sessionManager: SessionManager,
@@ -86,6 +97,17 @@ export class RemoteServer {
    *  Electron IPC handlers use (mirrors setLastTopic / broadcastStatusData). */
   setNativeRuntime(rt: { nativeHost: NativeSessionHost; providerRegistry: ProviderRegistry; modelCatalog: ModelCatalog; engineManager: EngineManager }): void {
     this.nativeRuntime = rt;
+  }
+
+  /** Injected by ipc-handlers after main.ts builds the lease client/requester,
+   *  so remote WS clients reach the SAME lease state the Electron IPC handlers
+   *  use (mirrors setNativeRuntime). deviceId marks self in list-devices. */
+  setLeaseWiring(w: {
+    client: import('./conversations/lease-client').LeaseClient;
+    requester: import('./conversations/takeover').RequesterTakeoverType;
+    deviceId: string;
+  }): void {
+    this.leaseWiring = w;
   }
 
   private loadTokens(): void {
@@ -1332,6 +1354,44 @@ export class RemoteServer {
       }
       case 'syncspaces:stop-project': {
         this.respond(client.ws, type, id, await syncSpacesStopProject(String(payload?.name ?? '')));
+        break;
+      }
+      // Conversation-lease takeover (Plan 2b Task 9/11). Thin passthroughs to the
+      // lease client (query) and requester flow (takeover/force), matching the
+      // desktop ipc handlers. When wiring is absent (sync disabled) they degrade
+      // to a free/error answer so the remote resume gate proceeds (spec §3 never-block).
+      case 'syncspaces:lease-query': {
+        // query() is async — await before respond (unlike ipcMain.handle, respond
+        // doesn't unwrap promises).
+        this.respond(client.ws, type, id,
+          (await this.leaseWiring?.client.query(String(payload?.claudeSessionId ?? ''))) ?? { held: false, source: 'none' });
+        break;
+      }
+      case 'syncspaces:lease-takeover': {
+        this.respond(client.ws, type, id,
+          (await this.leaseWiring?.requester.takeover(String(payload?.claudeSessionId ?? ''))) ?? { outcome: 'error' });
+        break;
+      }
+      case 'syncspaces:lease-force': {
+        this.respond(client.ws, type, id,
+          (await this.leaseWiring?.requester.force(String(payload?.claudeSessionId ?? ''))) ?? { ok: false });
+        break;
+      }
+      // Device registry (Plan 2b spec §10a). readDevices/renameDevice are direct
+      // service-level calls (like the syncspaces:* rows above); self:true marks
+      // the current machine via the injected deviceId.
+      case 'syncspaces:list-devices': {
+        const pr = getManagedRoots()?.personalRoot;
+        const selfId = this.leaseWiring?.deviceId ?? '';
+        this.respond(client.ws, type, id,
+          pr ? readDevices(pr).map((d) => ({ ...d, self: d.id === selfId })) : []);
+        break;
+      }
+      case 'syncspaces:rename-device': {
+        const pr = getManagedRoots()?.personalRoot;
+        if (!pr) { this.respond(client.ws, type, id, { ok: false }); break; }
+        try { await renameDevice(pr, String(payload?.id ?? ''), String(payload?.name ?? '')); this.respond(client.ws, type, id, { ok: true }); }
+        catch { this.respond(client.ws, type, id, { ok: false }); }
         break;
       }
 

--- a/desktop/src/main/sync-hub-socket.ts
+++ b/desktop/src/main/sync-hub-socket.ts
@@ -33,13 +33,24 @@ export type WebSocketCtor = new (
   opts: { headers: Record<string, string> },
 ) => SyncHubWebSocketLike;
 
+// Who currently holds a session lease (returned on lease-result, and carried in
+// takeover-request events as `from`). expiresAt is an epoch-ms deadline.
+export interface LeaseHolder { deviceId: string; device: string; expiresAt: number }
+
+// The reply to a request() call — mapped from a server `lease-result` frame.
+// `holder` is the current lease owner (or null when the op cleared/failed).
+export interface LeaseResult { ok: boolean; op: string; sessionId: string; holder: LeaseHolder | null }
+
 // The single event shape the consumer (Task 5 service wiring) sees. Replay and
 // live signals collapse to the same 'signal' event — device/at are dropped
-// because the engine only needs "some space changed, go sync it".
+// because the engine only needs "some space changed, go sync it". `lease-event`
+// carries UNSOLICITED server pushes (another device released/took a lease, or is
+// asking us to hand one over) — these are not tied to a request() reqId.
 export type SyncHubEvent =
   | { type: 'connected' }
   | { type: 'disconnected' }
-  | { type: 'signal'; kind: string; spaceKey: string };
+  | { type: 'signal'; kind: string; spaceKey: string }
+  | { type: 'lease-event'; kind: 'released' | 'taken' | 'takeover-request'; sessionId: string; device?: string; from?: { deviceId: string; device: string } };
 
 export interface SyncHubSocketOpts {
   getToken: () => string | null;
@@ -51,6 +62,10 @@ export interface SyncHubSocketOpts {
 export interface SyncHubSocket {
   setDesired(want: boolean): void;
   sendSignal(kind: string, spaceKey: string): boolean;
+  // Request/response lease op (acquire/release/takeover). Resolves the matching
+  // server `lease-result` by reqId; resolves null on timeout, when not connected,
+  // or when the socket goes down mid-flight — NEVER blocks the caller.
+  request(op: string, sessionId: string, deviceId: string): Promise<LeaseResult | null>;
   isConnected(): boolean;
   destroy(): void;
 }
@@ -66,6 +81,21 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
   let attempts = 0;
   let pingTimer: NodeJS.Timeout | null = null;
   let retryTimer: NodeJS.Timeout | null = null;
+
+  // In-flight lease requests, keyed by the client-generated reqId. A matching
+  // server `lease-result` (or the 5s timeout) removes the entry and resolves it.
+  let reqCounter = 0;
+  const pending = new Map<string, { resolve: (r: LeaseResult | null) => void; timer: NodeJS.Timeout }>();
+
+  // Resolve EVERY in-flight request to null and clear the map. Called from all
+  // teardown paths (handleDown / setDesired(false) / destroy) so a request that
+  // was awaiting a reply when the socket died never hangs forever across a
+  // reconnect — the never-block guarantee. The caller sees null (treat as "no
+  // answer"), same as a timeout.
+  function failAllPending() {
+    for (const [, p] of pending) { clearTimeout(p.timer); p.resolve(null); }
+    pending.clear();
+  }
 
   function clearTimers() {
     if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
@@ -116,6 +146,16 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
         } else if (msg && msg.type === 'signal' && msg.kind && msg.spaceKey) {
           // Same guard on live frames — never hand the consumer undefined fields.
           opts.onEvent({ type: 'signal', kind: msg.kind, spaceKey: msg.spaceKey });
+        } else if (msg && msg.type === 'lease-result' && typeof msg.reqId === 'string' && pending.has(msg.reqId)) {
+          // Correlate the reply to its request() promise by reqId. An unknown
+          // reqId (stale/duplicate) matches nothing and is dropped harmlessly.
+          const p = pending.get(msg.reqId)!; pending.delete(msg.reqId); clearTimeout(p.timer);
+          p.resolve({ ok: !!msg.ok, op: msg.op, sessionId: msg.sessionId, holder: msg.holder ?? null });
+        } else if (msg && msg.type === 'lease-event' && msg.kind && msg.sessionId) {
+          // Unsolicited server push (not tied to a reqId) — forward to the
+          // consumer. Per-field guard mirrors the signal branch: no kind/sessionId
+          // means we never hand the consumer undefined fields.
+          opts.onEvent({ type: 'lease-event', kind: msg.kind, sessionId: msg.sessionId, device: msg.device, from: msg.from });
         }
         // pong (or any other frame): ignore — pings are fire-and-forget liveness.
       } catch { /* non-JSON frame: ignore */ }
@@ -133,6 +173,7 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
 
   function handleDown() {
     clearTimers();
+    failAllPending(); // socket died — a request awaiting a reply must resolve null, not hang across the reconnect
     ws = null;
     opts.onEvent({ type: 'disconnected' });
     if (desired) {
@@ -158,6 +199,7 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
       desired = want;
       if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
       if (want) { connect(); return; }
+      failAllPending(); // intentional teardown — resolve any in-flight request to null so the caller never blocks on a socket we're closing
       const s = ws;
       ws = null;
       clearTimers();
@@ -180,8 +222,24 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
       }
       return false;
     },
+    // Request/response lease op. Sends a {type:'lease', op, sessionId, deviceId,
+    // reqId} frame and resolves the matching server `lease-result` by reqId.
+    // NEVER blocks the caller: resolves null immediately when not connected, on a
+    // 5s timeout, if the send throws, or if the socket goes down mid-flight
+    // (failAllPending). The consumer treats null as "no answer / fall back".
+    request(op, sessionId, deviceId) {
+      if (ws === null || ws.readyState !== WebSocket.OPEN) return Promise.resolve(null); // never-block
+      const reqId = `r${++reqCounter}`;
+      return new Promise<LeaseResult | null>((resolve) => {
+        const timer = setTimeout(() => { pending.delete(reqId); resolve(null); }, 5_000);
+        timer.unref?.(); // don't keep the Electron main process alive just for a lease timeout
+        pending.set(reqId, { resolve, timer });
+        try { ws!.send(JSON.stringify({ type: 'lease', op, sessionId, deviceId, reqId })); }
+        catch { pending.delete(reqId); clearTimeout(timer); resolve(null); }
+      });
+    },
     // True only when a socket exists AND finished its handshake.
     isConnected() { return ws !== null && ws.readyState === WebSocket.OPEN; },
-    destroy() { desired = false; clearTimers(); try { ws?.close(); } catch { /* noop */ } ws = null; },
+    destroy() { desired = false; clearTimers(); failAllPending(); try { ws?.close(); } catch { /* noop */ } ws = null; },
   };
 }

--- a/desktop/src/main/sync-spaces/device-registry.ts
+++ b/desktop/src/main/sync-spaces/device-registry.ts
@@ -182,6 +182,9 @@ export function upsertSelf(
  *  somehow absent. Skips the write when the name already matches (no churn). */
 export function renameDevice(personalRoot: string, id: string, name: string): Promise<void> {
   return mutateCanonical(personalRoot, id, (cur) => {
+    // Refuse an empty name: empty names are rejected on read (parseEntry requires
+    // a non-empty name), so writing one would silently disappear on the next read.
+    if (!name.trim()) return null;
     if (cur && cur.name === name) return null; // no change — skip
     const now = Date.now();
     return {

--- a/desktop/src/main/sync-spaces/device-registry.ts
+++ b/desktop/src/main/sync-spaces/device-registry.ts
@@ -1,0 +1,196 @@
+// desktop/src/main/sync-spaces/device-registry.ts
+// Per-device registry that stores a friendly, editable name for each device
+// (Plan 2b Task 4, spec §10a). One JSON file per device, synced INSIDE the
+// always-present Personal space so every device sees the same "Your devices"
+// list (surfaced in Task 12).
+//
+// Layout mirrors the Conversation Store + Project Registry
+// (Personal/<Kind>/<id>.json): a VISIBLE per-file folder under Personal. That
+// convention sidesteps the reserved `.youcoded/` basename (the transport's
+// hidden git dir AND a DEFAULT_IGNORES entry — anything under it never syncs).
+//
+// The filename is `<deviceId>.json` where `deviceId` is a UUID (Task 3's device
+// identity). Because a UUID can NEVER contain the " (from " substring, this is
+// exactly the Conversation Store's situation — we can use isConflictCopyName /
+// extractConflictBase DIRECTLY and do NOT need Project Registry's
+// canonicalBaseFor precedence hack (that existed only because project filenames
+// are user-chosen folder names that may contain parentheses).
+//
+// Records are MUTABLE (a device can be renamed on any device), so this is a
+// convergent record set: per-file, fail-soft parse, locked read-modify-write,
+// and fold-on-read that resolves the transport's conflict copies. Since each
+// device normally writes only its OWN file, conflicts arise only from
+// cross-device renames of the same device — healed by fold-on-read.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { mutateFileUnderLock } from '../artifacts/cas-write';
+import { laterOf, isConflictCopyName, extractConflictBase } from '../conversations/store-core';
+
+export const DEVICE_REGISTRY_SCHEMA = 1;
+
+export interface DeviceRecord {
+  schemaVersion: number;
+  id: string;        // stable device id (UUID) — the immutable filename identity
+  name: string;      // synced, user-editable friendly label; defaults to os.hostname()
+  platform: string;  // process.platform of the device (win32 / darwin / linux / ...)
+  lastSeen: number;  // ms epoch — last heartbeat; merges as MAX
+  updatedAt: number; // ms epoch — last NAME edit; drives last-writer-wins for name
+}
+
+function registryDir(personalRoot: string): string {
+  return path.join(personalRoot, 'Devices');
+}
+
+// FAIL-SOFT parse: corrupt / partial / unknown-schema files return null so a bad
+// file damages exactly one device row, never the whole list (dev instance + built
+// app share the tree). `id` and `name` are the core identity — a record missing
+// either is treated as invalid.
+function parseEntry(json: string): DeviceRecord | null {
+  let raw: any;
+  try { raw = JSON.parse(json); } catch { return null; }
+  if (!raw || typeof raw !== 'object') return null;
+  if (raw.schemaVersion !== DEVICE_REGISTRY_SCHEMA) return null;
+  if (typeof raw.id !== 'string' || !raw.id) return null;
+  if (typeof raw.name !== 'string' || !raw.name) return null;
+  return {
+    schemaVersion: DEVICE_REGISTRY_SCHEMA,
+    id: raw.id,
+    name: raw.name,
+    platform: typeof raw.platform === 'string' ? raw.platform : '',
+    lastSeen: typeof raw.lastSeen === 'number' && Number.isFinite(raw.lastSeen) ? raw.lastSeen : 0,
+    updatedAt: typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt) ? raw.updatedAt : 0,
+  };
+}
+
+// PURE. Field-wise merge. Commutative + associative (a lattice join), so a plain
+// reduce over any copy order converges:
+//   - name  : last-writer-wins by updatedAt (content-tiebroken via laterOf so two
+//             devices resolve an exact-updatedAt tie identically → merge(a,b)===merge(b,a)).
+//   - platform : rides with the name-winner (deterministic; for one device they match anyway).
+//   - lastSeen : MAX (the most recent heartbeat from any copy).
+//   - updatedAt: MAX (equals the name-winner's updatedAt).
+export function mergeDeviceEntries(a: DeviceRecord, b: DeviceRecord): DeviceRecord {
+  const winner = laterOf(a, b, a.updatedAt, b.updatedAt); // name + platform LWW winner
+  return {
+    schemaVersion: DEVICE_REGISTRY_SCHEMA,
+    id: winner.id,
+    name: winner.name,
+    platform: winner.platform,
+    lastSeen: Math.max(a.lastSeen, b.lastSeen),
+    updatedAt: Math.max(a.updatedAt, b.updatedAt),
+  };
+}
+
+export function foldDeviceEntries(entries: DeviceRecord[]): DeviceRecord {
+  return entries.reduce((acc, e) => mergeDeviceEntries(acc, e));
+}
+
+/** Read + fold every device record. FAIL-SOFT: corrupt / partial / unknown-schema
+ *  files are skipped, never thrown. Conflict copies are folded into their
+ *  canonical `<id>.json` in memory (fold-on-read is load-bearing — a cross-device
+ *  rename left as a transport copy must not lose to the stale canonical). Copy
+ *  files are left on disk (rare, inert). */
+export function readDevices(personalRoot: string): DeviceRecord[] {
+  const dir = registryDir(personalRoot);
+  let names: string[];
+  try { names = fs.readdirSync(dir); } catch { return []; }
+  const groups = new Map<string, DeviceRecord[]>();
+  for (const n of names) {
+    if (!n.endsWith('.json')) continue;
+    const full = path.join(dir, n);
+    let e: DeviceRecord | null = null;
+    try { if (fs.lstatSync(full).isFile()) e = parseEntry(fs.readFileSync(full, 'utf8')); }
+    catch { /* corrupt / vanished — skip */ }
+    if (!e) continue;
+    // Group by the canonical `<id>.json`. A UUID id can't contain " (from ", so
+    // this grouping is unambiguous (unlike Project Registry's paren-able names).
+    const base = isConflictCopyName(n) ? extractConflictBase(n) : n;
+    // Guard: the filename must map to the record's own id. Rejects a hand-mangled
+    // file whose name doesn't match its content — keeps a stray file from folding
+    // into the wrong device.
+    if (!base || base !== `${e.id}.json`) continue;
+    const arr = groups.get(base) ?? [];
+    arr.push(e);
+    groups.set(base, arr);
+  }
+  const out: DeviceRecord[] = [];
+  for (const arr of groups.values()) out.push(foldDeviceEntries(arr));
+  return out;
+}
+
+// Locked read-modify-write on the CANONICAL `<id>.json`. The lock
+// (mutateFileUnderLock) guards the SAME-DEVICE race (dev instance + built app
+// writing this file concurrently) where there is no git conflict copy to fold.
+// The callback may return null to SKIP the write (no-op — avoids watcher churn +
+// a redundant push).
+async function mutateCanonical(
+  personalRoot: string, id: string,
+  fn: (cur: DeviceRecord | null) => DeviceRecord | null,
+): Promise<void> {
+  if (!id || typeof id !== 'string') throw new Error(`device-registry: invalid id '${id}'`);
+  const dir = registryDir(personalRoot);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${id}.json`);
+  const committed = await mutateFileUnderLock(file, (onDisk) => {
+    const cur = onDisk ? parseEntry(onDisk) : null;
+    const next = fn(cur);
+    return next === null ? null : JSON.stringify(next, null, 2) + '\n'; // null → skip write
+  });
+  if (!committed) throw new Error(`device-registry: could not write ${id} (lock timeout)`);
+}
+
+/** Heartbeat + create-if-absent for THIS device's own file. Absent → create with
+ *  `name = name ?? os.hostname()` (a friendly default). Present → ALWAYS bump
+ *  lastSeen, but only change `name` + bump `updatedAt` when a `name` arg is given
+ *  AND actually differs — so a bare heartbeat never clobbers a newer synced name
+ *  from another device nor churns updatedAt. `platform` is kept fresh from the arg. */
+export function upsertSelf(
+  personalRoot: string, input: { id: string; name?: string; platform: string },
+): Promise<void> {
+  return mutateCanonical(personalRoot, input.id, (cur) => {
+    const now = Date.now();
+    if (!cur) {
+      return {
+        schemaVersion: DEVICE_REGISTRY_SCHEMA,
+        id: input.id,
+        name: input.name ?? os.hostname(), // default friendly name
+        platform: input.platform,
+        lastSeen: now,
+        updatedAt: now,
+      };
+    }
+    // Only a provided-and-different name is a real rename.
+    const nameChanged = input.name !== undefined && input.name !== cur.name;
+    const next: DeviceRecord = {
+      schemaVersion: DEVICE_REGISTRY_SCHEMA,
+      id: cur.id,
+      name: nameChanged ? input.name! : cur.name,
+      platform: input.platform, // keep fresh
+      lastSeen: now,            // liveness always advances
+      updatedAt: nameChanged ? now : cur.updatedAt,
+    };
+    // Skip only if truly nothing changed (same-ms heartbeat with identical fields).
+    if (next.name === cur.name && next.platform === cur.platform
+      && next.lastSeen === cur.lastSeen && next.updatedAt === cur.updatedAt) return null;
+    return next;
+  });
+}
+
+/** Rename: set `name` + bump `updatedAt` (the LWW stamp), PRESERVE lastSeen /
+ *  platform. Seeds a record (platform from process.platform, lastSeen = now) if
+ *  somehow absent. Skips the write when the name already matches (no churn). */
+export function renameDevice(personalRoot: string, id: string, name: string): Promise<void> {
+  return mutateCanonical(personalRoot, id, (cur) => {
+    if (cur && cur.name === name) return null; // no change — skip
+    const now = Date.now();
+    return {
+      schemaVersion: DEVICE_REGISTRY_SCHEMA,
+      id,
+      name,
+      platform: cur?.platform ?? process.platform,
+      lastSeen: cur?.lastSeen ?? now,
+      updatedAt: now,
+    };
+  });
+}

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -319,6 +319,16 @@ export async function stopSyncSpaces(): Promise<void> {
   engine = null;
 }
 
+// Cheap SYNCHRONOUS "is sync on?" check. Reads the same enable flag
+// syncSpacesStatus() exposes, without the async project-registry read that
+// function does. Used by the CC SessionStart lease-acquire gate so we don't take
+// a lease (+ 30s renew timer + Personal/Leases writes) for users who never
+// enabled sync — leases only coordinate CROSS-DEVICE writers, which only exist
+// once a conversation is actually synced.
+export function isSyncSpacesEnabled(): boolean {
+  return manager?.isEnabled() ?? false;
+}
+
 // ---- IPC-facing functions (also used by remote-server cases) ----
 export async function syncSpacesStatus() {
   const registry = roots ? readProjectRegistry(roots.personalRoot) : [];

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -11,6 +11,7 @@ import { SpaceSyncEngine } from './engine';
 import { DailyBackup, BackupTarget } from './daily-backup';
 import { importProjectFolder } from './import-project';
 import { createSyncHubSocket } from '../sync-hub-socket';
+import type { LeaseResult, SyncHubEvent } from '../sync-hub-socket';
 import { readProjectRegistry, ensureProjectEntry, setProjectDisplayName, setProjectStopped } from './project-registry';
 import { planReconcile, activeManagedSpaces } from './materialization-planner';
 import type { SpaceSyncEvent } from './types';
@@ -36,6 +37,24 @@ let authStore: { getToken(): string | null } | null = null;
 export function setSyncSpacesAuthStore(store: { getToken(): string | null } | null): void {
   authStore = store;
 }
+
+// Lease client bridge (Plan 2b Task 8). The lease client lives in main.ts (it
+// needs sessionIdMap via ipc-handlers), but the hub SOCKET lives here — so this
+// module exposes a thin passthrough for the client's request() transport, and a
+// listener facade to forward the hub's UNSOLICITED lease-events back to the
+// client. Both are narrow facades so service.ts never imports the lease client.
+
+// Route a lease op to the hub socket. Returns null when the hub is down (the
+// lease client treats null as "no answer" and falls back to its file / never-block).
+export function hubLeaseRequest(op: string, sessionId: string, deviceId: string): Promise<LeaseResult | null> {
+  return hubSocket?.request(op, sessionId, deviceId) ?? Promise.resolve(null);
+}
+
+type LeaseEvent = Extract<SyncHubEvent, { type: 'lease-event' }>;
+let leaseEventListener: ((ev: LeaseEvent) => void) | null = null;
+// main.ts wires this to leaseClient.handleTakeoverRequest so a hub takeover-request
+// reaches the holder. Kept as a facade so service.ts doesn't import the lease client.
+export function setSyncSpacesLeaseEventListener(fn: ((ev: LeaseEvent) => void) | null): void { leaseEventListener = fn; }
 
 // Why: enable(true) racing enable(false) (two windows, or panel double-click)
 // would otherwise interleave — the disable stops the half-started engine and
@@ -273,6 +292,10 @@ async function startEngine(log: (m: string) => void): Promise<void> {
       } else if (ev.type === 'disconnected') {
         hubStatus = 'disconnected';
         broadcast({ type: 'hub-status', spaceId: 'hub', status: 'disconnected' });
+      } else if (ev.type === 'lease-event') {
+        // DO-pushed lease notification (released/taken/takeover-request). Forward
+        // to main.ts's listener (the lease client filters by held session).
+        leaseEventListener?.(ev);
       }
     },
   });

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -19,6 +19,7 @@ const WELCOME_MODEL_LABELS: Record<string, string> = {
   fable: 'Fable',
 };
 import ErrorBoundary from './components/ErrorBoundary';
+import { Scrim, OverlayPanel } from './components/overlays/Overlay';
 import GamePanel from './components/game/GamePanel';
 import { ChatProvider, useChatDispatch, useChatState, useChatStateMap } from './state/chat-context';
 import { artifactReducer, initialArtifactState } from './state/artifact-tracker';
@@ -191,6 +192,25 @@ function AppInner() {
   const [viewedSessions, setViewedSessions] = useState<Set<string>>(new Set());
   const [resumeInfo, setResumeInfo] = useState<Map<string, { claudeSessionId: string; projectSlug: string }>>(new Map());
   const [resumeRequested, setResumeRequested] = useState(false);
+  // Conversation-lease takeover dialog (Plan 2b Task 9). When resuming a
+  // conversation held live on another device, we ask before yanking it here.
+  // The resume flow AWAITS the user's choice via a promise resolved by the
+  // dialog buttons (takeoverResolveRef), so handleResumeSession stays one linear
+  // async function instead of splitting across callbacks. phase 'confirm' is the
+  // first ask; 'force' is the "holder isn't responding — take over anyway?" ask.
+  const [takeoverPrompt, setTakeoverPrompt] = useState<{ device: string; phase: 'confirm' | 'force' } | null>(null);
+  const takeoverResolveRef = useRef<((choice: boolean) => void) | null>(null);
+  const askTakeover = useCallback((device: string, phase: 'confirm' | 'force') =>
+    new Promise<boolean>((resolve) => {
+      takeoverResolveRef.current = resolve;
+      setTakeoverPrompt({ device, phase });
+    }), []);
+  const resolveTakeover = useCallback((choice: boolean) => {
+    setTakeoverPrompt(null);
+    const r = takeoverResolveRef.current;
+    takeoverResolveRef.current = null;
+    r?.(choice);
+  }, []);
   // Shown when the user closes an active session — offers to mark it complete
   // in one step so it's hidden from the resume menu by default.
   const [closePromptFor, setClosePromptFor] = useState<string | null>(null);
@@ -1856,6 +1876,34 @@ function AppInner() {
   const handleResumeSession = useCallback(async (claudeSessionId: string, projectSlug: string, projectPath: string, resumeModel?: string, resumeDangerous?: boolean, launchInNewWindow?: boolean, provider?: string) => {
     const cwd = projectPath;
 
+    // Plan 2b Task 9 — conversation-lease takeover gate. Before resuming, ask the
+    // hub whether this conversation is actively held on another device. If so,
+    // offer to take over here (the holder hands off), falling back to a
+    // force-takeover if the holder doesn't respond. NEVER hard-blocks the resume:
+    // any lease error just proceeds (spec §3 never-block).
+    //
+    // Self-device decision: we can't cheaply get THIS device's hostname in the
+    // renderer, so we gate the dialog on "a lease exists at all" (q.held) rather
+    // than comparing q.device to self. If the lease turns out to be OUR OWN, the
+    // main-side takeover flow (which DOES know selfDevice) sees held===self, treats
+    // it as free, and returns 'acquired' fast with no real handoff — so offering
+    // takeover on a self-held lease is harmless.
+    try {
+      const q = await window.claude.syncSpaces?.leaseQuery?.(claudeSessionId);
+      if (q?.held) {
+        const device = q.device || 'another device';
+        const confirmed = await askTakeover(device, 'confirm');
+        if (!confirmed) return; // "Never mind" — abort the resume
+        const r = await window.claude.syncSpaces?.leaseTakeover?.(claudeSessionId);
+        if (r?.outcome === 'timeout') {
+          const forced = await askTakeover(device, 'force');
+          if (!forced) return; // "Never mind" — abort
+          await window.claude.syncSpaces?.leaseForce?.(claudeSessionId);
+        }
+        // 'acquired' or 'error' -> fall through and resume (never-block).
+      }
+    } catch { /* never-block: a lease query/takeover failure must not stop the resume */ }
+
     // Native-harness resume: the model binding lives in the session's stored
     // header, so we send NO binding — SessionManager's native branch tolerates a
     // missing binding when resumeSessionId is set (it only throws for a FRESH
@@ -1915,7 +1963,7 @@ function AppInner() {
     } catch (err) {
       console.error('Failed to load history:', err);
     }
-  }, [dispatch, currentModel]);
+  }, [dispatch, currentModel, askTakeover]);
 
   const currentViewMode = sessionId ? (viewModes.get(sessionId) || 'chat') : 'chat';
 
@@ -2753,6 +2801,44 @@ function AppInner() {
         <div className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg bg-panel border border-edge text-sm text-fg shadow-lg">
           {toast}
         </div>
+      )}
+      {/* Plan 2b Task 9 — conversation-lease takeover confirm dialog. L2 popup via
+          the shared Scrim/OverlayPanel primitives (theme-driven scrim/blur/shadow;
+          PITFALLS → Overlays). Plain words, no status glyphs. 'confirm' asks to
+          take a live session over; 'force' asks after the holder didn't respond. */}
+      {takeoverPrompt && (
+        <>
+          <Scrim layer={2} onClick={() => resolveTakeover(false)} />
+          <OverlayPanel
+            layer={2}
+            role="dialog"
+            aria-modal
+            aria-label="Take over conversation"
+            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(92vw,26rem)] p-5"
+          >
+            <p className="text-sm text-fg mb-4">
+              {takeoverPrompt.phase === 'confirm'
+                ? `This session is active on ${takeoverPrompt.device} — take over here?`
+                : `${takeoverPrompt.device} isn't responding — take over anyway?`}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="px-3 py-1.5 rounded-lg border border-edge text-sm text-fg-2 hover:bg-inset"
+                onClick={() => resolveTakeover(false)}
+              >
+                Never mind
+              </button>
+              <button
+                type="button"
+                className="px-3 py-1.5 rounded-lg bg-accent text-on-accent text-sm hover:opacity-90"
+                onClick={() => resolveTakeover(true)}
+              >
+                Take over
+              </button>
+            </div>
+          </OverlayPanel>
+        </>
       )}
       <ZoomOverlay
         zoomPercent={zoomPercent}

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1007,6 +1007,15 @@ function AppInner() {
       );
     });
 
+    // Plan 2b Task 10: another device took over this session's lease. Drop a
+    // "this conversation moved to <device>" marker into the timeline so the
+    // user understands why chat activity stopped here. The reducer ends the
+    // in-flight turn cleanly (endTurn) as part of SESSION_MOVED.
+    const movedHandler = (window.claude.on as any).sessionMoved?.((payload: { sessionId: string; device?: string }) => {
+      if (!payload?.sessionId) return;
+      dispatch({ type: 'SESSION_MOVED', sessionId: payload.sessionId, device: payload.device });
+    });
+
     // Permission-mode detection (per-session) is wired up in a dedicated
     // effect below, scoped to the current sessions list. Previously this used
     // a global pty:output listener; that channel is no longer broadcast
@@ -1248,6 +1257,7 @@ function AppInner() {
       window.claude.off('session:destroyed', destroyedHandler);
       window.claude.off('hook:event', hookHandler);
       window.claude.off('session:renamed', renamedHandler);
+      if (movedHandler) window.claude.off('session:moved', movedHandler);
       window.claude.off('status:data', statusHandler);
       if (transcriptHandler) window.claude.off('transcript:event', transcriptHandler);
       if (shrinkHandler) window.claude.off('transcript:shrink', shrinkHandler);

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1891,20 +1891,19 @@ function AppInner() {
     const cwd = projectPath;
 
     // Plan 2b Task 9 — conversation-lease takeover gate. Before resuming, ask the
-    // hub whether this conversation is actively held on another device. If so,
+    // hub whether this conversation is actively held on ANOTHER device. If so,
     // offer to take over here (the holder hands off), falling back to a
     // force-takeover if the holder doesn't respond. NEVER hard-blocks the resume:
     // any lease error just proceeds (spec §3 never-block).
     //
-    // Self-device decision: we can't cheaply get THIS device's hostname in the
-    // renderer, so we gate the dialog on "a lease exists at all" (q.held) rather
-    // than comparing q.device to self. If the lease turns out to be OUR OWN, the
-    // main-side takeover flow (which DOES know selfDevice) sees held===self, treats
-    // it as free, and returns 'acquired' fast with no real handoff — so offering
-    // takeover on a self-held lease is harmless.
+    // Self-device decision: the query result's `self` flag is computed in the
+    // main process from the per-install deviceId (NOT the hostname label). We gate
+    // the dialog on "held AND not self" so a lease left over from OUR OWN install
+    // (e.g. after an unclean shutdown) resumes straight through instead of popping
+    // a confusing "active on <your-own-hostname>" takeover dialog.
     try {
       const q = await window.claude.syncSpaces?.leaseQuery?.(claudeSessionId);
-      if (q?.held) {
+      if (q?.held && !q.self) {
         const device = q.device || 'another device';
         const confirmed = await askTakeover(device, 'confirm');
         if (!confirmed) return; // "Never mind" — abort the resume

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -202,6 +202,10 @@ function AppInner() {
   const takeoverResolveRef = useRef<((choice: boolean) => void) | null>(null);
   const askTakeover = useCallback((device: string, phase: 'confirm' | 'force') =>
     new Promise<boolean>((resolve) => {
+      // Reentrancy guard: only one resolver slot exists. If a second resume opens
+      // a dialog while one is pending, resolve the prior one as "declined" so its
+      // awaiting handleResumeSession returns cleanly instead of hanging forever.
+      takeoverResolveRef.current?.(false);
       takeoverResolveRef.current = resolve;
       setTakeoverPrompt({ device, phase });
     }), []);

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -45,6 +45,7 @@ import { AppIcon, WelcomeAppIcon, ThemeMascot } from './components/Icons';
 import CommandDrawer from './components/CommandDrawer';
 import { TerminalScrollButtons } from './components/TerminalToolbar';
 import TrustGate, { useTrustGateActive } from './components/TrustGate';
+import MovedGate from './components/MovedGate';
 import SettingsPanel from './components/SettingsPanel';
 import ResumeBrowser from './components/ResumeBrowser';
 import CloseSessionPrompt, { CLOSE_PROMPT_SUPPRESS_KEY } from './components/CloseSessionPrompt';
@@ -192,6 +193,30 @@ function AppInner() {
   const [viewedSessions, setViewedSessions] = useState<Set<string>>(new Set());
   const [resumeInfo, setResumeInfo] = useState<Map<string, { claudeSessionId: string; projectSlug: string }>>(new Map());
   const [resumeRequested, setResumeRequested] = useState(false);
+  // Plan 2b "Moved Gate" (2026-07-14). Sessions another device took over: we keep
+  // the pill and render <MovedGate> (instead of chat/terminal) when it's clicked.
+  // The RENDER reads `movedSessions` state; the `destroyedHandler` — registered
+  // once in a mount effect whose only dep is the stable `dispatch`, so its closure
+  // captured `movedSessions` at mount (permanently the initial empty Map) — reads
+  // `movedSessionsRef.current` instead. recordMoved/clearMoved keep the state and
+  // the ref in lockstep, the ref updated synchronously so the destroy handler
+  // (which fires ms after the moved push) reliably sees the entry.
+  type MovedInfo = { device?: string; claudeSessionId?: string; projectSlug?: string; projectPath?: string };
+  const [movedSessions, setMovedSessions] = useState<Map<string, MovedInfo>>(new Map());
+  const movedSessionsRef = useRef(movedSessions);
+  const recordMoved = useCallback((sessionId: string, info: MovedInfo) => {
+    const next = new Map(movedSessionsRef.current);
+    next.set(sessionId, info);
+    movedSessionsRef.current = next;
+    setMovedSessions(next);
+  }, []);
+  const clearMoved = useCallback((sessionId: string) => {
+    if (!movedSessionsRef.current.has(sessionId)) return;
+    const next = new Map(movedSessionsRef.current);
+    next.delete(sessionId);
+    movedSessionsRef.current = next;
+    setMovedSessions(next);
+  }, []);
   // Conversation-lease takeover dialog (Plan 2b Task 9). When resuming a
   // conversation held live on another device, we ask before yanking it here.
   // The resume flow AWAITS the user's choice via a promise resolved by the
@@ -734,6 +759,21 @@ function AppInner() {
     });
 
     const destroyedHandler = window.claude.on.sessionDestroyed((id: string, exitCode: number = 0) => {
+      // Plan 2b Moved Gate: this session was TAKEN OVER, not closed. Keep its pill
+      // (so clicking it hits the gate), skip the "session died" banner
+      // (SESSION_PROCESS_EXITED), and DON'T wipe chat state (SESSION_REMOVE) — the
+      // gate replaces the view; state is freed on Exit/Resume. Read the REF, not
+      // `movedSessions`: this handler's mount-effect closure captured the state at
+      // mount (empty), so a state read here would never see the moved entry.
+      if (movedSessionsRef.current.has(id)) {
+        // Drop from the aux maps (inert once the gate owns the view). Dropping
+        // initializedSessions also keeps the input bar disabled as defence-in-depth.
+        setViewModes((prev) => { const n = new Map(prev); n.delete(id); return n; });
+        setPermissionModes((prev) => { const n = new Map(prev); n.delete(id); return n; });
+        setSessionModels((prev) => { const n = new Map(prev); n.delete(id); return n; });
+        setInitializedSessions((prev) => { if (!prev.has(id)) return prev; const n = new Set(prev); n.delete(id); return n; });
+        return;
+      }
       // Fire BEFORE removing the session from state — the reducer needs the
       // current SessionChatState to decide whether this warrants a 'session-died'
       // banner (in-flight tools OR nonzero exit). SESSION_REMOVE below wipes it.
@@ -1007,12 +1047,19 @@ function AppInner() {
       );
     });
 
-    // Plan 2b Task 10: another device took over this session's lease. Drop a
-    // "this conversation moved to <device>" marker into the timeline so the
-    // user understands why chat activity stopped here. The reducer ends the
-    // in-flight turn cleanly (endTurn) as part of SESSION_MOVED.
-    const movedHandler = (window.claude.on as any).sessionMoved?.((payload: { sessionId: string; device?: string }) => {
+    // Plan 2b Moved Gate: another device took over this session's lease. Record
+    // it so its pill survives the imminent destroy and clicking it renders
+    // <MovedGate>. Still dispatch SESSION_MOVED for its endTurn effect (cleanly
+    // stops any 'thinking' state on the now-dead session). The push carries the
+    // resume params so the gate's "Resume on this device" needs no extra lookup.
+    const movedHandler = (window.claude.on as any).sessionMoved?.((payload: { sessionId: string; device?: string; claudeSessionId?: string; projectSlug?: string; projectPath?: string }) => {
       if (!payload?.sessionId) return;
+      recordMoved(payload.sessionId, {
+        device: payload.device,
+        claudeSessionId: payload.claudeSessionId,
+        projectSlug: payload.projectSlug,
+        projectPath: payload.projectPath,
+      });
       dispatch({ type: 'SESSION_MOVED', sessionId: payload.sessionId, device: payload.device });
     });
 
@@ -1887,6 +1934,24 @@ function AppInner() {
     }
   }, [currentModel]);
 
+  // Client-side removal for a session that is ALREADY dead in the main process
+  // (Moved Gate Exit/Resume, where `session.destroy()` would no-op and emit no
+  // session:destroyed event). Mirrors destroyedHandler's state cleanup MINUS the
+  // death banner (SESSION_PROCESS_EXITED) — the session moved, it didn't die.
+  const removeSessionLocally = useCallback((id: string) => {
+    setSessions((prev) => {
+      const remaining = prev.filter((s) => s.id !== id);
+      setSessionId((curr) => (curr !== id ? curr : (remaining.length > 0 ? remaining[remaining.length - 1].id : null)));
+      return remaining;
+    });
+    setViewModes((prev) => { const n = new Map(prev); n.delete(id); return n; });
+    setPermissionModes((prev) => { const n = new Map(prev); n.delete(id); return n; });
+    setSessionModels((prev) => { const n = new Map(prev); n.delete(id); return n; });
+    setInitializedSessions((prev) => { if (!prev.has(id)) return prev; const n = new Set(prev); n.delete(id); return n; });
+    dispatch({ type: 'SESSION_REMOVE', sessionId: id });
+    clearMoved(id);
+  }, [dispatch, clearMoved]);
+
   const handleResumeSession = useCallback(async (claudeSessionId: string, projectSlug: string, projectPath: string, resumeModel?: string, resumeDangerous?: boolean, launchInNewWindow?: boolean, provider?: string) => {
     const cwd = projectPath;
 
@@ -2229,6 +2294,10 @@ function AppInner() {
   }, [trustGateActive, sessionId]);
 
   const sessionInitialized = sessionId ? initializedSessions.has(sessionId) : true;
+  // Plan 2b Moved Gate: when the active session was taken over by another device,
+  // its info lives here and we render <MovedGate> over the content instead of the
+  // (now-dead) chat/terminal view.
+  const movedGate = sessionId ? movedSessions.get(sessionId) : undefined;
 
   // Show a "something may be wrong" hint after 15s of waiting on initialization.
   // Resets whenever the active session changes or the session becomes initialized.
@@ -2468,7 +2537,7 @@ function AppInner() {
               {/* Initializing overlay — shown before Claude is ready, but only in chat view.
                  Terminal view must stay accessible during init so the user can interact there.
                  z-10: must stay below glassmorphism chrome (z-20) so header/bottom bars remain accessible */}
-              {!sessionInitialized && sessionId && currentViewMode !== 'terminal' && (
+              {!sessionInitialized && sessionId && currentViewMode !== 'terminal' && !movedGate && (
                 <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-canvas">
                   <ThemeMascot variant="idle" fallback={AppIcon} className="w-16 h-16 text-fg-dim mb-6 animate-pulse" />
                   <p className="text-sm text-fg-dim font-medium">Initializing session...</p>
@@ -2481,6 +2550,31 @@ function AppInner() {
                 </div>
               )}
               {trustGateActive && sessionId && <TrustGate sessionId={sessionId} />}
+              {/* Plan 2b Moved Gate — covers the content area for a taken-over
+                 session (the ChatView/TerminalView below are dead). z-10 like
+                 TrustGate so the header strip stays reachable to switch away. */}
+              {movedGate && sessionId && (
+                <MovedGate
+                  device={movedGate.device}
+                  // Resume from a remote browser would run on the HOST, not here —
+                  // hide it there to avoid the semantic oddity; local desktop always shows it.
+                  canResume={!isRemoteMode()}
+                  onExit={() => removeSessionLocally(sessionId)}
+                  onResume={() => {
+                    // Capture resume params BEFORE removeSessionLocally clears the entry.
+                    const info = movedSessionsRef.current.get(sessionId);
+                    // Drop the dead pill first so resume creates a fresh one (no duplicate).
+                    removeSessionLocally(sessionId);
+                    if (info?.claudeSessionId && info.projectSlug && info.projectPath) {
+                      void handleResumeSession(info.claudeSessionId, info.projectSlug, info.projectPath);
+                    } else {
+                      // Main couldn't resolve the resume params (no cwd) — fall back
+                      // to the Resume Browser so the user isn't stranded.
+                      setResumeRequested(true);
+                    }
+                  }}
+                />
+              )}
               {currentViewMode === 'chat' && (
                 <CommandDrawer
                   open={drawerOpen}
@@ -2506,7 +2600,7 @@ function AppInner() {
                 {/* TerminalToolbar (Esc/Tab/Ctrl/arrows) now renders inside
                     ChatInputBar when minimal={isTerminalTouch}, slotted in
                     the QuickChips position so both modes share one container. */}
-                <ChatInputBar ref={inputBarRef} sessionId={sessionId} view={currentViewMode} onOpenDrawer={handleOpenDrawer} onCloseDrawer={handleCloseDrawer} onDrawerSearch={setDrawerFilter} disabled={trustGateActive || !sessionInitialized} minimal={isTerminalTouch} onResumeCommand={() => setResumeRequested(true)} getUsageSnapshot={getUsageSnapshot} onOpenPreferences={() => setPreferencesOpen(true)} onToast={(msg) => { setToast(msg); setTimeout(() => setToast(null), 3000); }} getSessionState={(sid) => chatStateMapRef.current.get(sid)} onOpenModelPicker={() => setModelPickerOpen(true)} initialInput={currentSession?.initialInput} provider={currentSession?.provider} />
+                <ChatInputBar ref={inputBarRef} sessionId={sessionId} view={currentViewMode} onOpenDrawer={handleOpenDrawer} onCloseDrawer={handleCloseDrawer} onDrawerSearch={setDrawerFilter} disabled={trustGateActive || !!movedGate || !sessionInitialized} minimal={isTerminalTouch} onResumeCommand={() => setResumeRequested(true)} getUsageSnapshot={getUsageSnapshot} onOpenPreferences={() => setPreferencesOpen(true)} onToast={(msg) => { setToast(msg); setTimeout(() => setToast(null), 3000); }} getSessionState={(sid) => chatStateMapRef.current.get(sid)} onOpenModelPicker={() => setModelPickerOpen(true)} initialInput={currentSession?.initialInput} provider={currentSession?.provider} />
                 <StatusBar
                   statusData={{
                     usage: statusData.usage,

--- a/desktop/src/renderer/components/MovedGate.tsx
+++ b/desktop/src/renderer/components/MovedGate.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { AppIcon, ThemeMascot } from './Icons';
+
+// Plan 2b "Moved Gate" (2026-07-14). When another device takes over a session's
+// lease, the holder side cleanly interrupts → flushes → releases → destroys the
+// local CC session (unchanged). The session is GONE — but we keep its pill in the
+// strip and, when the user clicks it, render THIS full-page gate instead of the
+// chat/terminal view.
+//
+// Why a gate and not an inline "moved" marker (the original Task 10 design): the
+// holder destroys the session immediately after the moved push, and SESSION_REMOVE
+// wipes the whole chat state — so a timeline marker was appended then deleted
+// back-to-back and never rendered. A dedicated gate also sidesteps three tails of
+// keeping a dead session in the normal view: (1) the terminal-view xterm write
+// path isn't gated by !sessionInitialized, so a second writer could re-open the
+// conversation; (2) an already-dead session's ✕ no-ops (un-removable zombie);
+// (3) SESSION_PROCESS_EXITED would flash a competing "session died" banner. The
+// gate's ONLY interactions are Exit / Resume, so none of those can happen.
+//
+// Modeled on TrustGate: a full-cover content-area gate at z-10 (BELOW the
+// glassmorphism chrome at z-20) so the header session strip + settings stay
+// reachable — the user can switch to another session or resume/exit here.
+
+interface Props {
+  device?: string;
+  onExit: () => void;
+  onResume: () => void;
+  // Resume actually runs on the HOST when clicked from a remote browser, which is
+  // a mild semantic oddity — the caller hides the button in remote mode.
+  canResume?: boolean;
+}
+
+export default function MovedGate({ device, onExit, onResume, canResume = true }: Props) {
+  return (
+    // z-10: must stay below glassmorphism chrome (z-20) so header/bottom bars remain accessible
+    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-canvas px-6">
+      <ThemeMascot variant="idle" fallback={AppIcon} className="w-16 h-16 text-fg-dim mb-6" />
+      <p className="text-sm text-fg font-medium mb-1">
+        This session was taken over on {device ?? 'another device'}.
+      </p>
+      <p className="text-xs text-fg-muted mb-6 max-w-sm text-center">
+        Claude Code ended here when the conversation moved. You can resume it on this
+        device, or close it out.
+      </p>
+      <div className="flex gap-3">
+        <button
+          onClick={onExit}
+          className="px-4 py-1.5 text-sm font-medium rounded-md transition-colors bg-inset hover:bg-edge text-fg"
+        >
+          Exit Session
+        </button>
+        {canResume && (
+          <button
+            onClick={onResume}
+            className="px-4 py-1.5 text-sm font-medium rounded-md transition-colors bg-accent hover:bg-accent text-on-accent"
+          >
+            Resume on this device
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -1264,7 +1264,7 @@ function YourDevices({ enabled }: { enabled: boolean }) {
   const load = useCallback(async () => {
     // Method-exists guard: on remote / older Android without the handler the
     // invoke is absent, so degrade to an empty list instead of throwing.
-    const fn = (window as any).claude?.syncSpaces?.listDevices;
+    const fn = window.claude?.syncSpaces?.listDevices;
     if (typeof fn !== 'function') { setDevices([]); return; }
     try { setDevices(await fn()); } catch { setDevices([]); }
   }, []);
@@ -1281,7 +1281,7 @@ function YourDevices({ enabled }: { enabled: boolean }) {
     if (!name) return;
     const current = devices?.find(d => d.id === id);
     if (current && current.name === name) return;
-    const fn = (window as any).claude?.syncSpaces?.renameDevice;
+    const fn = window.claude?.syncSpaces?.renameDevice;
     if (typeof fn !== 'function') return;
     try { await fn(id, name); } catch {}
     // Re-fetch so the merged/synced name (fold-on-read authoritative) is shown.

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -111,6 +111,32 @@ function timeAgo(epoch: number): string {
   return `${days}d ago`;
 }
 
+// Relative time from a MILLISECOND epoch (the device registry stores lastSeen in
+// ms, unlike the sync backends above which use seconds). Plain words on purpose —
+// the "Your devices" list is spec'd as plain text with no status glyphs.
+function relativeMs(ms: number): string {
+  if (!ms || !Number.isFinite(ms)) return 'unknown';
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 45) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+// Map process.platform to a plain, human word. Empty string (unknown platform)
+// falls through to '' so the caller can omit it rather than print a raw code.
+function platformLabel(p: string): string {
+  switch (p) {
+    case 'win32': return 'Windows';
+    case 'darwin': return 'macOS';
+    case 'linux': return 'Linux';
+    default: return p || '';
+  }
+}
+
 // Map the derived sync display state to a status-dot tailwind class.
 // All three helpers keep the dot, label, and badge in lock-step — the old
 // time-only derivation could read "Synced 3m ago" while the popup showed
@@ -769,6 +795,14 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                   Sync now
                 </button>
               )}
+
+              {/* Your devices (Plan 2b spec §10a) — the synced device registry.
+                  Plain text only (no status dots/glyphs — user preference); the
+                  current machine is marked "(this device)" and each name is an
+                  inline-editable nickname. Gated on sync being on: the registry
+                  lives inside the Personal space, so there's nothing to list until
+                  sync has a personal root. */}
+              <YourDevices enabled={!!spacesStatus?.enabled} />
             </section>
 
             {/* Divider between the primary GitHub system and the optional extras. */}
@@ -1202,6 +1236,106 @@ function ConfirmDialog({
       </OverlayPanel>
     </>,
     document.body,
+  );
+}
+
+// --- "Your devices" list (Plan 2b spec §10a) ---
+// Shows every device in the synced device registry: friendly (inline-editable)
+// name, "last seen <relative>", and a plain "(this device)" suffix for the
+// current machine. Deliberately PLAIN TEXT — no status dots or ●◐○ glyphs
+// (the section is spec'd plain, and the owner dislikes status glyphs).
+
+interface DeviceRow {
+  schemaVersion: number;
+  id: string;
+  name: string;
+  platform: string;
+  lastSeen: number;
+  updatedAt: number;
+  self: boolean; // marks THIS machine (matched by deviceId in the main handler)
+}
+
+function YourDevices({ enabled }: { enabled: boolean }) {
+  // null = not loaded yet; [] = loaded-but-empty (sync off / no personal root).
+  const [devices, setDevices] = useState<DeviceRow[] | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+
+  const load = useCallback(async () => {
+    // Method-exists guard: on remote / older Android without the handler the
+    // invoke is absent, so degrade to an empty list instead of throwing.
+    const fn = (window as any).claude?.syncSpaces?.listDevices;
+    if (typeof fn !== 'function') { setDevices([]); return; }
+    try { setDevices(await fn()); } catch { setDevices([]); }
+  }, []);
+
+  // Load on mount and whenever sync flips on — the first enable provisions the
+  // Personal space that backs the registry, so the list can go empty → populated.
+  useEffect(() => { void load(); }, [load, enabled]);
+
+  const commitRename = useCallback(async (id: string) => {
+    const name = draft.trim();
+    setEditingId(null);
+    // Reject empty/whitespace (the store no-ops on empty anyway) and skip a
+    // no-op rename so we don't fire a pointless invoke + refetch.
+    if (!name) return;
+    const current = devices?.find(d => d.id === id);
+    if (current && current.name === name) return;
+    const fn = (window as any).claude?.syncSpaces?.renameDevice;
+    if (typeof fn !== 'function') return;
+    try { await fn(id, name); } catch {}
+    // Re-fetch so the merged/synced name (fold-on-read authoritative) is shown.
+    await load();
+  }, [draft, devices, load]);
+
+  if (!enabled) return null;
+
+  return (
+    <div className="mt-3">
+      <h4 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-1.5">Your devices</h4>
+      {devices !== null && devices.length === 0 ? (
+        <p className="text-[11px] text-fg-muted">No devices yet — they appear here once sync has run.</p>
+      ) : (
+        <ul className="space-y-1">
+          {(devices ?? []).map(d => {
+            const plat = platformLabel(d.platform);
+            const activity = d.self ? 'active now' : `last seen ${relativeMs(d.lastSeen)}`;
+            const right = plat ? `${plat} · ${activity}` : activity;
+            return (
+              <li key={d.id} className="flex items-center justify-between gap-2">
+                <div className="min-w-0 flex items-center gap-1.5">
+                  {editingId === d.id ? (
+                    <input
+                      value={draft}
+                      autoFocus
+                      onChange={(e) => setDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') void commitRename(d.id);
+                        if (e.key === 'Escape') setEditingId(null); // cancel — no rename
+                      }}
+                      onBlur={() => void commitRename(d.id)}
+                      className="bg-inset text-fg text-xs rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none min-w-0"
+                    />
+                  ) : (
+                    // Click the name to edit — it's just a nickname, so no confirm gate.
+                    <button
+                      type="button"
+                      onClick={() => { setEditingId(d.id); setDraft(d.name); }}
+                      className="text-xs text-fg-2 hover:text-fg truncate text-left"
+                      title="Click to rename this device"
+                    >
+                      {d.name}
+                    </button>
+                  )}
+                  {d.self && <span className="text-[10px] text-fg-muted shrink-0">(this device)</span>}
+                </div>
+                <span className="text-[10px] text-fg-muted shrink-0">{right}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
   );
 }
 

--- a/desktop/src/renderer/components/SystemMarker.tsx
+++ b/desktop/src/renderer/components/SystemMarker.tsx
@@ -1,14 +1,18 @@
 import React, { useState } from 'react';
 import type { SystemMarker as SystemMarkerData } from '../state/chat-types';
 
-// Thin horizontal divider used for /clear and /compact markers. Permanent —
-// user sees "these messages end here" when scrolling back. Deliberately quiet
-// styling so it doesn't compete with actual conversation content.
+// Thin horizontal divider used for /clear, /compact, and "moved" markers.
+// Permanent — user sees "these messages end here" when scrolling back.
+// Deliberately quiet styling so it doesn't compete with actual conversation content.
 //
 // When a /compact marker carries a `summary` (CC-produced conversation summary
 // from the isCompactSummary line), clicking the label toggles an inline panel
 // that reveals the full summary. Replaces CC's terminal "ctrl+o" affordance,
 // which never worked inside YouCoded because the chat view consumes that key.
+//
+// Plan 2b Task 10 — a `variant: 'moved'` marker ("This conversation moved to
+// <device>") carries no summary, so it renders through the plain non-expandable
+// branch below (no chevron). The label text is the whole signal.
 
 interface Props {
   marker: SystemMarkerData;

--- a/desktop/src/renderer/components/SystemMarker.tsx
+++ b/desktop/src/renderer/components/SystemMarker.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { SystemMarker as SystemMarkerData } from '../state/chat-types';
 
-// Thin horizontal divider used for /clear, /compact, and "moved" markers.
+// Thin horizontal divider used for /clear and /compact markers.
 // Permanent — user sees "these messages end here" when scrolling back.
 // Deliberately quiet styling so it doesn't compete with actual conversation content.
 //
@@ -9,10 +9,6 @@ import type { SystemMarker as SystemMarkerData } from '../state/chat-types';
 // from the isCompactSummary line), clicking the label toggles an inline panel
 // that reveals the full summary. Replaces CC's terminal "ctrl+o" affordance,
 // which never worked inside YouCoded because the chat view consumes that key.
-//
-// Plan 2b Task 10 — a `variant: 'moved'` marker ("This conversation moved to
-// <device>") carries no summary, so it renders through the plain non-expandable
-// branch below (no chevron). The label text is the whole signal.
 
 interface Props {
   marker: SystemMarkerData;

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -295,9 +295,17 @@ declare global {
         // guards every call. leaseQuery answers who holds the session; leaseTakeover
         // asks the holder to hand off then polls+acquires; leaseForce overwrites a
         // stale lease when the holder is unresponsive.
-        leaseQuery?: (claudeSessionId: string) => Promise<{ held: boolean; device?: string; source?: string }>;
+        // `self` is derived in the main process from the per-install deviceId, so
+        // the resume gate can skip the takeover dialog for OUR OWN held lease.
+        leaseQuery?: (claudeSessionId: string) => Promise<{ held: boolean; device?: string; deviceId?: string; self?: boolean; source?: string }>;
         leaseTakeover?: (claudeSessionId: string) => Promise<{ outcome: 'acquired' | 'timeout' | 'error' }>;
         leaseForce?: (claudeSessionId: string) => Promise<{ ok: boolean }>;
+        // Device registry (Plan 2b spec §10a): the "Your devices" list. Optional so
+        // remote / older Android builds without the handler still typecheck — every
+        // caller keeps a `typeof fn === 'function'` runtime guard. listDevices marks
+        // the current machine with self:true; renameDevice sets a friendly label.
+        listDevices?: () => Promise<Array<{ schemaVersion: number; id: string; name: string; platform: string; lastSeen: number; updatedAt: number; self: boolean }>>;
+        renameDevice?: (id: string, name: string) => Promise<{ ok: boolean }>;
         onEvent: (cb: (e: unknown) => void) => () => void;
       };
     };

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -290,6 +290,14 @@ declare global {
         // Cross-device rename (display-name only) + stop-syncing (2026-07-12).
         renameProject?: (name: string, displayName: string) => Promise<{ ok: boolean; error?: string }>;
         stopProject?: (name: string) => Promise<{ ok: boolean; error?: string }>;
+        // Conversation-lease takeover (Plan 2b Task 9). Optional so remote/Android
+        // builds predating these members still typecheck; the Resume Browser gate
+        // guards every call. leaseQuery answers who holds the session; leaseTakeover
+        // asks the holder to hand off then polls+acquires; leaseForce overwrites a
+        // stale lease when the holder is unresponsive.
+        leaseQuery?: (claudeSessionId: string) => Promise<{ held: boolean; device?: string; source?: string }>;
+        leaseTakeover?: (claudeSessionId: string) => Promise<{ outcome: 'acquired' | 'timeout' | 'error' }>;
+        leaseForce?: (claudeSessionId: string) => Promise<{ ok: boolean }>;
         onEvent: (cb: (e: unknown) => void) => () => void;
       };
     };

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1108,6 +1108,14 @@ export function installShim(): void {
       renameProject: (name: string, displayName: string) =>
         invoke('syncspaces:rename-project', { name, displayName }),
       stopProject: (name: string) => invoke('syncspaces:stop-project', { name }),
+      // Conversation-lease takeover (Plan 2b Task 9). Same shape as preload for
+      // parity (PITFALLS rule) so a remote browser doesn't crash when the resume
+      // dialog calls leaseQuery. Remote-server routing lands in Task 11 — until
+      // then these reject/time out and the renderer resume gate degrades (proceeds
+      // with the resume, never hard-blocks — spec §3 never-block).
+      leaseQuery: (claudeSessionId: string) => invoke('syncspaces:lease-query', { claudeSessionId }),
+      leaseTakeover: (claudeSessionId: string) => invoke('syncspaces:lease-takeover', { claudeSessionId }),
+      leaseForce: (claudeSessionId: string) => invoke('syncspaces:lease-force', { claudeSessionId }),
       onEvent: (cb: (e: unknown) => void) => {
         const handler: Callback = (e: any) => cb(e);
         addListener('syncspaces:event', handler);

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1125,6 +1125,10 @@ export function installShim(): void {
       leaseQuery: (claudeSessionId: string) => invoke('syncspaces:lease-query', { claudeSessionId }),
       leaseTakeover: (claudeSessionId: string) => invoke('syncspaces:lease-takeover', { claudeSessionId }),
       leaseForce: (claudeSessionId: string) => invoke('syncspaces:lease-force', { claudeSessionId }),
+      // Device registry (Plan 2b spec §10a). Object-payload invoke over WS to
+      // match the shim's convention; routed by remote-server (Task 11).
+      listDevices: () => invoke('syncspaces:list-devices'),
+      renameDevice: (id: string, name: string) => invoke('syncspaces:rename-device', { id, name }),
       onEvent: (cb: (e: unknown) => void) => {
         const handler: Callback = (e: any) => cb(e);
         addListener('syncspaces:event', handler);

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -213,6 +213,12 @@ function handleMessage(data: string): void {
     case 'session:renamed':
       dispatchEvent('session:renamed', payload.sessionId, payload.name);
       break;
+    case 'session:moved':
+      // Plan 2b Task 10 — another device took over this session's lease.
+      // Forward the whole { sessionId, device? } payload so App.tsx can drop
+      // the "this conversation moved to <device>" marker (parity with preload).
+      dispatchEvent('session:moved', payload);
+      break;
     case 'session:meta-changed':
       dispatchEvent('session:meta-changed', payload.sessionId, { flag: payload.flag, value: payload.value });
       break;
@@ -749,6 +755,9 @@ export function installShim(): void {
       hookEvent: (cb: Callback) => addListener('hook:event', cb),
       statusData: (cb: Callback) => addListener('status:data', cb),
       sessionRenamed: (cb: Callback) => addListener('session:renamed', cb),
+      // Plan 2b Task 10 — "this conversation moved to <device>" push (parity
+      // with preload's sessionMoved). Returns the cb so off() can remove it.
+      sessionMoved: (cb: Callback) => addListener('session:moved', cb),
       // Return UNSUBSCRIBE fns (not the raw cb) so the tag hooks' off() cleanup
       // actually removes the listener — parity with preload, prevents leaks.
       sessionMetaChanged: (cb: Callback) => { addListener('session:meta-changed', cb); return () => removeListener('session:meta-changed', cb); },

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -214,9 +214,10 @@ function handleMessage(data: string): void {
       dispatchEvent('session:renamed', payload.sessionId, payload.name);
       break;
     case 'session:moved':
-      // Plan 2b Task 10 — another device took over this session's lease.
-      // Forward the whole { sessionId, device? } payload so App.tsx can drop
-      // the "this conversation moved to <device>" marker (parity with preload).
+      // Plan 2b — another device took over this session's lease. Forward the
+      // whole payload ({ sessionId, device?, claudeSessionId?, projectSlug?,
+      // projectPath? }) so App.tsx's MovedGate can show it and offer Resume
+      // (parity with preload's enriched sessionMoved).
       dispatchEvent('session:moved', payload);
       break;
     case 'session:meta-changed':

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -25,15 +25,6 @@ function nextTurnId(): string {
   return `turn-${++turnCounter}`;
 }
 
-let markerCounter = 0;
-// Stable, unique id for system-marker timeline entries generated inside the
-// reducer (e.g. SESSION_MOVED). Most markers carry an id from the action
-// (CLEAR_TIMELINE / COMPACTION_COMPLETE), but the moved marker's push event
-// doesn't include one — mirror the counter idiom used for messages/turns.
-function nextMarkerId(): string {
-  return `marker-${++markerCounter}`;
-}
-
 /**
  * Key-order-independent JSON serialization, used to compare a permission
  * hook's `tool_input` against a transcript tool's `input`. The two arrive
@@ -420,33 +411,21 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return next;
     }
 
-    // Plan 2b Task 10: another device took over this session's lease. End the
-    // local turn cleanly (endTurn resets attentionState to 'ok' — the moved
-    // marker is the signal, NOT a terminal error banner) and append a permanent
-    // "moved" divider. Same spread-then-override shape as SESSION_PROCESS_EXITED,
-    // except we override the TIMELINE (which endTurn never touches) instead of
-    // attentionState — so the appended marker survives the endTurn spread.
+    // Plan 2b: another device took over this session's lease. See the inline
+    // comment below — as of the "Moved Gate" follow-up this only ends the turn
+    // cleanly; the user-facing surface moved to App.tsx's MovedGate.
     case 'SESSION_MOVED': {
       const session = next.get(action.sessionId);
       if (!session) return state;
-      next.set(action.sessionId, {
-        ...session,
-        ...endTurn(session),
-        timeline: [
-          ...session.timeline,
-          {
-            kind: 'system-marker',
-            marker: {
-              id: nextMarkerId(),
-              timestamp: Date.now(),
-              // No summary → SystemMarker renders it as a plain (non-expandable)
-              // divider. Falls back to a generic label when no device is known.
-              label: `This conversation moved to ${action.device ?? 'another device'}`,
-              variant: 'moved',
-            },
-          },
-        ],
-      });
+      // Plan 2b "Moved Gate" (2026-07-14): SESSION_MOVED now ONLY ends the
+      // in-flight turn cleanly (endTurn — attention resets to 'ok', NOT a
+      // terminal error). It NO LONGER appends a timeline marker: the holder side
+      // destroys the session immediately after (SESSION_REMOVE wipes the whole
+      // chat state, so any appended marker was deleted back-to-back and never
+      // rendered). The user-facing "this session was taken over on <device>"
+      // surface is now App.tsx's MovedGate (a full-page gate over the session),
+      // driven off the enriched session:moved push — not this reducer.
+      next.set(action.sessionId, { ...session, ...endTurn(session) });
       return next;
     }
 

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -25,6 +25,15 @@ function nextTurnId(): string {
   return `turn-${++turnCounter}`;
 }
 
+let markerCounter = 0;
+// Stable, unique id for system-marker timeline entries generated inside the
+// reducer (e.g. SESSION_MOVED). Most markers carry an id from the action
+// (CLEAR_TIMELINE / COMPACTION_COMPLETE), but the moved marker's push event
+// doesn't include one — mirror the counter idiom used for messages/turns.
+function nextMarkerId(): string {
+  return `marker-${++markerCounter}`;
+}
+
 /**
  * Key-order-independent JSON serialization, used to compare a permission
  * hook's `tool_input` against a transcript tool's `input`. The two arrive
@@ -407,6 +416,36 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         ...endTurn(session, action.message),
         attentionState: 'error',
         errorMessage: action.message,
+      });
+      return next;
+    }
+
+    // Plan 2b Task 10: another device took over this session's lease. End the
+    // local turn cleanly (endTurn resets attentionState to 'ok' — the moved
+    // marker is the signal, NOT a terminal error banner) and append a permanent
+    // "moved" divider. Same spread-then-override shape as SESSION_PROCESS_EXITED,
+    // except we override the TIMELINE (which endTurn never touches) instead of
+    // attentionState — so the appended marker survives the endTurn spread.
+    case 'SESSION_MOVED': {
+      const session = next.get(action.sessionId);
+      if (!session) return state;
+      next.set(action.sessionId, {
+        ...session,
+        ...endTurn(session),
+        timeline: [
+          ...session.timeline,
+          {
+            kind: 'system-marker',
+            marker: {
+              id: nextMarkerId(),
+              timestamp: Date.now(),
+              // No summary → SystemMarker renders it as a plain (non-expandable)
+              // divider. Falls back to a generic label when no device is known.
+              label: `This conversation moved to ${action.device ?? 'another device'}`,
+              variant: 'moved',
+            },
+          },
+        ],
       });
       return next;
     }

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -83,7 +83,9 @@ export interface SystemMarker {
   id: string;
   timestamp: number;
   label: string;                                // e.g. "Conversation cleared"
-  variant?: 'clear' | 'compact' | 'info';       // For styling hooks
+  // 'moved' marks a "this conversation moved to <device>" divider — dropped in
+  // when another device takes over the session lease (Plan 2b Task 10).
+  variant?: 'clear' | 'compact' | 'info' | 'moved'; // For styling hooks
   // Optional long-form text the marker can reveal on click. Currently only
   // set on compact markers — the actual conversation summary CC produced.
   summary?: string;
@@ -232,6 +234,17 @@ export type ChatAction =
       type: 'NATIVE_SESSION_ERROR';
       sessionId: string;
       message: string;
+    }
+  | {
+      // Plan 2b Task 10: another device took over this session's lease. The
+      // holder side ends the local turn cleanly (endTurn — attention resets to
+      // 'ok', NOT a terminal error state) and appends a permanent "moved"
+      // system marker so the user sees why chat activity stopped here. Pushed
+      // from the main process as 'session:moved'; device is the new holder's
+      // label (may be absent → generic "another device").
+      type: 'SESSION_MOVED';
+      sessionId: string;
+      device?: string;
     }
   | {
       // Classifier-driven attention state change. Pure state write; no

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -83,9 +83,7 @@ export interface SystemMarker {
   id: string;
   timestamp: number;
   label: string;                                // e.g. "Conversation cleared"
-  // 'moved' marks a "this conversation moved to <device>" divider — dropped in
-  // when another device takes over the session lease (Plan 2b Task 10).
-  variant?: 'clear' | 'compact' | 'info' | 'moved'; // For styling hooks
+  variant?: 'clear' | 'compact' | 'info'; // For styling hooks
   // Optional long-form text the marker can reveal on click. Currently only
   // set on compact markers — the actual conversation summary CC produced.
   summary?: string;
@@ -236,12 +234,13 @@ export type ChatAction =
       message: string;
     }
   | {
-      // Plan 2b Task 10: another device took over this session's lease. The
-      // holder side ends the local turn cleanly (endTurn — attention resets to
-      // 'ok', NOT a terminal error state) and appends a permanent "moved"
-      // system marker so the user sees why chat activity stopped here. Pushed
-      // from the main process as 'session:moved'; device is the new holder's
-      // label (may be absent → generic "another device").
+      // Plan 2b: another device took over this session's lease. The holder side
+      // ends the local turn cleanly (endTurn — attention resets to 'ok', NOT a
+      // terminal error state). As of the "Moved Gate" follow-up (2026-07-14) this
+      // no longer appends a timeline marker — the session is destroyed immediately
+      // after, which would wipe any marker. The user-facing surface is App.tsx's
+      // MovedGate, driven off the enriched 'session:moved' push. `device` is the
+      // new holder's label (may be absent → generic "another device").
       type: 'SESSION_MOVED';
       sessionId: string;
       device?: string;

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -825,6 +825,11 @@ export const IPC = {
   SYNC_SPACES_IMPORT_PROJECT: 'syncspaces:import-project',
   SYNC_SPACES_RENAME_PROJECT: 'syncspaces:rename-project',
   SYNC_SPACES_STOP_PROJECT: 'syncspaces:stop-project',
+  // Conversation-lease takeover (Plan 2b Task 9). query = who holds this session;
+  // takeover = ask-hand-off-then-poll-and-acquire; force = overwrite a stale lease.
+  SYNC_SPACES_LEASE_QUERY: 'syncspaces:lease-query',
+  SYNC_SPACES_LEASE_TAKEOVER: 'syncspaces:lease-takeover',
+  SYNC_SPACES_LEASE_FORCE: 'syncspaces:lease-force',
   SYNC_SPACES_EVENT: 'syncspaces:event',
   // Multi-window detach subsystem (Renderer <-> Main)
   WINDOW_GET_ID: 'window:get-id',

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -830,6 +830,9 @@ export const IPC = {
   SYNC_SPACES_LEASE_QUERY: 'syncspaces:lease-query',
   SYNC_SPACES_LEASE_TAKEOVER: 'syncspaces:lease-takeover',
   SYNC_SPACES_LEASE_FORCE: 'syncspaces:lease-force',
+  // Device registry (Plan 2b spec §10a) — the "Your devices" list + rename.
+  SYNC_SPACES_LIST_DEVICES: 'syncspaces:list-devices',
+  SYNC_SPACES_RENAME_DEVICE: 'syncspaces:rename-device',
   SYNC_SPACES_EVENT: 'syncspaces:event',
   // Multi-window detach subsystem (Renderer <-> Main)
   WINDOW_GET_ID: 'window:get-id',

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -701,6 +701,10 @@ export const IPC = {
   // Main -> Renderer
   SESSION_CREATED: 'session:created',
   SESSION_DESTROYED: 'session:destroyed',
+  // Plan 2b Task 8: pushed to the renderer + remote when another device took over
+  // a conversation this device held — the holder-side takeover ends the local
+  // session and the UI shows a "moved to <device>" banner.
+  SESSION_MOVED: 'session:moved',
   PTY_OUTPUT: 'pty:output',
   HOOK_EVENT: 'hook:event',
   SESSION_RENAMED: 'session:renamed',

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -8,6 +8,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+// Real (pure) — used to compute the exact on-disk transcript path the service
+// derives, so the quiescence tests can grow the same file the loop stats.
+import { ccProjectSlug } from '../src/main/project-conversations';
 
 // vi.mock factories are hoisted above imports, so shared fake state must be
 // created via vi.hoisted for the factories to close over it.
@@ -91,6 +94,7 @@ describe('conversations service composition root', () => {
     vi.useRealTimers();
     h.syncListeners.clear();
     h.store.upsert.mockReset().mockResolvedValue({ id: 'x' } as any);
+    h.store.get.mockReset().mockResolvedValue(null as any);
     h.store.list.mockReset().mockResolvedValue([]);
     h.store.setFlag.mockReset().mockResolvedValue(undefined as any);
     h.store.setTitle.mockReset().mockResolvedValue(undefined as any);
@@ -228,6 +232,113 @@ describe('conversations service composition root', () => {
     await vi.waitFor(() => expect(h.materializeOut).toHaveBeenCalled());
     expect(h.materializeOut).toHaveBeenCalledTimes(1);
     expect(h.materializeOut.mock.calls[0][0].localJsonlPath).toContain(`${idleRec.id}.jsonl`);
+  });
+
+  // Bug 2 Part 2 (Plan 2b Task 7): noteSessionEnded releases the per-session
+  // materialize guard. A record that was SKIPPED while its session was live
+  // must materialize once the session ends — proven here via the full sweep
+  // (store.get returns null by default, so the targeted materialize is a no-op
+  // and the sweep is the sole materializer).
+  it('noteSessionEnded releases the guard so a later sweep materializes the record', async () => {
+    const dir = path.join(tmpRoot, 'ended-proj');
+    fs.mkdirSync(dir, { recursive: true });
+    const rec = {
+      id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', provider: 'claude',
+      projectName: 'ended-proj', originalPath: dir,
+      transcriptRef: 'claude/transcripts/ended-proj/eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee.jsonl',
+    };
+    h.store.list.mockResolvedValue([rec] as any);
+    const svc = await freshService(startOpts());
+    svc.noteSessionStarted(rec.id, dir); // now LIVE → guarded
+    fireSync({ type: 'synced', spaceId: 'personal', updated: true, pushed: false });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(h.materializeOut).not.toHaveBeenCalled(); // skipped while live
+    svc.noteSessionEnded(rec.id); // releases the guard
+    fireSync({ type: 'synced', spaceId: 'personal', updated: true, pushed: false });
+    await vi.waitFor(() => expect(h.materializeOut).toHaveBeenCalled());
+    expect(h.materializeOut.mock.calls[0][0].localJsonlPath).toContain(`${rec.id}.jsonl`);
+  });
+
+  // The targeted materialize gates on the LOCAL transcript being quiescent:
+  // session-exit fires before CC finishes flushing its final turn, so the copy
+  // waits until the file's size stops changing across one probe interval.
+  it('materialize-after-end waits for the local file size to stabilize', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    const dir = path.join(tmpRoot, 'quiesce-proj');
+    fs.mkdirSync(dir, { recursive: true });
+    const id = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+    const rec = {
+      id, provider: 'claude', projectName: 'quiesce-proj', originalPath: dir,
+      transcriptRef: `claude/transcripts/quiesce-proj/${id}.jsonl`,
+    };
+    h.store.get.mockResolvedValue(rec as any);
+    // The exact on-disk path the loop stats — mirror localJsonlPath's derivation.
+    const localPath = path.join(startOpts().projectsDir, ccProjectSlug(dir), `${id}.jsonl`);
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    fs.writeFileSync(localPath, 'aaaa'); // initial size
+
+    svc.noteSessionStarted(id, dir);
+    svc.noteSessionEnded(id);            // kicks the async targeted materialize
+    await vi.advanceTimersByTimeAsync(0); // flush get() → first stat → arm probe
+    // Grow the file mid-wait: the next probe sees a DIFFERENT size, so the copy
+    // must NOT have happened yet.
+    fs.writeFileSync(localPath, 'aaaabbbbcccc');
+    await vi.advanceTimersByTimeAsync(750); // probe 2: size changed → keep waiting
+    expect(h.materializeOut).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(750); // probe 3: size stable → copy now
+    expect(h.materializeOut).toHaveBeenCalledTimes(1);
+    expect(h.materializeOut.mock.calls[0][0].localJsonlPath).toBe(localPath);
+    svc.stopConversationStore();
+    vi.useRealTimers();
+  });
+
+  // The targeted materialize touches ONLY the ended session's record — it is
+  // NOT a full-store scan (that's materializeSweep's job).
+  it('materialize-after-end is targeted to the ended session only', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    const dirA = path.join(tmpRoot, 'targ-a');
+    const dirB = path.join(tmpRoot, 'targ-b');
+    fs.mkdirSync(dirA, { recursive: true });
+    fs.mkdirSync(dirB, { recursive: true });
+    const recA = {
+      id: 'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa', provider: 'claude',
+      projectName: 'targ-a', originalPath: dirA,
+      transcriptRef: 'claude/transcripts/targ-a/aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl',
+    };
+    const recB = {
+      id: 'bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb', provider: 'claude',
+      projectName: 'targ-b', originalPath: dirB,
+      transcriptRef: 'claude/transcripts/targ-b/bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl',
+    };
+    // get resolves the requested id; list (the sweep path) would return BOTH —
+    // asserting a single materializeOut proves the ended path never full-scans.
+    h.store.get.mockImplementation(async (_p: string, gid: string) => (gid === recA.id ? recA : recB) as any);
+    h.store.list.mockResolvedValue([recA, recB] as any);
+
+    svc.noteSessionStarted(recA.id, dirA);
+    svc.noteSessionEnded(recA.id);
+    await vi.advanceTimersByTimeAsync(0);   // flush get() → first stat (absent → size 0) → arm probe
+    await vi.advanceTimersByTimeAsync(750); // probe 2: size 0 stable → copy recA only
+    expect(h.materializeOut).toHaveBeenCalledTimes(1);
+    expect(h.materializeOut.mock.calls[0][0].localJsonlPath).toContain(`${recA.id}.jsonl`);
+    svc.stopConversationStore();
+    vi.useRealTimers();
+  });
+
+  // Store not started (or stopped) → noteSessionEnded must be a silent no-op,
+  // never a throw (it's called from the session-exit IPC handler).
+  it('noteSessionEnded with no store is a no-op and never throws', async () => {
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    // store is null (startConversationStore never called this module instance).
+    expect(() => svc.noteSessionEnded('claude-no-store')).not.toThrow();
+    expect(h.materializeOut).not.toHaveBeenCalled();
   });
 
   // Review fix 4: start must be idempotent — a second start without stop must

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -392,6 +392,46 @@ describe('conversations service composition root', () => {
     vi.useRealTimers();
   });
 
+  // Plan 2b Task 8: flushSessionToSpace waits for the local transcript to go
+  // quiescent, then mirrors local->space and nudges a personal-space sync. Used
+  // by the holder-side takeover to push the FINAL interrupted turn before the
+  // lease releases. Unlike materializeEndedSession it pushes REGARDLESS of the
+  // quiescence result (mirrorIn is grow-only, never touches CC's open file).
+  it('flushSessionToSpace mirrors local->space after quiescence and pushes personal', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    const dir = path.join(tmpRoot, 'flush-proj');
+    fs.mkdirSync(dir, { recursive: true });
+    const id = '33333333-3333-3333-3333-333333333333';
+    // Seed the local transcript at the exact path the service derives, stable size.
+    const localPath = path.join(startOpts().projectsDir, ccProjectSlug(dir), `${id}.jsonl`);
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    fs.writeFileSync(localPath, 'the-final-turn');
+
+    svc.noteSessionStarted(id, dir); // learn the cwd so flush can locate the file
+    const p = svc.flushSessionToSpace(id);
+    await vi.advanceTimersByTimeAsync(0);   // first stat → arm the probe sleep
+    await vi.advanceTimersByTimeAsync(750); // probe 2: size stable → quiescent → mirror + push
+    await p;
+    expect(h.mirrorIn).toHaveBeenCalledTimes(1);
+    expect(h.mirrorIn.mock.calls[0][0].localJsonlPath).toBe(localPath);
+    // Space transcript path is <root>/claude/transcripts/<projectKey>/<id>.jsonl.
+    expect(h.mirrorIn.mock.calls[0][0].spaceTranscriptPath).toContain(`${id}.jsonl`);
+    expect(h.syncSpacesSyncNow).toHaveBeenCalledWith('personal');
+    svc.stopConversationStore();
+    vi.useRealTimers();
+  });
+
+  // No known cwd for the id → flush is a silent no-op (can't locate the transcript).
+  it('flushSessionToSpace with no known session is a no-op', async () => {
+    const svc = await freshService(startOpts());
+    await svc.flushSessionToSpace('never-announced');
+    expect(h.mirrorIn).not.toHaveBeenCalled();
+    expect(h.syncSpacesSyncNow).not.toHaveBeenCalled();
+  });
+
   // Store not started (or stopped) → noteSessionEnded must be a silent no-op,
   // never a throw (it's called from the session-exit IPC handler).
   it('noteSessionEnded with no store is a no-op and never throws', async () => {

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -331,6 +331,67 @@ describe('conversations service composition root', () => {
     vi.useRealTimers();
   });
 
+  // Data-loss guard: if the local transcript NEVER stops growing before
+  // QUIESCE_MAX_MS, CC is still flushing — the materialize must SKIP, never
+  // rename over the file CC still has open (POSIX inode-detach → chat freeze +
+  // lost turns). The reconciler/startup sweep catch up once it's quiet.
+  it('materialize-after-end SKIPS (does not materialize) when the file never stabilizes', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    const dir = path.join(tmpRoot, 'grow-forever');
+    fs.mkdirSync(dir, { recursive: true });
+    const id = '11111111-1111-1111-1111-111111111111';
+    const rec = {
+      id, provider: 'claude', projectName: 'grow-forever', originalPath: dir,
+      transcriptRef: `claude/transcripts/grow-forever/${id}.jsonl`,
+    };
+    h.store.get.mockResolvedValue(rec as any);
+    // Make statSync report an ever-growing size on EVERY probe so quiescence is
+    // never reached (simulates CC still flushing the whole time).
+    let sz = 100;
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation(() => ({ size: (sz += 100) } as any));
+
+    svc.noteSessionStarted(id, dir);
+    svc.noteSessionEnded(id);
+    // Advance well past QUIESCE_MAX_MS (6s) — every probe sees a bigger size.
+    for (let i = 0; i < 12; i++) await vi.advanceTimersByTimeAsync(750);
+    expect(h.materializeOut).not.toHaveBeenCalled();
+
+    statSpy.mockRestore();
+    svc.stopConversationStore();
+    vi.useRealTimers();
+  });
+
+  // Re-open guard: if the SAME session restarts during the quiescence wait, the
+  // live guard wins — the targeted materialize must NOT touch the transcript CC
+  // is now appending to again.
+  it('materialize-after-end skips when the session is re-opened during the wait', async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const svc = await import('../src/main/conversations/service');
+    await svc.startConversationStore(startOpts());
+    const dir = path.join(tmpRoot, 'reopen-proj');
+    fs.mkdirSync(dir, { recursive: true });
+    const id = '22222222-2222-2222-2222-222222222222';
+    const rec = {
+      id, provider: 'claude', projectName: 'reopen-proj', originalPath: dir,
+      transcriptRef: `claude/transcripts/reopen-proj/${id}.jsonl`,
+    };
+    h.store.get.mockResolvedValue(rec as any);
+    // Local file absent (size 0), so it would reach quiescence on probe 2 — but
+    // we re-open the session first, and the post-wait guard must win.
+    svc.noteSessionStarted(id, dir);
+    svc.noteSessionEnded(id);              // deletes guard, kicks async materialize
+    await vi.advanceTimersByTimeAsync(0);  // flush get() → first probe (size 0) → arm sleep
+    svc.noteSessionStarted(id, dir);       // session re-opens mid-wait → re-adds the guard
+    await vi.advanceTimersByTimeAsync(750); // probe 2: size 0 stable → quiesced, but guard is set
+    expect(h.materializeOut).not.toHaveBeenCalled();
+    svc.stopConversationStore();
+    vi.useRealTimers();
+  });
+
   // Store not started (or stopped) → noteSessionEnded must be a silent no-op,
   // never a throw (it's called from the session-exit IPC handler).
   it('noteSessionEnded with no store is a no-op and never throws', async () => {

--- a/desktop/tests/device-identity.test.ts
+++ b/desktop/tests/device-identity.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getDeviceIdentity } from '../src/main/device-identity';
+
+// A loose UUID shape check — we only need to confirm randomUUID produced a real id.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-device-id-'));
+});
+afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+describe('getDeviceIdentity', () => {
+  it('creates device-id.json with a UUID id on first call', () => {
+    const { id } = getDeviceIdentity(tmp);
+    expect(id).toMatch(UUID_RE);
+    // The id must have been persisted to disk under the userData dir.
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmp, 'device-id.json'), 'utf8'));
+    expect(onDisk.id).toBe(id);
+  });
+
+  it('returns the SAME id on a second call (persistence, no regeneration)', () => {
+    const first = getDeviceIdentity(tmp).id;
+    // Prove the second call reads the existing file rather than rewriting it:
+    // if the id changed, persistence is broken.
+    const second = getDeviceIdentity(tmp).id;
+    expect(second).toBe(first);
+  });
+
+  it('replaces a corrupt file with a fresh valid id and never throws', () => {
+    const p = path.join(tmp, 'device-id.json');
+    fs.writeFileSync(p, '{not valid json at all');
+    const { id } = getDeviceIdentity(tmp);
+    expect(id).toMatch(UUID_RE);
+    // The corrupt bytes were overwritten with the fresh, valid record.
+    const onDisk = JSON.parse(fs.readFileSync(p, 'utf8'));
+    expect(onDisk.id).toBe(id);
+  });
+
+  it('treats valid JSON with a missing/empty id as corrupt (regenerates)', () => {
+    const p = path.join(tmp, 'device-id.json');
+    fs.writeFileSync(p, JSON.stringify({ id: '' }));
+    const { id } = getDeviceIdentity(tmp);
+    expect(id).toMatch(UUID_RE);
+    expect(id).not.toBe('');
+    const onDisk = JSON.parse(fs.readFileSync(p, 'utf8'));
+    expect(onDisk.id).toBe(id);
+  });
+});

--- a/desktop/tests/holder-takeover.test.ts
+++ b/desktop/tests/holder-takeover.test.ts
@@ -107,6 +107,19 @@ describe('createHolderTakeover', () => {
     ]);
   });
 
+  it('never throws when pushMoved throws AND still runs destroy (step 8)', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['d1'] });
+    deps.sessionIdMap.set('d1', 'c1');
+    // pushMoved can throw synchronously (remoteServer.broadcast -> ws.send on a
+    // socket mid-teardown). The handler must swallow it AND still destroy.
+    (deps.pushMoved as any) = vi.fn((did: string) => { deps.order.push(`push:${did}`); throw new Error('ws send failed'); });
+    const handler = createHolderTakeover(deps as any);
+    await expect(handler('c1', { deviceId: 'x', device: 'X' })).resolves.toBeUndefined();
+    // Step 8 still runs after the guarded push throw — no half-done handoff.
+    expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d1');
+    expect(deps.order).toEqual(['interrupt:d1:"\\u001b"', 'flush:c1', 'release:c1', 'push:d1', 'destroy:d1']);
+  });
+
   it('never throws even when the lease release rejects', async () => {
     const deps = makeDeps({ liveDesktopIds: ['d1'] });
     deps.sessionIdMap.set('d1', 'c1');

--- a/desktop/tests/holder-takeover.test.ts
+++ b/desktop/tests/holder-takeover.test.ts
@@ -1,0 +1,120 @@
+// Plan 2b Task 8 — pins the holder-side takeover sequence (createHolderTakeover).
+// When another device requests a session THIS device holds, the holder must:
+//   interrupt (ESC to PTY) -> flush local->space -> release lease -> pushMoved -> destroy
+// The ORDER is load-bearing: MIRROR-BEFORE-RELEASE (the requester pulls on seeing
+// the release, so the final turn must already be in the space) and
+// RELEASE-BEFORE-DESTROY (release must land before the local session ends). All
+// collaborators are injected fakes — this tests ONLY the sequence, not the IO.
+import { describe, it, expect, vi } from 'vitest';
+import { createHolderTakeover } from '../src/main/conversations/takeover';
+
+// Build a deps bundle whose every fake pushes a label into a shared order log, so
+// tests can assert both WHICH steps ran and in WHAT order.
+function makeDeps(opts?: { liveDesktopIds?: string[]; flushRejects?: boolean }) {
+  const order: string[] = [];
+  const live = new Set(opts?.liveDesktopIds ?? []);
+  const sessionIdMap = new Map<string, string>();
+  const deps = {
+    order,
+    sessionIdMap,
+    sessionManager: {
+      // A desktop id is "live" only if it's in the live set.
+      getSession: (id: string) => (live.has(id) ? { id } : undefined),
+      sendInput: vi.fn((id: string, text: string) => { order.push(`interrupt:${id}:${JSON.stringify(text)}`); return true; }),
+      destroySession: vi.fn((id: string) => { order.push(`destroy:${id}`); return true; }),
+    },
+    leaseClient: {
+      release: vi.fn(async (sid: string) => { order.push(`release:${sid}`); }),
+    },
+    flushSessionToSpace: vi.fn(async (cid: string) => {
+      order.push(`flush:${cid}`);
+      if (opts?.flushRejects) throw new Error('flush blew up');
+    }),
+    pushMoved: vi.fn((did: string, device?: string) => { order.push(`push:${did}:${device ?? ''}`); }),
+  };
+  return deps;
+}
+
+describe('createHolderTakeover', () => {
+  it('runs interrupt -> flush -> release -> pushMoved -> destroy for a live held session', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['desktop-1'] });
+    // desktop-1 holds claude-abc; a stray other mapping must be ignored.
+    deps.sessionIdMap.set('desktop-1', 'claude-abc');
+    deps.sessionIdMap.set('desktop-2', 'claude-other');
+    const handler = createHolderTakeover(deps as any);
+
+    await handler('claude-abc', { deviceId: 'dev-b', device: 'Laptop-B' });
+
+    expect(deps.order).toEqual([
+      'interrupt:desktop-1:"\\u001b"', // single ESC byte to the PTY
+      'flush:claude-abc',
+      'release:claude-abc',
+      'push:desktop-1:Laptop-B',       // desktopId reverse-mapped, from.device forwarded
+      'destroy:desktop-1',
+    ]);
+    // The reverse-map picked the correct desktop id, not desktop-2.
+    expect(deps.sessionManager.sendInput).toHaveBeenCalledWith('desktop-1', '\x1b');
+    expect(deps.pushMoved).toHaveBeenCalledWith('desktop-1', 'Laptop-B');
+  });
+
+  it('mirror-before-release AND release-before-destroy hold', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['d1'] });
+    deps.sessionIdMap.set('d1', 'c1');
+    const handler = createHolderTakeover(deps as any);
+    await handler('c1', { deviceId: 'x', device: 'X' });
+    const iFlush = deps.order.indexOf('flush:c1');
+    const iRelease = deps.order.indexOf('release:c1');
+    const iDestroy = deps.order.indexOf('destroy:d1');
+    expect(iFlush).toBeGreaterThanOrEqual(0);
+    expect(iRelease).toBeGreaterThan(iFlush);   // MIRROR (flush) before RELEASE
+    expect(iDestroy).toBeGreaterThan(iRelease); // RELEASE before DESTROY
+  });
+
+  it('with NO mapping for the claude id, only releases the lease (no interrupt/flush/push/destroy)', async () => {
+    const deps = makeDeps({ liveDesktopIds: [] }); // empty map
+    const handler = createHolderTakeover(deps as any);
+    await handler('claude-ghost', { deviceId: 'x', device: 'X' });
+    expect(deps.order).toEqual(['release:claude-ghost']);
+    expect(deps.sessionManager.sendInput).not.toHaveBeenCalled();
+    expect(deps.flushSessionToSpace).not.toHaveBeenCalled();
+    expect(deps.pushMoved).not.toHaveBeenCalled();
+    expect(deps.sessionManager.destroySession).not.toHaveBeenCalled();
+  });
+
+  it('with a mapping but the session no longer live (getSession undefined), only releases', async () => {
+    // Mapping exists but the desktop id is not in the live set → not actually held.
+    const deps = makeDeps({ liveDesktopIds: [] });
+    deps.sessionIdMap.set('d-dead', 'claude-dead');
+    const handler = createHolderTakeover(deps as any);
+    await handler('claude-dead');
+    expect(deps.order).toEqual(['release:claude-dead']);
+  });
+
+  it('never throws and runs release/push/destroy even when flush rejects', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['d1'], flushRejects: true });
+    deps.sessionIdMap.set('d1', 'c1');
+    const handler = createHolderTakeover(deps as any);
+    // Must resolve (not reject) despite the flush rejection.
+    await expect(handler('c1', { deviceId: 'x', device: 'X' })).resolves.toBeUndefined();
+    // Each step is independently try/caught, so a flush reject does NOT abort the
+    // rest — release/push/destroy still run.
+    expect(deps.order).toEqual([
+      'interrupt:d1:"\\u001b"',
+      'flush:c1',
+      'release:c1',
+      'push:d1:X',     // from.device still forwarded despite the flush reject
+      'destroy:d1',
+    ]);
+  });
+
+  it('never throws even when the lease release rejects', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['d1'] });
+    deps.sessionIdMap.set('d1', 'c1');
+    (deps.leaseClient.release as any) = vi.fn(async () => { throw new Error('release failed'); });
+    const handler = createHolderTakeover(deps as any);
+    await expect(handler('c1', { deviceId: 'x', device: 'X' })).resolves.toBeUndefined();
+    // push + destroy still run after a rejected release.
+    expect(deps.pushMoved).toHaveBeenCalledWith('d1', 'X');
+    expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d1');
+  });
+});

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -547,6 +547,13 @@ describe('syncspaces:* channel parity (desktop surfaces)', () => {
     ['syncspaces:import-project', 'IPC.SYNC_SPACES_IMPORT_PROJECT'],
     ['syncspaces:rename-project', 'IPC.SYNC_SPACES_RENAME_PROJECT'],
     ['syncspaces:stop-project', 'IPC.SYNC_SPACES_STOP_PROJECT'],
+    // Plan 2b Task 11 — conversation leases + device registry. Full four-surface
+    // desktop parity (preload / remote-shim / ipc-handlers constant / remote-server).
+    ['syncspaces:lease-query', 'IPC.SYNC_SPACES_LEASE_QUERY'],
+    ['syncspaces:lease-takeover', 'IPC.SYNC_SPACES_LEASE_TAKEOVER'],
+    ['syncspaces:lease-force', 'IPC.SYNC_SPACES_LEASE_FORCE'],
+    ['syncspaces:list-devices', 'IPC.SYNC_SPACES_LIST_DEVICES'],
+    ['syncspaces:rename-device', 'IPC.SYNC_SPACES_RENAME_DEVICE'],
   ];
   const preload = fs.readFileSync(path.join(__dirname, '../src/main/preload.ts'), 'utf8');
   const shim = fs.readFileSync(path.join(__dirname, '../src/renderer/remote-shim.ts'), 'utf8');
@@ -563,6 +570,36 @@ describe('syncspaces:* channel parity (desktop surfaces)', () => {
   it('syncspaces:event push channel present in preload + remote-shim', () => {
     expect(preload).toContain('syncspaces:event');
     expect(shim).toContain('syncspaces:event');
+  });
+
+  // Plan 2b Task 11 — the five lease/device REQUEST channels also have an Android
+  // stub (SessionService.kt returns not-implemented-on-mobile) so a mobile invoke
+  // rejects fast instead of 30s-timing-out. Assert the Kotlin stub covers all five.
+  const kotlinPath = path.join(__dirname, '../../app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt');
+  const leaseDeviceRequestChannels = [
+    'syncspaces:lease-query',
+    'syncspaces:lease-takeover',
+    'syncspaces:lease-force',
+    'syncspaces:list-devices',
+    'syncspaces:rename-device',
+  ];
+  if (fs.existsSync(kotlinPath)) {
+    const kotlin = fs.readFileSync(kotlinPath, 'utf8');
+    for (const ch of leaseDeviceRequestChannels) {
+      it(`${ch} has an Android not-implemented-on-mobile stub in SessionService.kt`, () => {
+        expect(kotlin).toContain(`"${ch}"`);
+      });
+    }
+  } else {
+    it.skip('SessionService.kt not found — skipping Android lease/device stub check', () => {});
+  }
+
+  // session:moved is a PUSH event (Task 8 broadcasts it), NOT a request — so it
+  // has no ipc-handlers/Kotlin request handler. Assert only the two surfaces that
+  // CONSUME it: preload (ipcRenderer.on) + remote-shim (addListener push routing).
+  it('session:moved push channel present in preload + remote-shim', () => {
+    expect(preload).toContain('session:moved');
+    expect(shim).toContain('session:moved');
   });
 });
 

--- a/desktop/tests/lease-client.test.ts
+++ b/desktop/tests/lease-client.test.ts
@@ -1,0 +1,204 @@
+// Unit tests for the lease-client (Plan 2b, Task 6). No network, no real hub —
+// hubRequest is injected as a vi.fn() whose responses each test scripts. Renew
+// timers are driven by vitest fake timers; the lease-file fallback is asserted
+// against a REAL temp dir (readFileSync/existsSync), not mocks.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createLeaseClient, type LeaseClient } from '../src/main/conversations/lease-client';
+import type { LeaseResult } from '../src/main/sync-hub-socket';
+
+const DEVICE_ID = 'dev-A';
+const DEVICE_NAME = 'laptop-A';
+const RENEW_MS = 30_000;
+
+function okResult(op: string, sessionId: string, expiresAt: number): LeaseResult {
+  return { ok: true, op, sessionId, holder: { deviceId: DEVICE_ID, device: DEVICE_NAME, expiresAt } };
+}
+function lostResult(op: string, sessionId: string): LeaseResult {
+  // Force-acquired by another device: ok=false, holder is now someone else.
+  return { ok: false, op, sessionId, holder: { deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() + 300_000 } };
+}
+
+function leaseFilePath(root: string, sessionId: string): string {
+  return path.join(root, 'Leases', `${sessionId}.json`);
+}
+
+describe('lease-client', () => {
+  let tmpRoot: string;
+  let hubRequest: ReturnType<typeof vi.fn>;
+  let takeoverSpy: ReturnType<typeof vi.fn>;
+  let client: LeaseClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lease-test-'));
+    hubRequest = vi.fn();
+    takeoverSpy = vi.fn();
+    client = createLeaseClient({
+      deviceId: DEVICE_ID,
+      deviceName: DEVICE_NAME,
+      personalRoot: () => tmpRoot,
+      hubRequest: hubRequest as any,
+      onTakeoverRequest: takeoverSpy as any,
+    });
+  });
+
+  afterEach(() => {
+    client.destroy();
+    vi.useRealTimers();
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  it('acquire starts a renew timer and writes the lease file', async () => {
+    const expiresAt = Date.now() + 300_000;
+    hubRequest.mockResolvedValue(okResult('acquire', 's1', expiresAt));
+
+    await client.acquire('s1');
+
+    expect(client.isHeld('s1')).toBe(true);
+    // Lease file written on acquire.
+    const file = leaseFilePath(tmpRoot, 's1');
+    expect(fs.existsSync(file)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(parsed.deviceId).toBe(DEVICE_ID);
+    expect(parsed.device).toBe(DEVICE_NAME);
+    expect(parsed.expiresAt).toBe(expiresAt);
+
+    // Renew timer fires at 30s.
+    hubRequest.mockClear();
+    hubRequest.mockResolvedValue(okResult('renew', 's1', Date.now() + 300_000));
+    await vi.advanceTimersByTimeAsync(RENEW_MS);
+    expect(hubRequest).toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+  });
+
+  it('release stops the timer, deletes the file, and calls the hub', async () => {
+    hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
+    await client.acquire('s1');
+    expect(fs.existsSync(leaseFilePath(tmpRoot, 's1'))).toBe(true);
+
+    hubRequest.mockClear();
+    hubRequest.mockResolvedValue(okResult('release', 's1', 0));
+    await client.release('s1');
+
+    expect(client.isHeld('s1')).toBe(false);
+    expect(fs.existsSync(leaseFilePath(tmpRoot, 's1'))).toBe(false);
+    expect(hubRequest).toHaveBeenCalledWith('release', 's1', DEVICE_ID);
+
+    // No further renew after release.
+    hubRequest.mockClear();
+    await vi.advanceTimersByTimeAsync(RENEW_MS * 2);
+    expect(hubRequest).not.toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+  });
+
+  it('query prefers the hub result', async () => {
+    hubRequest.mockResolvedValue({ ok: true, op: 'get', sessionId: 's1', holder: { deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() + 100 } });
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: true, device: 'phone-B', expiresAt: expect.any(Number), source: 'hub' });
+  });
+
+  it('query falls back to an unexpired lease file when the hub returns null', async () => {
+    hubRequest.mockResolvedValue(null);
+    const dir = path.join(tmpRoot, 'Leases');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), JSON.stringify({ deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() + 100_000 }));
+
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: true, device: 'phone-B', expiresAt: expect.any(Number), source: 'file' });
+  });
+
+  it('query treats an expired lease file as free', async () => {
+    hubRequest.mockResolvedValue(null);
+    const dir = path.join(tmpRoot, 'Leases');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), JSON.stringify({ deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() - 1000 }));
+
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: false, source: 'none' });
+  });
+
+  it('query with hub null and no file reports free', async () => {
+    hubRequest.mockResolvedValue(null);
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: false, source: 'none' });
+  });
+
+  it('handleTakeoverRequest invokes the callback only for a HELD session', async () => {
+    hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
+    await client.acquire('s1');
+
+    const from = { deviceId: 'dev-B', device: 'phone-B' };
+    client.handleTakeoverRequest('s1', from);
+    expect(takeoverSpy).toHaveBeenCalledWith('s1', from);
+
+    // Unheld session — ignored.
+    takeoverSpy.mockClear();
+    client.handleTakeoverRequest('s-unheld', from);
+    expect(takeoverSpy).not.toHaveBeenCalled();
+  });
+
+  it('renew failure (force-acquired) stops the timer, deletes the file, and calls onTakeoverRequest', async () => {
+    hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
+    await client.acquire('s1');
+    expect(fs.existsSync(leaseFilePath(tmpRoot, 's1'))).toBe(true);
+
+    // Next renew fails — another device force-acquired.
+    hubRequest.mockClear();
+    hubRequest.mockResolvedValue(lostResult('renew', 's1'));
+    await vi.advanceTimersByTimeAsync(RENEW_MS);
+
+    expect(client.isHeld('s1')).toBe(false);
+    expect(fs.existsSync(leaseFilePath(tmpRoot, 's1'))).toBe(false);
+    // Called with sessionId only (no `from` on the force-acquire path).
+    expect(takeoverSpy).toHaveBeenCalledWith('s1');
+
+    // Timer is stopped — no further renew.
+    hubRequest.mockClear();
+    await vi.advanceTimersByTimeAsync(RENEW_MS * 2);
+    expect(hubRequest).not.toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+  });
+
+  it('destroy clears all renew timers', async () => {
+    hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
+    await client.acquire('s1');
+    hubRequest.mockResolvedValue(okResult('acquire', 's2', Date.now() + 300_000));
+    await client.acquire('s2');
+
+    client.destroy();
+    expect(client.isHeld('s1')).toBe(false);
+    expect(client.isHeld('s2')).toBe(false);
+
+    hubRequest.mockClear();
+    await vi.advanceTimersByTimeAsync(RENEW_MS * 2);
+    expect(hubRequest).not.toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+    expect(hubRequest).not.toHaveBeenCalledWith('renew', 's2', DEVICE_ID);
+  });
+
+  it('acquire on a hub reject (someone else holds it) does not start a timer or write a file', async () => {
+    hubRequest.mockResolvedValue(lostResult('acquire', 's1'));
+    const res = await client.acquire('s1');
+
+    expect(res && res.ok).toBe(false);
+    expect(client.isHeld('s1')).toBe(false);
+    expect(fs.existsSync(leaseFilePath(tmpRoot, 's1'))).toBe(false);
+
+    hubRequest.mockClear();
+    await vi.advanceTimersByTimeAsync(RENEW_MS);
+    expect(hubRequest).not.toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+  });
+
+  it('acquire on hub-disconnected (null) optimistically holds locally', async () => {
+    hubRequest.mockResolvedValue(null);
+    const res = await client.acquire('s1');
+
+    expect(res && res.ok).toBe(true);
+    expect(client.isHeld('s1')).toBe(true);
+    // File written with a locally-synthesized expiry.
+    const file = leaseFilePath(tmpRoot, 's1');
+    expect(fs.existsSync(file)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(parsed.deviceId).toBe(DEVICE_ID);
+    expect(typeof parsed.expiresAt).toBe('number');
+  });
+});

--- a/desktop/tests/lease-client.test.ts
+++ b/desktop/tests/lease-client.test.ts
@@ -159,6 +159,40 @@ describe('lease-client', () => {
     expect(hubRequest).not.toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
   });
 
+  it('transient-null renew keeps the lease and keeps renewing', async () => {
+    hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
+    await client.acquire('s1');
+
+    // Next renew: hub transiently disconnected (null). Lease must NOT drop.
+    hubRequest.mockClear();
+    hubRequest.mockResolvedValue(null);
+    await vi.advanceTimersByTimeAsync(RENEW_MS);
+
+    expect(hubRequest).toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+    expect(client.isHeld('s1')).toBe(true);
+    // File fallback still present and fresh (local-clock deadline in the future).
+    const file = leaseFilePath(tmpRoot, 's1');
+    expect(fs.existsSync(file)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(file, 'utf8')).expiresAt).toBeGreaterThan(Date.now());
+
+    // A SECOND renew is attempted on the next tick — the timer kept running.
+    hubRequest.mockClear();
+    hubRequest.mockResolvedValue(okResult('renew', 's1', Date.now() + 300_000));
+    await vi.advanceTimersByTimeAsync(RENEW_MS);
+    expect(hubRequest).toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
+    expect(client.isHeld('s1')).toBe(true);
+  });
+
+  it('query treats a malformed lease file as free', async () => {
+    hubRequest.mockResolvedValue(null);
+    const dir = path.join(tmpRoot, 'Leases');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), '{ not json');
+
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: false, source: 'none' });
+  });
+
   it('destroy clears all renew timers', async () => {
     hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
     await client.acquire('s1');

--- a/desktop/tests/lease-client.test.ts
+++ b/desktop/tests/lease-client.test.ts
@@ -92,20 +92,45 @@ describe('lease-client', () => {
     expect(hubRequest).not.toHaveBeenCalledWith('renew', 's1', DEVICE_ID);
   });
 
-  it('query prefers the hub result', async () => {
+  it('query prefers the hub result (holder is another device -> self:false)', async () => {
     hubRequest.mockResolvedValue({ ok: true, op: 'get', sessionId: 's1', holder: { deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() + 100 } });
     const r = await client.query('s1');
-    expect(r).toEqual({ held: true, device: 'phone-B', expiresAt: expect.any(Number), source: 'hub' });
+    // deviceId carried through; self false because holder deviceId !== our DEVICE_ID.
+    expect(r).toEqual({ held: true, device: 'phone-B', deviceId: 'dev-B', self: false, expiresAt: expect.any(Number), source: 'hub' });
   });
 
-  it('query falls back to an unexpired lease file when the hub returns null', async () => {
+  it('query hub result with OUR deviceId reports self:true (label is irrelevant)', async () => {
+    // Same-label collision guard: even if the holder label differs, self keys on
+    // the per-install deviceId. Here deviceId === DEVICE_ID -> self:true.
+    hubRequest.mockResolvedValue({ ok: true, op: 'get', sessionId: 's1', holder: { deviceId: DEVICE_ID, device: 'some-other-label', expiresAt: Date.now() + 100 } });
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: true, device: 'some-other-label', deviceId: DEVICE_ID, self: true, expiresAt: expect.any(Number), source: 'hub' });
+  });
+
+  it('query hub free reports self:false', async () => {
+    hubRequest.mockResolvedValue({ ok: true, op: 'get', sessionId: 's1', holder: null });
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: false, self: false, source: 'hub' });
+  });
+
+  it('query falls back to an unexpired lease file when the hub returns null (self:false for another device)', async () => {
     hubRequest.mockResolvedValue(null);
     const dir = path.join(tmpRoot, 'Leases');
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), JSON.stringify({ deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() + 100_000 }));
 
     const r = await client.query('s1');
-    expect(r).toEqual({ held: true, device: 'phone-B', expiresAt: expect.any(Number), source: 'file' });
+    expect(r).toEqual({ held: true, device: 'phone-B', deviceId: 'dev-B', self: false, expiresAt: expect.any(Number), source: 'file' });
+  });
+
+  it('query file fallback with OUR deviceId reports self:true', async () => {
+    hubRequest.mockResolvedValue(null);
+    const dir = path.join(tmpRoot, 'Leases');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), JSON.stringify({ deviceId: DEVICE_ID, device: DEVICE_NAME, expiresAt: Date.now() + 100_000 }));
+
+    const r = await client.query('s1');
+    expect(r).toEqual({ held: true, device: DEVICE_NAME, deviceId: DEVICE_ID, self: true, expiresAt: expect.any(Number), source: 'file' });
   });
 
   it('query treats an expired lease file as free', async () => {
@@ -115,13 +140,13 @@ describe('lease-client', () => {
     fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), JSON.stringify({ deviceId: 'dev-B', device: 'phone-B', expiresAt: Date.now() - 1000 }));
 
     const r = await client.query('s1');
-    expect(r).toEqual({ held: false, source: 'none' });
+    expect(r).toEqual({ held: false, self: false, source: 'none' });
   });
 
   it('query with hub null and no file reports free', async () => {
     hubRequest.mockResolvedValue(null);
     const r = await client.query('s1');
-    expect(r).toEqual({ held: false, source: 'none' });
+    expect(r).toEqual({ held: false, self: false, source: 'none' });
   });
 
   it('handleTakeoverRequest invokes the callback only for a HELD session', async () => {
@@ -190,7 +215,7 @@ describe('lease-client', () => {
     fs.writeFileSync(leaseFilePath(tmpRoot, 's1'), '{ not json');
 
     const r = await client.query('s1');
-    expect(r).toEqual({ held: false, source: 'none' });
+    expect(r).toEqual({ held: false, self: false, source: 'none' });
   });
 
   it('destroy clears all renew timers', async () => {

--- a/desktop/tests/requester-takeover.test.ts
+++ b/desktop/tests/requester-takeover.test.ts
@@ -1,0 +1,129 @@
+// Plan 2b Task 9 — pins the requester-side takeover flow (createRequesterTakeover).
+// When the user resumes a conversation another device holds, THIS device asks the
+// holder to hand off, polls the lease until it frees (or times out at 10s), then
+// pulls the peer's final turn and acquires the lease. All collaborators are
+// injected fakes; the poll loop is driven with fake timers. The flow must NEVER
+// throw (spec §3 never-block) — errors surface as {outcome:'error'}/{ok:false}.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequesterTakeover } from '../src/main/conversations/takeover';
+
+// Build a deps bundle whose success-path fakes push a label into a shared order
+// log so tests can assert BOTH which steps ran and in WHAT order.
+function makeDeps(opts: {
+  // query returns these results in sequence; the last one repeats forever.
+  queryResults: Array<{ held: boolean; device?: string }>;
+  selfDevice?: string;
+  takeoverThrows?: boolean;
+  queryThrows?: boolean;
+  forceThrows?: boolean;
+}) {
+  const order: string[] = [];
+  let qi = 0;
+  const deps = {
+    order,
+    leaseClient: {
+      takeover: vi.fn(async (sid: string) => {
+        order.push(`takeover:${sid}`);
+        if (opts.takeoverThrows) throw new Error('takeover blew up');
+      }),
+      query: vi.fn(async (_sid: string) => {
+        if (opts.queryThrows) throw new Error('query blew up');
+        const r = opts.queryResults[Math.min(qi, opts.queryResults.length - 1)];
+        qi += 1;
+        return r;
+      }),
+      acquire: vi.fn(async (sid: string) => { order.push(`acquire:${sid}`); }),
+    },
+    syncNow: vi.fn(async () => { order.push('syncNow'); }),
+    materializeOne: vi.fn(async (sid: string) => { order.push(`materialize:${sid}`); }),
+    forceAcquire: vi.fn(async (sid: string) => {
+      order.push(`force:${sid}`);
+      if (opts.forceThrows) throw new Error('force blew up');
+    }),
+    // Real timer-backed delay so vi.advanceTimersByTimeAsync drives the poll.
+    delay: (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+    selfDevice: opts.selfDevice ?? 'This-Device',
+  };
+  return deps;
+}
+
+describe('createRequesterTakeover', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('takeover: holder releases after 2 polls -> acquired, in order syncNow -> materialize -> acquire', async () => {
+    // held twice (holder hasn't released yet), then free.
+    const deps = makeDeps({
+      queryResults: [{ held: true, device: 'Laptop-B' }, { held: true, device: 'Laptop-B' }, { held: false }],
+    });
+    const flow = createRequesterTakeover(deps as any);
+    const p = flow.takeover('c1');
+    // Drive the two 1s poll gaps.
+    await vi.advanceTimersByTimeAsync(2_000);
+    const res = await p;
+    expect(res).toEqual({ outcome: 'acquired' });
+    // takeover first, then the free-path trio in the required order.
+    expect(deps.order).toEqual(['takeover:c1', 'syncNow', 'materialize:c1', 'acquire:c1']);
+    expect(deps.leaseClient.query).toHaveBeenCalledTimes(3);
+  });
+
+  it('takeover: already free on the FIRST query -> acquired fast without waiting a poll', async () => {
+    const deps = makeDeps({ queryResults: [{ held: false }] });
+    const flow = createRequesterTakeover(deps as any);
+    // No timer advance — the free check happens BEFORE the first sleep.
+    const res = await flow.takeover('c1');
+    expect(res).toEqual({ outcome: 'acquired' });
+    expect(deps.leaseClient.query).toHaveBeenCalledTimes(1);
+    expect(deps.order).toEqual(['takeover:c1', 'syncNow', 'materialize:c1', 'acquire:c1']);
+  });
+
+  it('takeover: a lease held by US (device === selfDevice) counts as free', async () => {
+    const deps = makeDeps({ queryResults: [{ held: true, device: 'This-Device' }], selfDevice: 'This-Device' });
+    const flow = createRequesterTakeover(deps as any);
+    const res = await flow.takeover('c1');
+    expect(res).toEqual({ outcome: 'acquired' });
+    expect(deps.order).toContain('acquire:c1');
+  });
+
+  it('takeover: holder never releases -> timeout after 10s (no acquire)', async () => {
+    const deps = makeDeps({ queryResults: [{ held: true, device: 'Laptop-B' }] });
+    const flow = createRequesterTakeover(deps as any);
+    const p = flow.takeover('c1');
+    // Advance well past MAX_MS so every poll interval elapses and the loop exits.
+    await vi.advanceTimersByTimeAsync(11_000);
+    const res = await p;
+    expect(res).toEqual({ outcome: 'timeout' });
+    expect(deps.leaseClient.acquire).not.toHaveBeenCalled();
+    expect(deps.syncNow).not.toHaveBeenCalled();
+    expect(deps.materializeOne).not.toHaveBeenCalled();
+  });
+
+  it('takeover: takeover() throwing -> error', async () => {
+    const deps = makeDeps({ queryResults: [{ held: false }], takeoverThrows: true });
+    const flow = createRequesterTakeover(deps as any);
+    const res = await flow.takeover('c1');
+    expect(res).toEqual({ outcome: 'error' });
+  });
+
+  it('takeover: query() throwing -> error', async () => {
+    const deps = makeDeps({ queryResults: [{ held: false }], queryThrows: true });
+    const flow = createRequesterTakeover(deps as any);
+    const res = await flow.takeover('c1');
+    expect(res).toEqual({ outcome: 'error' });
+  });
+
+  it('force: forceAcquire + syncNow + materialize -> ok, in order', async () => {
+    const deps = makeDeps({ queryResults: [{ held: false }] });
+    const flow = createRequesterTakeover(deps as any);
+    const res = await flow.force('c1');
+    expect(res).toEqual({ ok: true });
+    expect(deps.order).toEqual(['force:c1', 'syncNow', 'materialize:c1']);
+  });
+
+  it('force: forceAcquire throwing -> {ok:false}', async () => {
+    const deps = makeDeps({ queryResults: [{ held: false }], forceThrows: true });
+    const flow = createRequesterTakeover(deps as any);
+    const res = await flow.force('c1');
+    expect(res).toEqual({ ok: false });
+  });
+});

--- a/desktop/tests/requester-takeover.test.ts
+++ b/desktop/tests/requester-takeover.test.ts
@@ -11,8 +11,10 @@ import { createRequesterTakeover } from '../src/main/conversations/takeover';
 // log so tests can assert BOTH which steps ran and in WHAT order.
 function makeDeps(opts: {
   // query returns these results in sequence; the last one repeats forever.
-  queryResults: Array<{ held: boolean; device?: string }>;
-  selfDevice?: string;
+  // `self` is the deviceId-derived "held by US" flag the lease client computes —
+  // the requester keys on it, NOT on the `device` label (which collides across
+  // installs that share a hostname).
+  queryResults: Array<{ held: boolean; device?: string; self?: boolean }>;
   takeoverThrows?: boolean;
   queryThrows?: boolean;
   forceThrows?: boolean;
@@ -42,7 +44,6 @@ function makeDeps(opts: {
     }),
     // Real timer-backed delay so vi.advanceTimersByTimeAsync drives the poll.
     delay: (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
-    selfDevice: opts.selfDevice ?? 'This-Device',
   };
   return deps;
 }
@@ -77,12 +78,36 @@ describe('createRequesterTakeover', () => {
     expect(deps.order).toEqual(['takeover:c1', 'syncNow', 'materialize:c1', 'acquire:c1']);
   });
 
-  it('takeover: a lease held by US (device === selfDevice) counts as free', async () => {
-    const deps = makeDeps({ queryResults: [{ held: true, device: 'This-Device' }], selfDevice: 'This-Device' });
+  it('takeover: a lease held by US (self:true, deviceId match) counts as free', async () => {
+    // The lease client sets self:true when the holder's deviceId === our deviceId.
+    const deps = makeDeps({ queryResults: [{ held: true, device: 'This-Device', self: true }] });
     const flow = createRequesterTakeover(deps as any);
     const res = await flow.takeover('c1');
     expect(res).toEqual({ outcome: 'acquired' });
     expect(deps.order).toContain('acquire:c1');
+  });
+
+  it('takeover: a DIFFERENT install with the SAME device label is NOT self — the requester waits, never short-circuits', async () => {
+    // Two installs share a hostname (the dev instance + built app dogfood gate,
+    // or two same-hostname machines). The holder's label equals ours but its
+    // per-install deviceId differs, so the lease client returns self:false. The
+    // requester MUST NOT treat this as free — it polls until a genuine release,
+    // here never happening, so it times out.
+    //
+    // Regression guard: the OLD label-based check (`q.device === selfDevice`)
+    // would see device 'This-Device' === selfDevice 'This-Device' → treat it as
+    // free → syncNow/materialize/acquire immediately → outcome 'acquired'. This
+    // test asserts the opposite, so it FAILS against the old label-based code.
+    const deps = makeDeps({ queryResults: [{ held: true, device: 'This-Device', self: false }] });
+    const flow = createRequesterTakeover(deps as any);
+    const p = flow.takeover('c1');
+    await vi.advanceTimersByTimeAsync(11_000);
+    const res = await p;
+    expect(res).toEqual({ outcome: 'timeout' });
+    // Did NOT short-circuit on a same-label lease: no free-path work ran.
+    expect(deps.leaseClient.acquire).not.toHaveBeenCalled();
+    expect(deps.syncNow).not.toHaveBeenCalled();
+    expect(deps.materializeOne).not.toHaveBeenCalled();
   });
 
   it('takeover: holder never releases -> timeout after 10s (no acquire)', async () => {

--- a/desktop/tests/session-moved-reducer.test.ts
+++ b/desktop/tests/session-moved-reducer.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { chatReducer } from '../src/renderer/state/chat-reducer';
+import { ChatState, ChatAction } from '../src/renderer/state/chat-types';
+
+// Plan 2b Task 10 — SESSION_MOVED ("this conversation moved to <device>") banner.
+// When another device takes over a session lease, the holder side ends the local
+// turn cleanly and drops a permanent "moved" system marker into the timeline so
+// the user understands why chat activity stopped here.
+
+const SESSION = 'test-session';
+
+function initState(): ChatState {
+  const state: ChatState = new Map();
+  return chatReducer(state, { type: 'SESSION_INIT', sessionId: SESSION });
+}
+
+function dispatch(state: ChatState, action: ChatAction): ChatState {
+  return chatReducer(state, action);
+}
+
+describe('SESSION_MOVED reducer action', () => {
+  let state: ChatState;
+
+  beforeEach(() => {
+    state = initState();
+  });
+
+  it('mid-turn: clears isThinking, fails running tools with "Turn ended", appends a moved marker', () => {
+    // Start a turn + emit a tool so there is in-flight state to tear down.
+    state = dispatch(state, {
+      type: 'TRANSCRIPT_USER_MESSAGE',
+      sessionId: SESSION,
+      uuid: 'u1',
+      text: 'hi',
+      timestamp: 1000,
+    });
+    state = dispatch(state, {
+      type: 'TRANSCRIPT_TOOL_USE',
+      sessionId: SESSION,
+      uuid: 'u2',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+    });
+    expect(state.get(SESSION)!.isThinking).toBe(true);
+    expect(state.get(SESSION)!.toolCalls.get('tool-1')!.status).toBe('running');
+
+    state = dispatch(state, {
+      type: 'SESSION_MOVED',
+      sessionId: SESSION,
+      device: 'MacBook Pro',
+    });
+
+    const session = state.get(SESSION)!;
+    // endTurn() effects
+    expect(session.isThinking).toBe(false);
+    expect(session.activeTurnToolIds.size).toBe(0);
+    expect(session.toolCalls.get('tool-1')!.status).toBe('failed');
+    expect(session.toolCalls.get('tool-1')!.error).toBe('Turn ended');
+    // Attention resets to 'ok' — this is a clean turn end, NOT a terminal error state.
+    expect(session.attentionState).toBe('ok');
+
+    // A moved system marker was appended, carrying the device name.
+    const markers = session.timeline.filter((e) => e.kind === 'system-marker');
+    expect(markers.length).toBe(1);
+    const marker = (markers[0] as { kind: 'system-marker'; marker: any }).marker;
+    expect(marker.variant).toBe('moved');
+    expect(marker.label).toContain('MacBook Pro');
+    // Not expandable — no summary.
+    expect(marker.summary).toBeUndefined();
+  });
+
+  it('idle: appends only the marker, no spurious tool changes', () => {
+    const before = state.get(SESSION)!;
+    expect(before.isThinking).toBe(false);
+    expect(before.timeline.length).toBe(0);
+
+    state = dispatch(state, {
+      type: 'SESSION_MOVED',
+      sessionId: SESSION,
+      device: 'Linux Desktop',
+    });
+
+    const session = state.get(SESSION)!;
+    expect(session.toolCalls.size).toBe(0);
+    expect(session.isThinking).toBe(false);
+    const markers = session.timeline.filter((e) => e.kind === 'system-marker');
+    expect(markers.length).toBe(1);
+    const marker = (markers[0] as { kind: 'system-marker'; marker: any }).marker;
+    expect(marker.variant).toBe('moved');
+    expect(marker.label).toContain('Linux Desktop');
+  });
+
+  it('missing device: falls back to a generic "another device" label', () => {
+    state = dispatch(state, {
+      type: 'SESSION_MOVED',
+      sessionId: SESSION,
+    });
+    const session = state.get(SESSION)!;
+    const markers = session.timeline.filter((e) => e.kind === 'system-marker');
+    expect(markers.length).toBe(1);
+    const marker = (markers[0] as { kind: 'system-marker'; marker: any }).marker;
+    expect(marker.variant).toBe('moved');
+    expect(marker.label).toContain('another device');
+  });
+
+  it('unknown sessionId: returns state unchanged (no throw)', () => {
+    const before = state;
+    const after = dispatch(state, {
+      type: 'SESSION_MOVED',
+      sessionId: 'no-such-session',
+      device: 'Phantom',
+    });
+    expect(after).toBe(before);
+  });
+});

--- a/desktop/tests/session-moved-reducer.test.ts
+++ b/desktop/tests/session-moved-reducer.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { chatReducer } from '../src/renderer/state/chat-reducer';
 import { ChatState, ChatAction } from '../src/renderer/state/chat-types';
 
-// Plan 2b Task 10 — SESSION_MOVED ("this conversation moved to <device>") banner.
-// When another device takes over a session lease, the holder side ends the local
-// turn cleanly and drops a permanent "moved" system marker into the timeline so
-// the user understands why chat activity stopped here.
+// Plan 2b SESSION_MOVED — another device took over this session's lease.
+//
+// As of the "Moved Gate" follow-up (2026-07-14) SESSION_MOVED ONLY ends the
+// in-flight turn cleanly (endTurn); it NO LONGER appends a timeline marker. The
+// holder destroys the session immediately after, so any appended marker would be
+// wiped by SESSION_REMOVE back-to-back and never render. The user-facing
+// "this session was taken over on <device>" surface is App.tsx's MovedGate, not
+// the timeline. These tests pin that endTurn still runs and NO marker is added.
 
 const SESSION = 'test-session';
 
@@ -25,7 +29,7 @@ describe('SESSION_MOVED reducer action', () => {
     state = initState();
   });
 
-  it('mid-turn: clears isThinking, fails running tools with "Turn ended", appends a moved marker', () => {
+  it('mid-turn: clears isThinking, fails running tools with "Turn ended", appends NO marker', () => {
     // Start a turn + emit a tool so there is in-flight state to tear down.
     state = dispatch(state, {
       type: 'TRANSCRIPT_USER_MESSAGE',
@@ -45,6 +49,8 @@ describe('SESSION_MOVED reducer action', () => {
     expect(state.get(SESSION)!.isThinking).toBe(true);
     expect(state.get(SESSION)!.toolCalls.get('tool-1')!.status).toBe('running');
 
+    const timelineLenBefore = state.get(SESSION)!.timeline.length;
+
     state = dispatch(state, {
       type: 'SESSION_MOVED',
       sessionId: SESSION,
@@ -60,17 +66,14 @@ describe('SESSION_MOVED reducer action', () => {
     // Attention resets to 'ok' — this is a clean turn end, NOT a terminal error state.
     expect(session.attentionState).toBe('ok');
 
-    // A moved system marker was appended, carrying the device name.
+    // NO system marker is appended (the Moved Gate is the surface now) and the
+    // timeline length is otherwise unchanged.
     const markers = session.timeline.filter((e) => e.kind === 'system-marker');
-    expect(markers.length).toBe(1);
-    const marker = (markers[0] as { kind: 'system-marker'; marker: any }).marker;
-    expect(marker.variant).toBe('moved');
-    expect(marker.label).toContain('MacBook Pro');
-    // Not expandable — no summary.
-    expect(marker.summary).toBeUndefined();
+    expect(markers.length).toBe(0);
+    expect(session.timeline.length).toBe(timelineLenBefore);
   });
 
-  it('idle: appends only the marker, no spurious tool changes', () => {
+  it('idle: no marker, no spurious tool changes', () => {
     const before = state.get(SESSION)!;
     expect(before.isThinking).toBe(false);
     expect(before.timeline.length).toBe(0);
@@ -85,23 +88,7 @@ describe('SESSION_MOVED reducer action', () => {
     expect(session.toolCalls.size).toBe(0);
     expect(session.isThinking).toBe(false);
     const markers = session.timeline.filter((e) => e.kind === 'system-marker');
-    expect(markers.length).toBe(1);
-    const marker = (markers[0] as { kind: 'system-marker'; marker: any }).marker;
-    expect(marker.variant).toBe('moved');
-    expect(marker.label).toContain('Linux Desktop');
-  });
-
-  it('missing device: falls back to a generic "another device" label', () => {
-    state = dispatch(state, {
-      type: 'SESSION_MOVED',
-      sessionId: SESSION,
-    });
-    const session = state.get(SESSION)!;
-    const markers = session.timeline.filter((e) => e.kind === 'system-marker');
-    expect(markers.length).toBe(1);
-    const marker = (markers[0] as { kind: 'system-marker'; marker: any }).marker;
-    expect(marker.variant).toBe('moved');
-    expect(marker.label).toContain('another device');
+    expect(markers.length).toBe(0);
   });
 
   it('unknown sessionId: returns state unchanged (no throw)', () => {

--- a/desktop/tests/sync-hub-socket.test.ts
+++ b/desktop/tests/sync-hub-socket.test.ts
@@ -297,4 +297,139 @@ describe('sync-hub-socket state machine', () => {
     expect(inst.sent).toEqual([]); // no leaked ping timer
     sock.destroy();
   });
+
+  // ---- Task 5: lease request/response frames + request correlation ----
+
+  // Helper: pull the reqId the client generated out of the frame it sent, so the
+  // test can echo back a matching lease-result (the client owns the reqId).
+  function sentReqId(inst: FakeSocket): string {
+    const last = JSON.parse(inst.sent[inst.sent.length - 1]);
+    return last.reqId;
+  }
+
+  // Lease 1: request() on an OPEN socket sends a {type:'lease',...} frame and
+  // resolves the matching lease-result (by reqId) with the holder mapped.
+  it('request sends a lease frame and resolves the matching lease-result by reqId', async () => {
+    const { sock } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    const p = sock.request('acquire', 'sess-1', 'dev-1');
+    const frame = JSON.parse(inst.sent[inst.sent.length - 1]);
+    expect(frame).toMatchObject({ type: 'lease', op: 'acquire', sessionId: 'sess-1', deviceId: 'dev-1' });
+    expect(typeof frame.reqId).toBe('string');
+
+    const holder = { deviceId: 'dev-2', device: 'Other', expiresAt: 999 };
+    inst.emit('message', JSON.stringify({
+      type: 'lease-result', reqId: frame.reqId, op: 'acquire', sessionId: 'sess-1', ok: true, holder,
+    }));
+    await expect(p).resolves.toEqual({ ok: true, op: 'acquire', sessionId: 'sess-1', holder });
+    sock.destroy();
+  });
+
+  // Lease 2: a lease-result whose reqId does NOT match must not resolve the
+  // pending request. The correct reqId (or the 5s timeout) still resolves it.
+  it('does not resolve a request on a mismatched reqId', async () => {
+    const { sock } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    const p = sock.request('acquire', 'sess-1', 'dev-1');
+    let settled: unknown = 'PENDING';
+    void p.then((v) => { settled = v; });
+
+    // Wrong reqId → ignored, promise still pending.
+    inst.emit('message', JSON.stringify({ type: 'lease-result', reqId: 'r-nope', op: 'acquire', sessionId: 'sess-1', ok: true, holder: null }));
+    await Promise.resolve();
+    expect(settled).toBe('PENDING');
+
+    // Correct reqId → resolves.
+    const reqId = sentReqId(inst);
+    inst.emit('message', JSON.stringify({ type: 'lease-result', reqId, op: 'acquire', sessionId: 'sess-1', ok: false, holder: null }));
+    await Promise.resolve();
+    expect(settled).toEqual({ ok: false, op: 'acquire', sessionId: 'sess-1', holder: null });
+    sock.destroy();
+  });
+
+  // Lease 3: a request with no matching response times out to null after 5s.
+  it('request times out to null after 5s', async () => {
+    const { sock } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    const p = sock.request('acquire', 'sess-1', 'dev-1');
+    vi.advanceTimersByTime(5_000);
+    await expect(p).resolves.toBeNull();
+    sock.destroy();
+  });
+
+  // Lease 4: request() resolves null immediately (never-block) when not connected.
+  it('request resolves null immediately when not connected', async () => {
+    const { sock } = makeSocket(() => 'tok');
+    // No socket at all.
+    await expect(sock.request('acquire', 'sess-1', 'dev-1')).resolves.toBeNull();
+
+    // Connecting (not OPEN yet) → still null, no frame sent.
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    await expect(sock.request('acquire', 'sess-1', 'dev-1')).resolves.toBeNull();
+    expect(inst.sent).toEqual([]);
+    sock.destroy();
+  });
+
+  // Lease 5a: a pending request is resolved to null when the socket goes down
+  // (unexpected close → handleDown → failAllPending). A stranded request must
+  // never hang across a reconnect.
+  it('resolves a pending request to null when the socket goes down', async () => {
+    const { sock } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    const p = sock.request('acquire', 'sess-1', 'dev-1');
+    inst.emit('close', 1006, 'blip'); // drives handleDown → failAllPending
+    await expect(p).resolves.toBeNull();
+    sock.destroy();
+  });
+
+  // Lease 5b: intentional teardown (setDesired(false)) also fails pending requests.
+  it('resolves a pending request to null on setDesired(false)', async () => {
+    const { sock } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    const p = sock.request('acquire', 'sess-1', 'dev-1');
+    sock.setDesired(false); // intentional teardown → failAllPending
+    await expect(p).resolves.toBeNull();
+    sock.destroy();
+  });
+
+  // Lease 6: lease-event frames emit as SyncHubEvents (unsolicited server pushes,
+  // not tied to a reqId).
+  it('emits lease-event frames as onEvent lease-event', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    inst.emit('message', JSON.stringify({ type: 'lease-event', kind: 'released', sessionId: 's', device: 'D' }));
+    expect(events[events.length - 1]).toEqual({ type: 'lease-event', kind: 'released', sessionId: 's', device: 'D' });
+
+    inst.emit('message', JSON.stringify({
+      type: 'lease-event', kind: 'takeover-request', sessionId: 's2', from: { deviceId: 'dev-2', device: 'Other' },
+    }));
+    expect(events[events.length - 1]).toEqual({
+      type: 'lease-event', kind: 'takeover-request', sessionId: 's2', from: { deviceId: 'dev-2', device: 'Other' },
+    });
+
+    // Malformed lease-event (missing sessionId) emits nothing.
+    const before = events.length;
+    inst.emit('message', JSON.stringify({ type: 'lease-event', kind: 'released' }));
+    expect(events.length).toBe(before);
+    sock.destroy();
+  });
 });

--- a/desktop/tests/sync-spaces-device-registry.test.ts
+++ b/desktop/tests/sync-spaces-device-registry.test.ts
@@ -8,7 +8,7 @@ import os from 'os';
 import path from 'path';
 import {
   readDevices, upsertSelf, renameDevice,
-  mergeDeviceEntries, DEVICE_REGISTRY_SCHEMA, type DeviceRecord,
+  mergeDeviceEntries, foldDeviceEntries, DEVICE_REGISTRY_SCHEMA, type DeviceRecord,
 } from '../src/main/sync-spaces/device-registry';
 
 let personal: string;
@@ -101,6 +101,20 @@ describe('device registry store — I/O', () => {
     write('future.json', { schemaVersion: 999, id: 'future', name: 'x', platform: 'p', lastSeen: 1, updatedAt: 1 });
     expect(readDevices(personal).map((e) => e.id).sort()).toEqual(['dev-1']);
   });
+
+  it('skips a file whose name does not match its content id (filename↔id guard)', () => {
+    // File is named dev-1.json but its parsed content id is dev-2 — a mangled /
+    // mislabeled file that must NOT fold into either device.
+    write('dev-1.json', E({ id: 'dev-2', name: 'Mislabeled' }));
+    expect(readDevices(personal)).toEqual([]);
+  });
+
+  it('renameDevice to an empty name is refused — stored name unchanged', async () => {
+    write('dev-1.json', E({ name: 'Keep Me', updatedAt: 5 }));
+    await renameDevice(personal, 'dev-1', '   '); // whitespace-only → refused
+    const got = readDevices(personal)[0];
+    expect(got.name).toBe('Keep Me'); // empty names are rejected on read, so we never write one
+  });
 });
 
 describe('device registry store — pure merge', () => {
@@ -113,5 +127,32 @@ describe('device registry store — pure merge', () => {
     expect(ab.name).toBe('B');       // updatedAt 9 wins
     expect(ab.lastSeen).toBe(100);   // max
     expect(ab.updatedAt).toBe(9);    // max
+  });
+
+  it('mergeDeviceEntries is commutative through the equal-updatedAt content tiebreak', () => {
+    // Same updatedAt, different name/platform: laterOf falls back to the JSON
+    // content comparison, which must pick the SAME winner regardless of arg order.
+    const a = E({ name: 'Alpha', platform: 'linux', updatedAt: 7 });
+    const b = E({ name: 'Beta', platform: 'darwin', updatedAt: 7 });
+    const ab = mergeDeviceEntries(a, b);
+    const ba = mergeDeviceEntries(b, a);
+    expect(ab).toEqual(ba);                 // deterministic tiebreak → convergent
+    expect(['Alpha', 'Beta']).toContain(ab.name);
+    // platform rides with the name-winner, so the winning pair stays consistent.
+    expect(ab.platform).toBe(ab.name === 'Alpha' ? 'linux' : 'darwin');
+  });
+
+  it('foldDeviceEntries is associative / order-independent across 3 copies', () => {
+    // Equal updatedAt forces the content tiebreak for name; lastSeen is a plain
+    // max. Any permutation of the same three copies must fold identically.
+    const a = E({ name: 'A', platform: 'win32', lastSeen: 10, updatedAt: 7 });
+    const b = E({ name: 'B', platform: 'linux', lastSeen: 30, updatedAt: 7 });
+    const c = E({ name: 'C', platform: 'darwin', lastSeen: 20, updatedAt: 7 });
+    const abc = foldDeviceEntries([a, b, c]);
+    const cba = foldDeviceEntries([c, b, a]);
+    const bca = foldDeviceEntries([b, c, a]);
+    expect(abc).toEqual(cba);
+    expect(abc).toEqual(bca);
+    expect(abc.lastSeen).toBe(30); // max across all three
   });
 });

--- a/desktop/tests/sync-spaces-device-registry.test.ts
+++ b/desktop/tests/sync-spaces-device-registry.test.ts
@@ -1,0 +1,117 @@
+// desktop/tests/sync-spaces-device-registry.test.ts
+// Covers the Personal/Devices friendly-name registry (Plan 2b Task 4, spec §10a):
+// round-trip, heartbeat that must not clobber a synced rename, fold-on-read of a
+// cross-device conflict copy, and fail-soft skipping of malformed files.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  readDevices, upsertSelf, renameDevice,
+  mergeDeviceEntries, DEVICE_REGISTRY_SCHEMA, type DeviceRecord,
+} from '../src/main/sync-spaces/device-registry';
+
+let personal: string;
+beforeEach(() => { personal = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-dreg-')); });
+afterEach(() => { fs.rmSync(personal, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); });
+
+const dir = () => path.join(personal, 'Devices');
+const write = (file: string, obj: unknown) => {
+  fs.mkdirSync(dir(), { recursive: true });
+  fs.writeFileSync(path.join(dir(), file), JSON.stringify(obj));
+};
+// Device ids are UUIDs; the fixture id below stands in for one (it just has to
+// be a stable string that can never contain the " (from " conflict-copy marker).
+const E = (over: Partial<DeviceRecord>): DeviceRecord => ({
+  schemaVersion: DEVICE_REGISTRY_SCHEMA, id: 'dev-1', name: 'Laptop',
+  platform: 'win32', lastSeen: 1, updatedAt: 1, ...over,
+});
+
+describe('device registry store — I/O', () => {
+  it('round-trips a device record through upsertSelf + readDevices', async () => {
+    await upsertSelf(personal, { id: 'dev-1', name: 'My Laptop', platform: 'win32' });
+    expect(fs.existsSync(path.join(dir(), 'dev-1.json'))).toBe(true);
+    const got = readDevices(personal);
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({ id: 'dev-1', name: 'My Laptop', platform: 'win32' });
+    expect(got[0].lastSeen).toBeGreaterThan(0);
+    expect(got[0].updatedAt).toBeGreaterThan(0);
+  });
+
+  it('upsertSelf defaults the friendly name to os.hostname() when none is given', async () => {
+    await upsertSelf(personal, { id: 'dev-2', platform: 'darwin' });
+    expect(readDevices(personal)[0].name).toBe(os.hostname());
+  });
+
+  it('returns [] when the Devices dir does not exist', () => {
+    expect(readDevices(personal)).toEqual([]);
+  });
+
+  it('upsertSelf heartbeat bumps lastSeen but does NOT clobber a newer synced name', async () => {
+    // Another device renamed us and that edit synced here with a high updatedAt.
+    write('dev-1.json', E({ name: 'Renamed On Phone', lastSeen: 10, updatedAt: 9_999_999_999_999 }));
+    await upsertSelf(personal, { id: 'dev-1', platform: 'win32' }); // bare heartbeat, no name
+    const got = readDevices(personal)[0];
+    expect(got.name).toBe('Renamed On Phone');      // name preserved
+    expect(got.lastSeen).toBeGreaterThan(10);       // liveness advanced
+    expect(got.updatedAt).toBe(9_999_999_999_999);  // updatedAt NOT churned
+  });
+
+  it('upsertSelf with a differing name bumps updatedAt and changes the name', async () => {
+    write('dev-1.json', E({ name: 'Old', updatedAt: 5 }));
+    await upsertSelf(personal, { id: 'dev-1', name: 'New', platform: 'win32' });
+    const got = readDevices(personal)[0];
+    expect(got.name).toBe('New');
+    expect(got.updatedAt).toBeGreaterThan(5);
+  });
+
+  it('renameDevice sets name + bumps updatedAt, preserving lastSeen/platform', async () => {
+    write('dev-1.json', E({ name: 'Old', platform: 'linux', lastSeen: 42, updatedAt: 5 }));
+    await renameDevice(personal, 'dev-1', 'Fresh');
+    const got = readDevices(personal)[0];
+    expect(got.name).toBe('Fresh');
+    expect(got.platform).toBe('linux'); // preserved
+    expect(got.lastSeen).toBe(42);      // preserved
+    expect(got.updatedAt).toBeGreaterThan(5);
+  });
+
+  it('renameDevice to the identical name is a no-op (no mtime churn)', async () => {
+    write('dev-1.json', E({ name: 'Same', updatedAt: 5 }));
+    const file = path.join(dir(), 'dev-1.json');
+    const m1 = fs.statSync(file).mtimeMs;
+    await new Promise((r) => setTimeout(r, 15));
+    await renameDevice(personal, 'dev-1', 'Same');
+    expect(fs.statSync(file).mtimeMs).toBe(m1); // skipped
+  });
+
+  it('folds a conflict copy on read — newer name wins AND lastSeen is the max', () => {
+    // Canonical: older name, higher lastSeen. Conflict copy (a cross-device
+    // rename the transport left as a copy): newer name, lower lastSeen.
+    write('dev-1.json', E({ name: 'Old Name', lastSeen: 100, updatedAt: 10 }));
+    write('dev-1 (from OtherDevice, 2026-07-14).json', E({ name: 'New Name', lastSeen: 50, updatedAt: 20 }));
+    const got = readDevices(personal);
+    expect(got).toHaveLength(1);        // folded into one record
+    expect(got[0].name).toBe('New Name'); // updatedAt 20 wins (LWW)
+    expect(got[0].lastSeen).toBe(100);    // max across both copies
+  });
+
+  it('skips corrupt / unknown-schema files without throwing', () => {
+    write('dev-1.json', E({ name: 'Good' }));
+    fs.writeFileSync(path.join(dir(), 'bad.json'), '{ not json');
+    write('future.json', { schemaVersion: 999, id: 'future', name: 'x', platform: 'p', lastSeen: 1, updatedAt: 1 });
+    expect(readDevices(personal).map((e) => e.id).sort()).toEqual(['dev-1']);
+  });
+});
+
+describe('device registry store — pure merge', () => {
+  it('mergeDeviceEntries is commutative (name LWW by updatedAt, lastSeen = max)', () => {
+    const a = E({ name: 'A', lastSeen: 100, updatedAt: 3 });
+    const b = E({ name: 'B', lastSeen: 50, updatedAt: 9 });
+    const ab = mergeDeviceEntries(a, b);
+    const ba = mergeDeviceEntries(b, a);
+    expect(ab).toEqual(ba);          // convergent
+    expect(ab.name).toBe('B');       // updatedAt 9 wins
+    expect(ab.lastSeen).toBe(100);   // max
+    expect(ab.updatedAt).toBe(9);    // max
+  });
+});

--- a/desktop/tests/sync-spaces-service.test.ts
+++ b/desktop/tests/sync-spaces-service.test.ts
@@ -73,6 +73,10 @@ const h = vi.hoisted(() => {
       sendSignal: vi.fn(() => true),
       isConnected: vi.fn(() => false),
       destroy: vi.fn(),
+      // Lease transport (Task 8): hubLeaseRequest routes through this when the
+      // socket exists. Default resolves a fake LeaseResult so the passthrough
+      // test can assert it reached the socket.
+      request: vi.fn(async (_op: string, sessionId: string, deviceId: string) => ({ ok: true, op: _op, sessionId, holder: { deviceId, device: 'd', expiresAt: 0 } })),
     },
   };
 });
@@ -149,6 +153,7 @@ vi.mock('../src/main/sync-hub-socket', () => ({
       sendSignal: h.hub.sendSignal,
       isConnected: h.hub.isConnected,
       destroy: h.hub.destroy,
+      request: h.hub.request,
     };
   },
 }));
@@ -193,6 +198,7 @@ describe('sync-spaces service transition serialization', () => {
     h.hub.sendSignal.mockClear();
     h.hub.isConnected.mockClear();
     h.hub.destroy.mockClear();
+    h.hub.request.mockClear();
   });
 
   it('disable issued mid-start waits for the start, then stops that engine (no interleave)', async () => {
@@ -521,5 +527,33 @@ describe('sync-spaces service transition serialization', () => {
     const row = st.spaces.find((s: any) => s.id === 'project:app');
     expect(row.displayName).toBe('Cool App');
     expect(row.state).toBe('active');
+  });
+
+  // ---- Lease bridge (Task 8): hubLeaseRequest passthrough + lease-event facade ----
+
+  it('hubLeaseRequest resolves null when no hub socket exists (sync disabled)', async () => {
+    const svc = await freshService(); // not enabled → no hub socket created
+    await expect(svc.hubLeaseRequest('get', 's1', 'dev-a')).resolves.toBeNull();
+  });
+
+  it('hubLeaseRequest routes through the hub socket when enabled', async () => {
+    const svc = await enabledMultiSpaceService();
+    const res = await svc.hubLeaseRequest('acquire', 's2', 'dev-a');
+    expect(h.hub.request).toHaveBeenCalledWith('acquire', 's2', 'dev-a');
+    expect(res).toMatchObject({ ok: true, op: 'acquire', sessionId: 's2' });
+  });
+
+  it('a hub lease-event reaches the registered lease-event listener', async () => {
+    const svc = await enabledMultiSpaceService();
+    const received: any[] = [];
+    svc.setSyncSpacesLeaseEventListener((ev: any) => received.push(ev));
+    const leaseEvent = { type: 'lease-event', kind: 'takeover-request', sessionId: 's3', from: { deviceId: 'dev-b', device: 'Laptop-B' } };
+    h.hub.opts.onEvent(leaseEvent);
+    expect(received).toEqual([leaseEvent]);
+    // Non-lease events (signal/connected/disconnected) must NOT reach it.
+    received.length = 0;
+    h.hub.opts.onEvent({ type: 'connected' });
+    expect(received).toEqual([]);
+    svc.setSyncSpacesLeaseEventListener(null); // clean up module facade
   });
 });


### PR DESCRIPTION
Implements **Plan 2b** (`docs/superpowers/plans/2026-07-14-phase2-plan-2b-leases-takeover.md`) — session leases + takeover on top of Phase 2a conversation sync. Executed via subagent-driven-development (Opus implementers, two-stage spec+code review per task, whole-branch review).

## What ships
- **Per-install device identity** (`device-identity.ts`) + **device registry** (`sync-spaces/device-registry.ts`, convergent per-file) → **"Your devices"** list in Backup & Sync.
- **Lease authority**: hub-socket lease request/response frames (`request()` + `failAllPending` on teardown); **lease client** (`conversations/lease-client.ts`) with 30s heartbeat renew, file fallback, generation-guarded acquire.
- **Takeover** (`conversations/takeover.ts`): holder-side (interrupt→flush→release→pushMoved→destroy, load-bearing ordering) + requester-side (op:takeover → poll → syncNow → materialize → acquire, force fallback). Resume-Browser takeover dialogs (plain words, `Scrim`/`OverlayPanel`).
- **Materialize-on-release (Bug 2 Part 2)**: `noteSessionEnded` releases the guard + a quiescence-gated targeted `materializeOne` (skips on timeout to avoid clobbering a still-flushing transcript — a data-loss defect caught in review).
- **Bug 1 (Resume Browser stale-active)**: browse filters `sessionIdMap` to live sessions (the map is a cache, not truth).
- **SESSION_MOVED** reducer + "This conversation moved to <device>" banner.
- Full **IPC parity** (5 request channels + `session:moved` push) across preload/remote-shim/ipc-handlers/remote-server + **Android stubs**.

## Gating & safety
Dormant behind `native.supported=false` (`YOUCODED_NATIVE`) until v1.3, **except** materialize-on-release, the Bug-1 fix, and the SessionStart lease acquire, which run for real CC sessions and are null-safe / sync-gated (`isSyncSpacesEnabled()`).

## Verification
Full desktop suite **1878 passed / 0 failed**, `tsc --noEmit` clean, `npm run build` (Windows installer) succeeded. Whole-branch review found + fixed one Important cross-task defect (requester self-check now keys on the per-install deviceId, not the hostname label) + 3 minors.

## Depends on
wecoded-marketplace `feat/sync-leases` (SyncGroupRoom lease table) — companion PR. Cross-cutting docs (PITFALLS + handoff + investigation) land in `youcoded-dev` at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)