### PR TITLE
feat(local-models): memory-polite model lifecycle + load-state UX

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3579,6 +3579,13 @@ class SessionService : Service() {
             "models:delete",
             "models:installed",
             "endpoints:detect",
+            // Model memory lifecycle (2026-07-14) — per-model residency, memory
+            // guard, [Reload Model]. Desktop-only; no Android runtime. The push
+            // events engine:models-changed / native:model-state are outbound-only
+            // (no inbound handler needed).
+            "engine:models",
+            "models:memory-check",
+            "models:load",
             // Cross-device project rename (display-name) + stop-syncing (2026-07-12)
             // are desktop-only (Phase 3 on Android).
             "syncspaces:rename-project",

--- a/desktop/src/main/engine/cache-scan.ts
+++ b/desktop/src/main/engine/cache-scan.ts
@@ -42,6 +42,7 @@ export function scanGgufCache(cacheDir: string): EngineModel[] {
       id: ggufIdFromFileName(ent.name),
       sizeBytes,
       loaded: false,
+      state: 'unloaded', // cache scan = engine-off view; nothing is resident
     });
   }
   for (const [firstId, extra] of partSizes) {

--- a/desktop/src/main/engine/engine-manager.ts
+++ b/desktop/src/main/engine/engine-manager.ts
@@ -17,7 +17,7 @@ import { readEngineConfig, updateEngineConfig } from './engine-config';
 import { scanGgufCache } from './cache-scan';
 import { parseGgufName, quantDescription } from '../models/quant-parser';
 import type {
-  EngineBackend, EngineInstallProgress, EngineStatus,
+  EngineBackend, EngineInstallProgress, EngineStatus, EngineModel,
 } from '../../shared/engine-types';
 import type { CatalogModel } from '../../shared/provider-types';
 import type { InstalledLocalModel } from '../../shared/model-manager-types';
@@ -177,6 +177,33 @@ export class EngineManager extends EventEmitter {
     // Fan out supervisor transitions so the EngineCard tracks crash/idle live.
     this.supervisor.on('status-changed', () => this.emit('status-changed'));
     this.supervisor.on('crashed', (info) => this.emit('crashed', info));
+    // Fan out per-model residency (load/sleep/unload) → the model-state
+    // coordinator turns this into per-session banners (unloaded/loading UI).
+    this.supervisor.on('models-changed', (models) => this.emit('models-changed', models));
+  }
+
+  /** Best-effort per-model unload — used when the last session bound to a model
+   *  goes away (frees its memory immediately, ahead of the 5-min sleep). */
+  async unloadModel(modelId: string): Promise<void> {
+    if (!this.supervisor) return;
+    await this.supervisor.unloadModel(modelId);
+  }
+
+  /** Force a model resident (the [Reload Model] button). Boots the engine if
+   *  needed, then warms the model so its state flips loading → loaded. */
+  async loadModel(modelId: string): Promise<void> {
+    const inst = this.currentInstall();
+    if (!inst) throw new Error('The local engine is not installed yet.');
+    await this.rebuildSupervisor(inst);
+    await this.supervisor!.loadModel(modelId);
+  }
+
+  /** Live per-model residency for the create-time memory guard + coordinator. */
+  async liveModels(): Promise<EngineModel[]> {
+    const inst = this.currentInstall();
+    if (!inst) return [];
+    await this.rebuildSupervisor(inst);
+    return this.supervisor!.listModels();
   }
 
   /** User-initiated recovery: clear the strike-out and boot fresh. */
@@ -223,7 +250,7 @@ export class EngineManager extends EventEmitter {
       providerId: 'local',
       label: m.id,
       contextLength: cfg.contextSize,
-      local: { sizeBytes: m.sizeBytes ?? 0, quant: 'unknown', installed: true },
+      local: { sizeBytes: m.sizeBytes ?? 0, quant: 'unknown', installed: true, state: m.state },
     }));
   }
 

--- a/desktop/src/main/engine/engine-supervisor.ts
+++ b/desktop/src/main/engine/engine-supervisor.ts
@@ -12,7 +12,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import { EventEmitter } from 'events';
-import type { EngineModel, EngineRunState } from '../../shared/engine-types';
+import type { EngineModel, EngineModelState, EngineRunState } from '../../shared/engine-types';
 import { scanGgufCache } from './cache-scan';
 
 export interface EngineSupervisorOpts {
@@ -26,6 +26,8 @@ export interface EngineSupervisorOpts {
   readyPollMs?: number;      // default 250
   idleMs?: number;           // default 10 min (spec §3.2)
   idleCheckMs?: number;      // default 60s
+  sleepIdleSeconds?: number; // per-model auto-sleep; default 300 (5 min)
+  modelPollMs?: number;      // /models state poll cadence; default 1500
 }
 
 // Keep at most 2 models resident: the router's LRU default (4) can overcommit
@@ -33,6 +35,11 @@ export interface EngineSupervisorOpts {
 // switching between a chat and a utility model free. Recorded in
 // docs/engine-dependencies.md.
 const MODELS_MAX = 2;
+// Per-model idle sleep: the router frees an idle model's memory after this many
+// seconds (status → 'sleeping'); the next request wakes it. 5 min per product
+// decision 2026-07-14. This is FINER-grained than the engine-wide idle stop
+// (idleMs, 10 min) which tears down the whole process. Verified b9992.
+const SLEEP_IDLE_SECONDS = 300;
 // Crash strike-out (spec §3.2): 3 crashes within 5 minutes → error state,
 // stop retrying until the user acts (EngineCard's Restart button).
 const STRIKE_LIMIT = 3;
@@ -48,6 +55,8 @@ export class EngineSupervisor extends EventEmitter {
   private lastActivity = Date.now();
   private idleTimer: NodeJS.Timeout | null = null;
   private intentionalShutdown = false;
+  private modelPollTimer: NodeJS.Timeout | null = null; // per-model /models state poll
+  private lastModelSig = '';                             // last emitted (id→state) signature
 
   constructor(private readonly opts: EngineSupervisorOpts) { super(); }
 
@@ -137,6 +146,10 @@ export class EngineSupervisor extends EventEmitter {
         // cache dir so a dropped GGUF and an -hf pull live side by side.
         '--models-dir', this.opts.cacheDir,
         '--models-max', String(MODELS_MAX),
+        // Per-model auto-sleep: the router frees an idle model's memory after N
+        // seconds and wakes it on the next request. Keeps residency proportional
+        // to use without tearing down the whole engine. See engine-dependencies.md.
+        '--sleep-idle-seconds', String(this.opts.sleepIdleSeconds ?? SLEEP_IDLE_SECONDS),
         '-c', String(this.opts.contextSize),
       ],
       {
@@ -177,6 +190,7 @@ export class EngineSupervisor extends EventEmitter {
           child.off('exit', startupExitListener);
           child.on('exit', (code) => this.onExit(code));
           this.armIdleTimer();
+          this.startModelPoll();
           this.emit('status-changed');
           return this.baseUrl()!;
         }
@@ -206,6 +220,7 @@ export class EngineSupervisor extends EventEmitter {
     const wasRunning = this.state === 'running';
     this.child = null;
     this.disarmIdleTimer();
+    this.stopModelPoll();
     if (this.intentionalShutdown) { this.state = 'stopped'; this.emit('status-changed'); return; }
     if (!wasRunning) return;
     const now = Date.now();
@@ -231,6 +246,7 @@ export class EngineSupervisor extends EventEmitter {
 
   private async _stop(): Promise<void> {
     this.disarmIdleTimer();
+    this.stopModelPoll();
     if (!this.child) {
       if (this.state !== 'error') this.state = 'stopped';
       return;
@@ -327,24 +343,111 @@ export class EngineSupervisor extends EventEmitter {
       const rows: any[] = Array.isArray(payload?.data) ? payload.data
         : Array.isArray(payload?.models) ? payload.models
         : Array.isArray(payload) ? payload : [];
+      // /models rows carry no size — the cache scan does, so index sizes by id
+      // and merge them in (the UI's loading banner shows the model size).
+      const sizeById = new Map<string, number | null>();
+      for (const m of scanGgufCache(this.opts.cacheDir)) sizeById.set(m.id, m.sizeBytes);
       const out: EngineModel[] = [];
       for (const row of rows) {
         const id = typeof row?.id === 'string' ? row.id : typeof row?.name === 'string' ? row.name : null;
         if (!id) continue; // skip malformed
         // b9992's /models reports status as an OBJECT ({value:'loaded'|'unloaded'
-        // |'loading'}), NOT a bare string. Handle both so a schema shift either
-        // way still reads. (/models rows carry no size — cache scan provides it.)
+        // |'loading'|'sleeping'}), NOT a bare string. Handle both so a schema
+        // shift either way still reads.
         const statusValue = typeof row?.status === 'object' && row?.status
           ? row.status.value : row?.status;
+        const state = mapModelState(statusValue);
         out.push({
           id,
-          sizeBytes: typeof row?.size === 'number' ? row.size : null,
-          loaded: statusValue === 'loaded',
+          sizeBytes: typeof row?.size === 'number' ? row.size
+            : (sizeById.has(id) ? sizeById.get(id)! : null),
+          loaded: state === 'loaded',
+          state,
         });
       }
       return out;
     } catch {
       return scanGgufCache(this.opts.cacheDir); // engine died mid-call — degrade to scan
     }
+  }
+
+  // ---- per-model state polling (drives the UI's load/sleep/unload signals) --
+
+  /** Poll GET /models while running and emit 'models-changed' only when the set
+   *  of (id → state) actually changes. llama-server has no push channel, so a
+   *  cheap localhost poll is how the renderer learns a model slept/loaded/was
+   *  evicted. Unref'd; started on ready, stopped on teardown. */
+  private startModelPoll(): void {
+    this.stopModelPoll();
+    const everyMs = this.opts.modelPollMs ?? 1500;
+    const tick = async () => {
+      if (this.state !== 'running') return;
+      let models: EngineModel[];
+      try { models = await this.listModels(); } catch { return; }
+      const sig = models.map((m) => `${m.id}:${m.state}`).sort().join('|');
+      if (sig !== this.lastModelSig) {
+        this.lastModelSig = sig;
+        this.emit('models-changed', models);
+      }
+    };
+    this.modelPollTimer = setInterval(() => { void tick(); }, everyMs);
+    this.modelPollTimer.unref?.();
+    void tick(); // emit an initial snapshot promptly
+  }
+
+  private stopModelPoll(): void {
+    if (this.modelPollTimer) { clearInterval(this.modelPollTimer); this.modelPollTimer = null; }
+    this.lastModelSig = '';
+  }
+
+  /** Best-effort per-model unload (frees its memory now). Used when the last
+   *  session bound to a model goes away. Silent on failure — a lingering model
+   *  is harmless (the 5-min sleep reaps it), and there's no user to inform. */
+  async unloadModel(modelId: string): Promise<void> {
+    if (this.state !== 'running') return;
+    try {
+      await (this.opts.fetchImpl ?? fetch)(`${this.rootUrl()}/models/unload`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: modelId }),
+      });
+    } catch { /* best-effort */ }
+    void this.pollModelsNow();
+  }
+
+  /** Force a model resident by sending a 1-token warm-up completion — the router
+   *  loads (or wakes) it. Used by the [Reload Model] button. Routed through
+   *  trackedFetch so it counts as activity (won't be reaped mid-load). */
+  async loadModel(modelId: string): Promise<void> {
+    const base = await this.ensureRunning(); // http://127.0.0.1:port/v1
+    try {
+      await this.trackedFetch(`${base}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: modelId, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1, stream: false }),
+      });
+    } catch { /* best-effort — the model state poll reflects the outcome */ }
+    void this.pollModelsNow();
+  }
+
+  /** Emit a fresh models-changed on demand (after an unload/load nudges state). */
+  async pollModelsNow(): Promise<void> {
+    if (this.state !== 'running') return;
+    try {
+      const models = await this.listModels();
+      const sig = models.map((m) => `${m.id}:${m.state}`).sort().join('|');
+      if (sig !== this.lastModelSig) { this.lastModelSig = sig; this.emit('models-changed', models); }
+    } catch { /* ignore */ }
+  }
+}
+
+/** Map llama-server's /models status.value to our EngineModelState. Unknown →
+ *  'unloaded' (safe default; never claims a model is resident when unsure). */
+function mapModelState(statusValue: unknown): EngineModelState {
+  switch (statusValue) {
+    case 'loaded': return 'loaded';
+    case 'loading': return 'loading';
+    case 'sleeping': return 'sleeping';
+    default: return 'unloaded';
   }
 }

--- a/desktop/src/main/harness/native-session-host.ts
+++ b/desktop/src/main/harness/native-session-host.ts
@@ -40,6 +40,12 @@ interface LiveEntry {
 
 export class NativeSessionHost extends EventEmitter {
   private live = new Map<string, LiveEntry>();
+  // Reverse index: modelId → sessionIds currently bound to it. The ONLY
+  // session→model usage tracking in the app. Drives "unload a model when no
+  // session is using it" (#1) — when a model's set empties, onModelReleased
+  // fires so the engine can free it immediately (ahead of the 5-min sleep).
+  private modelRefs = new Map<string, Set<string>>();
+  private onModelReleased?: (modelId: string) => void;
 
   constructor(
     private store: SessionStore,
@@ -49,11 +55,43 @@ export class NativeSessionHost extends EventEmitter {
     super();
   }
 
+  /** Wire the "no session uses model X anymore" callback (→ engine unload). */
+  setModelReleasedHandler(fn: (modelId: string) => void): void {
+    this.onModelReleased = fn;
+  }
+
+  private retainModel(sessionId: string, modelId: string): void {
+    let set = this.modelRefs.get(modelId);
+    if (!set) { set = new Set(); this.modelRefs.set(modelId, set); }
+    set.add(sessionId);
+  }
+
+  private releaseModel(sessionId: string, modelId: string): void {
+    const set = this.modelRefs.get(modelId);
+    if (!set) return;
+    set.delete(sessionId);
+    if (set.size === 0) {
+      this.modelRefs.delete(modelId);
+      try { this.onModelReleased?.(modelId); } catch { /* best-effort */ }
+    }
+  }
+
+  /** Live sessions currently bound to a model (for the state coordinator). */
+  sessionsForModel(modelId: string): string[] {
+    return [...(this.modelRefs.get(modelId) ?? [])];
+  }
+
+  /** The model a live session is bound to right now (null if not live). */
+  modelForSession(sessionId: string): string | null {
+    return this.live.get(sessionId)?.session.binding.modelId ?? null;
+  }
+
   /** Subscribe a freshly-built HarnessSession: forward its events to the
    *  renderer immediately, and enqueue each on the session's append chain. */
   private wire(sessionId: string, cwd: string, session: HarnessSession): void {
     const entry: LiveEntry = { session, cwd, appendChain: Promise.resolve() };
     this.live.set(sessionId, entry);
+    this.retainModel(sessionId, session.binding.modelId); // ref-count this model
     session.on('transcript-event', (event: TranscriptEvent) => {
       // (1) Forward NOW — not gated on the disk write (see module header).
       this.emit('transcript-event', event);
@@ -158,7 +196,14 @@ export class NativeSessionHost extends EventEmitter {
   async setBinding(sessionId: string, binding: ModelBinding): Promise<boolean> {
     const entry = this.live.get(sessionId);
     if (!entry) return false;
+    const oldModelId = entry.session.binding.modelId;
     entry.session.setBinding(binding, await this.contextLengthFor(binding));
+    if (oldModelId !== binding.modelId) {
+      // Swap the ref-count: releasing the old model may unload it if this was
+      // its last session (#1); retain the new one so it isn't unloaded.
+      this.retainModel(sessionId, binding.modelId);
+      this.releaseModel(sessionId, oldModelId);
+    }
     return true;
   }
 
@@ -199,10 +244,12 @@ export class NativeSessionHost extends EventEmitter {
   async destroy(sessionId: string): Promise<void> {
     const entry = this.live.get(sessionId);
     if (!entry) return;
+    const modelId = entry.session.binding.modelId; // capture before teardown
     entry.session.destroy();             // abort stream + remove our listener → no new appends
     await entry.appendChain;             // drain already-enqueued appends
     await this.store.dispose(sessionId); // flush the buffered open part
     this.live.delete(sessionId);
+    this.releaseModel(sessionId, modelId); // last session gone → unload it (#1)
   }
 
   /** App-shutdown path: destroy every live session, then flush any residue. */

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -23,6 +23,7 @@ import { SecretsStore } from './providers/secrets-store';
 import { ProviderRegistry } from './providers/provider-registry';
 import { ModelCatalog } from './providers/model-catalog';
 import { EngineManager } from './engine/engine-manager';
+import type { EngineModel as EngineModelType } from '../shared/engine-types';
 import { ModelManager } from './models/model-manager';
 import { detectEndpoints } from './models/endpoint-detectors';
 import { ENGINE_PORT } from '../shared/ports';
@@ -1943,6 +1944,30 @@ export function registerIpcHandlers(
     send(IPC.ENGINE_STATUS_CHANGED, s);
     remoteServer?.broadcast({ type: 'engine:status-changed', payload: s });
   });
+  // --- Per-model residency → per-session model-state coordinator (2026-07-14) ---
+  // #1: when the last session using a model releases it, unload it immediately.
+  nativeHost.setModelReleasedHandler((modelId) => { void engineManager.unloadModel(modelId); });
+  // Join per-model residency (engine) with session→model (host): push each live
+  // native session its bound model's state so ChatView can show the unloaded /
+  // loading banner (#4/#5). Only push on change per session.
+  const lastSessionModelState = new Map<string, string>();
+  engineManager.on('models-changed', (models: EngineModelType[]) => {
+    for (const m of models) {
+      const payload = { modelId: m.id, state: m.state, sizeBytes: m.sizeBytes };
+      for (const sessionId of nativeHost.sessionsForModel(m.id)) {
+        if (lastSessionModelState.get(sessionId) === m.state) continue;
+        lastSessionModelState.set(sessionId, m.state);
+        const full = { sessionId, ...payload };
+        sendForSession(sessionId, IPC.NATIVE_MODEL_STATE, full);
+        remoteServer?.broadcast({ type: 'native:model-state', payload: full });
+      }
+    }
+  });
+  // Whole live per-model state (initial fetch for the coordinator's consumers).
+  ipcMain.handle(IPC.ENGINE_MODELS, async () => engineManager.liveModels());
+  // #2 create-time / swap-time memory guard; #4 [Reload Model].
+  ipcMain.handle(IPC.MODELS_MEMORY_CHECK, async (_e, modelId: string) => modelManager.memoryCheck(modelId));
+  ipcMain.handle(IPC.MODELS_LOAD, async (_e, modelId: string) => { await engineManager.loadModel(modelId); return true; });
   // --- Model manager IPC (Plan C) ---
   // Download progress fans out to every window + remotes on one push channel,
   // mirroring the engine install-progress emitter above.

--- a/desktop/src/main/models/fit-estimator.ts
+++ b/desktop/src/main/models/fit-estimator.ts
@@ -41,6 +41,61 @@ export function estimateFit(
   return { fit: 'too-large', label: 'Too large for this machine' };
 }
 
+/** Create-time / swap-time memory guard (2026-07-14). Answers "is it safe to
+ *  load THIS model given what's already resident?" Distinct from estimateFit,
+ *  which asks "could this machine ever run it?". Decision (Destin): BLOCK only
+ *  when clearly too large (won't fit even alone); otherwise WARN with a
+ *  "show more" detail explaining LRU eviction + swap. PURE — caller injects
+ *  os.totalmem(), gpu VRAM, and the summed footprint of loaded models. */
+export interface MemoryVerdict {
+  verdict: 'ok' | 'tight' | 'too-large';
+  headline: string; // short warning row; '' when verdict === 'ok'
+  detail: string;   // "show more" explanation; '' when verdict === 'ok'
+}
+
+export function checkMemoryForLoad(args: {
+  chosenBytes: number;
+  totalMemBytes: number;
+  totalVramBytes: number | null;
+  /** Σ sizeBytes of models already loaded/loading, EXCLUDING the chosen one. */
+  loadedBytes: number;
+}): MemoryVerdict {
+  const { chosenBytes, totalMemBytes, totalVramBytes, loadedBytes } = args;
+  // Unified-memory machines (APU/iGPU) report null VRAM (it IS system RAM), so
+  // capacity is just totalMem — never double-counted. A dedicated GPU adds VRAM.
+  const capacity = totalMemBytes + (totalVramBytes ?? 0);
+  const g = (n: number) => (n / GB).toFixed(1);
+
+  // BLOCK: clearly too large — can't fit even alone on a fresh machine.
+  if (estimateFit(chosenBytes, totalMemBytes, totalVramBytes).fit === 'too-large') {
+    return {
+      verdict: 'too-large',
+      headline: 'This model is too large for this computer.',
+      detail:
+        `${g(chosenBytes)} GB (plus working memory) is more than the ${g(capacity)} GB this ` +
+        `computer can hold, even on its own. It would fail to load or run extremely slowly. ` +
+        `Try a smaller model or a more compressed version (a lower "quant").`,
+    };
+  }
+
+  // WARN: fits alone, but adding it to what's already loaded over-commits memory.
+  const combined = chosenBytes + loadedBytes + OVERHEAD_BYTES;
+  if (loadedBytes > 0 && combined > capacity * 0.85) {
+    return {
+      verdict: 'tight',
+      headline: 'This may use more memory than you have free.',
+      detail:
+        `You currently have about ${g(loadedBytes)} GB of models loaded. Adding this ` +
+        `${g(chosenBytes)} GB model can push past your ${g(capacity)} GB of memory. ` +
+        `YouCoded keeps at most 2 models in memory at once, so an older model will be ` +
+        `unloaded to make room. If things still don't fit, your computer falls back to ` +
+        `slower disk-backed memory (swap) and replies get slower. You can still continue.`,
+    };
+  }
+
+  return { verdict: 'ok', headline: '', detail: '' };
+}
+
 /** Pre-download disk guard (spec §4.3). Returns null when OK, else a
  *  plain-language refusal. 5% margin covers the in-flight .partial file. */
 export function checkDiskSpace(downloadBytes: number, freeBytes: number): string | null {

--- a/desktop/src/main/models/model-manager.ts
+++ b/desktop/src/main/models/model-manager.ts
@@ -11,7 +11,7 @@ import { readEngineConfig } from '../engine/engine-config';
 import { CuratedCatalog } from './curated-catalog';
 import { HfClient } from './hf-client';
 import { ModelDownloader } from './model-downloader';
-import { estimateFit, checkDiskSpace } from './fit-estimator';
+import { estimateFit, checkDiskSpace, checkMemoryForLoad, type MemoryVerdict } from './fit-estimator';
 import { detectGpu } from './gpu-detector';
 import type {
   CuratedModel, DownloadProgress, FitEstimate, HFSearchHit, QuantOption,
@@ -69,6 +69,26 @@ export class ModelManager extends EventEmitter {
   async quants(repo: string): Promise<Array<QuantOption & { fit: FitEstimate }>> {
     const [opts, vram] = await Promise.all([this.hf.quantOptions(repo), this.vram()]);
     return opts.map((o) => ({ ...o, fit: this.fitFor(o.totalSizeBytes, vram) }));
+  }
+
+  /** Create-time / swap-time memory guard for an INSTALLED model id: is it safe
+   *  to load it given what's already resident? Blocks only when clearly too
+   *  large; otherwise warns (see checkMemoryForLoad). Unknown model/size → 'ok'
+   *  (never block on missing data). Used by the new-session picker + swap popup. */
+  async memoryCheck(modelId: string): Promise<MemoryVerdict> {
+    const [models, vram] = await Promise.all([this.engine.liveModels(), this.vram()]);
+    const chosen = models.find((m) => m.id === modelId);
+    const chosenBytes = chosen?.sizeBytes ?? 0;
+    if (chosenBytes <= 0) return { verdict: 'ok', headline: '', detail: '' };
+    const loadedBytes = models
+      .filter((m) => m.id !== modelId && (m.state === 'loaded' || m.state === 'loading'))
+      .reduce((sum, m) => sum + (m.sizeBytes ?? 0), 0);
+    return checkMemoryForLoad({
+      chosenBytes,
+      totalMemBytes: this.opts.totalMemBytes ?? os.totalmem(),
+      totalVramBytes: vram,
+      loadedBytes,
+    });
   }
 
   /** Free bytes on the volume holding `dir`, walking UP to the nearest EXISTING

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -335,6 +335,12 @@ const IPC = {
   MODELS_DELETE: 'models:delete',
   MODELS_INSTALLED: 'models:installed',
   ENDPOINTS_DETECT: 'endpoints:detect',
+  // Model memory lifecycle (2026-07-14) — keep in sync with shared/types.ts.
+  ENGINE_MODELS: 'engine:models',
+  ENGINE_MODELS_CHANGED: 'engine:models-changed',
+  NATIVE_MODEL_STATE: 'native:model-state',
+  MODELS_MEMORY_CHECK: 'models:memory-check',
+  MODELS_LOAD: 'models:load',
 } as const;
 
 contextBridge.exposeInMainWorld('claude', {
@@ -1096,6 +1102,13 @@ contextBridge.exposeInMainWorld('claude', {
     // Request-response: match the positional ipcMain.handle signatures.
     setBinding: (sessionId: string, binding: unknown) => ipcRenderer.invoke(IPC.NATIVE_SET_BINDING, sessionId, binding),
     sessionsList: () => ipcRenderer.invoke(IPC.NATIVE_SESSIONS_LIST),
+    // Per-session bound-model residency push (unloaded/loading/loaded/sleeping)
+    // → ChatView's model-unloaded banner + loading indicator (2026-07-14).
+    onModelState: (cb: (s: unknown) => void) => {
+      const listener = (_e: unknown, s: unknown) => cb(s);
+      ipcRenderer.on(IPC.NATIVE_MODEL_STATE, listener);
+      return () => ipcRenderer.removeListener(IPC.NATIVE_MODEL_STATE, listener);
+    },
   },
   // Provider registry — CRUD + connection test + model catalog for native
   // runtime model providers. All request-response; positional args match the
@@ -1126,6 +1139,13 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.on(IPC.ENGINE_STATUS_CHANGED, listener);
       return () => ipcRenderer.removeListener(IPC.ENGINE_STATUS_CHANGED, listener);
     },
+    // Live per-model residency (state: unloaded|loading|loaded|sleeping).
+    models: (): Promise<unknown> => ipcRenderer.invoke(IPC.ENGINE_MODELS),
+    onModelsChanged: (cb: (models: unknown) => void) => {
+      const listener = (_e: unknown, models: unknown) => cb(models);
+      ipcRenderer.on(IPC.ENGINE_MODELS_CHANGED, listener);
+      return () => ipcRenderer.removeListener(IPC.ENGINE_MODELS_CHANGED, listener);
+    },
   },
   // Model manager (Plan C) — curated catalog, HF search, downloads, endpoint
   // detectors, engine backend switch. Download progress pushes return an
@@ -1140,6 +1160,9 @@ contextBridge.exposeInMainWorld('claude', {
     installed: () => ipcRenderer.invoke(IPC.MODELS_INSTALLED),
     detectEndpoints: () => ipcRenderer.invoke(IPC.ENDPOINTS_DETECT),
     setBackend: (backend: string) => ipcRenderer.invoke(IPC.ENGINE_SET_BACKEND, backend),
+    // Create-time / swap memory guard + [Reload Model] (2026-07-14).
+    memoryCheck: (modelId: string) => ipcRenderer.invoke(IPC.MODELS_MEMORY_CHECK, modelId),
+    load: (modelId: string) => ipcRenderer.invoke(IPC.MODELS_LOAD, modelId),
     onDownloadProgress: (cb: (p: unknown) => void) => {
       const listener = (_e: unknown, p: unknown) => cb(p);
       ipcRenderer.on(IPC.MODELS_DOWNLOAD_PROGRESS, listener);

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -853,6 +853,35 @@ export class RemoteServer {
         }
         break;
       }
+      case 'engine:models': {
+        try {
+          const res = this.nativeRuntime ? await this.nativeRuntime.engineManager.liveModels() : [];
+          this.respond(client.ws, type, id, res);
+        } catch (err: any) {
+          this.respond(client.ws, type, id, { ok: false, error: err?.message ?? String(err) });
+        }
+        break;
+      }
+      case 'models:memory-check': {
+        try {
+          const res = this.nativeRuntime
+            ? await this.nativeRuntime.modelManager.memoryCheck(payload.modelId ?? payload)
+            : { verdict: 'ok', headline: '', detail: '' };
+          this.respond(client.ws, type, id, res);
+        } catch (err: any) {
+          this.respond(client.ws, type, id, { ok: false, error: err?.message ?? String(err) });
+        }
+        break;
+      }
+      case 'models:load': {
+        try {
+          if (this.nativeRuntime) await this.nativeRuntime.engineManager.loadModel(payload.modelId ?? payload);
+          this.respond(client.ws, type, id, true);
+        } catch (err: any) {
+          this.respond(client.ws, type, id, { ok: false, error: err?.message ?? String(err) });
+        }
+        break;
+      }
       case 'endpoints:detect': {
         try {
           const res = this.nativeRuntime

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -724,6 +724,23 @@ function AppInner() {
     return unsubscribe;
   }, []);
 
+  // Native local-model residency → per-session ModelStateBanner (2026-07-14).
+  // Main joins per-model engine state with session→model and pushes each native
+  // session its bound model's state (loaded/loading/sleeping/unloaded).
+  useEffect(() => {
+    const off = window.claude.native?.onModelState?.((s: any) => {
+      if (!s?.sessionId || !s?.modelId || !s?.state) return;
+      dispatch({
+        type: 'NATIVE_MODEL_STATE_CHANGED',
+        sessionId: s.sessionId,
+        state: s.state,
+        modelId: s.modelId,
+        sizeBytes: typeof s.sizeBytes === 'number' ? s.sizeBytes : null,
+      });
+    });
+    return () => { off?.(); };
+  }, []);
+
   useEffect(() => {
     const createdHandler = window.claude.on.sessionCreated((info) => {
       setSessions((prev) => {

--- a/desktop/src/renderer/components/ChatView.tsx
+++ b/desktop/src/renderer/components/ChatView.tsx
@@ -10,6 +10,7 @@ import CompactingCard from './CompactingCard';
 import CopyPicker from './CopyPicker';
 import ThinkingIndicator from './ThinkingIndicator';
 import AttentionBanner from './AttentionBanner';
+import ModelStateBanner from './ModelStateBanner';
 import { useAttentionClassifier } from '../hooks/useAttentionClassifier';
 import { useTheme } from '../state/theme-context';
 import { useArtifact } from '../state/ArtifactContext';
@@ -498,6 +499,14 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
           )}
           <div ref={scrollContainerRef} className="chat-scroll h-full overflow-y-auto">
            <div ref={contentRef}>
+        {/* Native local-model residency: unloaded-to-save-memory + [Reload],
+            or a loading indicator (size + spinner). No-op for claude sessions
+            (modelInfo stays null). (2026-07-14 memory-lifecycle feature) */}
+        <ModelStateBanner
+          modelState={state.modelState}
+          modelInfo={state.modelInfo}
+          onReload={(modelId) => { void window.claude.models.load(modelId); }}
+        />
         {state.timeline.length === 0 && !state.isThinking ? (
           <div className="flex items-center justify-center h-full text-fg-muted text-sm">
             Start a conversation with Claude

--- a/desktop/src/renderer/components/ModelStateBanner.tsx
+++ b/desktop/src/renderer/components/ModelStateBanner.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import type { EngineModelState } from '../../shared/engine-types';
+import BrailleSpinner from './BrailleSpinner';
+
+// Per-session banner for a NATIVE (local-model) session, mounted at the top of
+// the chat timeline. Two jobs (2026-07-14 memory-lifecycle feature):
+//   #4  model was unloaded/slept to save memory → offer [Reload Model].
+//   #5  model is (re)loading → show its size + a spinner + elapsed time.
+// Renders nothing when the model is 'loaded' or state is unknown (null).
+
+interface Props {
+  modelState: EngineModelState | null;
+  modelInfo: { modelId: string; sizeBytes: number | null } | null;
+  /** Called by [Reload Model] — wired to window.claude.models.load(modelId). */
+  onReload: (modelId: string) => void;
+}
+
+/** Trim a GGUF id to something human: drop the split suffix + quant tag. */
+function friendlyName(modelId: string): string {
+  return modelId
+    .replace(/-\d{5}-of-\d{5}$/i, '')                 // multi-part suffix
+    .replace(/-(UD-)?[QIF]\d[^-]*(_[A-Z0-9]+)*$/i, '') // trailing quant (best-effort)
+    .replace(/-(UD-)?(BF16|F16|F32|MXFP4(_MOE)?)$/i, '');
+}
+
+function gb(bytes: number | null): string | null {
+  if (bytes == null || bytes <= 0) return null;
+  return (bytes / 1024 ** 3).toFixed(1) + ' GB';
+}
+
+export default function ModelStateBanner({ modelState, modelInfo, onReload }: Props) {
+  const loading = modelState === 'loading';
+  // Elapsed-seconds ticker, only while loading (cold loads of big models are slow
+  // and llama-server exposes no % — elapsed time is the honest progress signal).
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!loading) { setElapsed(0); return; }
+    const started = Date.now();
+    const t = setInterval(() => setElapsed(Math.floor((Date.now() - started) / 1000)), 1000);
+    return () => clearInterval(t);
+  }, [loading, modelInfo?.modelId]);
+
+  if (!modelInfo) return null;
+  if (modelState !== 'sleeping' && modelState !== 'unloaded' && modelState !== 'loading') {
+    return null; // 'loaded' or unknown → nothing to show
+  }
+
+  const name = friendlyName(modelInfo.modelId);
+  const size = gb(modelInfo.sizeBytes);
+
+  return (
+    <div className="flex flex-col items-start gap-1 px-4 py-2 in-view">
+      <div className="flex items-center gap-2 bg-inset rounded-2xl px-4 py-2.5 max-w-full">
+        {loading ? (
+          <>
+            <BrailleSpinner size="base" />
+            <span className="text-sm text-fg-muted">
+              Loading <span className="text-fg-2">{name}</span>
+              {size ? <span className="text-fg-dim"> · {size}</span> : null}
+              <span className="text-fg-faint"> · {elapsed}s</span>
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="text-sm text-fg-muted">
+              Model unloaded to save memory.
+            </span>
+            <button
+              type="button"
+              onClick={() => onReload(modelInfo.modelId)}
+              className="text-xs font-medium px-2.5 py-1 rounded-full bg-accent text-on-accent hover:opacity-90 shrink-0"
+            >
+              Reload model
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -205,6 +205,10 @@ export default function SessionStrip({
     return () => { cancelled = true; };
   }, [nativeSupported, runtime, showNewForm]);
 
+  // Create-time memory guard (#2, 2026-07-14) — local-engine models only.
+  const [memVerdict, setMemVerdict] = useState<{ verdict: 'ok' | 'tight' | 'too-large'; headline: string; detail: string } | null>(null);
+  const [memDetailOpen, setMemDetailOpen] = useState(false);
+
   // Derived binding selection (pure — no state writes, so no update loop).
   const readyProviders = providersList.filter((p) => p.ready);
   const selectedProviderId = (binding && readyProviders.some((p) => p.id === binding.providerId))
@@ -232,7 +236,22 @@ export default function SessionStrip({
   const effectiveBinding = selectedProviderId && resolvedModelId
     ? { providerId: selectedProviderId, modelId: resolvedModelId }
     : null;
-  const nativeCreateBlocked = runtime === 'native' && (readyProviders.length === 0 || !effectiveBinding);
+  // Ask main whether this local model fits given what's already resident. Runs
+  // only for the local-engine provider (cloud models don't consume our memory).
+  // liveModels() falls back to a cache scan when the engine is off, so this is
+  // cheap and never boots the engine. Decision (Destin): block only 'too-large'.
+  const isLocalEngine = runtime === 'native' && selectedProviderId === 'local';
+  useEffect(() => {
+    let cancelled = false;
+    setMemDetailOpen(false);
+    if (!isLocalEngine || !resolvedModelId) { setMemVerdict(null); return; }
+    (window.claude.models as any).memoryCheck?.(resolvedModelId)
+      .then((v: any) => { if (!cancelled) setMemVerdict(v && v.verdict ? v : null); })
+      .catch(() => { if (!cancelled) setMemVerdict(null); });
+    return () => { cancelled = true; };
+  }, [isLocalEngine, resolvedModelId]);
+  const memBlocked = memVerdict?.verdict === 'too-large';
+  const nativeCreateBlocked = runtime === 'native' && (readyProviders.length === 0 || !effectiveBinding || memBlocked);
   // Launch the new session in its own peer window instead of this one.
   // Hidden on platforms without multi-window support (Android / remote-shim).
   const [launchInNewWindow, setLaunchInNewWindow] = useState(false);
@@ -1110,6 +1129,35 @@ export default function SessionStrip({
                           </select>
                         )}
                       </div>
+                      {/* Memory guard (#2): block only when clearly too large;
+                          otherwise a warning with a "Show more" detail (overflow
+                          + LRU eviction). local-engine models only. */}
+                      {memVerdict && memVerdict.verdict !== 'ok' && (
+                        <div
+                          className={`text-[11px] rounded-sm px-2 py-1.5 border ${
+                            memVerdict.verdict === 'too-large'
+                              ? 'border-[var(--destructive)] text-fg-2'
+                              : 'border-edge bg-well text-fg-dim'
+                          }`}
+                        >
+                          <div className="flex items-start gap-1.5">
+                            <span aria-hidden>{memVerdict.verdict === 'too-large' ? '⛔' : '⚠️'}</span>
+                            <div className="flex-1 min-w-0">
+                              <span>{memVerdict.headline}</span>{' '}
+                              <button
+                                type="button"
+                                onClick={() => setMemDetailOpen((o) => !o)}
+                                className="underline text-fg-muted hover:text-fg whitespace-nowrap"
+                              >
+                                {memDetailOpen ? 'Show less' : 'Show more'}
+                              </button>
+                              {memDetailOpen && (
+                                <p className="mt-1 text-fg-muted leading-snug">{memVerdict.detail}</p>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      )}
                     </>
                   )}
                 </div>

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -249,6 +249,9 @@ declare global {
         interrupt: (sessionId: string) => void;
         setBinding: (sessionId: string, binding: { providerId: string; modelId: string }) => Promise<boolean>;
         sessionsList: () => Promise<any[]>;
+        // Per-session bound-model residency push (2026-07-14): { sessionId,
+        // modelId, state: 'unloaded'|'loading'|'loaded'|'sleeping', sizeBytes }.
+        onModelState: (cb: (s: any) => void) => () => void;
       };
       // Provider registry — native runtime model providers (desktop-only; the
       // Android/remote stubs reject with not-implemented).
@@ -271,6 +274,9 @@ declare global {
         setContext: (contextSize: number) => Promise<any>;
         onInstallProgress: (cb: (p: any) => void) => () => void;
         onStatusChanged: (cb: (s: any) => void) => () => void;
+        // Live per-model residency (2026-07-14).
+        models: () => Promise<import('../../shared/engine-types').EngineModel[]>;
+        onModelsChanged: (cb: (models: import('../../shared/engine-types').EngineModel[]) => void) => () => void;
       };
       // Model manager (Plan C) — curated catalog, HF search, downloads, endpoint
       // detectors, engine backend switch. Task 9's Local Models panel consumes
@@ -286,6 +292,9 @@ declare global {
         detectEndpoints: () => Promise<any[]>;
         setBackend: (backend: string) => Promise<any>;
         onDownloadProgress: (cb: (p: any) => void) => () => void;
+        // Create-time / swap memory guard + [Reload Model] (2026-07-14).
+        memoryCheck: (modelId: string) => Promise<{ verdict: 'ok' | 'tight' | 'too-large'; headline: string; detail: string }>;
+        load: (modelId: string) => Promise<boolean>;
       };
       // Platform integration for hardware back button (Android). On desktop,
       // both methods are no-op stubs (preload.ts). On Android, notifyStackState

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -298,6 +298,14 @@ function handleMessage(data: string): void {
       // WHY: models.onDownloadProgress subscribers listen on this channel.
       dispatchEvent('models:download-progress', payload);
       break;
+    case 'engine:models-changed':
+      // WHY: engine.onModelsChanged subscribers listen on this channel.
+      dispatchEvent('engine:models-changed', payload);
+      break;
+    case 'native:model-state':
+      // WHY: native.onModelState subscribers (ChatView banner) listen here.
+      dispatchEvent('native:model-state', payload);
+      break;
     case 'system:back':
       // Android hardware back press → routed to useDismissTop via the
       // window.claude.system.onBack subscriber registered in App.tsx. No
@@ -1429,6 +1437,11 @@ export function installShim(): void {
       interrupt: (sessionId: string) => fire('native:interrupt', { sessionId }),
       setBinding: (sessionId: string, binding: unknown) => invoke('native:set-binding', { sessionId, binding }),
       sessionsList: () => invoke('native:sessions-list'),
+      onModelState: (cb: (s: unknown) => void) => {
+        const handler: Callback = (payload: any) => cb(payload);
+        addListener('native:model-state', handler);
+        return () => removeListener('native:model-state', handler);
+      },
     },
     // Provider registry — WS transport. upsert sends the config as the whole
     // payload (remote-server reads `payload` directly); remove/test read
@@ -1461,6 +1474,12 @@ export function installShim(): void {
         addListener('engine:status-changed', handler);
         return () => removeListener('engine:status-changed', handler);
       },
+      models: () => invoke('engine:models'),
+      onModelsChanged: (cb: (models: unknown) => void) => {
+        const handler: Callback = (payload: any) => cb(payload);
+        addListener('engine:models-changed', handler);
+        return () => removeListener('engine:models-changed', handler);
+      },
     },
     // Model manager (Plan C) — WS transport. Positional-ish payloads match how
     // remote-server.ts's WS cases read them (payload.query / payload.repo /
@@ -1476,6 +1495,8 @@ export function installShim(): void {
       installed: () => invoke('models:installed'),
       detectEndpoints: () => invoke('endpoints:detect'),
       setBackend: (backend: string) => invoke('engine:set-backend', { backend }),
+      memoryCheck: (modelId: string) => invoke('models:memory-check', { modelId }),
+      load: (modelId: string) => invoke('models:load', { modelId }),
       onDownloadProgress: (cb: (p: unknown) => void) => {
         const handler: Callback = (payload: any) => cb(payload);
         addListener('models:download-progress', handler);

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -411,6 +411,22 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       return next;
     }
 
+    // Native model residency changed (loaded/loading/sleeping/unloaded). Purely
+    // informational — does NOT touch the turn/attention machinery. Drives the
+    // ModelStateBanner (unloaded → reload; loading → loading indicator).
+    case 'NATIVE_MODEL_STATE_CHANGED': {
+      const session = next.get(action.sessionId);
+      if (!session) return state;
+      if (session.modelState === action.state
+          && session.modelInfo?.modelId === action.modelId) return state; // no-op
+      next.set(action.sessionId, {
+        ...session,
+        modelState: action.state,
+        modelInfo: { modelId: action.modelId, sizeBytes: action.sizeBytes },
+      });
+      return next;
+    }
+
     // Plan 2b: another device took over this session's lease. See the inline
     // comment below — as of the "Moved Gate" follow-up this only ends the turn
     // cleanly; the user-facing surface moved to App.tsx's MovedGate.

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -159,6 +159,17 @@ export interface SessionChatState {
    * how much was freed.
    */
   compactionPending: { startedAt: number; beforeContextTokens: number | null } | null;
+  /**
+   * Native (local-model) sessions only. Residency of the session's bound model,
+   * pushed from main (native:model-state). Drives ChatView's ModelStateBanner:
+   * 'sleeping'/'unloaded' → "Model unloaded to save memory · [Reload Model]";
+   * 'loading' → the loading indicator (size + spinner). null = not a native
+   * session (or state not yet known). Separate from attentionState on purpose —
+   * this is engine model residency, not turn/thinking state.
+   */
+  modelState: import('../../shared/engine-types').EngineModelState | null;
+  /** Bound model id + size for the banner copy (from native:model-state). */
+  modelInfo: { modelId: string; sizeBytes: number | null } | null;
 }
 
 export function createSessionChatState(): SessionChatState {
@@ -177,6 +188,8 @@ export function createSessionChatState(): SessionChatState {
     errorMessage: null,
     lastBufferActivityAt: 0,
     compactionPending: null,
+    modelState: null,
+    modelInfo: null,
   };
 }
 
@@ -223,6 +236,16 @@ export type ChatAction =
       type: 'SESSION_PROCESS_EXITED';
       sessionId: string;
       exitCode: number;
+    }
+  | {
+      // Native runtime only: the session's bound model's residency changed
+      // (loaded/loading/sleeping/unloaded), pushed from main. Drives the
+      // ModelStateBanner (unloaded-to-save-memory + [Reload Model], loading UI).
+      type: 'NATIVE_MODEL_STATE_CHANGED';
+      sessionId: string;
+      state: import('../../shared/engine-types').EngineModelState;
+      modelId: string;
+      sizeBytes: number | null;
     }
   | {
       // Native runtime only: a provider/stream failure ended the turn.
@@ -446,6 +469,8 @@ export interface SerializedSessionChatState {
   errorMessage: string | null;
   lastBufferActivityAt: number;
   compactionPending: { startedAt: number; beforeContextTokens: number | null } | null;
+  modelState?: import('../../shared/engine-types').EngineModelState | null;
+  modelInfo?: { modelId: string; sizeBytes: number | null } | null;
 }
 
 export interface SerializedChatState {
@@ -472,6 +497,8 @@ export function serializeChatState(state: ChatState): SerializedChatState {
         errorMessage: s.errorMessage,
         lastBufferActivityAt: s.lastBufferActivityAt,
         compactionPending: s.compactionPending,
+        modelState: s.modelState,
+        modelInfo: s.modelInfo,
       },
     ]);
   }
@@ -498,6 +525,9 @@ export function deserializeChatState(s: SerializedChatState): ChatState {
       errorMessage: ser.errorMessage ?? null,
       lastBufferActivityAt: ser.lastBufferActivityAt,
       compactionPending: ser.compactionPending,
+      // Older hosts predate these — default null so a pre-field snapshot hydrates.
+      modelState: ser.modelState ?? null,
+      modelInfo: ser.modelInfo ?? null,
     });
   }
   return result;

--- a/desktop/src/shared/engine-types.ts
+++ b/desktop/src/shared/engine-types.ts
@@ -24,9 +24,16 @@ export type EngineInstallProgress =
   | { kind: 'done'; version: string; backend: EngineBackend }
   | { kind: 'error'; message: string };
 
+/** Per-model residency, read from GET /models `status.value` (llama-server b9992).
+ *  'sleeping' = auto-slept by --sleep-idle-seconds (memory freed, wakes on next
+ *  request). 'unloaded' = not resident (never loaded, LRU-evicted, or a cache
+ *  scan while the engine is off). See docs/engine-dependencies.md. */
+export type EngineModelState = 'unloaded' | 'loading' | 'loaded' | 'sleeping';
+
 /** One GGUF the engine can serve — from GET /models when running, else a cache scan. */
 export interface EngineModel {
   id: string;              // what /v1/chat/completions expects in its "model" field
   sizeBytes: number | null;
-  loaded: boolean;         // always false when derived from a cache scan (engine not running)
+  loaded: boolean;         // convenience: state === 'loaded'. False from a cache scan.
+  state: EngineModelState; // 'unloaded' when derived from a cache scan (engine not running)
 }

--- a/desktop/src/shared/provider-types.ts
+++ b/desktop/src/shared/provider-types.ts
@@ -31,7 +31,8 @@ export interface CatalogModel {
   pricing?: { in: number; out: number };
   // Local-engine models only (Plan B/C). fit is Plan C's estimator; Plan B
   // fills sizeBytes/quant('unknown')/installed(true) from the cache scan.
-  local?: { sizeBytes: number; quant: string; installed: boolean; fit?: 'fits' | 'tight' | 'too-large' };
+  local?: { sizeBytes: number; quant: string; installed: boolean; fit?: 'fits' | 'tight' | 'too-large';
+            state?: import('./engine-types').EngineModelState };
 }
 
 /** provider:list row — config + derived status, never the key.

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -955,6 +955,12 @@ export const IPC = {
   MODELS_DELETE: 'models:delete',
   MODELS_INSTALLED: 'models:installed',
   ENDPOINTS_DETECT: 'endpoints:detect',
+  // ---- Model memory lifecycle (2026-07-14): per-model residency + guards ----
+  ENGINE_MODELS: 'engine:models',                 // invoke → EngineModel[] with live state
+  ENGINE_MODELS_CHANGED: 'engine:models-changed', // push → EngineModel[] on any state change
+  NATIVE_MODEL_STATE: 'native:model-state',       // push → per-session bound-model state
+  MODELS_MEMORY_CHECK: 'models:memory-check',     // invoke(modelId) → MemoryVerdict
+  MODELS_LOAD: 'models:load',                     // invoke(modelId) → true ([Reload Model])
 } as const;
 
 // Performance / GPU configuration snapshot — returned by performance:get-config.

--- a/desktop/tests/cache-scan.test.ts
+++ b/desktop/tests/cache-scan.test.ts
@@ -18,7 +18,7 @@ describe('scanGgufCache', () => {
     touch('notes.txt');
     const models = scanGgufCache(dir);
     expect(models).toEqual([
-      { id: 'Qwen3-4B-Instruct-2507-UD-Q4_K_XL', sizeBytes: 16, loaded: false },
+      { id: 'Qwen3-4B-Instruct-2507-UD-Q4_K_XL', sizeBytes: 16, loaded: false, state: 'unloaded' },
     ]);
   });
 
@@ -27,7 +27,7 @@ describe('scanGgufCache', () => {
     touch('Big-Model-UD-Q4_K_XL-00002-of-00002.gguf', 20);
     const models = scanGgufCache(dir);
     expect(models).toEqual([
-      { id: 'Big-Model-UD-Q4_K_XL-00001-of-00002', sizeBytes: 30, loaded: false },
+      { id: 'Big-Model-UD-Q4_K_XL-00001-of-00002', sizeBytes: 30, loaded: false, state: 'unloaded' },
     ]);
   });
 

--- a/desktop/tests/chat-reducer.test.ts
+++ b/desktop/tests/chat-reducer.test.ts
@@ -380,4 +380,23 @@ describe('native runtime reducer paths', () => {
     expect(session.attentionState).toBe('ok');
     expect(session.errorMessage).toBeNull();
   });
+
+  it('NATIVE_MODEL_STATE_CHANGED sets modelState + modelInfo without touching turn state', () => {
+    state = dispatch(state, { type: 'USER_PROMPT', sessionId: SESSION, content: 'hi', timestamp: 1 });
+    expect(state.get(SESSION)!.isThinking).toBe(true);
+
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loading', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    let s = state.get(SESSION)!;
+    expect(s.modelState).toBe('loading');
+    expect(s.modelInfo).toEqual({ modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(s.isThinking).toBe(true); // model residency is orthogonal to the turn
+
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'sleeping', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(state.get(SESSION)!.modelState).toBe('sleeping');
+
+    // No-op when unchanged → same object reference (cheap, no needless render).
+    const before = state.get(SESSION)!;
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'sleeping', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(state.get(SESSION)!).toBe(before);
+  });
 });

--- a/desktop/tests/engine-manager.test.ts
+++ b/desktop/tests/engine-manager.test.ts
@@ -74,7 +74,7 @@ describe('EngineManager', () => {
       providerId: 'local',
       label: 'tiny-Q4_K_M',
       contextLength: 8192, // the -c we spawn with, NOT the model's trained max
-      local: { sizeBytes: 4, quant: 'unknown', installed: true },
+      local: { sizeBytes: 4, quant: 'unknown', installed: true, state: 'unloaded' },
     }]);
   });
 

--- a/desktop/tests/engine-supervisor.test.ts
+++ b/desktop/tests/engine-supervisor.test.ts
@@ -104,6 +104,7 @@ describe('EngineSupervisor', () => {
       '--no-webui', '--jinja',
       '--models-dir', 'C:/fake/cache', // discovers dropped GGUFs (LLAMA_CACHE alone doesn't)
       '--models-max', '2',
+      '--sleep-idle-seconds', '300', // per-model 5-min auto-sleep (2026-07-14)
       '-c', '32768',
     ]);
     expect(args).not.toContain('-m'); // router mode = no model arg
@@ -209,7 +210,46 @@ describe('EngineSupervisor', () => {
     sup = makeSupervisor(fetchImpl);
     await sup.ensureRunning();
     const models = await sup.listModels();
-    expect(models).toEqual([{ id: 'foo-Q4_K_M', sizeBytes: null, loaded: true }]);
+    expect(models).toEqual([{ id: 'foo-Q4_K_M', sizeBytes: null, loaded: true, state: 'loaded' }]);
+  });
+
+  it('listModels maps /models status.value → EngineModelState (unknown → unloaded)', async () => {
+    mockSpawn.mockReturnValue(makeFakeChild());
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/health')) return { ok: true, status: 200 } as any;
+      if (String(url).endsWith('/models')) {
+        return { ok: true, status: 200, json: async () => ({ data: [
+          { id: 'a', status: { value: 'loaded' } },
+          { id: 'b', status: { value: 'sleeping' } },
+          { id: 'c', status: { value: 'loading' } },
+          { id: 'd', status: { value: 'unloaded' } },
+          { id: 'e', status: { value: 'some-future-state' } },
+        ] }) } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+    sup = makeSupervisor(fetchImpl);
+    await sup.ensureRunning();
+    const byId = Object.fromEntries((await sup.listModels()).map((m) => [m.id, m.state]));
+    expect(byId).toEqual({ a: 'loaded', b: 'sleeping', c: 'loading', d: 'unloaded', e: 'unloaded' });
+  });
+
+  it('emits models-changed after boot with the live model set (drives the per-session banner)', async () => {
+    mockSpawn.mockReturnValue(makeFakeChild());
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).endsWith('/health')) return { ok: true, status: 200 } as any;
+      if (String(url).endsWith('/models')) {
+        return { ok: true, status: 200, json: async () => ({ data: [{ id: 'a', status: { value: 'loaded' } }] }) } as any;
+      }
+      return { ok: false, status: 404 } as any;
+    });
+    sup = makeSupervisor(fetchImpl);
+    const changed: any[] = [];
+    sup.on('models-changed', (m) => changed.push(m));
+    await sup.ensureRunning();
+    await new Promise((r) => setTimeout(r, 30)); // let the initial poll tick resolve
+    expect(changed.length).toBeGreaterThan(0);
+    expect(changed[changed.length - 1][0]).toMatchObject({ id: 'a', state: 'loaded' });
   });
 
   it('ensureRunning during an in-flight stop WAITS for it, then respawns (no URL to the dying server)', async () => {

--- a/desktop/tests/fit-estimator.test.ts
+++ b/desktop/tests/fit-estimator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { estimateFit, checkDiskSpace } from '../src/main/models/fit-estimator';
+import { estimateFit, checkDiskSpace, checkMemoryForLoad } from '../src/main/models/fit-estimator';
 
 const GB = 1024 ** 3;
 
@@ -54,5 +54,40 @@ describe('checkDiskSpace', () => {
   it('passes when free space exceeds size + 5% margin, fails below', () => {
     expect(checkDiskSpace(10 * GB, 20 * GB)).toBeNull();
     expect(checkDiskSpace(10 * GB, 10.4 * GB)).toMatch(/free space/i);
+  });
+});
+
+describe('checkMemoryForLoad (create-time guard)', () => {
+  const MEM = 32 * GB;
+  it('ok: a small model with nothing loaded', () => {
+    const v = checkMemoryForLoad({ chosenBytes: 4 * GB, totalMemBytes: MEM, totalVramBytes: null, loadedBytes: 0 });
+    expect(v.verdict).toBe('ok');
+    expect(v.headline).toBe('');
+  });
+  it('BLOCKS (too-large) a model that cannot fit even alone', () => {
+    // 40GB + 2GB overhead > 32GB machine (RAM-only) → too-large even at loadedBytes 0.
+    const v = checkMemoryForLoad({ chosenBytes: 40 * GB, totalMemBytes: MEM, totalVramBytes: null, loadedBytes: 0 });
+    expect(v.verdict).toBe('too-large');
+    expect(v.headline).toMatch(/too large/i);
+    expect(v.detail).toMatch(/smaller model|quant/i);
+  });
+  it('WARNS (tight) when it fits alone but over-commits alongside loaded models', () => {
+    // 12GB fits alone on 32GB, but 12 + 18 already-loaded + 2 overhead = 32 > 0.85*32.
+    const v = checkMemoryForLoad({ chosenBytes: 12 * GB, totalMemBytes: MEM, totalVramBytes: null, loadedBytes: 18 * GB });
+    expect(v.verdict).toBe('tight');
+    expect(v.headline).toMatch(/memory/i);
+    expect(v.detail).toMatch(/unload|swap/i);
+  });
+  it('does not warn when nothing else is loaded (loadedBytes 0), even if largish', () => {
+    // 20GB alone on 32GB is not too-large; with nothing loaded it must not warn.
+    const v = checkMemoryForLoad({ chosenBytes: 20 * GB, totalMemBytes: MEM, totalVramBytes: null, loadedBytes: 0 });
+    expect(v.verdict).toBe('ok');
+  });
+  it('dedicated VRAM raises capacity, upgrading a tight verdict to ok', () => {
+    const args = { chosenBytes: 20 * GB, totalMemBytes: MEM, loadedBytes: 15 * GB };
+    // RAM-only (32GB): 20 + 15 + 2 = 37 > 0.85*32 (27.2) → tight.
+    expect(checkMemoryForLoad({ ...args, totalVramBytes: null }).verdict).toBe('tight');
+    // +16GB dedicated VRAM → capacity 48GB: 37 < 0.85*48 (40.8) → ok.
+    expect(checkMemoryForLoad({ ...args, totalVramBytes: 16 * GB }).verdict).toBe('ok');
   });
 });

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -791,3 +791,34 @@ describe('models:* + engine:set-* channel parity (Plan C)', () => {
     for (const [ch] of channels) expect(src).toContain(`"${ch}"`);
   });
 });
+
+// Model memory lifecycle (2026-07-14): per-model residency push + memory guard
+// + [Reload Model]. Same self-contained parity shape as the Plan B/C describes.
+describe('model memory lifecycle channel parity (2026-07-14)', () => {
+  const read = (...p: string[]) => fs.readFileSync(path.join(__dirname, '..', ...p), 'utf8');
+  const invokeChannels: Array<[string, string]> = [
+    ['engine:models', 'ENGINE_MODELS'],
+    ['models:memory-check', 'MODELS_MEMORY_CHECK'],
+    ['models:load', 'MODELS_LOAD'],
+  ];
+  const pushChannels = ['engine:models-changed', 'native:model-state'];
+
+  it('preload exposes every channel (request + push)', () => {
+    const src = read('src', 'main', 'preload.ts');
+    for (const [ch] of invokeChannels) expect(src).toContain(`'${ch}'`);
+    for (const ch of pushChannels) expect(src).toContain(`'${ch}'`);
+  });
+  it('remote-shim exposes every channel (request + push)', () => {
+    const src = read('src', 'renderer', 'remote-shim.ts');
+    for (const [ch] of invokeChannels) expect(src).toContain(`'${ch}'`);
+    for (const ch of pushChannels) expect(src).toContain(`'${ch}'`);
+  });
+  it('ipc-handlers registers every request-response channel via its IPC.* constant', () => {
+    const src = read('src', 'main', 'ipc-handlers.ts');
+    for (const [, konst] of invokeChannels) expect(src).toContain(`IPC.${konst}`);
+  });
+  it('SessionService.kt stubs every request-response channel', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', '..', 'app', 'src', 'main', 'kotlin', 'com', 'youcoded', 'app', 'runtime', 'SessionService.kt'), 'utf8');
+    for (const [ch] of invokeChannels) expect(src).toContain(`"${ch}"`);
+  });
+});

--- a/desktop/tests/native-session-host.test.ts
+++ b/desktop/tests/native-session-host.test.ts
@@ -139,4 +139,39 @@ describe('NativeSessionHost', () => {
     expect(types).toContain('turn-complete');  // chain kept going after the failure
     await failHost.destroyAll();
   });
+
+  // ---- model ref-count (#1: unload a model when no session uses it) ----
+  describe('model ref-count', () => {
+    it('fires onModelReleased ONLY when the last session for a model is destroyed', async () => {
+      const released: string[] = [];
+      host.setModelReleasedHandler((id) => released.push(id));
+      await host.create({ sessionId: 'a', cwd: root, binding: { providerId: 'local', modelId: 'M1' } });
+      await host.create({ sessionId: 'b', cwd: root, binding: { providerId: 'local', modelId: 'M1' } });
+      expect(host.sessionsForModel('M1').sort()).toEqual(['a', 'b']);
+
+      await host.destroy('a');            // one of two → M1 still in use
+      expect(released).toEqual([]);
+      expect(host.sessionsForModel('M1')).toEqual(['b']);
+
+      await host.destroy('b');            // last one → release M1
+      expect(released).toEqual(['M1']);
+      expect(host.sessionsForModel('M1')).toEqual([]);
+    });
+
+    it('setBinding swaps the ref-count: releases the old model, retains the new', async () => {
+      const released: string[] = [];
+      host.setModelReleasedHandler((id) => released.push(id));
+      await host.create({ sessionId: 's', cwd: root, binding: { providerId: 'local', modelId: 'OLD' } });
+      expect(host.modelForSession('s')).toBe('OLD');
+
+      await host.setBinding('s', { providerId: 'local', modelId: 'NEW' });
+      expect(released).toEqual(['OLD']);           // OLD had no other session → released
+      expect(host.modelForSession('s')).toBe('NEW');
+      expect(host.sessionsForModel('NEW')).toEqual(['s']);
+    });
+
+    it('modelForSession is null for an unknown session', () => {
+      expect(host.modelForSession('nope')).toBeNull();
+    });
+  });
 });

--- a/docs/engine-dependencies.md
+++ b/docs/engine-dependencies.md
@@ -46,6 +46,11 @@ Exact router-mode arg list (no `-m`):
   stderr so a startup exit surfaces the engine's REAL message instead of a guess.
 - **`--models-max 2`** — the router's LRU default is 4; 2 bounds RAM on consumer
   machines while keeping chat↔utility switching cheap.
+- **`--sleep-idle-seconds 300` (2026-07-14)** — the router frees an idle model's
+  memory after 5 min (status → `'sleeping'`) and wakes it on the next request.
+  Verified b9992. FINER-grained than the engine-wide idle stop (`idleMs`, 10 min)
+  which tears down the whole process — the two are complementary. `SLEEP_IDLE_SECONDS`
+  in `engine-supervisor.ts`; the flag presence is pinned in `engine-supervisor.test.ts`.
 - **`--jinja`** from day one so Phase 2 tool calling needs no process-shape change.
 - **`-c` is inherited by every loaded model instance** — confirmed: the router
   writes each model's preset with `ctx-size = <-c>` (seen in `/models` `status`).
@@ -88,13 +93,21 @@ Observed b9992 shape:
     "architecture": { "input_modalities": ["text"], "output_modalities": ["text"] },
     "source": "models_dir", "can_remove": false } ] }
 ```
-- **`status` is an OBJECT `{value: 'loaded'|'unloaded'|'loading'}`, NOT a bare
-  string.** `listModels` reads `row.status.value` (with a string fallback). The
-  original `row.status === 'loaded'` was always false. Regression-pinned in
+- **`status` is an OBJECT `{value: 'loaded'|'unloaded'|'loading'|'sleeping'}`, NOT
+  a bare string.** `listModels` maps `row.status.value` → `EngineModelState` via
+  `mapModelState` (unknown → `'unloaded'`, the safe default). `'sleeping'` is
+  produced by `--sleep-idle-seconds` (below). Regression-pinned in
   `engine-supervisor.test.ts`.
-- **No `size` field** on `/models` rows — `sizeBytes` comes from the cache scan.
-- `POST /models/load` / `/models/unload` take `{"model":"<id>"}` (unused in Plan B;
-  auto-load on first chat request is what we rely on).
+- **No `size` field** on `/models` rows — `sizeBytes` comes from the cache scan,
+  merged in by id (the loading banner needs the model size).
+- **Per-model state polling (2026-07-14):** the supervisor polls `GET /models`
+  every ~1.5s while running and emits `models-changed` only on an (id→state)
+  diff (llama-server has no push channel). `ipc-handlers` joins this with the
+  session→model ref-count and pushes `native:model-state` per session → the
+  ChatView unloaded/loading banner. Cheap localhost GET; timer is `.unref()`'d.
+- `POST /models/unload` takes `{"model":"<id>"}` — used to free a model the
+  moment its last session releases it (`NativeSessionHost` ref-count → 0, #1).
+  `loadModel` warms a model via a 1-token `/v1/chat/completions` ([Reload Model]).
 
 ### `/v1/chat/completions` streaming (harness via @ai-sdk/openai-compatible; probe-chat.mjs)
 


### PR DESCRIPTION
Five interlocking local-model (llama.cpp) features, all dormant behind `YOUCODED_NATIVE=1`. Design doc: `youcoded-dev/docs/superpowers/plans/2026-07-14-local-model-memory-lifecycle.md`.

**Motivation:** on a Strix Halo box, two big models loaded at 128k context held ~100 GB with nothing freeing it until the 10-min engine-wide idle. This makes residency proportional to actual use, and makes load state legible.

**Key finding:** llama-server b9992 does most of the work natively, so we read **real** state instead of guessing (per `docs/error-message-standards.md`): per-model `GET /models` `status.value` ∈ `unloaded|loading|loaded|sleeping`, `--sleep-idle-seconds`, `POST /models/unload`, response `timings`.

## The five features
1. **Unload a model when no session uses it.** New session→model ref-count in `NativeSessionHost` (retain in `wire`, release in `destroy`/`setBinding`). When the last session for a model releases it → `engineManager.unloadModel` (`POST /models/unload`) frees it immediately.
2. **Memory guard at create.** `checkMemoryForLoad` (pure) sums loaded-model footprint vs `os.freemem` + VRAM. **Blocks only when clearly too large** (won't fit even alone); otherwise **warns** with an **(i)/"Show more"** detail explaining LRU eviction + swap. In `SessionStrip`'s native picker (local-engine models only).
3. **Sleep idle models after 5 min.** `--sleep-idle-seconds 300` frees an idle model's memory (`status: 'sleeping'`) without tearing down the engine.
4. **"Model unloaded to save memory · [Reload Model]" banner.** New `modelState` on `SessionChatState`, driven by a per-model `/models` poll → `models-changed` → per-session `native:model-state` push. `ChatView` renders `ModelStateBanner` at the top of the timeline; [Reload Model] → `engineManager.loadModel`.
5. **Loading indicator.** Same banner shows model **size + spinner + elapsed** while `loading` (llama exposes no %, so elapsed is the honest signal); tok/s from existing per-turn metadata.

## Infra
`EngineModel` gains `state` (`loaded` kept as derived, no caller churn). Supervisor polls `/models` (1.5s, `.unref()`'d) and emits `models-changed` on an (id→state) diff. Five new IPC channels (`engine:models`, `engine:models-changed`, `native:model-state`, `models:memory-check`, `models:load`) with full 4-surface parity + Android stubs + remote-server WS cases.

## Decisions (Destin, 2026-07-14)
- Memory guard: block only if clearly too large, else warn with a "Show more" explainer.
- Unloading: both immediate-unload-on-close **and** 5-min sleep.

## Tests
New: ref-count (retain/release/swap, release only at zero), memory-guard verdicts (block/warn/ok, VRAM upgrade), status→state mapping, `models-changed` emit, reducer `NATIVE_MODEL_STATE_CHANGED`, IPC parity for all 5 channels. Full desktop suite green; the one flaky failure (`artifact-store.test.ts`, CAS-lock timing) is pre-existing and unrelated (passes 3/3 on retry, touches no code in this PR). `tsc` clean; renderer + main bundle successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)