### PR TITLE
fix(local-models): no spurious Reload on cold start + "finalizing" load phase

### DIFF
--- a/desktop/src/renderer/components/ChatView.tsx
+++ b/desktop/src/renderer/components/ChatView.tsx
@@ -709,6 +709,7 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
         modelState={state.modelState}
         modelInfo={state.modelInfo}
         loadedBytes={state.modelLoadedBytes}
+        everResident={state.modelEverResident}
         isThinking={state.isThinking}
         onReload={(modelId) => { void window.claude.models.load(modelId); }}
       />

--- a/desktop/src/renderer/components/ModelLoadingBar.tsx
+++ b/desktop/src/renderer/components/ModelLoadingBar.tsx
@@ -1,13 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { EngineModelState } from '../../shared/engine-types';
 
 // Centered status strip that floats just ABOVE the input area for a NATIVE
-// (local-model) session. Two states (2026-07-14 memory-lifecycle UX):
-//   • LOADING  — the model is (re)loading into RAM. When main can measure the
-//     model child's resident bytes, shows a DETERMINATE bar + "N GB / M GB"
-//     (Unsloth-Studio style); otherwise an indeterminate bar + elapsed seconds.
-//   • UNLOADED — the model slept to save memory and no turn is in flight:
-//     "Model unloaded to save memory · [Reload Model]".
+// (local-model) session. States (2026-07-14 memory-lifecycle UX):
+//   • LOADING — the model is coming up. Three visual phases:
+//       – Reading:    determinate bar tracks resident bytes → "N GB / M GB".
+//       – Finalizing: weights are in RAM but the backend is still initializing
+//         (KV-cache + compute buffers, Vulkan VRAM upload, warm-up pass). llama-
+//         server reports 'loading' this whole time with the byte count pinned at
+//         100%, so a plain determinate bar looks frozen — we switch to a full bar
+//         with a moving highlight + "Preparing…" so it reads as still-working.
+//       – Indeterminate: no byte measurement (non-Linux / racing) — a sweep.
+//   • UNLOADED — the model SLEPT after use and no turn is in flight:
+//     "Model unloaded to save memory · [Reload Model]". Only shown once the model
+//     has actually been resident this session (everResident) so a fresh session's
+//     initial cold state shows the loading bar instead of a spurious Reload.
 // Renders nothing when the model is loaded (or state unknown). Positioned by the
 // caller in ChatView's outer absolute container so it isn't clipped by chat-pane.
 
@@ -16,6 +23,10 @@ interface Props {
   modelInfo: { modelId: string; sizeBytes: number | null } | null;
   /** Bytes resident so far while loading (null when unavailable / not loading). */
   loadedBytes: number | null;
+  /** True once the model has reached 'loaded' at least once this session. Gates
+   *  the Reload prompt so a fresh session that's still doing its FIRST load never
+   *  flashes "unloaded · Reload" during the cold-start race window. */
+  everResident: boolean;
   isThinking: boolean;
   onReload: (modelId: string) => void;
 }
@@ -32,14 +43,29 @@ function gbNum(bytes: number | null | undefined): string {
   return ((bytes ?? 0) / 1024 ** 3).toFixed(1);
 }
 
-export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, isThinking, onReload }: Props) {
-  // The model is coming up if it's explicitly loading, OR a turn is in flight
-  // while the model is still asleep/unloaded (the send is waking it).
-  const notResident = modelState === 'sleeping' || modelState === 'unloaded';
-  const loading = modelState === 'loading' || (isThinking && notResident);
-  const showReload = !isThinking && notResident;
+// Fraction of the file that must be resident before we consider the RAM read
+// "done" and switch to the finalizing phase. On Vulkan the child's RSS can peak
+// slightly below the file size (weights stream to VRAM/GTT and RSS drops), so
+// this is <1 rather than exactly 100%.
+const FINALIZE_PCT = 99;
+// If resident bytes stop climbing for this long while still 'loading', treat it
+// as finalizing too — covers models whose peak RSS plateaus below FINALIZE_PCT.
+const PLATEAU_MS = 2500;
 
-  // Elapsed-seconds ticker (fallback signal when byte-progress isn't available).
+export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, everResident, isThinking, onReload }: Props) {
+  const notResident = modelState === 'sleeping' || modelState === 'unloaded';
+  // The model is coming up if it's explicitly loading, OR a turn is in flight
+  // while it's still asleep/unloaded (the send is waking it), OR it's a fresh
+  // session whose model hasn't finished its first load yet (eager load in flight).
+  const loading =
+    modelState === 'loading' ||
+    (isThinking && notResident) ||
+    (notResident && !everResident);
+  // Reload prompt ONLY after the model was resident and then dropped while idle.
+  const showReload = !isThinking && notResident && everResident;
+
+  // Elapsed-seconds ticker — also serves as a 1s re-render heartbeat so the
+  // plateau check below re-evaluates even when byte updates have stopped arriving.
   const [elapsed, setElapsed] = useState(0);
   useEffect(() => {
     if (!loading) { setElapsed(0); return; }
@@ -48,6 +74,18 @@ export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, is
     return () => clearInterval(t);
   }, [loading, modelInfo?.modelId]);
 
+  // Track the last time resident bytes increased, to detect a plateau (weights
+  // fully read, backend still initializing) independent of the exact peak %.
+  const lastBytesRef = useRef<number | null>(null);
+  const lastGrowthAtRef = useRef<number>(0);
+  useEffect(() => {
+    if (!loading) { lastBytesRef.current = null; lastGrowthAtRef.current = 0; return; }
+    if (loadedBytes != null && (lastBytesRef.current == null || loadedBytes > lastBytesRef.current)) {
+      lastBytesRef.current = loadedBytes;
+      lastGrowthAtRef.current = Date.now();
+    }
+  }, [loading, loadedBytes]);
+
   if (!modelInfo || (!loading && !showReload)) return null;
 
   const name = friendlyName(modelInfo.modelId);
@@ -55,6 +93,11 @@ export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, is
   // Determinate GB progress when we have both resident bytes and a total size.
   const hasProgress = loading && loadedBytes != null && loadedBytes > 0 && size != null && size > 0;
   const pct = hasProgress ? Math.min(100, Math.round((loadedBytes! / size!) * 100)) : 0;
+  // Finalizing: weights are in RAM (near-full % OR bytes plateaued) but the
+  // backend is still initializing — show a full, animated "Preparing…" bar.
+  const plateaued =
+    hasProgress && lastGrowthAtRef.current > 0 && Date.now() - lastGrowthAtRef.current > PLATEAU_MS;
+  const finalizing = hasProgress && (pct >= FINALIZE_PCT || plateaued);
 
   return (
     <div className="model-status-strip absolute left-1/2 -translate-x-1/2 z-10 w-[min(88%,26rem)]">
@@ -62,19 +105,38 @@ export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, is
         {loading ? (
           <div className="flex flex-col gap-2">
             <div className="flex items-baseline justify-center gap-1.5 text-sm text-fg-2">
-              <span className="italic">Loading</span>
-              <span className="font-medium">{name}</span>
-              {hasProgress ? (
-                <span className="text-fg-dim text-xs tabular-nums">
-                  · {gbNum(loadedBytes)} / {gbNum(size)} GB
-                </span>
-              ) : size != null ? (
-                <span className="text-fg-dim text-xs">· {gbNum(size)} GB · {elapsed}s</span>
+              {finalizing ? (
+                <>
+                  <span className="italic">Preparing</span>
+                  <span className="font-medium">{name}</span>
+                  <span
+                    className="text-fg-dim text-xs"
+                    title="Weights are loaded — allocating memory and warming up the model"
+                  >
+                    · finishing up · {elapsed}s
+                  </span>
+                </>
               ) : (
-                <span className="text-fg-faint text-xs tabular-nums">· {elapsed}s</span>
+                <>
+                  <span className="italic">Loading</span>
+                  <span className="font-medium">{name}</span>
+                  {hasProgress ? (
+                    <span className="text-fg-dim text-xs tabular-nums">
+                      · {gbNum(loadedBytes)} / {gbNum(size)} GB
+                    </span>
+                  ) : size != null ? (
+                    <span className="text-fg-dim text-xs">· {gbNum(size)} GB · {elapsed}s</span>
+                  ) : (
+                    <span className="text-fg-faint text-xs tabular-nums">· {elapsed}s</span>
+                  )}
+                </>
               )}
             </div>
-            {hasProgress ? (
+            {finalizing ? (
+              // Full bar + moving highlight: RAM read is done, backend is still
+              // initializing. Never sits frozen at 100%.
+              <div className="model-load-finalize h-1.5 rounded-full" />
+            ) : hasProgress ? (
               // Determinate: fill tracks resident bytes / total size.
               <div className="h-1.5 rounded-full bg-well overflow-hidden">
                 <div

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -418,16 +418,22 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       const session = next.get(action.sessionId);
       if (!session) return state;
       const loadedBytes = action.loadedBytes ?? null;
-      // No-op unless state, model, OR load-progress bytes changed (bytes climb
-      // while state stays 'loading', and must re-render the progress bar).
+      // Latches true the first time the model reaches 'loaded'. The Reload prompt
+      // keys on this so a fresh session's initial 'unloaded'/'loading' (before its
+      // eager load completes) shows the loading bar, not a spurious Reload button.
+      const everResident = session.modelEverResident || action.state === 'loaded';
+      // No-op unless state, model, load-progress bytes, OR the ever-resident latch
+      // changed (bytes climb while state stays 'loading', and must re-render).
       if (session.modelState === action.state
           && session.modelInfo?.modelId === action.modelId
-          && session.modelLoadedBytes === loadedBytes) return state;
+          && session.modelLoadedBytes === loadedBytes
+          && session.modelEverResident === everResident) return state;
       next.set(action.sessionId, {
         ...session,
         modelState: action.state,
         modelInfo: { modelId: action.modelId, sizeBytes: action.sizeBytes },
         modelLoadedBytes: loadedBytes,
+        modelEverResident: everResident,
       });
       return next;
     }

--- a/desktop/src/renderer/state/chat-types.ts
+++ b/desktop/src/renderer/state/chat-types.ts
@@ -173,6 +173,13 @@ export interface SessionChatState {
   /** While modelState==='loading': bytes resident in RAM so far, for the
    *  "N GB / M GB" progress bar. null when not loading / progress unavailable. */
   modelLoadedBytes: number | null;
+  /** True once this session's model has been seen fully 'loaded' at least once.
+   *  Distinguishes "unloaded because it slept after use" (→ show the Reload
+   *  prompt) from "unloaded because it hasn't finished its FIRST load yet" (a
+   *  fresh session eager-loading → show the loading bar, never a reload prompt).
+   *  Without this, a brand-new session flashes "Model unloaded · Reload" in the
+   *  race window before the eager load flips the poll to 'loading'. */
+  modelEverResident: boolean;
 }
 
 export function createSessionChatState(): SessionChatState {
@@ -194,6 +201,7 @@ export function createSessionChatState(): SessionChatState {
     modelState: null,
     modelInfo: null,
     modelLoadedBytes: null,
+    modelEverResident: false,
   };
 }
 
@@ -477,6 +485,7 @@ export interface SerializedSessionChatState {
   modelState?: import('../../shared/engine-types').EngineModelState | null;
   modelInfo?: { modelId: string; sizeBytes: number | null } | null;
   modelLoadedBytes?: number | null;
+  modelEverResident?: boolean;
 }
 
 export interface SerializedChatState {
@@ -506,6 +515,7 @@ export function serializeChatState(state: ChatState): SerializedChatState {
         modelState: s.modelState,
         modelInfo: s.modelInfo,
         modelLoadedBytes: s.modelLoadedBytes,
+        modelEverResident: s.modelEverResident,
       },
     ]);
   }
@@ -536,6 +546,7 @@ export function deserializeChatState(s: SerializedChatState): ChatState {
       modelState: ser.modelState ?? null,
       modelInfo: ser.modelInfo ?? null,
       modelLoadedBytes: ser.modelLoadedBytes ?? null,
+      modelEverResident: ser.modelEverResident ?? false,
     });
   }
   return result;

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -550,6 +550,33 @@ body[data-mode="buddy-chat"] #theme-bg {
     opacity: 0.5;
   }
 }
+/* Finalizing phase: weights are in RAM but the backend is still initializing
+   (KV cache, compute buffers, Vulkan VRAM upload, warm-up). The bar is FULL
+   (solid accent) and a lighter highlight sweeps across so it never looks frozen
+   at 100%. Shares the model-load-sweep keyframe with the indeterminate track. */
+.model-load-finalize {
+  position: relative;
+  overflow: hidden;
+  background: var(--accent);
+}
+.model-load-finalize::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 35%;
+  left: -35%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--on-accent) 55%, transparent),
+    transparent
+  );
+  animation: model-load-sweep 1.25s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .model-load-finalize::after { animation: none; opacity: 0; }
+}
 
 /* Lightweight containment — skip layout/style for off-screen chat messages.
    Uses layout+style containment (not paint) so box-shadow glows from community

--- a/desktop/tests/chat-reducer.test.ts
+++ b/desktop/tests/chat-reducer.test.ts
@@ -415,4 +415,22 @@ describe('native runtime reducer paths', () => {
     state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loading', modelId: 'Qwen-9B', sizeBytes: 9_000_000_000, loadedBytes: 6_000_000_000 });
     expect(state.get(SESSION)!).toBe(same);
   });
+
+  it('modelEverResident latches on first loaded and stays true through sleep/unload', () => {
+    // Fresh session's cold state: not yet resident → the Reload prompt must NOT
+    // key on this (ModelLoadingBar shows the loading bar instead).
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'unloaded', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(state.get(SESSION)!.modelEverResident).toBe(false);
+
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loading', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(state.get(SESSION)!.modelEverResident).toBe(false);
+
+    // First time fully loaded → latch true.
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'loaded', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(state.get(SESSION)!.modelEverResident).toBe(true);
+
+    // Idle sleep after use → still true, so the Reload prompt is now valid.
+    state = dispatch(state, { type: 'NATIVE_MODEL_STATE_CHANGED', sessionId: SESSION, state: 'sleeping', modelId: 'Qwen-2B', sizeBytes: 2_000_000_000 });
+    expect(state.get(SESSION)!.modelEverResident).toBe(true);
+  });
 });


### PR DESCRIPTION
Two local-model loading-UX bugs reported live on a Strix Halo native session (dev-only, behind \`YOUCODED_NATIVE=1\`).

## 1. New session flashed "Model unloaded · Reload model"
`ModelLoadingBar` couldn't tell *"unloaded because it slept after use"* (→ show Reload) from *"unloaded because its **first** load hasn't finished"* (→ show loading bar). On a fresh session the engine poll reports `unloaded` for a beat before the eager load flips it to `loading`, and that beat rendered the Reload prompt.

**Fix:** a per-session **`modelEverResident`** latch (set true the first time the model reaches `loaded`). The Reload prompt now requires it, so a fresh session's cold-start shows the loading bar and never the Reload button.

## 2. Sat on "Loading" after the GB bar hit 100%
After the weights are read into RAM, `llama-server` still allocates the KV cache + compute buffers, uploads weights to VRAM/GTT (Vulkan), and runs a warm-up pass — reporting `loading` the whole time with the byte count pinned at max, so a determinate bar looked frozen.

**Fix:** a distinct **"finalizing" phase**. Once resident bytes reach ~99% *or* plateau (the Vulkan case, where child RSS peaks below 100% as weights move to VRAM), the bar switches to a full accent bar with a moving highlight and the caption becomes *"Preparing <model> · finishing up · Ns"*. Reduced-motion falls back to a solid full bar.

## Scope
Renderer-only: `ModelLoadingBar.tsx`, `ChatView.tsx`, `chat-reducer.ts`, `chat-types.ts`, `globals.css`. New reducer test pins the `everResident` latch. Typecheck clean, chat-reducer + transcript-reducer + pty-input-gate tests green. No IPC/Android surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)