### PR TITLE
feat(local-models): post-boot catalog rescan (K2) + orphaned .partial scan IPC

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3578,6 +3578,7 @@ class SessionService : Service() {
             "models:download-cancel",
             "models:delete",
             "models:installed",
+            "models:orphaned-partials",  // orphaned .partial scan (2026-07-15) — desktop-only
             "endpoints:detect",
             // Model memory lifecycle (2026-07-14) — per-model residency, memory
             // guard, [Reload Model]. Desktop-only; no Android runtime. The push

--- a/desktop/src/main/engine/cache-scan.ts
+++ b/desktop/src/main/engine/cache-scan.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { EngineModel } from '../../shared/engine-types';
+import type { OrphanedPartial } from '../../shared/model-manager-types';
 
 // llama.cpp split-GGUF convention: <name>-00001-of-000NN.gguf. The model is
 // addressed through its FIRST part; other parts are the same model's payload.
@@ -50,4 +51,38 @@ export function scanGgufCache(cacheDir: string): EngineModel[] {
     if (first && first.sizeBytes !== null) first.sizeBytes += extra;
   }
   return [...out.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Scan the cache dir for `.gguf.partial` files — the downloader's in-flight
+ *  bytes (model-downloader.ts writes `<final>.partial`, publish is a rename).
+ *  A partial left behind by an app restart is invisible everywhere else: the
+ *  router and scanGgufCache only see `.gguf`, and the downloader only tracks
+ *  THIS session's downloads in memory. This scan is how the UI finds orphans
+ *  so they can be cleaned or resumed. The caller (ModelManager) filters out
+ *  partials that belong to a download currently running in this session. */
+export function scanPartialFiles(cacheDir: string): OrphanedPartial[] {
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(cacheDir, { withFileTypes: true });
+  } catch {
+    return []; // cache dir not created yet — no partials, not an error
+  }
+  const out: OrphanedPartial[] = [];
+  for (const ent of entries) {
+    if (!ent.isFile() || !/\.gguf\.partial$/i.test(ent.name)) continue;
+    let stat: fs.Stats;
+    try { stat = fs.statSync(path.join(cacheDir, ent.name)); } catch { continue; } // raced delete
+    // The final file this partial was downloading, e.g. 'M-Q4_K_M.gguf'.
+    const finalName = ent.name.replace(/\.partial$/i, '');
+    const partialId = ggufIdFromFileName(finalName);
+    // models:delete addresses a split model through its FIRST part and removes
+    // every sibling part + .partial — so report the first-part id for splits,
+    // making the row directly cleanable with the existing delete IPC.
+    const part = PART_RE.exec(finalName);
+    const modelId = part
+      ? partialId.replace(/-\d{5}-of-\d{5}$/, `-00001-of-${part[2]}`)
+      : partialId;
+    out.push({ fileName: ent.name, modelId, sizeBytes: stat.size, mtimeMs: stat.mtimeMs });
+  }
+  return out.sort((a, b) => a.fileName.localeCompare(b.fileName));
 }

--- a/desktop/src/main/engine/engine-supervisor.ts
+++ b/desktop/src/main/engine/engine-supervisor.ts
@@ -332,7 +332,9 @@ export class EngineSupervisor extends EventEmitter {
 
   // ---- model listing ----------------------------------------------------
 
-  /** Running → GET /models (live status); stopped → cache scan (loaded:false).
+  /** Running → GET /models (live status) UNIONED with a fresh disk scan, so a
+   *  model downloaded after boot is listed without a restart (Amendment K2);
+   *  stopped → cache scan alone (loaded:false).
    *  Upstream /models schema is a tracked coupling — parse DEFENSIVELY, and
    *  keep the exact observed shape pinned in test-engine/probe-models.mjs +
    *  docs/engine-dependencies.md. */
@@ -347,8 +349,9 @@ export class EngineSupervisor extends EventEmitter {
         : Array.isArray(payload) ? payload : [];
       // /models rows carry no size — the cache scan does, so index sizes by id
       // and merge them in (the UI's loading banner shows the model size).
+      const scanned = scanGgufCache(this.opts.cacheDir);
       const sizeById = new Map<string, number | null>();
-      for (const m of scanGgufCache(this.opts.cacheDir)) sizeById.set(m.id, m.sizeBytes);
+      for (const m of scanned) sizeById.set(m.id, m.sizeBytes);
       const out: EngineModel[] = [];
       for (const row of rows) {
         const id = typeof row?.id === 'string' ? row.id : typeof row?.name === 'string' ? row.name : null;
@@ -366,6 +369,16 @@ export class EngineSupervisor extends EventEmitter {
           loaded: state === 'loaded',
           state,
         });
+      }
+      // Fix (Amendment K2): the router discovers GGUFs at BOOT, and whether a
+      // file downloaded AFTER boot ever shows up in GET /models is unverified
+      // upstream — so union in the fresh disk scan. A just-downloaded model is
+      // then immediately visible (new-session picker via catalogModels, memory
+      // guard via liveModels) without an engine restart. Router rows win — they
+      // carry live residency state; disk-only rows are 'unloaded' by definition.
+      const routerIds = new Set(out.map((m) => m.id));
+      for (const m of scanned) {
+        if (!routerIds.has(m.id)) out.push(m);
       }
       return out;
     } catch {

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -1988,6 +1988,10 @@ export function registerIpcHandlers(
   ipcMain.handle(IPC.MODELS_DOWNLOAD_CANCEL, async (_e, downloadId: string) => { modelManager.cancel(downloadId); return true; });
   ipcMain.handle(IPC.MODELS_DELETE, async (_e, id: string) => { await engineManager.deleteModel(id); return true; });
   ipcMain.handle(IPC.MODELS_INSTALLED, async () => engineManager.installedModels());
+  // Orphaned .partial scan (2026-07-15): .partial files left by a PREVIOUS app
+  // run are invisible to the in-memory downloader — this lets the UI list them
+  // (clean via models:delete; resume by re-starting the same download).
+  ipcMain.handle(IPC.MODELS_ORPHANED_PARTIALS, async () => modelManager.orphanedPartials());
   ipcMain.handle(IPC.ENDPOINTS_DETECT, async () =>
     detectEndpoints(fetch, ((await providerRegistry.list()) as any[])));
   // /clear and /compact both truncate or rewrite the JSONL. App.tsx listens

--- a/desktop/src/main/models/model-downloader.ts
+++ b/desktop/src/main/models/model-downloader.ts
@@ -23,6 +23,7 @@ interface ActiveDownload {
   abort: AbortController;
   promise: Promise<void>;
   cancelled: boolean;
+  fileNames: string[];               // basenames this download writes — the orphan scan excludes their .partials
 }
 
 export class ModelDownloader {
@@ -39,7 +40,10 @@ export class ModelDownloader {
     }
     const downloadId = ulid();
     const abort = new AbortController();
-    const entry: ActiveDownload = { key, abort, cancelled: false, promise: Promise.resolve() };
+    const entry: ActiveDownload = {
+      key, abort, cancelled: false, promise: Promise.resolve(),
+      fileNames: quant.files.map((f) => path.basename(f)),
+    };
     entry.promise = this.run(downloadId, repo, quant, entry, onProgress)
       .finally(() => { /* keep the entry until wait() consumers observe it */ });
     this.active.set(downloadId, entry);
@@ -57,6 +61,17 @@ export class ModelDownloader {
     if (!entry) return;
     entry.cancelled = true;
     entry.abort.abort();
+  }
+
+  /** Basenames of the `.partial` files THIS session's live downloads may be
+   *  writing. The orphan scan (ModelManager.orphanedPartials) subtracts these —
+   *  an in-flight download is not an orphan, it's just not finished yet. */
+  activePartialNames(): Set<string> {
+    const out = new Set<string>();
+    for (const d of this.active.values()) {
+      for (const name of d.fileNames) out.add(`${name}.partial`);
+    }
+    return out;
   }
 
   private async run(

--- a/desktop/src/main/models/model-manager.ts
+++ b/desktop/src/main/models/model-manager.ts
@@ -8,13 +8,14 @@ import * as path from 'path';
 import { NativeHome } from '../native-home';
 import { EngineManager } from '../engine/engine-manager';
 import { readEngineConfig } from '../engine/engine-config';
+import { scanPartialFiles } from '../engine/cache-scan';
 import { CuratedCatalog } from './curated-catalog';
 import { HfClient } from './hf-client';
 import { ModelDownloader } from './model-downloader';
 import { estimateFit, checkDiskSpace, checkMemoryForLoad, type MemoryVerdict } from './fit-estimator';
 import { detectGpu } from './gpu-detector';
 import type {
-  CuratedModel, DownloadProgress, FitEstimate, HFSearchHit, QuantOption,
+  CuratedModel, DownloadProgress, FitEstimate, HFSearchHit, OrphanedPartial, QuantOption,
 } from '../../shared/model-manager-types';
 
 export class ModelManager extends EventEmitter {
@@ -137,4 +138,15 @@ export class ModelManager extends EventEmitter {
   }
 
   cancel(downloadId: string): void { this.getDownloader().cancel(downloadId); }
+
+  /** `.partial` files in the cache dir with no live download attached — orphans
+   *  from a previous app run (quit/crash mid-download). The downloader only
+   *  tracks THIS session's downloads in memory, so these are otherwise invisible
+   *  to the UI. Listing only (v1): the panel cleans one via models:delete with
+   *  `modelId` (delete removes every part + .partial), or resumes by re-starting
+   *  the same repo+quant download (the Range request continues the partial). */
+  orphanedPartials(): OrphanedPartial[] {
+    const active = this.getDownloader().activePartialNames();
+    return scanPartialFiles(this.cacheDir()).filter((p) => !active.has(p.fileName));
+  }
 }

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -324,6 +324,7 @@ const IPC = {
   MODELS_DOWNLOAD_PROGRESS: 'models:download-progress',  // push
   MODELS_DELETE: 'models:delete',
   MODELS_INSTALLED: 'models:installed',
+  MODELS_ORPHANED_PARTIALS: 'models:orphaned-partials',
   ENDPOINTS_DETECT: 'endpoints:detect',
   // Model memory lifecycle (2026-07-14) — keep in sync with shared/types.ts.
   ENGINE_MODELS: 'engine:models',
@@ -1125,6 +1126,9 @@ contextBridge.exposeInMainWorld('claude', {
     downloadCancel: (downloadId: string) => ipcRenderer.invoke(IPC.MODELS_DOWNLOAD_CANCEL, downloadId),
     delete: (id: string) => ipcRenderer.invoke(IPC.MODELS_DELETE, id),
     installed: () => ipcRenderer.invoke(IPC.MODELS_INSTALLED),
+    // Orphaned .partial files from a previous app run (clean via delete(modelId),
+    // resume by re-downloading the same repo+quant — Range continues the bytes).
+    orphanedPartials: () => ipcRenderer.invoke(IPC.MODELS_ORPHANED_PARTIALS),
     detectEndpoints: () => ipcRenderer.invoke(IPC.ENDPOINTS_DETECT),
     setBackend: (backend: string) => ipcRenderer.invoke(IPC.ENGINE_SET_BACKEND, backend),
     // Create-time / swap memory guard + [Reload Model] (2026-07-14).

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -852,6 +852,16 @@ export class RemoteServer {
         }
         break;
       }
+      // Orphaned .partial scan (2026-07-15) — mirrors the Electron IPC handler.
+      case 'models:orphaned-partials': {
+        try {
+          const res = this.nativeRuntime ? this.nativeRuntime.modelManager.orphanedPartials() : [];
+          this.respond(client.ws, type, id, res);
+        } catch (err: any) {
+          this.respond(client.ws, type, id, { ok: false, error: err?.message ?? String(err) });
+        }
+        break;
+      }
       case 'engine:models': {
         try {
           const res = this.nativeRuntime ? await this.nativeRuntime.engineManager.liveModels() : [];

--- a/desktop/src/renderer/hooks/useIpc.ts
+++ b/desktop/src/renderer/hooks/useIpc.ts
@@ -289,6 +289,9 @@ declare global {
         downloadCancel: (downloadId: string) => Promise<boolean>;
         delete: (id: string) => Promise<boolean>;
         installed: () => Promise<any[]>;
+        // Orphaned .partial files from a previous app run (2026-07-15) — clean
+        // via delete(modelId); resume by re-downloading the same repo+quant.
+        orphanedPartials: () => Promise<import('../../shared/model-manager-types').OrphanedPartial[]>;
         detectEndpoints: () => Promise<any[]>;
         setBackend: (backend: string) => Promise<any>;
         onDownloadProgress: (cb: (p: any) => void) => () => void;

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1461,6 +1461,7 @@ export function installShim(): void {
       downloadCancel: (downloadId: string) => invoke('models:download-cancel', { downloadId }),
       delete: (id: string) => invoke('models:delete', { id }),
       installed: () => invoke('models:installed'),
+      orphanedPartials: () => invoke('models:orphaned-partials'),
       detectEndpoints: () => invoke('endpoints:detect'),
       setBackend: (backend: string) => invoke('engine:set-backend', { backend }),
       memoryCheck: (modelId: string) => invoke('models:memory-check', { modelId }),

--- a/desktop/src/shared/model-manager-types.ts
+++ b/desktop/src/shared/model-manager-types.ts
@@ -71,6 +71,20 @@ export interface InstalledLocalModel {
   parts: number;              // 1 for single-file models
 }
 
+/** A `.gguf.partial` file in the cache dir with NO live download attached —
+ *  orphaned by an app restart/crash mid-download. The downloader only tracks
+ *  THIS session's downloads in memory, so without this scan an orphan is
+ *  invisible to the UI (it can't be resumed or cleaned). Listing only in v1:
+ *  clean via models:delete with `modelId` (it removes every part + .partial),
+ *  resume by re-starting the same repo+quant download (the Range request picks
+ *  the partial bytes back up). */
+export interface OrphanedPartial {
+  fileName: string;   // e.g. 'M-Q4_K_M.gguf.partial' — the on-disk file
+  modelId: string;    // the id models:delete expects (first-part id for splits)
+  sizeBytes: number;  // bytes downloaded so far
+  mtimeMs: number;    // last write time — shows how stale the orphan is
+}
+
 export interface DetectedEndpoint {
   kind: 'ollama' | 'lmstudio';
   label: string;              // 'Ollama (local)' / 'LM Studio (local)'

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -944,6 +944,9 @@ export const IPC = {
   MODELS_DOWNLOAD_PROGRESS: 'models:download-progress',  // push
   MODELS_DELETE: 'models:delete',
   MODELS_INSTALLED: 'models:installed',
+  // Orphaned .partial scan (2026-07-15) — invoke → OrphanedPartial[]; lists
+  // .partial files left by a PREVIOUS app run so the UI can clean/resume them.
+  MODELS_ORPHANED_PARTIALS: 'models:orphaned-partials',
   ENDPOINTS_DETECT: 'endpoints:detect',
   // ---- Model memory lifecycle (2026-07-14): per-model residency + guards ----
   ENGINE_MODELS: 'engine:models',                 // invoke → EngineModel[] with live state

--- a/desktop/tests/cache-scan.test.ts
+++ b/desktop/tests/cache-scan.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { scanGgufCache, ggufIdFromFileName } from '../src/main/engine/cache-scan';
+import { scanGgufCache, scanPartialFiles, ggufIdFromFileName } from '../src/main/engine/cache-scan';
 
 let dir: string;
 beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gguf-cache-')); });
@@ -37,5 +37,41 @@ describe('scanGgufCache', () => {
 
   it('ggufIdFromFileName strips the extension only (router ids are filename-based)', () => {
     expect(ggufIdFromFileName('foo-Q4_K_M.gguf')).toBe('foo-Q4_K_M');
+  });
+});
+
+// Orphaned-.partial surfacing (2026-07-15): a .partial left by a previous app
+// run is invisible to scanGgufCache AND to the in-memory downloader — this scan
+// is the UI's only way to find it (models:orphaned-partials).
+describe('scanPartialFiles', () => {
+  it('lists .gguf.partial files with size + mtime; ignores whole .gguf files and unrelated files', () => {
+    touch('M-Q4_K_M.gguf.partial', 12);
+    touch('Finished-Q4_K_M.gguf', 99);   // published model — not a partial
+    touch('notes.txt.partial');          // not a GGUF download — ignored
+    const partials = scanPartialFiles(dir);
+    expect(partials).toHaveLength(1);
+    expect(partials[0]).toMatchObject({
+      fileName: 'M-Q4_K_M.gguf.partial',
+      modelId: 'M-Q4_K_M',
+      sizeBytes: 12,
+    });
+    // mtime comes from a real stat — just assert it's a plausible timestamp.
+    expect(partials[0].mtimeMs).toBeGreaterThan(0);
+  });
+
+  it('maps a multi-part .partial to the FIRST-part id (what models:delete expects)', () => {
+    touch('Big-UD-Q4_K_XL-00003-of-00005.gguf.partial', 7);
+    const partials = scanPartialFiles(dir);
+    expect(partials).toEqual([expect.objectContaining({
+      fileName: 'Big-UD-Q4_K_XL-00003-of-00005.gguf.partial',
+      // deleteModel('…-00001-of-00005') removes every sibling part + .partial,
+      // so this id makes the orphan row directly cleanable.
+      modelId: 'Big-UD-Q4_K_XL-00001-of-00005',
+      sizeBytes: 7,
+    })]);
+  });
+
+  it('returns [] for a missing directory', () => {
+    expect(scanPartialFiles(path.join(dir, 'nope'))).toEqual([]);
   });
 });

--- a/desktop/tests/engine-supervisor.test.ts
+++ b/desktop/tests/engine-supervisor.test.ts
@@ -213,6 +213,38 @@ describe('EngineSupervisor', () => {
     expect(models).toEqual([{ id: 'foo-Q4_K_M', sizeBytes: null, loaded: true, state: 'loaded' }]);
   });
 
+  it('listModels UNIONS the disk scan into GET /models — a GGUF downloaded after boot is listed without a restart (Amendment K2)', async () => {
+    // Real temp cache dir: fs.readdirSync/statSync are NOT mocked (only
+    // mkdirSync is), so scanGgufCache reads real files dropped here.
+    const realFs = await vi.importActual<typeof import('fs')>('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const cacheDir = realFs.mkdtempSync(path.join(os.tmpdir(), 'k2-cache-'));
+    try {
+      mockSpawn.mockReturnValue(makeFakeChild());
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (String(url).endsWith('/health')) return { ok: true, status: 200 } as any;
+        if (String(url).endsWith('/models')) {
+          // The router only knows what it discovered at BOOT.
+          return { ok: true, status: 200, json: async () => ({ data: [{ id: 'boot-model-Q4_K_M', status: { value: 'loaded' } }] }) } as any;
+        }
+        return { ok: false, status: 404 } as any;
+      });
+      sup = makeSupervisor(fetchImpl, { cacheDir });
+      await sup.ensureRunning();
+      // Simulate a download finishing AFTER boot: the file just appears on disk.
+      realFs.writeFileSync(path.join(cacheDir, 'boot-model-Q4_K_M.gguf'), Buffer.alloc(4));
+      realFs.writeFileSync(path.join(cacheDir, 'downloaded-later-Q4_K_M.gguf'), Buffer.alloc(8));
+      const byId = Object.fromEntries((await sup.listModels()).map((m) => [m.id, m]));
+      // The router's row wins for the model it knows (live residency state)…
+      expect(byId['boot-model-Q4_K_M']).toMatchObject({ state: 'loaded', sizeBytes: 4 });
+      // …and the post-boot download is unioned in from the scan as 'unloaded'.
+      expect(byId['downloaded-later-Q4_K_M']).toMatchObject({ state: 'unloaded', loaded: false, sizeBytes: 8 });
+    } finally {
+      realFs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
   it('listModels maps /models status.value → EngineModelState (unknown → unloaded)', async () => {
     mockSpawn.mockReturnValue(makeFakeChild());
     const fetchImpl = vi.fn(async (url: string) => {

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -768,6 +768,9 @@ describe('models:* + engine:set-* channel parity (Plan C)', () => {
     ['models:download-cancel', 'MODELS_DOWNLOAD_CANCEL'],
     ['models:delete', 'MODELS_DELETE'],
     ['models:installed', 'MODELS_INSTALLED'],
+    // Orphaned .partial scan (2026-07-15) — Android stubs it like the rest of
+    // the desktop-only model-manager surface.
+    ['models:orphaned-partials', 'MODELS_ORPHANED_PARTIALS'],
     ['endpoints:detect', 'ENDPOINTS_DETECT'],
   ];
   const pushChannels = ['models:download-progress'];

--- a/desktop/tests/model-downloader.test.ts
+++ b/desktop/tests/model-downloader.test.ts
@@ -121,4 +121,19 @@ describe('ModelDownloader', () => {
     expect(() => dl.start('unsloth/M-GGUF', quantOpt(), () => {})).toThrow(/already/i);
     await dl.wait(id);
   });
+
+  it('activePartialNames: reports in-flight .partial basenames, empty once the download settles (orphan-scan exclusion)', async () => {
+    const dl = new ModelDownloader(dir, fetchServing(bodies));
+    expect(dl.activePartialNames().size).toBe(0);
+    const id = dl.start('unsloth/M-GGUF', quantOpt(), () => {});
+    // While live, every file of the quant is claimed (basenames + .partial) —
+    // ModelManager.orphanedPartials subtracts these so an in-flight download
+    // is never mislabeled an orphan.
+    expect([...dl.activePartialNames()].sort()).toEqual([
+      'M-UD-Q4_K_XL-00001-of-00002.gguf.partial',
+      'M-UD-Q4_K_XL-00002-of-00002.gguf.partial',
+    ]);
+    await dl.wait(id);
+    expect(dl.activePartialNames().size).toBe(0);
+  });
 });

--- a/docs/engine-dependencies.md
+++ b/docs/engine-dependencies.md
@@ -157,14 +157,19 @@ first part and cache-scan sums the parts' sizes into one entry.
   downloaded on a 32 GB dev box. **PASS on b9992** (Windows x64 Vulkan,
   `Qwen3-0.6B-Q4_K_M` single + `Qwen3-0.6B-SPLIT-00001-of-00002`), 2026-07-14 —
   router discovered both ids from `--models-dir` and served the split model.
-- **Router hot-reload of `--models-dir` after boot — NOT yet verified live.** The
-  router discovers GGUFs at BOOT; whether a file downloaded AFTER boot appears in
-  `GET /models` (→ `catalogModels()` → the new-session picker's Local group)
-  without an engine restart is an open live-acceptance item (Amendment K2). The
-  Installed list (`scanGgufCache`) updates instantly regardless; the documented
-  mitigation is an engine restart (or a `scanGgufCache` fallback in the local
-  catalog source) after a download so a just-downloaded model is immediately
-  selectable. Resolve on Destin's dev machine during the Plan C live pass.
+- **Router hot-reload of `--models-dir` after boot — worked around in code
+  (2026-07-15); upstream behavior still NOT verified live.** The router discovers
+  GGUFs at BOOT; whether a file downloaded AFTER boot appears in `GET /models` is
+  unverified upstream (Amendment K2). `EngineSupervisor.listModels()` therefore
+  UNIONS a fresh `scanGgufCache` into the running router's `GET /models` rows
+  (router rows win — they carry live residency state; disk-only rows surface as
+  'unloaded'), so a just-downloaded model is immediately visible in
+  `catalogModels()` → the new-session picker's Local group, `liveModels()` → the
+  memory guard, and the model poll — no engine restart needed for LISTING.
+  Guard: engine-supervisor.test.ts "listModels UNIONS the disk scan". Still open
+  for the live pass: whether the running router can actually SERVE (hot-load) a
+  post-boot file when a completion requests it, or 400s until a restart — resolve
+  on Destin's dev machine.
 
 ## Verification
 


### PR DESCRIPTION
Two Plan C follow-ups from the 2026-07-15 PITFALLS sweep, both in the local-models subsystem. Premises were code-verified before implementing.

## Item A — Amendment K2: models downloaded after engine boot

**Verified premise:** `catalogModels()` → `EngineSupervisor.listModels()`. When the engine is *stopped*, the list already comes from a fresh `scanGgufCache` (always current). But when the engine is *running*, the list came solely from the router's `GET /models` — and the router discovers GGUFs at **boot**; whether it ever re-scans `--models-dir` is unverified upstream (`docs/engine-dependencies.md`, Amendment K2). So a GGUF downloaded while the engine was running could be missing from the new-session picker's Local group until an engine restart.

**Fix:** `listModels()` now unions a fresh disk scan into the router rows. Router rows win (they carry live residency state); disk-only rows surface as `unloaded`. One choke point fixes every consumer: `catalogModels()` (picker), `liveModels()` (create-time memory guard), and the model poll (`models-changed` → per-session banners).

**Still open for the live pass:** whether the running router can actually *serve* (hot-load) a post-boot file when a completion requests it, or 400s until a restart. Noted in `docs/engine-dependencies.md`; resolve on the dev machine during Plan C live acceptance.

## Item B — surface orphaned `.partial` files

**Verified premise:** `ModelDownloader.active` is an in-memory `Map`; `scanGgufCache` filters `\.gguf$`. A `.partial` file left behind by an app restart mid-download was invisible to the UI — it couldn't be resumed or cleaned (only a `models:delete` of the *same model* would incidentally remove it).

**Fix — new `models:orphaned-partials` IPC (listing only, v1):**
- `scanPartialFiles()` (pure, in `cache-scan.ts`) lists `*.gguf.partial` files with `fileName`, `sizeBytes`, `mtimeMs`, and `modelId` — the id `models:delete` expects (first-part id for split models), so each row is directly cleanable with the **existing** delete IPC.
- `ModelDownloader.activePartialNames()` + `ModelManager.orphanedPartials()` exclude this session's in-flight downloads, so a live download is never mislabeled an orphan.
- Wired through `shared/types.ts` + preload (`window.claude.models.orphanedPartials()`), `remote-shim.ts`, `remote-server.ts` WS case, and the standard `not-implemented-on-mobile` stub in `SessionService.kt` (native runtime is desktop-only — same convention as the rest of the `models:*` surface). Channel parity pinned in `ipc-channels.test.ts`.
- **Resume path:** re-starting the same repo+quant download resumes automatically via the existing Range logic — no new IPC needed.

**Documented follow-up (not in this PR):** the Local Models panel UI to render orphan rows (size, age, Clean up / Resume actions) on top of this plumbing.

## Verification

- New unit tests: supervisor union (real temp cache dir + mocked router), `scanPartialFiles` (single + multi-part id mapping + missing dir), `activePartialNames` lifecycle, parity-test channel row.
- Full desktop suite: **2016 passed / 34 skipped**; `tsc --noEmit` clean.
- Not verified live against a real `llama-server` (spawning the real engine is out of scope for this pass) — the K2 serving question stays open as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)