### PR TITLE
test(pins): prerequisite-installer Windows spawn invariants

### DIFF
--- a/desktop/src/main/prerequisite-installer.ts
+++ b/desktop/src/main/prerequisite-installer.ts
@@ -42,13 +42,23 @@ try { const w = require('which'); whichSync = w.sync; } catch { /* noop */ }
  * git URL, version flags, base64-ish API key) — none contain `cmd.exe`
  * metacharacters (& | > < ^ %), so `shell: true`'s relaxed quoting is safe.
  */
+/**
+ * Pure shell-flag decision for {@link runCommand} — exported for pinning tests.
+ * Returns true ONLY on Windows AND when the resolved command is a `.cmd`/`.bat`
+ * shim (the CVE-2024-27980 EINVAL case). Real `.exe`/bare paths return false so
+ * they keep the no-shell (`shell:false`) no-injection guarantee. Extracted so a
+ * unit test can pin the decision without spawning real processes.
+ */
+export function shouldUseShell(cmd: string, platform: NodeJS.Platform): boolean {
+  return platform === 'win32' && /\.(cmd|bat)$/i.test(cmd);
+}
+
 function runCommand(
   cmd: string,
   args: string[] = [],
   opts: ExecFileOptions = {},
 ): Promise<{ stdout: string; stderr: string }> {
-  const needsShell =
-    process.platform === 'win32' && /\.(cmd|bat)$/i.test(cmd);
+  const needsShell = shouldUseShell(cmd, process.platform);
   // Cast: we never pass `encoding: 'buffer'`, so stdout/stderr are strings.
   // The `shell: boolean` field is supported at runtime but the overloads in
   // @types/node default to the buffer-or-string union, so we narrow it here.
@@ -165,7 +175,8 @@ function persistPathToShellProfiles(dir: string): void {
  * Hardcoding System32 prevents relying on the app's potentially stale or
  * corrupted environment PATH to find the registry tool.
  */
-function getRegPath(): string {
+// exported for pinning tests (the quoted/unquoted asymmetry vs getPowerShellPath is load-bearing)
+export function getRegPath(): string {
   const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
   const regPath = path.join(systemRoot, 'System32', 'reg.exe');
   return fs.existsSync(regPath) ? `"${regPath}"` : 'reg';
@@ -183,7 +194,8 @@ function getRegPath(): string {
  * the filename and CreateProcess fails with ENOENT — verified empirically on
  * 2026-05-21 (the bug shipped briefly in the first PATH-hardening pass).
  */
-function getPowerShellPath(): string {
+// exported for pinning tests (must stay UNQUOTED — see the WHY comment above)
+export function getPowerShellPath(): string {
   const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
   const psPath = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
   return fs.existsSync(psPath) ? psPath : 'powershell';

--- a/desktop/tests/prerequisite-installer-pins.test.ts
+++ b/desktop/tests/prerequisite-installer-pins.test.ts
@@ -1,0 +1,53 @@
+// desktop/tests/prerequisite-installer-pins.test.ts
+// Pins the Windows-spawn invariants in prerequisite-installer.ts that previously
+// had no unit guard (see .claude/rules/prereq-installer.md — "Guard: none — candidate").
+import { describe, it, expect } from 'vitest';
+import {
+  shouldUseShell,
+  getRegPath,
+  getPowerShellPath,
+} from '../src/main/prerequisite-installer';
+
+// Invariant 1: runCommand flips `shell: true` ONLY for Windows .cmd/.bat shims
+// (the CVE-2024-27980 EINVAL mitigation). Real .exe/bare paths must stay
+// shell:false so the no-shell-injection guarantee holds; non-Windows never
+// needs the shell flag.
+describe('shouldUseShell (runCommand shell-flag decision)', () => {
+  it('uses shell for .cmd/.bat on win32 (case-insensitive)', () => {
+    expect(shouldUseShell('C:\\Program Files\\nodejs\\npm.cmd', 'win32')).toBe(true);
+    expect(shouldUseShell('npm.CMD', 'win32')).toBe(true);
+    expect(shouldUseShell('foo.bat', 'win32')).toBe(true);
+  });
+
+  it('does NOT use shell for .exe or bare commands on win32', () => {
+    expect(shouldUseShell('C:\\Windows\\System32\\reg.exe', 'win32')).toBe(false);
+    expect(shouldUseShell('claude.exe', 'win32')).toBe(false);
+    expect(shouldUseShell('git', 'win32')).toBe(false);
+  });
+
+  it('never uses shell off Windows, even for .cmd/.bat', () => {
+    expect(shouldUseShell('npm.cmd', 'darwin')).toBe(false);
+    expect(shouldUseShell('foo.bat', 'linux')).toBe(false);
+  });
+});
+
+// Invariant 2: getRegPath() returns a QUOTED path (interpolated into a cmd.exe
+// execSync string) while getPowerShellPath() returns an UNQUOTED path (passed as
+// the file arg of execFile with shell:false — embedded quotes would become part
+// of the filename and CreateProcess fails with ENOENT). The asymmetry is
+// load-bearing. These read System32 via fs.existsSync, so they only resolve to
+// the real absolute paths on Windows; on other OSes both fall back to bare names.
+describe.runIf(process.platform === 'win32')('reg/powershell path quoting asymmetry', () => {
+  it('getRegPath() is quoted and points at reg.exe', () => {
+    const reg = getRegPath();
+    expect(reg.startsWith('"')).toBe(true);
+    expect(reg.endsWith('"')).toBe(true);
+    expect(reg.endsWith('reg.exe"')).toBe(true);
+  });
+
+  it('getPowerShellPath() is UNQUOTED and points at powershell.exe', () => {
+    const ps = getPowerShellPath();
+    expect(ps.includes('"')).toBe(false);
+    expect(ps.endsWith('powershell.exe')).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds a ~50-LOC pinning test (`desktop/tests/prerequisite-installer-pins.test.ts`) for two Windows-spawn invariants in `prerequisite-installer.ts` that previously had **no unit guard** — `.claude/rules/prereq-installer.md` marked them "Guard: none — candidate".

## Invariants pinned

1. **`runCommand` flips `shell: true` on Windows ONLY for `.cmd`/`.bat`** (the CVE-2024-27980 EINVAL mitigation). Real `.exe`/bare paths stay `shell: false`, preserving the no-shell-injection guarantee; non-Windows never uses the shell. The inline decision was extracted into a pure exported `shouldUseShell(cmd, platform)` so the test pins the decision **without spawning real processes**. This test is platform-independent.

2. **`getRegPath()` returns a QUOTED path; `getPowerShellPath()` returns UNQUOTED.** The asymmetry is load-bearing: `getRegPath` is interpolated into a `cmd.exe` `execSync` string (which parses the quotes), while `getPowerShellPath` is the `file` arg of `execFile(..., {shell:false})` where embedded quotes become part of the filename → `ENOENT` (verified empirically 2026-05-21). Both helpers are now exported. These assertions read System32 via `fs.existsSync`, so they only resolve to real absolute paths on Windows — the block is `describe.runIf(process.platform === 'win32')` (desktop CI is ubuntu and skips them; they run locally on Windows).

## Diff shape

Minimal: added `export` to `getRegPath`/`getPowerShellPath`, extracted the one-line shell decision into an exported pure `shouldUseShell`, plus the new test file. No behavior change. WHY comments added for the non-developer maintainer.

Discharges the rule's "Guard: none — candidate" line for the `runCommand` / path-quoting invariants.

## Verification

- `npx vitest run tests/prerequisite-installer-pins.test.ts` → 5 passed
- `npx tsc --noEmit -p tsconfig.json` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)