### PR TITLE
fix: gate /fast and /effort PTY sends behind the pending-interaction guard

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2889,6 +2889,11 @@ function AppInner() {
           postSwitchTurnReady.current = false;
           (window.claude as any).model?.setPreference(m);
         }}
+        // /fast and /effort are PTY writes just like /model — route them
+        // through the same pending-prompt gate so they can't answer a live Ink
+        // menu (stray-Enter fix, youcoded#110). Returns false when refused so
+        // the popup skips its optimistic state writes.
+        sendPtyCommand={(text) => (sessionId ? guardedPtySend(sessionId, text) : false)}
         provider={currentSession?.provider}
         // Native model picker — the live bound modelId + a refresh callback so
         // the header reflects a mid-session swap (SessionInfo.model is the pill's

--- a/desktop/src/renderer/components/ModelPickerPopup.tsx
+++ b/desktop/src/renderer/components/ModelPickerPopup.tsx
@@ -142,9 +142,15 @@ interface Props {
   /** Native only — called after a successful setBinding so App can refresh its
    *  record of the session's model (the header pill sources SessionInfo.model). */
   onNativeModelChanged?: (modelId: string) => void;
+  /** Guarded PTY sender (App.guardedPtySend). /fast and /effort are PTY writes
+   *  just like /model — while a permission/plan/AskUserQuestion prompt is
+   *  pending, CC's Ink select menu is live in the PTY and a raw sendInput would
+   *  answer the menu instead of running the command (stray-Enter fix,
+   *  youcoded#110). Returns false when the send was refused. */
+  sendPtyCommand: (text: string) => boolean;
 }
 
-export default function ModelPickerPopup({ open, onClose, sessionId, currentModel, onSelectModel, provider, currentModelId, onNativeModelChanged }: Props) {
+export default function ModelPickerPopup({ open, onClose, sessionId, currentModel, onSelectModel, provider, currentModelId, onNativeModelChanged, sendPtyCommand }: Props) {
   useEscClose(open, onClose);
   const [fast, setFast] = useState(false);
   const [effort, setEffort] = useState<EffortLevel>('auto');
@@ -219,13 +225,15 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
   };
 
   const applyFast = (v: boolean) => {
+    // Forward to Claude Code via PTY first, guarded (pending-prompt gate) —
+    // a raw sendInput while CC shows an interactive prompt would answer the
+    // live Ink menu instead of running /fast. Refusing BEFORE the optimistic
+    // state writes keeps the toggle truthful when the command never reached
+    // CC. Mirrors the guarded /model path in App.onSelectModel.
+    if (sessionId && !sendPtyCommand(`/fast ${v ? 'on' : 'off'}\r`)) return;
     setFast(v);
     const api = (window.claude as any).modes;
     api?.set({ fast: v }).catch(() => {});
-    // Forward to Claude Code via PTY — command affects the running session
-    if (sessionId) {
-      window.claude.session.sendInput(sessionId, `/fast ${v ? 'on' : 'off'}\r`);
-    }
   };
 
   const handleFastToggle = () => {
@@ -239,12 +247,12 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
   };
 
   const updateEffort = (level: EffortLevel) => {
+    // Guarded like applyFast above — don't let /effort answer a live Ink
+    // prompt, and don't record a level CC never received.
+    if (sessionId && !sendPtyCommand(`/effort ${level}\r`)) return;
     setEffort(level);
     const api = (window.claude as any).modes;
     api?.set({ effort: level }).catch(() => {});
-    if (sessionId) {
-      window.claude.session.sendInput(sessionId, `/effort ${level}\r`);
-    }
   };
 
   if (!open) return null;


### PR DESCRIPTION
## Problem

In `ModelPickerPopup.tsx`, the `/fast` and `/effort` toggles called `window.claude.session.sendInput(sessionId, ...)` directly, with no `hasPendingInteraction` check. While Claude Code is showing an interactive Ink menu or prompt in the PTY (permission request, plan approval, AskUserQuestion), the sent text gets eaten as menu input and the trailing `\r` presses Enter on the highlighted option — silently answering the live prompt instead of running the slash command. This is the same failure mode as the stray-Enter fix (#110), and the `/model` send in this same popup was already fixed by routing through `App.guardedPtySend`.

## Fix

Mirror the established `/model` pattern:

- `App.tsx` threads a new `sendPtyCommand` prop into `ModelPickerPopup`, wired to the existing `guardedPtySend` helper (block + "Claude is waiting for your response — answer the prompt first." toast when a prompt is pending; returns `false` when the send was refused).
- `applyFast` and `updateEffort` now send through that guard FIRST, and skip their optimistic state writes (`setFast`/`setEffort` + `modes.set` persistence) when the send is refused — so the toggle/level shown in the UI never records a value Claude Code never received. This matches the "refuse before optimistic state writes" convention the `onSelectModel` handler documents.

No behavior change when no prompt is pending, and none for native-runtime sessions (their picker branch never sends PTY slash commands).

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 2010 passed / 1 failed: `sync-spaces-project-discovery.test.ts` timed out under full-suite load but passes in isolation; unrelated to this renderer-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)