### PR TITLE
fix(engine): create models cache dir before spawn + surface real startup error

### DIFF
--- a/desktop/src/main/engine/engine-supervisor.ts
+++ b/desktop/src/main/engine/engine-supervisor.ts
@@ -10,6 +10,7 @@
 // count until its response BODY is fully read (streams count as active for
 // their whole duration; a 10-minute generation must not be killed mid-stream).
 import { spawn, ChildProcess } from 'child_process';
+import * as fs from 'fs';
 import { EventEmitter } from 'events';
 import type { EngineModel, EngineRunState } from '../../shared/engine-types';
 import { scanGgufCache } from './cache-scan';
@@ -103,6 +104,24 @@ export class EngineSupervisor extends EventEmitter {
     const readyDeadlineMs = this.opts.readyDeadlineMs ?? 30_000;
     const readyPollMs = this.opts.readyPollMs ?? 250;
 
+    // Fix: llama-server's router mode treats a MISSING --models-dir as a fatal
+    // error and exits during startup. The cache dir is only created lazily when
+    // the first model downloads (model-downloader.ts), so a fresh install's
+    // verify-boot — which runs BEFORE any model exists — always spawned the
+    // engine against a nonexistent dir and it died instantly. Create it here so
+    // the engine can always boot (an empty router is valid — it just serves no
+    // models yet). A genuine mkdir failure (permissions, path is a file) is
+    // surfaced specifically rather than misattributed to a bad build below.
+    try {
+      fs.mkdirSync(this.opts.cacheDir, { recursive: true });
+    } catch (err) {
+      this.state = 'stopped';
+      this.emit('status-changed');
+      throw new Error(
+        `The local engine's model folder could not be created at ${this.opts.cacheDir}: ${(err as Error).message}`
+      );
+    }
+
     const child = spawn(
       this.opts.binaryPath,
       [
@@ -131,6 +150,19 @@ export class EngineSupervisor extends EventEmitter {
     );
     this.child = child;
 
+    // Capture the child's output so a startup failure surfaces the REAL reason
+    // (e.g. "'…/.cache/llama.cpp' does not exist or is not a directory") instead
+    // of a generic guess. Kept to a bounded tail — llama-server is chatty. Also
+    // DRAINS both pipes: an unread stdio: 'pipe' can back-pressure and stall the
+    // child once its OS pipe buffer fills. See docs/error-message-standards.md.
+    const MAX_OUTPUT_TAIL = 4000;
+    let outputTail = '';
+    const collect = (buf: Buffer) => {
+      outputTail = (outputTail + buf.toString('utf8')).slice(-MAX_OUTPUT_TAIL);
+    };
+    child.stdout?.on('data', collect);
+    child.stderr?.on('data', collect);
+
     let exitedDuringStartup = false;
     const startupExitListener = () => { exitedDuringStartup = true; };
     child.once('exit', startupExitListener);
@@ -157,7 +189,15 @@ export class EngineSupervisor extends EventEmitter {
     this.state = 'stopped';
     this.emit('status-changed');
     if (exitedDuringStartup) {
-      throw new Error('The local engine exited while starting up — its build may not run on this machine.');
+      // Surface the child's own last output — it names the actual cause. Only
+      // fall back to a general (non-committal, non-guessing) message when the
+      // child died silently. See docs/error-message-standards.md.
+      const detail = outputTail.trim();
+      throw new Error(
+        detail
+          ? `The local engine exited during startup. Engine output:\n${detail}`
+          : 'The local engine exited during startup without any output.'
+      );
     }
     throw new Error(`The local engine did not start within ${Math.round(readyDeadlineMs / 1000)} seconds.`);
   }

--- a/desktop/tests/engine-supervisor.test.ts
+++ b/desktop/tests/engine-supervisor.test.ts
@@ -9,6 +9,14 @@ vi.mock('child_process', async (orig) => ({
   spawn: (...args: any[]) => mockSpawn(...args),
 }));
 
+// fs is partially mocked: mkdirSync is a spy (the supervisor creates the models
+// cache dir before spawning) so tests don't create stray dirs from 'C:/fake/cache'.
+const mockMkdir = vi.fn();
+vi.mock('fs', async (orig) => ({
+  ...(await orig() as any),
+  mkdirSync: (...args: any[]) => mockMkdir(...args),
+}));
+
 function makeFakeChild(): ChildProcess {
   const ee = new EventEmitter() as any;
   ee.stdout = new EventEmitter();
@@ -46,10 +54,43 @@ function makeSupervisor(fetchImpl: any, extra: Record<string, any> = {}) {
 }
 
 let sup: EngineSupervisor;
-beforeEach(() => { mockSpawn.mockReset(); });
+beforeEach(() => { mockSpawn.mockReset(); mockMkdir.mockReset(); });
 afterEach(async () => { await sup?.stop(); });
 
 describe('EngineSupervisor', () => {
+  it('creates the models cache dir BEFORE spawning (router mode fatals on a missing --models-dir)', async () => {
+    mockSpawn.mockReturnValue(makeFakeChild());
+    sup = makeSupervisor(healthAfter(0));
+    await sup.ensureRunning();
+    expect(mockMkdir).toHaveBeenCalledWith('C:/fake/cache', { recursive: true });
+    // mkdir must precede the spawn, else the fresh-install verify-boot dies.
+    expect(mockMkdir.mock.invocationCallOrder[0]).toBeLessThan(mockSpawn.mock.invocationCallOrder[0]);
+  });
+
+  it('reports a SPECIFIC error (not a bad-build guess) when the cache dir cannot be created, and does not spawn', async () => {
+    mockMkdir.mockImplementationOnce(() => { throw new Error('EACCES: permission denied'); });
+    mockSpawn.mockReturnValue(makeFakeChild());
+    sup = makeSupervisor(healthAfter(0));
+    await expect(sup.ensureRunning()).rejects.toThrow(/model folder could not be created.*EACCES/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(sup.status()).toBe('stopped');
+  });
+
+  it('surfaces the child\'s OWN output (the real cause) when it exits during startup', async () => {
+    const child = makeFakeChild();
+    mockSpawn.mockReturnValue(child);
+    sup = makeSupervisor(vi.fn(async () => { throw new Error('ECONNREFUSED'); }), { readyDeadlineMs: 5_000 });
+    const p = sup.ensureRunning();
+    setImmediate(() => {
+      child.stderr!.emit('data', Buffer.from(
+        "failed to initialize router models: error: '/home/x/.cache/llama.cpp' does not exist or is not a directory"
+      ));
+      child.emit('exit', 1);
+    });
+    // The thrown error carries the engine's real message, NOT a hardware guess.
+    await expect(p).rejects.toThrow(/does not exist or is not a directory/i);
+  });
+
   it('ensureRunning spawns router-mode llama-server (no -m) with the pinned flag set and LLAMA_CACHE', async () => {
     mockSpawn.mockReturnValue(makeFakeChild());
     sup = makeSupervisor(healthAfter(20));

--- a/docs/engine-dependencies.md
+++ b/docs/engine-dependencies.md
@@ -35,6 +35,15 @@ Exact router-mode arg list (no `-m`):
   `/v1/chat/completions` returns HTTP 400 `model '…' not found` — the feature is
   completely non-functional. (This build also has no `LLAMA_CACHE`-based flat
   discovery; see below.)
+- **`--models-dir` MUST EXIST or the router exits during startup (verified b9992).**
+  A missing directory is FATAL: `error: '<dir>' does not exist or is not a directory`
+  and the process exits immediately — it is NOT treated as "zero models, empty
+  router." Since `cacheDir` (`~/.cache/llama.cpp`) is created lazily on the first
+  model download, a fresh install's verify-boot ran BEFORE any model existed and
+  always died this way. `EngineSupervisor.start()` therefore `fs.mkdirSync(cacheDir,
+  {recursive:true})` before spawning (an empty dir boots fine — the router just
+  serves no models yet). The supervisor also drains + tail-captures child stdout/
+  stderr so a startup exit surfaces the engine's REAL message instead of a guess.
 - **`--models-max 2`** — the router's LRU default is 4; 2 bounds RAM on consumer
   machines while keeping chat↔utility switching cheap.
 - **`--jinja`** from day one so Phase 2 tool calling needs no process-shape change.


### PR DESCRIPTION
## Problem

Installing the local-models engine on a fresh machine always failed with:

> Error invoking remote method 'engine:install': The local engine exited while starting up — **its build may not run on this machine.**

Every claim in that message was false. The binary runs fine. The real cause (discovered by running `llama-server` with the exact supervisor args and reading its stderr):

```
E srv llama_server: failed to initialize router models:
  error: '/home/<user>/.cache/llama.cpp' does not exist or is not a directory
```

The manager's **verify-boot** spawns `llama-server` with `--models-dir <cacheDir>`, but `cacheDir` (`~/.cache/llama.cpp`) is only created **lazily on the first model download** (`model-downloader.ts`). At install time — before any model exists — the directory is absent, and **b9992 router mode treats a missing `--models-dir` as fatal** and exits during startup. The supervisor spawned with `stdio: ['ignore','pipe','pipe']` but **never read the child's stderr**, so the true message was discarded and replaced with a confident, wrong guess about the hardware.

This is a chicken-and-egg bug: you can't download a model until the engine works, and the engine won't start until a model creates the dir.

## Fix

- **`EngineSupervisor.start()` creates `cacheDir` (recursive) before spawning.** An empty dir boots fine — the router just serves no models yet. A genuine `mkdir` failure (permissions, path-is-a-file) now throws a **specific** `The local engine's model folder could not be created at <dir>: <err>` instead of being misattributed to a bad build.
- **Drain + tail-capture the child's stdout/stderr.** On a startup exit, the thrown error now carries the engine's **own last output** (the real cause) rather than a hardware guess. Draining also prevents an unread `pipe` from back-pressuring the child once its OS buffer fills.

Follows the newly-adopted `docs/error-message-standards.md` (no misleading/guessed error messages).

## Tests

3 new cases in `engine-supervisor.test.ts`:
- cache dir is created **before** spawn (ordering pinned)
- a `mkdir` failure yields a specific error and **does not spawn**
- a child that exits during startup surfaces its **real stderr**, not a hardware guess

Full engine suite green (35 tests). Behavior pinned in `docs/engine-dependencies.md`.

## Verification

Reproduced the exact failure and the fix on Linux (CachyOS / AMD Strix Halo): with the dir absent, `llama-server` + the real supervisor args exits with the router error; after `mkdir -p ~/.cache/llama.cpp` (what this PR does automatically) it boots and `listening on http://127.0.0.1:<port>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)