### PR TITLE
feat(local-models): eager load-on-open + real GB load-progress bar

### DIFF
--- a/desktop/src/main/engine/engine-supervisor.ts
+++ b/desktop/src/main/engine/engine-supervisor.ts
@@ -27,7 +27,8 @@ export interface EngineSupervisorOpts {
   idleMs?: number;           // default 10 min (spec §3.2)
   idleCheckMs?: number;      // default 60s
   sleepIdleSeconds?: number; // per-model auto-sleep; default 300 (5 min)
-  modelPollMs?: number;      // /models state poll cadence; default 1500
+  modelPollMs?: number;      // /models state poll cadence when idle; default 1500
+  modelPollLoadingMs?: number; // faster cadence while a model is loading; default 400
 }
 
 // Keep at most 2 models resident: the router's LRU default (4) can overcommit
@@ -57,6 +58,7 @@ export class EngineSupervisor extends EventEmitter {
   private intentionalShutdown = false;
   private modelPollTimer: NodeJS.Timeout | null = null; // per-model /models state poll
   private lastModelSig = '';                             // last emitted (id→state) signature
+  private loadProgress = new Map<string, number>();      // modelId → max resident bytes seen while loading (monotonic)
 
   constructor(private readonly opts: EngineSupervisorOpts) { super(); }
 
@@ -373,31 +375,78 @@ export class EngineSupervisor extends EventEmitter {
 
   // ---- per-model state polling (drives the UI's load/sleep/unload signals) --
 
-  /** Poll GET /models while running and emit 'models-changed' only when the set
-   *  of (id → state) actually changes. llama-server has no push channel, so a
+  /** Poll GET /models while running and emit 'models-changed' when the set of
+   *  (id → state → loadedBytes) changes. llama-server has no push channel, so a
    *  cheap localhost poll is how the renderer learns a model slept/loaded/was
-   *  evicted. Unref'd; started on ready, stopped on teardown. */
+   *  evicted — and, while a model is LOADING, tracks its resident bytes for the
+   *  "N GB / M GB" progress bar. Adaptive cadence: fast while anything is loading
+   *  (smooth progress), slow otherwise (near-zero idle cost). Unref'd; started on
+   *  ready, stopped on teardown. */
   private startModelPoll(): void {
     this.stopModelPoll();
-    const everyMs = this.opts.modelPollMs ?? 1500;
-    const tick = async () => {
-      if (this.state !== 'running') return;
-      let models: EngineModel[];
-      try { models = await this.listModels(); } catch { return; }
-      const sig = models.map((m) => `${m.id}:${m.state}`).sort().join('|');
-      if (sig !== this.lastModelSig) {
-        this.lastModelSig = sig;
-        this.emit('models-changed', models);
-      }
+    const schedule = () => {
+      // Fast while a load is in flight (loadProgress tracks loading ids), else lazy.
+      const loading = this.loadProgress.size > 0;
+      const delay = loading ? (this.opts.modelPollLoadingMs ?? 400) : (this.opts.modelPollMs ?? 1500);
+      this.modelPollTimer = setTimeout(() => {
+        void this.emitModelsIfChanged().finally(() => {
+          if (this.state === 'running') schedule();
+        });
+      }, delay);
+      this.modelPollTimer.unref?.();
     };
-    this.modelPollTimer = setInterval(() => { void tick(); }, everyMs);
-    this.modelPollTimer.unref?.();
-    void tick(); // emit an initial snapshot promptly
+    void this.emitModelsIfChanged().finally(() => { if (this.state === 'running') schedule(); });
   }
 
   private stopModelPoll(): void {
-    if (this.modelPollTimer) { clearInterval(this.modelPollTimer); this.modelPollTimer = null; }
+    if (this.modelPollTimer) { clearTimeout(this.modelPollTimer); this.modelPollTimer = null; }
     this.lastModelSig = '';
+    this.loadProgress.clear();
+  }
+
+  /** Compute the live model set (with load progress) and emit if it changed. */
+  private async emitModelsIfChanged(): Promise<void> {
+    if (this.state !== 'running') return;
+    let models: EngineModel[];
+    try { models = await this.listModels(); } catch { return; }
+    for (const m of models) {
+      if (m.state === 'loading') {
+        // Resident bytes of the model's child process, monotonic (Vulkan drops
+        // RSS once weights move to VRAM, so hold the max seen this load).
+        const rss = this.residentBytesForModel(m.id) ?? 0;
+        const maxRss = Math.max(this.loadProgress.get(m.id) ?? 0, rss);
+        this.loadProgress.set(m.id, maxRss);
+        if (maxRss > 0) m.loadedBytes = m.sizeBytes ? Math.min(maxRss, m.sizeBytes) : maxRss;
+      } else {
+        this.loadProgress.delete(m.id); // load finished / not loading → drop tracker
+      }
+    }
+    const sig = models.map((m) => `${m.id}:${m.state}:${m.loadedBytes ?? ''}`).sort().join('|');
+    if (sig !== this.lastModelSig) { this.lastModelSig = sig; this.emit('models-changed', models); }
+  }
+
+  /** Resident bytes of the router's child process serving `modelId` (its VmRSS,
+   *  which climbs toward the file size as the GGUF is read into RAM). Linux only
+   *  (reads /proc); undefined elsewhere → the UI falls back to an elapsed-only,
+   *  indeterminate bar. The child's cmdline carries `--model …/<id>.gguf`, which
+   *  the router process (with `--models-dir`) does not, so the needle is unique. */
+  private residentBytesForModel(modelId: string): number | undefined {
+    if (process.platform !== 'linux') return undefined;
+    const needle = `/${modelId}.gguf`;
+    let pids: string[];
+    try { pids = fs.readdirSync('/proc'); } catch { return undefined; }
+    for (const pid of pids) {
+      if (!/^\d+$/.test(pid)) continue;
+      let cmd: string;
+      try { cmd = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8'); } catch { continue; } // NUL-separated
+      if (!cmd.includes('--model') || !cmd.includes(needle)) continue;
+      try {
+        const status = fs.readFileSync(`/proc/${pid}/status`, 'utf8');
+        const m = /VmRSS:\s+(\d+)\s+kB/.exec(status);
+        if (m) return parseInt(m[1], 10) * 1024;
+      } catch { /* raced exit */ }
+    }
+    return undefined;
   }
 
   /** Best-effort per-model unload (frees its memory now). Used when the last
@@ -412,32 +461,29 @@ export class EngineSupervisor extends EventEmitter {
         body: JSON.stringify({ model: modelId }),
       });
     } catch { /* best-effort */ }
-    void this.pollModelsNow();
+    void this.emitModelsIfChanged();
   }
 
-  /** Force a model resident by sending a 1-token warm-up completion — the router
-   *  loads (or wakes) it. Used by the [Reload Model] button. Routed through
-   *  trackedFetch so it counts as activity (won't be reaped mid-load). */
+  /** Force a model resident (the [Reload Model] button AND eager load-on-open).
+   *  Fires the warm-up completion WITHOUT awaiting it so the caller returns
+   *  immediately; the model poll (fast while loading) then tracks 'loading' +
+   *  resident bytes → the progress bar. Routed through trackedFetch so it counts
+   *  as activity (never reaped mid-load). */
   async loadModel(modelId: string): Promise<void> {
     const base = await this.ensureRunning(); // http://127.0.0.1:port/v1
-    try {
-      await this.trackedFetch(`${base}/chat/completions`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: modelId, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1, stream: false }),
-      });
-    } catch { /* best-effort — the model state poll reflects the outcome */ }
-    void this.pollModelsNow();
+    void this.trackedFetch(`${base}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: modelId, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1, stream: false }),
+    }).catch(() => { /* best-effort — the poll reflects the outcome */ });
+    // Nudge the poll so 'loading' + the progress bar appear promptly (don't wait
+    // for the next lazy tick). The adaptive poll then takes over at fast cadence.
+    void this.emitModelsIfChanged();
   }
 
-  /** Emit a fresh models-changed on demand (after an unload/load nudges state). */
+  /** Emit a fresh models-changed on demand. */
   async pollModelsNow(): Promise<void> {
-    if (this.state !== 'running') return;
-    try {
-      const models = await this.listModels();
-      const sig = models.map((m) => `${m.id}:${m.state}`).sort().join('|');
-      if (sig !== this.lastModelSig) { this.lastModelSig = sig; this.emit('models-changed', models); }
-    } catch { /* ignore */ }
+    await this.emitModelsIfChanged();
   }
 }
 

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -487,6 +487,11 @@ export function registerIpcHandlers(
       } catch (e) {
         log('ERROR', 'IPC', 'native session start failed', { sessionId: info.id, error: String(e) });
       }
+      // Eager-load the bound model the moment the session opens (like LM Studio),
+      // so the loading bar + GB progress appear immediately rather than only after
+      // the first message. Fire-and-forget; the model poll drives the UI.
+      const eagerModelId = nativeHost.modelForSession(info.id);
+      if (eagerModelId) { void engineManager.loadModel(eagerModelId).catch(() => { /* engine not installed / boot failed — the first send surfaces it */ }); }
     }
     // Assign the new session to the calling window so per-session events (transcript,
     // pty output, permission prompts) route here once Task 1.4 migrates the emits.
@@ -1950,13 +1955,16 @@ export function registerIpcHandlers(
   // Join per-model residency (engine) with session→model (host): push each live
   // native session its bound model's state so ChatView can show the unloaded /
   // loading banner (#4/#5). Only push on change per session.
+  // Signature includes loadedBytes so LOAD PROGRESS updates (state stays
+  // 'loading' while bytes climb) are pushed, not just state transitions.
   const lastSessionModelState = new Map<string, string>();
   engineManager.on('models-changed', (models: EngineModelType[]) => {
     for (const m of models) {
-      const payload = { modelId: m.id, state: m.state, sizeBytes: m.sizeBytes };
+      const payload = { modelId: m.id, state: m.state, sizeBytes: m.sizeBytes, loadedBytes: m.loadedBytes ?? null };
+      const sig = `${m.state}:${m.loadedBytes ?? ''}`;
       for (const sessionId of nativeHost.sessionsForModel(m.id)) {
-        if (lastSessionModelState.get(sessionId) === m.state) continue;
-        lastSessionModelState.set(sessionId, m.state);
+        if (lastSessionModelState.get(sessionId) === sig) continue;
+        lastSessionModelState.set(sessionId, sig);
         const full = { sessionId, ...payload };
         sendForSession(sessionId, IPC.NATIVE_MODEL_STATE, full);
         remoteServer?.broadcast({ type: 'native:model-state', payload: full });

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -743,6 +743,7 @@ function AppInner() {
         state: s.state,
         modelId: s.modelId,
         sizeBytes: typeof s.sizeBytes === 'number' ? s.sizeBytes : null,
+        loadedBytes: typeof s.loadedBytes === 'number' ? s.loadedBytes : null,
       });
     });
     return () => { off?.(); };

--- a/desktop/src/renderer/components/ChatView.tsx
+++ b/desktop/src/renderer/components/ChatView.tsx
@@ -708,6 +708,7 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
       <ModelLoadingBar
         modelState={state.modelState}
         modelInfo={state.modelInfo}
+        loadedBytes={state.modelLoadedBytes}
         isThinking={state.isThinking}
         onReload={(modelId) => { void window.claude.models.load(modelId); }}
       />

--- a/desktop/src/renderer/components/ModelLoadingBar.tsx
+++ b/desktop/src/renderer/components/ModelLoadingBar.tsx
@@ -3,8 +3,9 @@ import type { EngineModelState } from '../../shared/engine-types';
 
 // Centered status strip that floats just ABOVE the input area for a NATIVE
 // (local-model) session. Two states (2026-07-14 memory-lifecycle UX):
-//   • LOADING  — the model is (re)loading to answer: indeterminate bar + size +
-//     elapsed. Shown while the model isn't resident yet (cold load / waking).
+//   • LOADING  — the model is (re)loading into RAM. When main can measure the
+//     model child's resident bytes, shows a DETERMINATE bar + "N GB / M GB"
+//     (Unsloth-Studio style); otherwise an indeterminate bar + elapsed seconds.
 //   • UNLOADED — the model slept to save memory and no turn is in flight:
 //     "Model unloaded to save memory · [Reload Model]".
 // Renders nothing when the model is loaded (or state unknown). Positioned by the
@@ -13,6 +14,8 @@ import type { EngineModelState } from '../../shared/engine-types';
 interface Props {
   modelState: EngineModelState | null;
   modelInfo: { modelId: string; sizeBytes: number | null } | null;
+  /** Bytes resident so far while loading (null when unavailable / not loading). */
+  loadedBytes: number | null;
   isThinking: boolean;
   onReload: (modelId: string) => void;
 }
@@ -25,20 +28,18 @@ function friendlyName(modelId: string): string {
     .replace(/-(UD-)?(BF16|F16|F32|MXFP4(_MOE)?)$/i, '');
 }
 
-function gb(bytes: number | null): string | null {
-  if (bytes == null || bytes <= 0) return null;
-  return (bytes / 1024 ** 3).toFixed(1) + ' GB';
+function gbNum(bytes: number | null | undefined): string {
+  return ((bytes ?? 0) / 1024 ** 3).toFixed(1);
 }
 
-export default function ModelLoadingBar({ modelState, modelInfo, isThinking, onReload }: Props) {
+export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, isThinking, onReload }: Props) {
   // The model is coming up if it's explicitly loading, OR a turn is in flight
   // while the model is still asleep/unloaded (the send is waking it).
   const notResident = modelState === 'sleeping' || modelState === 'unloaded';
   const loading = modelState === 'loading' || (isThinking && notResident);
   const showReload = !isThinking && notResident;
 
-  // Elapsed-seconds ticker while loading (llama exposes no %, so elapsed is the
-  // honest progress signal). Reset when the shown model changes.
+  // Elapsed-seconds ticker (fallback signal when byte-progress isn't available).
   const [elapsed, setElapsed] = useState(0);
   useEffect(() => {
     if (!loading) { setElapsed(0); return; }
@@ -50,7 +51,10 @@ export default function ModelLoadingBar({ modelState, modelInfo, isThinking, onR
   if (!modelInfo || (!loading && !showReload)) return null;
 
   const name = friendlyName(modelInfo.modelId);
-  const size = gb(modelInfo.sizeBytes);
+  const size = modelInfo.sizeBytes;
+  // Determinate GB progress when we have both resident bytes and a total size.
+  const hasProgress = loading && loadedBytes != null && loadedBytes > 0 && size != null && size > 0;
+  const pct = hasProgress ? Math.min(100, Math.round((loadedBytes! / size!) * 100)) : 0;
 
   return (
     <div className="model-status-strip absolute left-1/2 -translate-x-1/2 z-10 w-[min(88%,26rem)]">
@@ -60,10 +64,28 @@ export default function ModelLoadingBar({ modelState, modelInfo, isThinking, onR
             <div className="flex items-baseline justify-center gap-1.5 text-sm text-fg-2">
               <span className="italic">Loading</span>
               <span className="font-medium">{name}</span>
-              {size ? <span className="text-fg-dim text-xs">· {size}</span> : null}
-              <span className="text-fg-faint text-xs tabular-nums">· {elapsed}s</span>
+              {hasProgress ? (
+                <span className="text-fg-dim text-xs tabular-nums">
+                  · {gbNum(loadedBytes)} / {gbNum(size)} GB
+                </span>
+              ) : size != null ? (
+                <span className="text-fg-dim text-xs">· {gbNum(size)} GB · {elapsed}s</span>
+              ) : (
+                <span className="text-fg-faint text-xs tabular-nums">· {elapsed}s</span>
+              )}
             </div>
-            <div className="model-load-track h-1 rounded-full bg-well" />
+            {hasProgress ? (
+              // Determinate: fill tracks resident bytes / total size.
+              <div className="h-1.5 rounded-full bg-well overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-accent transition-[width] duration-300 ease-out"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            ) : (
+              // Indeterminate: no byte measurement (non-Linux / racing) — sweep.
+              <div className="model-load-track h-1.5 rounded-full bg-well" />
+            )}
           </div>
         ) : (
           <div className="flex items-center justify-center gap-3">

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -417,12 +417,17 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'NATIVE_MODEL_STATE_CHANGED': {
       const session = next.get(action.sessionId);
       if (!session) return state;
+      const loadedBytes = action.loadedBytes ?? null;
+      // No-op unless state, model, OR load-progress bytes changed (bytes climb
+      // while state stays 'loading', and must re-render the progress bar).
       if (session.modelState === action.state
-          && session.modelInfo?.modelId === action.modelId) return state; // no-op
+          && session.modelInfo?.modelId === action.modelId
+          && session.modelLoadedBytes === loadedBytes) return state;
       next.set(action.sessionId, {
         ...session,
         modelState: action.state,
         modelInfo: { modelId: action.modelId, sizeBytes: action.sizeBytes },
+        modelLoadedBytes: loadedBytes,
       });
       return next;
     }

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -170,6 +170,9 @@ export interface SessionChatState {
   modelState: import('../../shared/engine-types').EngineModelState | null;
   /** Bound model id + size for the banner copy (from native:model-state). */
   modelInfo: { modelId: string; sizeBytes: number | null } | null;
+  /** While modelState==='loading': bytes resident in RAM so far, for the
+   *  "N GB / M GB" progress bar. null when not loading / progress unavailable. */
+  modelLoadedBytes: number | null;
 }
 
 export function createSessionChatState(): SessionChatState {
@@ -190,6 +193,7 @@ export function createSessionChatState(): SessionChatState {
     compactionPending: null,
     modelState: null,
     modelInfo: null,
+    modelLoadedBytes: null,
   };
 }
 
@@ -246,6 +250,7 @@ export type ChatAction =
       state: import('../../shared/engine-types').EngineModelState;
       modelId: string;
       sizeBytes: number | null;
+      loadedBytes?: number | null;
     }
   | {
       // Native runtime only: a provider/stream failure ended the turn.
@@ -471,6 +476,7 @@ export interface SerializedSessionChatState {
   compactionPending: { startedAt: number; beforeContextTokens: number | null } | null;
   modelState?: import('../../shared/engine-types').EngineModelState | null;
   modelInfo?: { modelId: string; sizeBytes: number | null } | null;
+  modelLoadedBytes?: number | null;
 }
 
 export interface SerializedChatState {
@@ -499,6 +505,7 @@ export function serializeChatState(state: ChatState): SerializedChatState {
         compactionPending: s.compactionPending,
         modelState: s.modelState,
         modelInfo: s.modelInfo,
+        modelLoadedBytes: s.modelLoadedBytes,
       },
     ]);
   }
@@ -528,6 +535,7 @@ export function deserializeChatState(s: SerializedChatState): ChatState {
       // Older hosts predate these — default null so a pre-field snapshot hydrates.
       modelState: ser.modelState ?? null,
       modelInfo: ser.modelInfo ?? null,
+      modelLoadedBytes: ser.modelLoadedBytes ?? null,
     });
   }
   return result;

--- a/desktop/src/shared/engine-types.ts
+++ b/desktop/src/shared/engine-types.ts
@@ -36,4 +36,8 @@ export interface EngineModel {
   sizeBytes: number | null;
   loaded: boolean;         // convenience: state === 'loaded'. False from a cache scan.
   state: EngineModelState; // 'unloaded' when derived from a cache scan (engine not running)
+  /** While state === 'loading': bytes of the model resident in RAM so far (the
+   *  model child's VmRSS, monotonic + clamped to sizeBytes) — drives the "N GB /
+   *  M GB" progress bar. Undefined off Linux or when not loading. */
+  loadedBytes?: number;
 }

--- a/desktop/tests/chat-reducer.test.ts
+++ b/desktop/tests/chat-reducer.test.ts
@@ -399,4 +399,20 @@ describe('native runtime reducer paths', () => {
     state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'sleeping', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
     expect(state.get(SESSION)!).toBe(before);
   });
+
+  it('NATIVE_MODEL_STATE_CHANGED re-renders on load-progress bytes even when state is unchanged', () => {
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loading', modelId: 'Qwen-9B', sizeBytes: 9_000_000_000, loadedBytes: 1_000_000_000 });
+    expect(state.get(SESSION)!.modelLoadedBytes).toBe(1_000_000_000);
+
+    // Same state, MORE bytes resident → must produce a new object (progress bar advances).
+    const before = state.get(SESSION)!;
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loading', modelId: 'Qwen-9B', sizeBytes: 9_000_000_000, loadedBytes: 6_000_000_000 });
+    expect(state.get(SESSION)!).not.toBe(before);
+    expect(state.get(SESSION)!.modelLoadedBytes).toBe(6_000_000_000);
+
+    // Identical bytes → no-op (same reference).
+    const same = state.get(SESSION)!;
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loading', modelId: 'Qwen-9B', sizeBytes: 9_000_000_000, loadedBytes: 6_000_000_000 });
+    expect(state.get(SESSION)!).toBe(same);
+  });
 });


### PR DESCRIPTION
Follow-up to #125. Two fixes to the local-model loading UX (feedback: "loading bar doesn't show until a message is sent; it should begin the second a session opens, and track loading into RAM in GB like Unsloth Studio").

## 1. Eager load on session open
Creating a native session now fires the model warm-up immediately (`ipc-handlers` SESSION_CREATE → `engineManager.loadModel`), like LM Studio — so the loading bar appears the moment the session opens, not only after the first message. `loadModel` no longer blocks on the warm-up; it fires-and-forgets and nudges the poll so `loading` surfaces right away. Fire-and-forget is `.catch()`-guarded (engine-not-installed can't crash main).

## 2. Real "N GB / M GB" progress into RAM (Unsloth-Studio style)
llama-server exposes **no** load %/bytes over HTTP (`/health` stays `ok`, `/models` only flips `loading`→`loaded`). But the router's per-model **child process RSS** climbs toward the file size as the GGUF is read in. So while a model is `loading`, the supervisor finds that child by its `--model …/<id>.gguf` arg and reads `VmRSS` from `/proc`:

- Tracked **monotonically** (Vulkan drops RSS once weights move to VRAM, so we hold the max seen) and **clamped** to `sizeBytes`.
- `EngineModel` gains `loadedBytes`; the model poll is now **adaptive** (400 ms while loading for a smooth bar, 1500 ms idle) and its change-signature includes `loadedBytes` so progress updates push.
- `ModelLoadingBar` shows a **determinate bar + "N GB / M GB"** when bytes are available, else falls back to the indeterminate sweep + elapsed (non-Linux / racing).

Verified live on this box: RSS `0.16 → 9.05 GB` for the 9B; the monotonic hold survives the post-load VRAM-copy drop to 1.24 GB, so the bar never regresses.

## Notes
`chat-types`/reducer carry `modelLoadedBytes` (re-renders on byte change even while state stays `loading`). +1 reducer test. Linux-only for the byte readout (native runtime is dev-only/Linux-tested today); other platforms degrade to the elapsed bar. `tsc` clean; renderer builds; affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)