### PR TITLE
feat(github): Connect GitHub modal (device-flow, non-terminal auth)

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3579,7 +3579,15 @@ class SessionService : Service() {
             "syncspaces:lease-takeover",
             "syncspaces:lease-force",
             "syncspaces:list-devices",
-            "syncspaces:rename-device" -> {
+            "syncspaces:rename-device",
+            // Connect-GitHub modal (device-flow auth) is desktop-only. Android
+            // signs into GitHub via its own gh-auth flow; the shared React modal
+            // degrades — these invokes reject fast with this stub instead of
+            // 30s-timing-out. (github:connect-done is a PUSH event — no handler.)
+            "github:status",
+            "github:connect-start",
+            "github:connect-cancel",
+            "github:install-gh" -> {
                 msg.id?.let { bridgeServer.respond(ws, msg.type, it,
                     org.json.JSONObject().put("ok", false).put("error", "not-implemented-on-mobile")) }
             }

--- a/desktop/src/main/github-auth.ts
+++ b/desktop/src/main/github-auth.ts
@@ -1,0 +1,445 @@
+/**
+ * GitHub device-flow authentication (main process).
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Non-developers can't be expected to open a terminal and run `gh auth login`.
+ * This module runs GitHub's OAuth *device flow* directly — the same flow the
+ * `gh` CLI uses under the hood — so the app can show a one-time code, poll for
+ * approval, and then hand the resulting token to `gh auth login --with-token`.
+ * That keeps `gh` as the single credential store the sync layer already relies
+ * on (its `.netrc` / `gh repo create|view` machinery keeps working unchanged),
+ * while giving us an in-app, non-terminal experience.
+ *
+ * PURE-CORE / IO-SHELL PATTERN
+ * ----------------------------
+ * Every function takes its network / process / timer I/O as an INJECTED
+ * function with a real default (`fetchFn`, `execFn`, `spawnFn`, `sleepFn`).
+ * That's the house pattern: tests drive the state machine deterministically
+ * with mocks, and never hit the network or spawn anything. Production callers
+ * omit the injected args and get the real adapters.
+ *
+ * TOKEN HYGIENE (load-bearing)
+ * ----------------------------
+ * The access token NEVER leaves this process, is NEVER logged, and is NEVER
+ * placed into a thrown Error message or over the remote WebSocket. Its only
+ * destination is `gh auth login --with-token`'s stdin. `completeLogin` is
+ * written so that no failure path can interpolate the token into an error
+ * string — a test forces a failure and asserts the token is absent.
+ */
+
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import { resolveCommand, detectWinget } from './prerequisite-installer';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * The `gh` CLI's own public OAuth client id. Reusing it means the token we mint
+ * is indistinguishable from a normal `gh` login — sync's `gh` calls keep
+ * working — and we avoid standing up a second OAuth app (a second consent
+ * screen + our own secret handling for zero benefit).
+ */
+export const CLIENT_ID = '178c6fc778ccc68e1d6a';
+
+/** gh's own default scope set. Space-separated per the device-flow spec. */
+export const SCOPES = 'repo read:org gist workflow';
+
+const DEVICE_CODE_URL = 'https://github.com/login/device/code';
+const TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+// ---------------------------------------------------------------------------
+// Injectable I/O types
+// ---------------------------------------------------------------------------
+
+/** Runs a command, resolving `{stdout, stderr}` on exit 0 and THROWING otherwise. */
+export type ExecFn = (
+  cmd: string,
+  args: string[],
+  opts?: { timeout?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+/** Minimal subset of `fetch` we depend on — real `fetch` satisfies it structurally. */
+export type FetchLike = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{ ok: boolean; status: number; json(): Promise<any> }>;
+
+/** Minimal subset of a spawned child process — real `ChildProcess` satisfies it. */
+export interface SpawnedProcess {
+  stdin: { write(chunk: string): unknown; end(): void } | null;
+  on(event: 'close', cb: (code: number | null) => void): void;
+  on(event: 'error', cb: (err: Error) => void): void;
+  on(event: string, cb: (arg: any) => void): void;
+}
+
+export type SpawnFn = (cmd: string, args: string[]) => SpawnedProcess;
+
+/** Resolves after `ms` milliseconds. Injected so tests use fake/no delays. */
+export type SleepFn = (ms: number) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Default (real) adapters
+// ---------------------------------------------------------------------------
+
+/**
+ * Default exec adapter. `gh`/`winget` are resolved via PATH (never hardcoded)
+ * and are real `.exe`s on Windows, so no `.cmd` shell flip is needed (unlike
+ * the npm/claude shims in prerequisite-installer). Throws on non-zero exit,
+ * which is exactly how `detectGh` reads `gh auth status`'s exit code.
+ */
+const defaultExec: ExecFn = async (cmd, args, opts) => {
+  const { stdout, stderr } = await execFileAsync(resolveCommand(cmd), args, {
+    encoding: 'utf8',
+    ...opts,
+  });
+  return { stdout: String(stdout), stderr: String(stderr) };
+};
+
+// Node 20+ ships a global `fetch` in the Electron main process.
+const defaultFetch: FetchLike = (url, init) => fetch(url, init as RequestInit);
+
+const defaultSpawn: SpawnFn = (cmd, args) =>
+  spawn(cmd, args) as unknown as SpawnedProcess;
+
+const defaultSleep: SleepFn = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// detectGh
+// ---------------------------------------------------------------------------
+
+export interface GhStatus {
+  installed: boolean;
+  authed: boolean;
+  login?: string;
+}
+
+/**
+ * Detect whether `gh` is installed and authenticated.
+ *
+ * - `gh --version` throwing (ENOENT or otherwise) ⇒ not installed.
+ * - `gh auth status` exit 0 ⇒ authenticated; non-zero (throws) ⇒ not.
+ * - When authed, `gh api user -q .login` fills the login handle (best-effort).
+ *
+ * NEVER throws — every branch resolves to a status object so callers (IPC,
+ * modal trigger) can treat it as a plain state read.
+ */
+export async function detectGh(execFn: ExecFn = defaultExec): Promise<GhStatus> {
+  // Step 1: is gh even installed?
+  try {
+    await execFn('gh', ['--version']);
+  } catch {
+    return { installed: false, authed: false };
+  }
+
+  // Step 2: is it authenticated? `gh auth status` exits non-zero when not,
+  // which surfaces here as a thrown error.
+  let authed = false;
+  try {
+    await execFn('gh', ['auth', 'status']);
+    authed = true;
+  } catch {
+    authed = false;
+  }
+  if (!authed) return { installed: true, authed: false };
+
+  // Step 3: best-effort login handle. A failure here must not downgrade the
+  // authed:true fact — we just leave `login` undefined.
+  let login: string | undefined;
+  try {
+    const { stdout } = await execFn('gh', ['api', 'user', '-q', '.login']);
+    const trimmed = stdout.trim();
+    if (trimmed) login = trimmed;
+  } catch {
+    /* leave login undefined */
+  }
+  return { installed: true, authed: true, login };
+}
+
+// ---------------------------------------------------------------------------
+// startDeviceFlow
+// ---------------------------------------------------------------------------
+
+export interface DeviceFlow {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  /** Absolute ms epoch when the code expires (now + expires_in*1000). */
+  expiresAt: number;
+  /** Server-suggested seconds between polls. */
+  interval: number;
+}
+
+/**
+ * Kick off the device flow: POST the device-code endpoint and normalize the
+ * response. Throws `Error('network')` on any transport/shape failure so callers
+ * have a single typed reason to render.
+ */
+export async function startDeviceFlow(
+  fetchFn: FetchLike = defaultFetch,
+): Promise<DeviceFlow> {
+  let res: Awaited<ReturnType<FetchLike>>;
+  try {
+    res = await fetchFn(DEVICE_CODE_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ client_id: CLIENT_ID, scope: SCOPES }).toString(),
+    });
+  } catch {
+    throw new Error('network');
+  }
+
+  let data: any;
+  try {
+    data = await res.json();
+  } catch {
+    throw new Error('network');
+  }
+  if (!data || !data.device_code) throw new Error('network');
+
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    // Convert relative expires_in (seconds) to an absolute deadline so the
+    // poll loop can compare against Date.now() without tracking elapsed time.
+    expiresAt: Date.now() + Number(data.expires_in) * 1000,
+    interval: Number(data.interval),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pollForToken
+// ---------------------------------------------------------------------------
+
+export interface PollOptions {
+  intervalMs: number;
+  expiresAt: number;
+  fetchFn?: FetchLike;
+  sleepFn?: SleepFn;
+  signal?: AbortSignal;
+}
+
+/**
+ * Poll the token endpoint until the user approves (or the flow fails).
+ *
+ * Loop: check abort/expiry → sleep(interval) → POST → interpret:
+ *   - `authorization_pending`  → normal, keep polling
+ *   - `slow_down`              → grow interval by 5s (and honor a returned
+ *                                interval), keep polling
+ *   - `access_token`           → resolve `{token}`
+ *   - `expired_token` / past   → reject Error('expired')
+ *   - `access_denied`          → reject Error('denied')
+ *   - transport failure        → reject Error('network')
+ * An aborted signal rejects Error('cancelled').
+ *
+ * `sleepFn` is injected so tests advance time without real delays.
+ */
+export async function pollForToken(
+  deviceCode: string,
+  opts: PollOptions,
+): Promise<{ token: string }> {
+  const fetchFn = opts.fetchFn ?? defaultFetch;
+  const sleepFn = opts.sleepFn ?? defaultSleep;
+  let interval = opts.intervalMs;
+
+  for (;;) {
+    // Cancelled by the user closing the modal / hitting cancel.
+    if (opts.signal?.aborted) throw new Error('cancelled');
+    // Whole-flow timeout: the one-time code is only valid until expiresAt.
+    if (Date.now() >= opts.expiresAt) throw new Error('expired');
+
+    // Wait the polling interval BEFORE hitting the endpoint — GitHub rejects
+    // polls that arrive faster than `interval` with slow_down.
+    await sleepFn(interval);
+
+    // Re-check abort after the (possibly long) sleep before spending a request.
+    if (opts.signal?.aborted) throw new Error('cancelled');
+
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await fetchFn(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: CLIENT_ID,
+          device_code: deviceCode,
+          grant_type: GRANT_TYPE,
+        }).toString(),
+        signal: opts.signal,
+      });
+    } catch {
+      throw new Error('network');
+    }
+
+    let data: any;
+    try {
+      data = await res.json();
+    } catch {
+      throw new Error('network');
+    }
+
+    // Success is signalled by the presence of an access_token, not an error field.
+    if (data && data.access_token) return { token: data.access_token };
+
+    switch (data && data.error) {
+      case 'authorization_pending':
+        continue;
+      case 'slow_down':
+        // Spec: back off by 5s AND respect any larger interval the server returns.
+        interval += 5000;
+        if (typeof data.interval === 'number') {
+          interval = Math.max(interval, data.interval * 1000);
+        }
+        continue;
+      case 'expired_token':
+        throw new Error('expired');
+      case 'access_denied':
+        throw new Error('denied');
+      default:
+        // Any unrecognized response is treated as a transport-level failure.
+        throw new Error('network');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// completeLogin
+// ---------------------------------------------------------------------------
+
+/**
+ * Hand the token to `gh auth login --with-token`, which reads the token from
+ * stdin. Resolves on exit 0, rejects on non-zero.
+ *
+ * WHY close stdin: `gh` reads its token from stdin until EOF. If we write the
+ * token but never call `stdin.end()`, gh blocks forever waiting for more input
+ * and this Promise never settles. Closing stdin is mandatory.
+ *
+ * TOKEN HYGIENE: no branch below interpolates `token` into any Error message.
+ * A test forces a non-zero exit and asserts the token is absent from the
+ * rejection — do not add the token to any error string here.
+ */
+export function completeLogin(
+  token: string,
+  spawnFn: SpawnFn = defaultSpawn,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let child: SpawnedProcess;
+    try {
+      // `gh` is a real .exe (no .cmd shell flip); resolve via PATH, not a
+      // hardcoded path, so it works wherever winget/brew/apt placed it.
+      child = spawnFn(resolveCommand('gh'), ['auth', 'login', '--with-token']);
+    } catch {
+      reject(new Error('Failed to start gh auth login'));
+      return;
+    }
+
+    child.on('error', () => reject(new Error('gh auth login failed to start')));
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      // Note: the token is deliberately NOT included in this message.
+      else reject(new Error(`gh auth login exited with code ${code ?? 'unknown'}`));
+    });
+
+    try {
+      child.stdin?.write(token + '\n');
+      child.stdin?.end(); // CLOSE stdin or gh hangs forever waiting for EOF.
+    } catch {
+      reject(new Error('Failed to send credential to gh'));
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// installGh
+// ---------------------------------------------------------------------------
+
+export interface InstallGhResult {
+  ok: boolean;
+  /** Windows: gh installed but PATH hasn't propagated — user must restart. */
+  restartRequired?: boolean;
+  error?: string;
+  /** Non-Windows: the copy-paste command the user should run themselves. */
+  manual?: string;
+}
+
+/**
+ * Install `gh` where we can (Windows via winget) or tell the user how (mac/linux).
+ *
+ * Windows: `detectWinget()` first (winget is an MSIX alias that can be absent),
+ * then `winget install --id GitHub.cli -e --silent ...`, then re-detect. If gh
+ * still isn't found, the binary is on disk but its dir hasn't propagated into
+ * THIS process's PATH — the deterministic fix is to quit and reopen the app
+ * (same rule as installClaude). We do NOT poll or rebuild PATH: a restart is
+ * the only reliable way for the running Electron process to pick up the new
+ * PATH entry (Windows updates HKCU; the live process keeps its old env).
+ *
+ * `detectWingetFn` is injectable so tests exercise both the winget-present and
+ * winget-missing branches without touching the real system.
+ *
+ * `platform` defaults to `process.platform` but is a parameter so tests can
+ * drive the win32 / darwin / linux branches directly.
+ */
+export async function installGh(
+  execFn: ExecFn = defaultExec,
+  detectWingetFn: () => Promise<{ installed: boolean; error?: string }> = detectWinget,
+  platform: NodeJS.Platform = process.platform,
+): Promise<InstallGhResult> {
+  if (platform === 'win32') {
+    const winget = await detectWingetFn();
+    if (!winget.installed) {
+      return { ok: false, error: winget.error };
+    }
+    try {
+      await execFn(
+        'winget',
+        [
+          'install',
+          '--id',
+          'GitHub.cli',
+          '-e',
+          '--silent',
+          '--accept-package-agreements',
+          '--accept-source-agreements',
+        ],
+        { timeout: 300000 },
+      );
+    } catch (err) {
+      return { ok: false, error: `winget failed to install GitHub CLI: ${String(err)}` };
+    }
+
+    const check = await detectGh(execFn);
+    if (!check.installed) {
+      return {
+        ok: false,
+        restartRequired: true,
+        error:
+          "GitHub CLI was installed but its location has not been added to this app's PATH yet. " +
+          'Quit and reopen YouCoded, then try again.',
+      };
+    }
+    return { ok: true };
+  }
+
+  // No auto-install on macOS/Linux in v1 — surface the one-liner instead.
+  if (platform === 'darwin') {
+    return { ok: false, manual: 'brew install gh' };
+  }
+  return { ok: false, manual: 'See https://github.com/cli/cli#installation' };
+}

--- a/desktop/src/main/github-connect.ts
+++ b/desktop/src/main/github-connect.ts
@@ -74,23 +74,32 @@ export function createGithubConnect(
 
   // The single in-flight flow's abort handle. Non-null only while a flow runs.
   let controller: AbortController | null = null;
-  // Guard so a late failure after cancel (or any double-settle) can't fire
-  // emitDone twice for one flow.
-  let settled = false;
-
-  const finish = (p: ConnectDonePayload) => {
-    if (settled) return;
-    settled = true;
-    controller = null;
-    emitDone(p);
-  };
+  // Monotonic id identifying the CURRENT flow. Each start() bumps it, which both
+  // supersedes any prior flow (its finish becomes a no-op) and, once a flow
+  // finishes, blocks that same flow from settling twice. This is per-flow rather
+  // than a single shared `settled` bool because the orchestrator is a singleton
+  // shared by desktop AND remote clients: two connect-starts without an
+  // intervening cancel (double-click, or desktop+remote racing) must not let an
+  // aborted old flow emit a spurious 'cancelled' that also blocks the new flow.
+  let activeFlowId = 0;
 
   async function start(): Promise<ConnectStartResult> {
-    // A new flow supersedes any prior one — abort it so its poll can't also
-    // settle. (start() is the modal opening; there should be at most one.)
+    // A new flow supersedes any prior one — abort it AND bump the id so its
+    // detached chain's finish() becomes a no-op (only an explicit user cancel of
+    // the CURRENT flow should emit). (start() is the modal opening; at most one.)
     controller?.abort();
-    controller = new AbortController();
-    settled = false;
+    const myId = ++activeFlowId;
+    const myController = new AbortController();
+    controller = myController;
+
+    // Settles THIS flow exactly once. A superseded flow (myId !== activeFlowId)
+    // is silenced; a completed flow bumps the id so it can't re-settle.
+    const finish = (p: ConnectDonePayload) => {
+      if (myId !== activeFlowId) return;
+      activeFlowId++;
+      if (controller === myController) controller = null;
+      emitDone(p);
+    };
 
     // startDeviceFlow throws Error('network') — let it reject start() so the
     // modal shows the network-error state immediately (no flow to run).
@@ -98,11 +107,11 @@ export function createGithubConnect(
     try {
       flow = await startDeviceFlow();
     } catch (err) {
-      controller = null;
+      if (controller === myController) controller = null;
       throw err;
     }
 
-    const signal = controller.signal;
+    const signal = myController.signal;
 
     // Detached background chain: poll → login → detect → emitDone. We do NOT
     // await this; start() returns the render fields immediately. Any throw maps

--- a/desktop/src/main/github-connect.ts
+++ b/desktop/src/main/github-connect.ts
@@ -1,0 +1,194 @@
+/**
+ * Connect-GitHub orchestrator (main process).
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * `github-auth.ts` is a set of pure-ish step functions (start the device flow,
+ * poll for a token, hand it to `gh`). This module is the tiny STATEFUL glue that
+ * sequences them into the single in-flight "connect" flow the UI drives, and
+ * keeps that state out of ipc-handlers.ts so it stays thin AND unit-testable.
+ *
+ * At most ONE flow runs at a time (a single modal). `start()` returns the public
+ * device-flow fields the modal renders (code + URL + expiry) and, in the
+ * background, drives poll → login → detect, calling `emitDone` exactly once with
+ * a public payload. `cancel()` aborts the in-flight poll.
+ *
+ * TOKEN HYGIENE (load-bearing)
+ * ----------------------------
+ * The token returned by `pollForToken` flows ONLY into `completeLogin`. It is
+ * NEVER placed into an `emitDone` payload, never logged, never returned. The
+ * done payload carries only `login` (a public handle) and a typed `error`
+ * reason string. A unit test asserts the token never appears in any emitDone.
+ */
+
+import {
+  startDeviceFlow as realStartDeviceFlow,
+  pollForToken as realPollForToken,
+  completeLogin as realCompleteLogin,
+  detectGh as realDetectGh,
+  type DeviceFlow,
+  type GhStatus,
+} from './github-auth';
+
+/** Public payload pushed on `github:connect-done`. Never carries the token. */
+export interface ConnectDonePayload {
+  ok: boolean;
+  login?: string;
+  /** Typed reason: 'expired' | 'denied' | 'network' | 'cancelled' | 'login-failed'. */
+  error?: string;
+}
+
+/** Public fields returned by `start()` — exactly what the modal needs to render. */
+export interface ConnectStartResult {
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+}
+
+/**
+ * Injectable github-auth dependencies. Default to the real implementations;
+ * tests pass fakes so the whole flow runs with no network / no spawn.
+ */
+export interface GithubConnectDeps {
+  startDeviceFlow?: typeof realStartDeviceFlow;
+  pollForToken?: typeof realPollForToken;
+  completeLogin?: typeof realCompleteLogin;
+  detectGh?: typeof realDetectGh;
+}
+
+export interface GithubConnect {
+  /** Begin a flow: returns the modal's render fields and kicks off polling. */
+  start(): Promise<ConnectStartResult>;
+  /** Abort the in-flight flow (poll rejects 'cancelled' → emitDone). */
+  cancel(): void;
+}
+
+export function createGithubConnect(
+  emitDone: (p: ConnectDonePayload) => void,
+  deps: GithubConnectDeps = {},
+): GithubConnect {
+  const startDeviceFlow = deps.startDeviceFlow ?? realStartDeviceFlow;
+  const pollForToken = deps.pollForToken ?? realPollForToken;
+  const completeLogin = deps.completeLogin ?? realCompleteLogin;
+  const detectGh = deps.detectGh ?? realDetectGh;
+
+  // The single in-flight flow's abort handle. Non-null only while a flow runs.
+  let controller: AbortController | null = null;
+  // Guard so a late failure after cancel (or any double-settle) can't fire
+  // emitDone twice for one flow.
+  let settled = false;
+
+  const finish = (p: ConnectDonePayload) => {
+    if (settled) return;
+    settled = true;
+    controller = null;
+    emitDone(p);
+  };
+
+  async function start(): Promise<ConnectStartResult> {
+    // A new flow supersedes any prior one — abort it so its poll can't also
+    // settle. (start() is the modal opening; there should be at most one.)
+    controller?.abort();
+    controller = new AbortController();
+    settled = false;
+
+    // startDeviceFlow throws Error('network') — let it reject start() so the
+    // modal shows the network-error state immediately (no flow to run).
+    let flow: DeviceFlow;
+    try {
+      flow = await startDeviceFlow();
+    } catch (err) {
+      controller = null;
+      throw err;
+    }
+
+    const signal = controller.signal;
+
+    // Detached background chain: poll → login → detect → emitDone. We do NOT
+    // await this; start() returns the render fields immediately. Any throw maps
+    // to a typed done payload. The token lives only inside this closure.
+    void (async () => {
+      let token: string;
+      try {
+        const result = await pollForToken(flow.deviceCode, {
+          intervalMs: flow.interval * 1000,
+          expiresAt: flow.expiresAt,
+          signal,
+        });
+        token = result.token;
+      } catch (err) {
+        // pollForToken rejects Error('expired'|'denied'|'network'|'cancelled') —
+        // map the reason straight through.
+        finish({ ok: false, error: reasonOf(err) });
+        return;
+      }
+
+      // A completeLogin failure is its own typed reason so the modal can tell
+      // "you never approved" apart from "gh choked on the token".
+      try {
+        await completeLogin(token);
+      } catch {
+        finish({ ok: false, error: 'login-failed' });
+        return;
+      }
+
+      // Best-effort: fetch the login handle for the success payload. A detect
+      // failure must NOT downgrade the success — we just omit `login`.
+      let login: string | undefined;
+      try {
+        const status: GhStatus = await detectGh();
+        if (status.login) login = status.login;
+      } catch {
+        /* leave login undefined */
+      }
+      finish({ ok: true, login });
+    })();
+
+    return {
+      userCode: flow.userCode,
+      verificationUri: flow.verificationUri,
+      expiresAt: flow.expiresAt,
+    };
+  }
+
+  function cancel(): void {
+    // Aborting makes the in-flight poll reject Error('cancelled'), which routes
+    // through finish({ok:false, error:'cancelled'}). If no flow is running this
+    // is a harmless no-op.
+    controller?.abort();
+  }
+
+  return { start, cancel };
+}
+
+// ---------------------------------------------------------------------------
+// Module singleton
+// ---------------------------------------------------------------------------
+//
+// ipc-handlers.ts creates the ONE orchestrator (its emitDone fans the done
+// event out to both Electron windows and remote clients) and registers it here.
+// remote-server.ts reads it so a remote browser's connect-start/cancel drives
+// the SAME in-flight flow — matching how the syncspaces:* rows share a single
+// service singleton. Without this, a remote-started flow and a desktop-started
+// flow would be two independent orchestrators and cancel would miss.
+
+let singleton: GithubConnect | null = null;
+
+/** Register the process-wide orchestrator (called once from ipc-handlers). */
+export function setGithubConnect(gc: GithubConnect): void {
+  singleton = gc;
+}
+
+/** Read the process-wide orchestrator (remote-server uses this). */
+export function getGithubConnect(): GithubConnect | null {
+  return singleton;
+}
+
+/** Map a thrown value to its typed reason string, defaulting to 'network'. */
+function reasonOf(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg === 'expired' || msg === 'denied' || msg === 'cancelled' || msg === 'network') {
+    return msg;
+  }
+  return 'network';
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -40,6 +40,10 @@ import {
   syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots, isSyncSpacesEnabled,
 } from './sync-spaces/service';
 import { readDevices, renameDevice } from './sync-spaces/device-registry';
+// Connect-GitHub modal (device-flow auth) — detectGh/installGh are step fns;
+// createGithubConnect is the stateful orchestrator that owns the in-flight flow.
+import { detectGh, installGh } from './github-auth';
+import { createGithubConnect, setGithubConnect } from './github-connect';
 import { getConfig as getMarketplaceConfig, setConfig as setMarketplaceConfig } from './marketplace-config-store';
 import { readComponent, type ComponentKind } from './marketplace-file-reader';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
@@ -2337,6 +2341,21 @@ export function registerIpcHandlers(
     try { await renameDevice(pr, String(p?.id ?? ''), String(p?.name ?? '')); return { ok: true }; }
     catch { return { ok: false }; }
   });
+
+  // Connect-GitHub modal (device-flow auth). ONE orchestrator holds the single
+  // in-flight flow; its emitDone fans the connect-done push out to BOTH the
+  // Electron windows (send) and remote clients (remoteServer.broadcast) — the
+  // same dual path as session:moved. The access token never enters this payload.
+  const githubConnect = createGithubConnect((payload) => {
+    send(IPC.GITHUB_CONNECT_DONE, payload);
+    remoteServer?.broadcast({ type: IPC.GITHUB_CONNECT_DONE, payload });
+  });
+  // Register as the process-wide singleton so remote clients drive the SAME flow.
+  setGithubConnect(githubConnect);
+  ipcMain.handle(IPC.GITHUB_STATUS, () => detectGh());
+  ipcMain.handle(IPC.GITHUB_CONNECT_START, () => githubConnect.start());
+  ipcMain.handle(IPC.GITHUB_CONNECT_CANCEL, () => { githubConnect.cancel(); return { ok: true }; });
+  ipcMain.handle(IPC.GITHUB_INSTALL_GH, () => installGh());
 
   // V2: Per-instance backend management (storage backends + multi-instance support)
   ipcMain.handle('sync:add-backend', (_e, instance) => addBackend(instance));

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -191,6 +191,12 @@ const IPC = {
   SYNC_SPACES_LIST_DEVICES: 'syncspaces:list-devices',
   SYNC_SPACES_RENAME_DEVICE: 'syncspaces:rename-device',
   SYNC_SPACES_EVENT: 'syncspaces:event',
+  // Connect-GitHub modal (device-flow auth) — inlined literals (preload can't import).
+  GITHUB_STATUS: 'github:status',
+  GITHUB_CONNECT_START: 'github:connect-start',
+  GITHUB_CONNECT_CANCEL: 'github:connect-cancel',
+  GITHUB_INSTALL_GH: 'github:install-gh',
+  GITHUB_CONNECT_DONE: 'github:connect-done',
   // Restore from backup (directional pull — see restore-service.ts)
   SYNC_RESTORE_LIST_VERSIONS: 'sync:restore:list-versions',
   SYNC_RESTORE_PREVIEW: 'sync:restore:preview',
@@ -842,6 +848,25 @@ contextBridge.exposeInMainWorld('claude', {
       const listener = (_: unknown, e: unknown) => cb(e);
       ipcRenderer.on(IPC.SYNC_SPACES_EVENT, listener);
       return () => ipcRenderer.removeListener(IPC.SYNC_SPACES_EVENT, listener);
+    },
+  },
+  // Connect-GitHub modal (device-flow auth). All the real work happens in the
+  // main process (github-auth.ts + github-connect.ts); this namespace just relays
+  // requests and the connect-done push event. The access token NEVER crosses this
+  // boundary — only the public status/login/error fields do.
+  github: {
+    status: () => ipcRenderer.invoke(IPC.GITHUB_STATUS),
+    // Returns {userCode, verificationUri, expiresAt} AND begins main-side polling;
+    // completion arrives via onConnectDone below.
+    connectStart: () => ipcRenderer.invoke(IPC.GITHUB_CONNECT_START),
+    connectCancel: () => ipcRenderer.invoke(IPC.GITHUB_CONNECT_CANCEL),
+    installGh: () => ipcRenderer.invoke(IPC.GITHUB_INSTALL_GH),
+    // Push subscription — returns an unsubscribe function (callers MUST invoke it
+    // on unmount to avoid leaking listeners across modal open/close cycles).
+    onConnectDone: (cb: (payload: { ok: boolean; login?: string; error?: string }) => void) => {
+      const handler = (_e: IpcRendererEvent, payload: any) => cb(payload);
+      ipcRenderer.on(IPC.GITHUB_CONNECT_DONE, handler);
+      return () => ipcRenderer.removeListener(IPC.GITHUB_CONNECT_DONE, handler);
     },
   },
   getFavorites: () => ipcRenderer.invoke('favorites:get'),

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -24,6 +24,11 @@ import { getRestoreService } from './restore-service';
 import { syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject, syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots } from './sync-spaces/service';
 import { readDevices, renameDevice } from './sync-spaces/device-registry';
 import { checkSyncPrereqs, installRclone, checkGdriveRemote, authGdrive, authGithub, createGithubRepo } from './sync-setup-handlers';
+// Connect-GitHub modal (device-flow auth). status/install are stateless direct
+// calls; connect start/cancel drive the shared orchestrator singleton created in
+// ipc-handlers (its emitDone broadcasts github:connect-done to remote clients).
+import { detectGh, installGh } from './github-auth';
+import { getGithubConnect } from './github-connect';
 
 const PTY_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB per session — enough for full conversation replay
 const HOOK_BUFFER_SIZE = 10_000; // ~10MB max, covers full conversations without excessive memory
@@ -1392,6 +1397,30 @@ export class RemoteServer {
         if (!pr) { this.respond(client.ws, type, id, { ok: false }); break; }
         try { await renameDevice(pr, String(payload?.id ?? ''), String(payload?.name ?? '')); this.respond(client.ws, type, id, { ok: true }); }
         catch { this.respond(client.ws, type, id, { ok: false }); }
+        break;
+      }
+
+      // Connect-GitHub modal (device-flow auth) — remote browser parity. The flow
+      // is all main-process; the browser just renders the code/URL and waits for
+      // the github:connect-done broadcast. The access token never crosses the WS.
+      case 'github:status': {
+        this.respond(client.ws, type, id, await detectGh());
+        break;
+      }
+      case 'github:connect-start': {
+        // Drives the shared orchestrator singleton; completion arrives as the
+        // github:connect-done broadcast (fanned out to every client).
+        const gc = getGithubConnect();
+        this.respond(client.ws, type, id, gc ? await gc.start() : { error: 'unavailable' });
+        break;
+      }
+      case 'github:connect-cancel': {
+        getGithubConnect()?.cancel();
+        this.respond(client.ws, type, id, { ok: true });
+        break;
+      }
+      case 'github:install-gh': {
+        this.respond(client.ws, type, id, await installGh());
         break;
       }
 

--- a/desktop/src/renderer/components/ConnectGithubModal.tsx
+++ b/desktop/src/renderer/components/ConnectGithubModal.tsx
@@ -1,0 +1,372 @@
+// desktop/src/renderer/components/ConnectGithubModal.tsx
+// Walks a non-developer through connecting GitHub via the device-code flow so
+// enabling Sync never dead-ends on "gh is not installed" / "Not signed in to
+// GitHub". Everything real happens in the main process (github-auth.ts +
+// github-connect.ts); this modal only renders state and relays requests over
+// window.claude.github. The access token NEVER reaches the renderer — only the
+// public {installed, authed, login} / {userCode, verificationUri, expiresAt} /
+// {ok, login?, error?} fields do — so the whole flow works identically over the
+// remote WebSocket. The one platform difference is opening the verification URL
+// (shell.openExternal on Electron; a copyable link on remote — see below).
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { useEscClose } from '../hooks/use-esc-close';
+import { getPlatform } from '../platform';
+
+type Stage = 'checking' | 'gh-missing' | 'code' | 'done' | 'error';
+
+// Typed connect-done reasons → friendly, non-technical copy.
+type ConnectError = 'expired' | 'denied' | 'network' | 'cancelled' | 'login-failed';
+const ERROR_COPY: Record<ConnectError, string> = {
+  expired: 'That code expired — try again.',
+  denied: 'Access was denied in the browser.',
+  network: "Couldn't reach GitHub — check your connection.",
+  cancelled: 'Connection was cancelled — try again.',
+  'login-failed': 'Signed in to GitHub but saving the credential failed — try again.',
+};
+
+interface Props {
+  onClose: () => void;
+  /** Fired once GitHub is connected (already-authed on open OR a fresh login).
+   *  The SyncPanel uses this to refresh status + re-kick a mid-flight enable. */
+  onConnected?: (login?: string) => void;
+}
+
+interface ConnectCode {
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+}
+
+// Result shape of window.claude.github.installGh().
+interface InstallResult {
+  ok: boolean;
+  restartRequired?: boolean;
+  error?: string;
+  manual?: string;
+}
+
+export default function ConnectGithubModal({ onClose, onConnected }: Props) {
+  const gh = (window as any).claude?.github;
+  const isElectron = getPlatform() === 'electron';
+
+  const [stage, setStage] = useState<Stage>('checking');
+  const [code, setCode] = useState<ConnectCode | null>(null);
+  const [login, setLogin] = useState<string | undefined>(undefined);
+  const [errorReason, setErrorReason] = useState<ConnectError | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // gh-missing sub-state (install button feedback). Kept local to that stage.
+  const [installBusy, setInstallBusy] = useState(false);
+  const [installNote, setInstallNote] =
+    useState<{ kind: 'restart' | 'manual' | 'error'; text: string } | null>(null);
+
+  // cancelledRef — the async check/connect chains and the close timer must not
+  // setState after unmount (the modal can be closed mid-flight).
+  const cancelledRef = useRef(false);
+
+  // Success is reached from two places (already-authed on open, and the
+  // connect-done push). Centralize so both refresh sync + auto-close the same.
+  const succeed = useCallback((who?: string) => {
+    if (cancelledRef.current) return;
+    setLogin(who);
+    setStage('done');
+    onConnected?.(who);
+    // Auto-close after a beat so the user sees the confirmation. Direct onClose
+    // (not the cancel-then-close path) — there's no live flow to abort.
+    setTimeout(() => { if (!cancelledRef.current) onClose(); }, 1500);
+  }, [onConnected, onClose]);
+
+  // Begin the device flow: ask main for the code + start its polling.
+  const startCode = useCallback(async () => {
+    setErrorReason(null);
+    setCode(null);
+    setStage('code');
+    try {
+      const c: ConnectCode = await gh.connectStart();
+      if (cancelledRef.current) return;
+      setCode(c);
+    } catch (err: any) {
+      // connectStart rejects (e.g. startDeviceFlow threw 'network') → show the
+      // error state immediately; there's no flow running to emit connect-done.
+      if (cancelledRef.current) return;
+      const reason = String(err?.message ?? err) as ConnectError;
+      setErrorReason(reason in ERROR_COPY ? reason : 'network');
+      setStage('error');
+    }
+  }, [gh]);
+
+  // status() → decide the entry stage. Reused by "Check again" after install.
+  const runCheck = useCallback(async () => {
+    setInstallNote(null);
+    setStage('checking');
+    try {
+      const s = await gh.status();
+      if (cancelledRef.current) return;
+      if (s?.authed) { succeed(s.login); return; }
+      if (!s?.installed) { setStage('gh-missing'); return; }
+      void startCode();
+    } catch (err: any) {
+      if (cancelledRef.current) return;
+      setErrorReason('network');
+      setStage('error');
+    }
+  }, [gh, succeed, startCode]);
+
+  // Mount: run the initial check and subscribe to the connect-done push for the
+  // whole lifetime (the push can land while we're on the 'code' screen).
+  useEffect(() => {
+    cancelledRef.current = false;
+    void runCheck();
+    const unsub = gh?.onConnectDone?.((p: { ok: boolean; login?: string; error?: string }) => {
+      if (cancelledRef.current) return;
+      if (p.ok) { succeed(p.login); return; }
+      const reason = (p.error ?? 'network') as ConnectError;
+      setErrorReason(reason in ERROR_COPY ? reason : 'network');
+      setStage('error');
+    });
+    return () => {
+      cancelledRef.current = true;
+      unsub?.();
+    };
+    // Intentionally mount-only — runCheck/succeed are stable enough and we must
+    // NOT re-subscribe/re-check on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Every user-initiated close path aborts main's poll first (harmless no-op if
+  // no flow is running) so a dangling device-flow poll doesn't keep spinning.
+  const handleClose = useCallback(() => {
+    try { gh?.connectCancel?.(); } catch { /* fire-and-forget */ }
+    onClose();
+  }, [gh, onClose]);
+
+  // ESC closes via the shared LIFO stack (no window-level listener).
+  useEscClose(true, handleClose);
+
+  const copyCode = useCallback(() => {
+    if (!code) return;
+    navigator.clipboard?.writeText(code.userCode).then(
+      () => { if (!cancelledRef.current) { setCopied(true); setTimeout(() => { if (!cancelledRef.current) setCopied(false); }, 1500); } },
+      () => {},
+    );
+  }, [code]);
+
+  // Windows: actually installs via winget; mac/linux: returns the manual command.
+  const handleInstallGh = useCallback(async () => {
+    setInstallBusy(true);
+    setInstallNote(null);
+    try {
+      const r: InstallResult = await gh.installGh();
+      if (cancelledRef.current) return;
+      if (r.ok) { void runCheck(); return; }
+      if (r.restartRequired) {
+        setInstallNote({ kind: 'restart', text: r.error ?? 'Quit and reopen YouCoded to finish.' });
+      } else if (r.manual) {
+        setInstallNote({ kind: 'manual', text: r.manual });
+      } else {
+        setInstallNote({ kind: 'error', text: r.error ?? 'Could not install GitHub CLI.' });
+      }
+    } catch (err: any) {
+      if (!cancelledRef.current) setInstallNote({ kind: 'error', text: String(err?.message ?? err) });
+    } finally {
+      if (!cancelledRef.current) setInstallBusy(false);
+    }
+  }, [gh, runCheck]);
+
+  const openVerificationUrl = useCallback(() => {
+    if (!code) return;
+    // Desktop: hand off to the OS default browser. Remote/Android render a link
+    // instead (handled in the JSX) — this path is Electron-only.
+    (window as any).claude?.shell?.openExternal?.(code.verificationUri);
+  }, [code]);
+
+  return (
+    <>
+      <Scrim layer={2} onClick={handleClose} />
+      <OverlayPanel
+        layer={2}
+        role="dialog"
+        aria-modal
+        aria-labelledby="connect-github-title"
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[26rem] max-w-[calc(100vw-2rem)] p-5"
+      >
+        {/* Header — consistent across every stage */}
+        <div className="flex items-start justify-between gap-3">
+          <div id="connect-github-title" className="text-sm font-semibold text-fg">Connect GitHub</div>
+          <button
+            onClick={handleClose}
+            aria-label="Close"
+            className="text-fg-muted hover:text-fg-2 text-lg leading-none w-6 h-6 flex items-center justify-center rounded hover:bg-inset -mt-1 -mr-1"
+          >
+            {'✕'}
+          </button>
+        </div>
+
+        {/* ---- checking ---- */}
+        {stage === 'checking' && (
+          <div className="mt-4 text-xs text-fg-muted">Checking your GitHub connection…</div>
+        )}
+
+        {/* ---- gh-missing ---- */}
+        {stage === 'gh-missing' && (
+          <div className="mt-3 space-y-3">
+            <p className="text-xs text-fg-2 leading-relaxed">
+              YouCoded needs GitHub's command-line tool (gh) to connect your account.
+            </p>
+
+            {installNote?.kind === 'restart' && (
+              <div className="rounded-md border border-edge bg-inset px-3 py-2 text-xs text-fg-dim">
+                {installNote.text}
+              </div>
+            )}
+            {installNote?.kind === 'manual' && (
+              <div className="space-y-1">
+                <div className="text-[11px] text-fg-muted">Run this in your terminal, then choose “Check again”:</div>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 font-mono text-xs text-fg-dim bg-inset px-2 py-1.5 rounded break-all">{installNote.text}</code>
+                  <button
+                    onClick={() => navigator.clipboard?.writeText(installNote.text).catch(() => {})}
+                    className="text-xs px-2 py-1 rounded bg-inset hover:bg-edge text-fg-dim shrink-0"
+                  >
+                    Copy
+                  </button>
+                </div>
+              </div>
+            )}
+            {installNote?.kind === 'error' && (
+              <div role="alert" className="text-xs text-red-500">{installNote.text}</div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                onClick={handleClose}
+                className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors"
+              >
+                Never mind
+              </button>
+              <button
+                onClick={() => void runCheck()}
+                disabled={installBusy}
+                className="text-sm px-3 py-1 rounded border border-edge-dim text-fg-2 hover:bg-inset disabled:opacity-50"
+              >
+                Check again
+              </button>
+              <button
+                onClick={() => void handleInstallGh()}
+                disabled={installBusy}
+                className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50"
+              >
+                {installBusy ? 'Installing…' : 'Install GitHub CLI'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ---- code (the main state) ---- */}
+        {stage === 'code' && (
+          <div className="mt-3 space-y-3">
+            <p className="text-xs text-fg-2 leading-relaxed">
+              Open GitHub and enter this one-time code to connect your account.
+            </p>
+
+            {code ? (
+              <>
+                {/* Big, easy-to-read code (mono). Copy sits alongside it. */}
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 font-mono text-2xl tracking-[0.25em] text-fg text-center bg-inset rounded-md py-3 select-all">
+                    {code.userCode}
+                  </div>
+                  <button
+                    onClick={copyCode}
+                    className="text-xs px-3 py-2 rounded bg-inset hover:bg-edge text-fg-2 shrink-0"
+                  >
+                    {copied ? 'Copied' : 'Copy'}
+                  </button>
+                </div>
+
+                {isElectron ? (
+                  // Desktop — open the OS browser directly.
+                  <button
+                    onClick={openVerificationUrl}
+                    className="w-full text-sm px-3 py-2 rounded bg-accent text-on-accent"
+                  >
+                    Open github.com/login/device
+                  </button>
+                ) : (
+                  // Remote / touch — no shell access; render a copyable link the
+                  // user opens themselves. <a target=_blank> works in a browser.
+                  <div className="space-y-1">
+                    <div className="text-[11px] text-fg-muted">Then open this address in your browser:</div>
+                    <div className="flex items-center gap-2">
+                      <a
+                        href={code.verificationUri}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex-1 text-xs text-accent underline break-all bg-inset px-2 py-1.5 rounded"
+                      >
+                        {code.verificationUri}
+                      </a>
+                      <button
+                        onClick={() => navigator.clipboard?.writeText(code.verificationUri).catch(() => {})}
+                        className="text-xs px-2 py-1 rounded bg-inset hover:bg-edge text-fg-dim shrink-0"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                <p className="text-[11px] text-fg-muted">Waiting for you to approve in your browser…</p>
+              </>
+            ) : (
+              <div className="text-xs text-fg-muted">Preparing your code…</div>
+            )}
+
+            <div className="flex justify-end pt-1">
+              <button
+                onClick={handleClose}
+                className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors"
+              >
+                Never mind
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ---- done ---- */}
+        {stage === 'done' && (
+          <div className="mt-4 space-y-2">
+            <p className="text-sm text-fg">
+              {login ? <>GitHub connected as <span className="font-medium">{login}</span>.</> : 'GitHub connected.'}
+            </p>
+            <p className="text-xs text-fg-muted">You're all set — this window will close automatically.</p>
+          </div>
+        )}
+
+        {/* ---- error ---- */}
+        {stage === 'error' && (
+          <div className="mt-4 space-y-3">
+            <p role="alert" className="text-sm text-fg-2">
+              {errorReason ? ERROR_COPY[errorReason] : ERROR_COPY.network}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={handleClose}
+                className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors"
+              >
+                Never mind
+              </button>
+              <button
+                onClick={() => void startCode()}
+                className="text-sm px-3 py-1 rounded bg-accent text-on-accent"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        )}
+      </OverlayPanel>
+    </>
+  );
+}

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -20,6 +20,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 import { RestoreWizard } from './restore/RestoreWizard';
 import { SnapshotsPanel } from './restore/SnapshotsPanel';
+import ConnectGithubModal from './ConnectGithubModal';
 
 // --- Explainer content (updated for V2 multi-instance model) ---
 
@@ -420,6 +421,19 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
   // First enable provisions GitHub repos and can take seconds — without a
   // visible pending state the checkbox reads as "didn't take" to a non-developer.
   const [enabling, setEnabling] = useState(false);
+  // GitHub connection state (device-flow modal). Sync's primary channel needs a
+  // GitHub sign-in; we surface a "Connect GitHub…" affordance whenever the
+  // structured github:status reports not-authed (NOT by parsing space-manager's
+  // error strings — those are a pinned UI contract we display verbatim).
+  const [githubStatus, setGithubStatus] = useState<{ installed: boolean; authed: boolean; login?: string } | null>(null);
+  const [showConnectGithub, setShowConnectGithub] = useState(false);
+  // When an enable attempt fails on a GitHub problem, remember it so a
+  // successful connect can re-kick enable automatically ("everything appears"
+  // without a second click).
+  const wasMidEnableRef = useRef(false);
+  // Latest handleSpacesEnable, so handleGithubConnected can re-invoke it without
+  // a declaration-order / stale-closure problem (the callback is defined below).
+  const handleSpacesEnableRef = useRef<((enabled: boolean) => Promise<void>) | null>(null);
 
   const claude = (window as any).claude;
 
@@ -600,6 +614,26 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
     return () => { off?.(); };
   }, [refreshSpacesStatus]);
 
+  // GitHub connection status. Method-exists guard so an older shim / Android
+  // (no handler) degrades to null (unknown → no affordance) instead of throwing.
+  const refreshGithubStatus = useCallback(async () => {
+    const fn = (window as any).claude?.github?.status;
+    if (typeof fn !== 'function') { setGithubStatus(null); return; }
+    try { setGithubStatus(await fn()); } catch { setGithubStatus(null); }
+  }, []);
+  useEffect(() => { void refreshGithubStatus(); }, [refreshGithubStatus]);
+
+  // Called by the modal after a successful connect: refresh both GitHub and
+  // sync status, and if the user was mid-enable (an enable failed on a GitHub
+  // problem), re-run enable so sync lights up without a second click.
+  const handleGithubConnected = useCallback(async () => {
+    await refreshGithubStatus();
+    if (wasMidEnableRef.current) {
+      wasMidEnableRef.current = false;
+      await handleSpacesEnableRef.current?.(true);
+    }
+  }, [refreshGithubStatus]);
+
   // Enable/disable toggle. try/catch: on rejection, surface the message in the
   // red note slot and re-fetch status so the checkbox reflects reality instead
   // of silently staying out of sync with the engine.
@@ -608,12 +642,21 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
     try {
       setSpacesStatus(await claude.syncSpaces.enable(enabled));
       setSpacesError(null);
+      wasMidEnableRef.current = false;
     } catch (err: any) {
       setSpacesError(String(err?.message ?? err));
+      // Remember an enable-turn-on that failed so a subsequent GitHub connect
+      // can re-kick it automatically. (Enable also emits a provisioning error
+      // event when gh is missing / not signed in — same recovery target.)
+      if (enabled) wasMidEnableRef.current = true;
       await refreshSpacesStatus();
+      // A failed enable is very often a GitHub problem — refresh github:status
+      // so the "Connect GitHub…" affordance next to the error note is accurate.
+      await refreshGithubStatus();
     }
     setEnabling(false);
-  }, [claude, refreshSpacesStatus]);
+  }, [claude, refreshSpacesStatus, refreshGithubStatus]);
+  useEffect(() => { handleSpacesEnableRef.current = handleSpacesEnable; }, [handleSpacesEnable]);
 
   // Recent sync events for DISPLAY only. `hub-status` entries drive the
   // "Instant sync" status line below (that's their surface); `projects-changed`
@@ -748,6 +791,25 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                 </div>
               </div>
 
+              {/* GitHub connection line. Shown whenever we know the status:
+                  a plain "connected as <login>" when authed (no status glyph),
+                  or a "Connect GitHub…" affordance when not. Gates on the
+                  structured github:status, never on the error strings. */}
+              {githubStatus && (
+                githubStatus.authed ? (
+                  <p className="text-xs text-fg-muted mt-2">
+                    GitHub connected{githubStatus.login ? <> as <span className="text-fg-2">{githubStatus.login}</span></> : ''}
+                  </p>
+                ) : (
+                  <button
+                    onClick={() => setShowConnectGithub(true)}
+                    className="text-xs mt-2 text-accent hover:underline"
+                  >
+                    Connect GitHub…
+                  </button>
+                )
+              )}
+
               {spacesStatus?.enabled && (
                 <ul className="mt-3 space-y-1">
                   {(spacesStatus.spaces?.map((s: any) => (
@@ -782,7 +844,24 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
               {(() => {
                 const engineError = [...visibleSpaceEvents].reverse().find((e: any) => e.type === 'error');
                 const msg = spacesError ?? engineError?.message;
-                return msg ? <p className="text-xs text-red-500 mt-2">{msg}</p> : null;
+                if (!msg) return null;
+                // Keep the raw message verbatim (space-manager's friendly strings
+                // are a pinned UI contract). The "Connect GitHub…" button is an
+                // ADDITIVE affordance, gated on the structured not-authed state —
+                // NOT on parsing the error text.
+                return (
+                  <div className="mt-2 space-y-1">
+                    <p className="text-xs text-red-500">{msg}</p>
+                    {githubStatus && !githubStatus.authed && (
+                      <button
+                        onClick={() => setShowConnectGithub(true)}
+                        className="text-xs text-accent hover:underline"
+                      >
+                        Connect GitHub…
+                      </button>
+                    )}
+                  </div>
+                );
               })()}
 
               {spacesStatus?.enabled && (
@@ -1138,6 +1217,16 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
         </div>
         )}
       </OverlayPanel>
+
+      {/* Connect-GitHub device-flow modal. Own L2 overlay so it sits above the
+          sync popup. onConnected refreshes github status + re-kicks a failed
+          enable; every close path aborts main's poll inside the modal. */}
+      {showConnectGithub && (
+        <ConnectGithubModal
+          onClose={() => setShowConnectGithub(false)}
+          onConnected={() => { void handleGithubConnected(); }}
+        />
+      )}
 
       {/* Restore-from-backup wizard — own modal layer so it overlays the sync popup.
           Refreshes sync status on close so lastPush/lastError reflect the restore. */}

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -264,6 +264,12 @@ function handleMessage(data: string): void {
       // Broadcast (no sessionId).
       dispatchEvent('syncspaces:event', payload);
       break;
+    case 'github:connect-done':
+      // Connect-GitHub device flow settled on the host. Payload is
+      // {ok, login?, error?} — the token NEVER travels over the WS. Flows to
+      // window.claude.github.onConnectDone(). Broadcast (no sessionId).
+      dispatchEvent('github:connect-done', payload);
+      break;
     case 'chat:hydrate':
       // Full chat state snapshot sent by the host when a remote client connects.
       // Dispatched into the chat reducer via window.claude.on.chatHydrate in App.tsx.
@@ -1134,6 +1140,21 @@ export function installShim(): void {
         const handler: Callback = (e: any) => cb(e);
         addListener('syncspaces:event', handler);
         return () => removeListener('syncspaces:event', handler);
+      },
+    },
+    // Connect-GitHub modal (device-flow auth). Same shared shape as preload's
+    // window.claude.github so the modal renders identically on remote browsers.
+    // The whole flow is main-process; the shim just relays requests + the
+    // connect-done push. Token never crosses the WS (only status/login/error do).
+    github: {
+      status: () => invoke('github:status'),
+      connectStart: () => invoke('github:connect-start'),
+      connectCancel: () => invoke('github:connect-cancel'),
+      installGh: () => invoke('github:install-gh'),
+      onConnectDone: (cb: (payload: { ok: boolean; login?: string; error?: string }) => void) => {
+        const handler: Callback = (p: any) => cb(p);
+        addListener('github:connect-done', handler);
+        return () => removeListener('github:connect-done', handler);
       },
     },
     folders: {

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -834,6 +834,15 @@ export const IPC = {
   SYNC_SPACES_LIST_DEVICES: 'syncspaces:list-devices',
   SYNC_SPACES_RENAME_DEVICE: 'syncspaces:rename-device',
   SYNC_SPACES_EVENT: 'syncspaces:event',
+  // Connect-GitHub modal (device-flow auth) — lets non-developers connect GitHub
+  // in-app so enabling Sync never dead-ends on "gh not installed / not signed in".
+  // status/install are plain request-response; connect-start kicks off main-side
+  // device-flow polling and pushes GITHUB_CONNECT_DONE when it settles.
+  GITHUB_STATUS: 'github:status',
+  GITHUB_CONNECT_START: 'github:connect-start',
+  GITHUB_CONNECT_CANCEL: 'github:connect-cancel',
+  GITHUB_INSTALL_GH: 'github:install-gh',
+  GITHUB_CONNECT_DONE: 'github:connect-done', // push: {ok, login?, error?}
   // Multi-window detach subsystem (Renderer <-> Main)
   WINDOW_GET_ID: 'window:get-id',
   WINDOW_DIRECTORY_UPDATED: 'window:directory-updated',

--- a/desktop/tests/github-auth.test.ts
+++ b/desktop/tests/github-auth.test.ts
@@ -1,0 +1,383 @@
+import { describe, test, expect, vi } from 'vitest';
+import {
+  CLIENT_ID,
+  SCOPES,
+  detectGh,
+  startDeviceFlow,
+  pollForToken,
+  completeLogin,
+  installGh,
+  type ExecFn,
+  type FetchLike,
+  type SpawnFn,
+  type SpawnedProcess,
+} from '../src/main/github-auth';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+//
+// Every function under test takes INJECTED I/O (fetch / exec / spawn / sleep),
+// so these tests never hit the network, never spawn a real process, and never
+// wait real time. That's the whole point of the pure-core / IO-shell split:
+// the state machine is exercised deterministically here, and only the thin
+// default adapters touch the outside world in production.
+// ---------------------------------------------------------------------------
+
+/** A mock exec that maps `cmd + ' ' + args` → a canned result or throws. */
+function makeExec(
+  handlers: Record<string, { stdout?: string; stderr?: string } | { throw: unknown }>,
+): ExecFn {
+  return async (cmd, args) => {
+    const key = [cmd, ...args].join(' ');
+    const h = handlers[key];
+    if (!h) throw new Error(`unexpected exec: ${key}`);
+    if ('throw' in h) throw h.throw;
+    return { stdout: h.stdout ?? '', stderr: h.stderr ?? '' };
+  };
+}
+
+/** Build a fetch-like that returns each queued JSON payload in order. */
+function makeFetch(payloads: any[]): FetchLike & { calls: any[] } {
+  let i = 0;
+  const fn: any = async (_url: string, init?: any) => {
+    fn.calls.push({ url: _url, init });
+    const body = payloads[Math.min(i, payloads.length - 1)];
+    i++;
+    if (body instanceof Error) throw body;
+    return { ok: true, status: 200, json: async () => body };
+  };
+  fn.calls = [];
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Module constants
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  test('client id and scopes match the gh CLI public app', () => {
+    expect(CLIENT_ID).toBe('178c6fc778ccc68e1d6a');
+    expect(SCOPES).toBe('repo read:org gist workflow');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectGh
+// ---------------------------------------------------------------------------
+
+describe('detectGh', () => {
+  test('gh absent (ENOENT) → installed:false, authed:false', async () => {
+    const err: any = new Error('spawn gh ENOENT');
+    err.code = 'ENOENT';
+    const exec = makeExec({ 'gh --version': { throw: err } });
+    const r = await detectGh(exec);
+    expect(r).toEqual({ installed: false, authed: false });
+  });
+
+  test('gh present but not authed → installed:true, authed:false, no login', async () => {
+    const authErr: any = new Error('gh auth status exit 1');
+    authErr.code = 1;
+    const exec = makeExec({
+      'gh --version': { stdout: 'gh version 2.88.0' },
+      'gh auth status': { throw: authErr },
+    });
+    const r = await detectGh(exec);
+    expect(r).toEqual({ installed: true, authed: false });
+  });
+
+  test('gh authed → login parsed from `gh api user`', async () => {
+    const exec = makeExec({
+      'gh --version': { stdout: 'gh version 2.88.0' },
+      'gh auth status': { stdout: 'Logged in to github.com' },
+      'gh api user -q .login': { stdout: 'itsdestin\n' },
+    });
+    const r = await detectGh(exec);
+    expect(r).toEqual({ installed: true, authed: true, login: 'itsdestin' });
+  });
+
+  test('authed but login lookup fails → still authed, login undefined', async () => {
+    const exec = makeExec({
+      'gh --version': { stdout: 'gh version 2.88.0' },
+      'gh auth status': { stdout: 'Logged in' },
+      'gh api user -q .login': { throw: new Error('api down') },
+    });
+    const r = await detectGh(exec);
+    expect(r).toEqual({ installed: true, authed: true, login: undefined });
+  });
+
+  test('never throws', async () => {
+    const exec: ExecFn = async () => {
+      throw new Error('boom');
+    };
+    await expect(detectGh(exec)).resolves.toEqual({ installed: false, authed: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startDeviceFlow
+// ---------------------------------------------------------------------------
+
+describe('startDeviceFlow', () => {
+  test('maps the device-code response and computes expiresAt', async () => {
+    const before = Date.now();
+    const fetchFn = makeFetch([
+      {
+        device_code: 'DC123',
+        user_code: '8E15-B86D',
+        verification_uri: 'https://github.com/login/device',
+        expires_in: 900,
+        interval: 5,
+      },
+    ]);
+    const r = await startDeviceFlow(fetchFn);
+    expect(r.deviceCode).toBe('DC123');
+    expect(r.userCode).toBe('8E15-B86D');
+    expect(r.verificationUri).toBe('https://github.com/login/device');
+    expect(r.interval).toBe(5);
+    // expiresAt ~= now + 900s (allow a small window for test execution time).
+    expect(r.expiresAt).toBeGreaterThanOrEqual(before + 900_000);
+    expect(r.expiresAt).toBeLessThanOrEqual(Date.now() + 900_000);
+    // POSTs to the device-code endpoint with client_id + scope in the body.
+    const call = fetchFn.calls[0];
+    expect(call.url).toContain('/login/device/code');
+    expect(call.init.body).toContain(CLIENT_ID);
+  });
+
+  test('network failure throws Error("network")', async () => {
+    const fetchFn: FetchLike = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    await expect(startDeviceFlow(fetchFn)).rejects.toThrow('network');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pollForToken
+// ---------------------------------------------------------------------------
+
+describe('pollForToken', () => {
+  const future = () => Date.now() + 900_000;
+
+  test('authorization_pending → keeps polling, then resolves on access_token', async () => {
+    const fetchFn = makeFetch([
+      { error: 'authorization_pending' },
+      { access_token: 'gho_secrettoken', token_type: 'bearer', scope: SCOPES },
+    ]);
+    const sleeps: number[] = [];
+    const sleepFn = async (ms: number) => {
+      sleeps.push(ms);
+    };
+    const r = await pollForToken('DC123', {
+      intervalMs: 5000,
+      expiresAt: future(),
+      fetchFn,
+      sleepFn,
+    });
+    expect(r).toEqual({ token: 'gho_secrettoken' });
+    // Slept once per poll attempt (both at the base interval).
+    expect(sleeps).toEqual([5000, 5000]);
+  });
+
+  test('slow_down grows the interval by 5s (and honors a returned interval)', async () => {
+    const fetchFn = makeFetch([
+      { error: 'slow_down', interval: 12 },
+      { access_token: 'gho_x' },
+    ]);
+    const sleeps: number[] = [];
+    const sleepFn = async (ms: number) => {
+      sleeps.push(ms);
+    };
+    await pollForToken('DC', {
+      intervalMs: 5000,
+      expiresAt: future(),
+      fetchFn,
+      sleepFn,
+    });
+    // First sleep at base 5000; after slow_down interval grows to max(5000+5000, 12000)=12000.
+    expect(sleeps).toEqual([5000, 12000]);
+  });
+
+  test('expired_token rejects Error("expired")', async () => {
+    const fetchFn = makeFetch([{ error: 'expired_token' }]);
+    await expect(
+      pollForToken('DC', { intervalMs: 1, expiresAt: future(), fetchFn, sleepFn: async () => {} }),
+    ).rejects.toThrow('expired');
+  });
+
+  test('past expiresAt rejects Error("expired") before hitting the network', async () => {
+    const fetchFn = makeFetch([{ access_token: 'should-not-be-reached' }]);
+    await expect(
+      pollForToken('DC', {
+        intervalMs: 1,
+        expiresAt: Date.now() - 1, // already expired
+        fetchFn,
+        sleepFn: async () => {},
+      }),
+    ).rejects.toThrow('expired');
+    expect(fetchFn.calls.length).toBe(0);
+  });
+
+  test('access_denied rejects Error("denied")', async () => {
+    const fetchFn = makeFetch([{ error: 'access_denied' }]);
+    await expect(
+      pollForToken('DC', { intervalMs: 1, expiresAt: future(), fetchFn, sleepFn: async () => {} }),
+    ).rejects.toThrow('denied');
+  });
+
+  test('network error during poll rejects Error("network")', async () => {
+    const fetchFn: FetchLike = async () => {
+      throw new Error('socket hang up');
+    };
+    await expect(
+      pollForToken('DC', { intervalMs: 1, expiresAt: future(), fetchFn, sleepFn: async () => {} }),
+    ).rejects.toThrow('network');
+  });
+
+  test('aborted signal rejects Error("cancelled")', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetchFn = makeFetch([{ access_token: 'nope' }]);
+    await expect(
+      pollForToken('DC', {
+        intervalMs: 1,
+        expiresAt: future(),
+        fetchFn,
+        sleepFn: async () => {},
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('cancelled');
+    expect(fetchFn.calls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeLogin
+// ---------------------------------------------------------------------------
+
+/** A fake child process whose exit code and stdin behavior are scriptable. */
+function makeFakeChild(exitCode: number | null) {
+  const writes: string[] = [];
+  let ended = false;
+  const listeners: Record<string, (arg: any) => void> = {};
+  const child: SpawnedProcess = {
+    stdin: {
+      write: (chunk: string) => {
+        writes.push(chunk);
+        return true;
+      },
+      end: () => {
+        ended = true;
+        // Fire close asynchronously once stdin is closed (mirrors gh reading EOF).
+        setTimeout(() => listeners['close']?.(exitCode), 0);
+      },
+    },
+    on: (event: string, cb: (arg: any) => void) => {
+      listeners[event] = cb;
+    },
+  };
+  return { child, writes, get ended() { return ended; } };
+}
+
+describe('completeLogin', () => {
+  test('writes token+newline, closes stdin, resolves on exit 0', async () => {
+    const fake = makeFakeChild(0);
+    const spawnFn: SpawnFn = () => fake.child;
+    await expect(completeLogin('gho_realtoken', spawnFn)).resolves.toBeUndefined();
+    expect(fake.writes).toEqual(['gho_realtoken\n']);
+    expect(fake.ended).toBe(true); // stdin MUST be closed or gh hangs forever
+  });
+
+  test('rejects on non-zero exit', async () => {
+    const fake = makeFakeChild(1);
+    const spawnFn: SpawnFn = () => fake.child;
+    await expect(completeLogin('gho_realtoken', spawnFn)).rejects.toThrow();
+  });
+
+  test('the token NEVER appears in a thrown error message', async () => {
+    const TOKEN = 'gho_supersecret_value_1234567890';
+    const fake = makeFakeChild(1);
+    const spawnFn: SpawnFn = () => fake.child;
+    let caught: Error | null = null;
+    try {
+      await completeLogin(TOKEN, spawnFn);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).not.toContain(TOKEN);
+    expect(String(caught!.stack ?? '')).not.toContain(TOKEN);
+  });
+
+  test('rejects (without leaking token) when spawn errors', async () => {
+    const TOKEN = 'gho_secret_on_spawn_error';
+    const spawnFn: SpawnFn = () => {
+      throw new Error('spawn failed');
+    };
+    let caught: Error | null = null;
+    try {
+      await completeLogin(TOKEN, spawnFn);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).not.toContain(TOKEN);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// installGh
+// ---------------------------------------------------------------------------
+
+describe('installGh', () => {
+  test('Windows: winget succeeds but gh still not on PATH → restartRequired', async () => {
+    const ghMissing: any = new Error('ENOENT');
+    ghMissing.code = 'ENOENT';
+    const exec = makeExec({
+      'winget install --id GitHub.cli -e --silent --accept-package-agreements --accept-source-agreements': {
+        stdout: 'installed',
+      },
+      // Post-install re-detect still fails (PATH not propagated to this process).
+      'gh --version': { throw: ghMissing },
+    });
+    const detectWingetFn = async () => ({ installed: true });
+    const r = await installGh(exec, detectWingetFn, 'win32');
+    expect(r.ok).toBe(false);
+    expect(r.restartRequired).toBe(true);
+    expect(r.error).toContain('Quit and reopen');
+  });
+
+  test('Windows: winget succeeds and gh detected → ok', async () => {
+    const exec = makeExec({
+      'winget install --id GitHub.cli -e --silent --accept-package-agreements --accept-source-agreements': {
+        stdout: 'installed',
+      },
+      'gh --version': { stdout: 'gh version 2.88.0' },
+      'gh auth status': { throw: new Error('not authed') },
+    });
+    const detectWingetFn = async () => ({ installed: true });
+    const r = await installGh(exec, detectWingetFn, 'win32');
+    expect(r).toEqual({ ok: true });
+  });
+
+  test('Windows: winget missing → surfaces its error, no ok', async () => {
+    const exec = makeExec({}); // should never be called
+    const detectWingetFn = async () => ({ installed: false, error: 'winget is missing' });
+    const r = await installGh(exec, detectWingetFn, 'win32');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('winget is missing');
+  });
+
+  test('macOS: returns a manual brew command, no auto-install', async () => {
+    const exec = makeExec({});
+    const r = await installGh(exec, async () => ({ installed: true }), 'darwin');
+    expect(r.ok).toBe(false);
+    expect(r.manual).toContain('brew install gh');
+  });
+
+  test('Linux: returns a manual docs pointer', async () => {
+    const exec = makeExec({});
+    const r = await installGh(exec, async () => ({ installed: true }), 'linux');
+    expect(r.ok).toBe(false);
+    expect(r.manual).toContain('github.com/cli/cli');
+  });
+});

--- a/desktop/tests/github-connect.test.ts
+++ b/desktop/tests/github-connect.test.ts
@@ -158,6 +158,35 @@ describe('createGithubConnect', () => {
     expect(calls).toHaveLength(0);
   });
 
+  test('a superseding start() silences the aborted prior flow (no spurious cancelled, new flow still settles)', async () => {
+    // The orchestrator is a singleton shared by desktop + remote. Two starts
+    // without an intervening cancel (double-click / racing clients) must not let
+    // the aborted first flow emit a 'cancelled' that also blocks the second.
+    const { emit, calls } = deferredDone();
+    // First flow's poll rejects 'cancelled' the moment its signal aborts.
+    const pollA: GithubConnectDeps['pollForToken'] = (_dc, opts) =>
+      new Promise((_res, reject) => {
+        opts.signal?.addEventListener('abort', () => reject(new Error('cancelled')));
+      });
+    // Second flow succeeds.
+    let poll = pollA;
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: (dc, opts) => poll(dc, opts),
+      completeLogin: async () => {},
+      detectGh: async () => ({ installed: true, authed: true, login: 'octocat' }),
+    });
+
+    await gc.start();                 // flow A begins polling
+    poll = async () => ({ token: SECRET }); // flow B will succeed
+    await gc.start();                 // supersedes A (aborts it)
+    // Let A's abort-rejection and B's success both flush.
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    // Exactly ONE emit — flow B's success — and NOT A's spurious 'cancelled'.
+    expect(calls).toEqual([{ ok: true, login: 'octocat' }]);
+  });
+
   test('emitDone fires at most once per flow (cancel after success is a no-op)', async () => {
     const { emit, done, calls } = deferredDone();
     const gc = createGithubConnect(emit, {

--- a/desktop/tests/github-connect.test.ts
+++ b/desktop/tests/github-connect.test.ts
@@ -1,0 +1,177 @@
+import { describe, test, expect, vi } from 'vitest';
+import { createGithubConnect, type GithubConnectDeps } from '../src/main/github-connect';
+
+// ---------------------------------------------------------------------------
+// The orchestrator drives a DETACHED background chain (poll → login → detect)
+// that calls emitDone once. These tests inject fakes for every github-auth step
+// so the whole flow runs with no network / no spawn / no real time, and use a
+// deferred "done" promise to await the detached chain's single emitDone call.
+// ---------------------------------------------------------------------------
+
+type DonePayload = { ok: boolean; login?: string; error?: string };
+
+/** A one-shot barrier: `emit` fulfills `done` with the first emitDone payload. */
+function deferredDone() {
+  let resolve!: (p: DonePayload) => void;
+  const done = new Promise<DonePayload>((r) => { resolve = r; });
+  const calls: DonePayload[] = [];
+  const emit = (p: DonePayload) => { calls.push(p); resolve(p); };
+  return { emit, done, calls };
+}
+
+const SECRET = 'gho_supersecrettoken_should_never_leak';
+
+/** Baseline device-flow fake — a code that's valid for 15 minutes. */
+const fakeStartDeviceFlow: GithubConnectDeps['startDeviceFlow'] = async () => ({
+  deviceCode: 'device-code-123',
+  userCode: 'ABCD-1234',
+  verificationUri: 'https://github.com/login/device',
+  expiresAt: Date.now() + 900_000,
+  interval: 5,
+});
+
+describe('createGithubConnect', () => {
+  test('start() returns the device-flow public render fields', async () => {
+    const { emit } = deferredDone();
+    // Poll never settles here so we only test the synchronous start() return.
+    const neverPoll: GithubConnectDeps['pollForToken'] = () => new Promise(() => {});
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: neverPoll,
+    });
+
+    const res = await gc.start();
+    expect(res).toEqual({
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://github.com/login/device',
+      expiresAt: expect.any(Number),
+    });
+    // The device code (internal) must NOT be exposed in the render fields.
+    expect(JSON.stringify(res)).not.toContain('device-code-123');
+  });
+
+  test('successful poll + login → emitDone({ok:true, login}) and NEVER the token', async () => {
+    const { emit, done } = deferredDone();
+    let loginToken: string | undefined;
+
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: async () => ({ token: SECRET }),
+      completeLogin: async (token) => { loginToken = token; },
+      detectGh: async () => ({ installed: true, authed: true, login: 'octocat' }),
+    });
+
+    await gc.start();
+    const payload = await done;
+
+    // The token flowed ONLY into completeLogin...
+    expect(loginToken).toBe(SECRET);
+    // ...and the public payload carries the login handle, not the token.
+    expect(payload).toEqual({ ok: true, login: 'octocat' });
+    expect(JSON.stringify(payload)).not.toContain(SECRET);
+  });
+
+  test('detectGh failure after login still succeeds (login omitted, never downgrades ok)', async () => {
+    const { emit, done } = deferredDone();
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: async () => ({ token: SECRET }),
+      completeLogin: async () => {},
+      detectGh: async () => { throw new Error('gh api failed'); },
+    });
+
+    await gc.start();
+    const payload = await done;
+    expect(payload).toEqual({ ok: true });
+    expect(JSON.stringify(payload)).not.toContain(SECRET);
+  });
+
+  test("poll rejecting 'expired' → emitDone({ok:false, error:'expired'})", async () => {
+    const { emit, done } = deferredDone();
+    const completeLogin = vi.fn(async () => {});
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: async () => { throw new Error('expired'); },
+      completeLogin,
+    });
+
+    await gc.start();
+    const payload = await done;
+    expect(payload).toEqual({ ok: false, error: 'expired' });
+    // A failed poll must never reach completeLogin.
+    expect(completeLogin).not.toHaveBeenCalled();
+  });
+
+  test("poll rejecting 'denied' maps straight through", async () => {
+    const { emit, done } = deferredDone();
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: async () => { throw new Error('denied'); },
+    });
+    await gc.start();
+    expect(await done).toEqual({ ok: false, error: 'denied' });
+  });
+
+  test("completeLogin throwing → emitDone({ok:false, error:'login-failed'}) with NO token", async () => {
+    const { emit, done } = deferredDone();
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: async () => ({ token: SECRET }),
+      // Force a failure whose message even CONTAINS the token — the orchestrator
+      // must not propagate it into the done payload.
+      completeLogin: async () => { throw new Error(`gh choked on ${SECRET}`); },
+    });
+
+    await gc.start();
+    const payload = await done;
+    expect(payload).toEqual({ ok: false, error: 'login-failed' });
+    expect(JSON.stringify(payload)).not.toContain(SECRET);
+  });
+
+  test("cancel() → poll observes abort → emitDone({ok:false, error:'cancelled'})", async () => {
+    const { emit, done } = deferredDone();
+    // Realistic poll fake: rejects 'cancelled' when the injected signal aborts.
+    const pollForToken: GithubConnectDeps['pollForToken'] = (_dc, opts) =>
+      new Promise((_resolve, reject) => {
+        if (opts.signal?.aborted) return reject(new Error('cancelled'));
+        opts.signal?.addEventListener('abort', () => reject(new Error('cancelled')));
+      });
+
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken,
+    });
+
+    await gc.start();
+    gc.cancel();
+    expect(await done).toEqual({ ok: false, error: 'cancelled' });
+  });
+
+  test('startDeviceFlow throwing rejects start() (no flow to run, no emitDone)', async () => {
+    const { emit, calls } = deferredDone();
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: async () => { throw new Error('network'); },
+    });
+
+    await expect(gc.start()).rejects.toThrow('network');
+    // No background chain ran, so emitDone was never called.
+    expect(calls).toHaveLength(0);
+  });
+
+  test('emitDone fires at most once per flow (cancel after success is a no-op)', async () => {
+    const { emit, done, calls } = deferredDone();
+    const gc = createGithubConnect(emit, {
+      startDeviceFlow: fakeStartDeviceFlow,
+      pollForToken: async () => ({ token: SECRET }),
+      completeLogin: async () => {},
+      detectGh: async () => ({ installed: true, authed: true, login: 'octocat' }),
+    });
+
+    await gc.start();
+    await done;
+    gc.cancel(); // late cancel must not emit a second (cancelled) payload
+    // Give any stray microtask a chance to run.
+    await Promise.resolve();
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -603,6 +603,55 @@ describe('syncspaces:* channel parity (desktop surfaces)', () => {
   });
 });
 
+// Connect-GitHub modal (device-flow auth, 2026-07-14). The four REQUEST channels
+// have full four-surface desktop parity (preload inlined literal / remote-shim
+// invoke literal / ipc-handlers IPC.* constant / remote-server switch case) plus
+// an Android not-implemented-on-mobile stub so a mobile invoke rejects fast. The
+// github:connect-done PUSH event is asserted only where it's CONSUMED (preload +
+// remote-shim) — same treatment as session:moved.
+describe('github:* channel parity (desktop surfaces)', () => {
+  const channels: Array<[string, string]> = [
+    ['github:status', 'IPC.GITHUB_STATUS'],
+    ['github:connect-start', 'IPC.GITHUB_CONNECT_START'],
+    ['github:connect-cancel', 'IPC.GITHUB_CONNECT_CANCEL'],
+    ['github:install-gh', 'IPC.GITHUB_INSTALL_GH'],
+  ];
+  const preload = fs.readFileSync(path.join(__dirname, '../src/main/preload.ts'), 'utf8');
+  const shim = fs.readFileSync(path.join(__dirname, '../src/renderer/remote-shim.ts'), 'utf8');
+  const handlers = fs.readFileSync(path.join(__dirname, '../src/main/ipc-handlers.ts'), 'utf8');
+  const remoteServer = fs.readFileSync(path.join(__dirname, '../src/main/remote-server.ts'), 'utf8');
+  for (const [ch, constant] of channels) {
+    it(`${ch} present in preload, remote-shim, ipc-handlers, remote-server`, () => {
+      expect(preload).toContain(ch);
+      expect(shim).toContain(ch);
+      expect(handlers).toContain(constant);
+      expect(remoteServer).toContain(ch);
+    });
+  }
+
+  // The four request channels also carry an Android stub (SessionService.kt
+  // returns not-implemented-on-mobile) so a mobile invoke rejects fast.
+  const kotlinPath = path.join(__dirname, '../../app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt');
+  if (fs.existsSync(kotlinPath)) {
+    const kotlin = fs.readFileSync(kotlinPath, 'utf8');
+    for (const [ch] of channels) {
+      it(`${ch} has an Android not-implemented-on-mobile stub in SessionService.kt`, () => {
+        expect(kotlin).toContain(`"${ch}"`);
+      });
+    }
+  } else {
+    it.skip('SessionService.kt not found — skipping Android github stub check', () => {});
+  }
+
+  // github:connect-done is a PUSH event (main broadcasts it when the flow settles),
+  // NOT a request — no Kotlin/ipc-handlers request handler. Assert only the two
+  // surfaces that CONSUME it: preload (ipcRenderer.on) + remote-shim (dispatch).
+  it('github:connect-done push channel present in preload + remote-shim', () => {
+    expect(preload).toContain('github:connect-done');
+    expect(shim).toContain('github:connect-done');
+  });
+});
+
 // Native runtime capability flag (platform roadmap Phase 0 seam).
 // preload and remote-shim must both expose window.claude.native.supported —
 // the renderer gates the runtime selector on it without platform branching.


### PR DESCRIPTION
Implements the **Connect-GitHub modal** — the sync GA prerequisite (spec §18): non-developers can connect GitHub from inside the app so enabling Sync never dead-ends on "gh is not installed" / "Not signed in to GitHub".

Plan: `docs/superpowers/plans/2026-07-14-connect-github-modal.md` (youcoded-dev).

## What it does
Runs GitHub's OAuth **device flow** in the main process (using gh's own public client id `178c6fc778ccc68e1d6a`), then pipes the resulting token to `gh auth login --with-token` — so `gh` stays the single credential store the sync layer already uses. The user sees a one-time code + opens the browser; main polls and pushes completion. On Windows, gh-missing offers a winget install with the restart-to-propagate-PATH rule; mac/linux show the one-liner.

## Layers
- **`github-auth.ts`** — pure-core/IO-shell device-flow module (detectGh, startDeviceFlow, pollForToken, completeLogin, installGh). All network/process/timer IO injected; 24 unit tests.
- **`github-connect.ts`** — stateful orchestrator (poll → login → detect → emitDone), single in-flight flow, per-flow settle guard so a superseding start silences an aborted prior flow. Module singleton so desktop + remote drive the same flow. 10 tests.
- **IPC** — `github:status` / `connect-start` / `connect-cancel` / `install-gh` + `github:connect-done` push, full 4-surface parity (preload, remote-shim, ipc-handlers, remote-server) + Kotlin `not-implemented-on-mobile` stub, pinned in `ipc-channels.test.ts`.
- **`ConnectGithubModal.tsx`** — themed L2 modal (Scrim/OverlayPanel + useEscClose, no glyphs); states checking → gh-missing → code → done → error; every close path cancels main's poll; desktop opens the URL via `shell.openExternal`, remote renders a copyable link.
- **`SyncPanel.tsx`** — "Connect GitHub…" affordance (gated on structured `github:status`, never on parsing the pinned error strings) both under the enable toggle and beside the sync error note; auto re-kicks a failed enable after a successful connect.

## Token hygiene
The access token never leaves the main process, is never logged, never enters an error message or the connect-done payload, and only ever flows into `gh auth login --with-token`'s stdin. Pinned by tests.

## Verification
- 173 tests across the new modules + IPC parity; full suite 1920 passed; `tsc --noEmit` clean; `npm run build` clean.
- **Still needs one live walkthrough by Destin** (a real GitHub sign-in) — Claude shouldn't complete a login as the user. Recommend NOT merging until that pass.

Desktop-only (Android stubs degrade gracefully), consistent with the v1.3 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)