### PR TITLE
chore: CC v2.1.211 built-in command lists + auto-mode red-stall classifier fixtures

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/CommandProvider.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/CommandProvider.kt
@@ -9,7 +9,12 @@ import java.io.File
 // see docs/cc-dependencies.md entry "CC built-in command list" and
 // docs/superpowers/specs/2026-04-21-command-drawer-search-commands-design.md.
 //
-// Last verified against Claude Code CLI v2.1.117 — 2026-04-21.
+// Last verified against Claude Code CLI v2.1.211 — 2026-07-15.
+//
+// Intentionally EXCLUDED (issue #85): top-level CLI subcommands are not
+// in-session slash commands, so they never belong in the CommandDrawer —
+// notably `claude project purge` (v2.1.126; destructive: deletes all CC
+// state for a project) and `claude ultrareview` (v2.1.120; CI runner).
 class CommandProvider(
   private val homeDir: File,
   private val skillProvider: LocalSkillProvider,
@@ -138,7 +143,8 @@ class CommandProvider(
       ccBuiltin("/status",          "Show session, config, and auth status"),
       ccBuiltin("/permissions",     "Manage tool permissions"),
       ccBuiltin("/memory",          "Edit CLAUDE.md memory files"),
-      ccBuiltin("/agents",          "Manage subagents"),
+      // /agents removed: CC v2.1.198 deleted the /agents wizard — the command
+      // now only prints a removal notice, so don't surface it in search.
       ccBuiltin("/mcp",             "Manage MCP servers"),
       ccBuiltin("/plugin",          "Manage plugins"),
       ccBuiltin("/hooks",           "Manage hooks"),
@@ -148,10 +154,17 @@ class CommandProvider(
       ccBuiltin("/review",          "Review a pull request"),
       ccBuiltin("/security-review", "Review pending changes for security issues"),
       ccBuiltin("/init",            "Initialize a CLAUDE.md file"),
-      ccBuiltin("/extra-usage",     "Show detailed usage data"),
+      // /extra-usage was renamed to /usage-credits in CC v2.1.144 (the old
+      // name still works as an alias); list the new canonical name only.
+      ccBuiltin("/usage-credits",   "Configure usage credits"),
       ccBuiltin("/heapdump",        "Dump a heap snapshot"),
       ccBuiltin("/insights",        "Show session insights"),
       ccBuiltin("/team-onboarding", "Team setup flow"),
+      // Added between the v2.1.117 and v2.1.211 anchors (issue #85 gap review):
+      ccBuiltin("/cd",              "Move this session to a new working directory"), // CC v2.1.169
+      ccBuiltin("/goal",            "Set a goal Claude checks before stopping"),     // CC v2.1.139
+      ccBuiltin("/reload-skills",   "Re-scan skill directories without restarting"), // CC v2.1.152
+      ccBuiltin("/scroll-speed",    "Adjust mouse wheel scroll speed"),              // CC v2.1.139
     )
 
     private fun youcoded(name: String, description: String) = JSONObject().apply {

--- a/desktop/src/main/cc-builtin-commands.ts
+++ b/desktop/src/main/cc-builtin-commands.ts
@@ -1,7 +1,13 @@
 // Hardcoded list of Claude Code built-in slash commands.
 //
-// Last verified against Claude Code CLI v2.1.117 — 2026-04-21.
+// Last verified against Claude Code CLI v2.1.211 — 2026-07-15.
 // Update this stamp when re-verified; see docs/cc-dependencies.md.
+//
+// Intentionally EXCLUDED (issue #85): top-level CLI subcommands are not
+// in-session slash commands, so they never belong in the CommandDrawer —
+// notably `claude project purge` (v2.1.126; destructive: deletes all CC
+// state for a project) and `claude ultrareview` (v2.1.120; CI runner).
+// Typing them into the PTY as `/project purge` would do nothing.
 //
 // Why hardcoded: Claude Code ships as a compiled binary with no filesystem-
 // discoverable manifest for its built-in commands. The SDK init message
@@ -26,7 +32,9 @@ export const CC_BUILTIN_COMMANDS: CommandEntry[] = [
   { name: '/status',          description: 'Show session, config, and auth status',            source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/status') },
   { name: '/permissions',     description: 'Manage tool permissions',                          source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/permissions') },
   { name: '/memory',          description: 'Edit CLAUDE.md memory files',                      source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/memory') },
-  { name: '/agents',          description: 'Manage subagents',                                 source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/agents') },
+  // /agents removed: CC v2.1.198 deleted the /agents wizard — the command now
+  // only prints "The /agents wizard has been removed." (verified against the
+  // v2.1.211 binary), so surfacing it in search would point users at a stub.
   { name: '/mcp',             description: 'Manage MCP servers',                               source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/mcp') },
   { name: '/plugin',          description: 'Manage plugins',                                   source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/plugin') },
   { name: '/hooks',           description: 'Manage hooks',                                     source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/hooks') },
@@ -36,8 +44,15 @@ export const CC_BUILTIN_COMMANDS: CommandEntry[] = [
   { name: '/review',          description: 'Review a pull request',                            source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/review') },
   { name: '/security-review', description: 'Review pending changes for security issues',       source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/security-review') },
   { name: '/init',            description: 'Initialize a CLAUDE.md file',                      source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/init') },
-  { name: '/extra-usage',     description: 'Show detailed usage data',                         source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/extra-usage') },
+  // /extra-usage was renamed to /usage-credits in CC v2.1.144 (the old name
+  // still works as an alias); list the new canonical name only.
+  { name: '/usage-credits',   description: 'Configure usage credits',                          source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/usage-credits') },
   { name: '/heapdump',        description: 'Dump a heap snapshot',                             source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/heapdump') },
   { name: '/insights',        description: 'Show session insights',                            source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/insights') },
   { name: '/team-onboarding', description: 'Team setup flow',                                  source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/team-onboarding') },
+  // Added between the v2.1.117 and v2.1.211 anchors (issue #85 gap review):
+  { name: '/cd',              description: 'Move this session to a new working directory',     source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/cd') },              // CC v2.1.169
+  { name: '/goal',            description: 'Set a goal Claude checks before stopping',         source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/goal') },            // CC v2.1.139
+  { name: '/reload-skills',   description: 'Re-scan skill directories without restarting',     source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/reload-skills') },   // CC v2.1.152
+  { name: '/scroll-speed',    description: 'Adjust mouse wheel scroll speed',                  source: 'cc-builtin', clickable: false, disabledReason: DISABLED_REASON('/scroll-speed') },    // CC v2.1.139
 ];

--- a/shared-fixtures/attention-classifier/auto-mode-red-stall-first-tick.expected.json
+++ b/shared-fixtures/attention-classifier/auto-mode-red-stall-first-tick.expected.json
@@ -1,0 +1,5 @@
+{
+  "class": "thinking-active",
+  "spinnerGlyph": "✳",
+  "counterSeconds": 45
+}

--- a/shared-fixtures/attention-classifier/auto-mode-red-stall-first-tick.input.json
+++ b/shared-fixtures/attention-classifier/auto-mode-red-stall-first-tick.input.json
@@ -1,0 +1,12 @@
+{
+  "description": "CC v2.1.126+ auto-mode red-stalled spinner (permission check stalls → spinner turns red), first classifier tick. The red is pure SGR color — getScreenText feeds the classifier ANSI-stripped text, so the buffer is byte-identical to a healthy spinner line. This fixture pins that the color change alone does NOT alter matching: the glyph still matches SPINNER_RE and a first observation gets the benefit of the doubt (thinking-active). Stall detection is cross-tick — see the companion auto-mode-red-stall-persistent fixture for the ≥30s frozen case. Issue youcoded#87.",
+  "bufferTail": [
+    "⏺ Bash(npm publish)",
+    "  ⎿  Running…",
+    "✳ Effervescing… (45s · ↓ 1.2k tokens)",
+    ""
+  ],
+  "previousSpinnerGlyph": null,
+  "secondsSincePreviousGlyph": 0,
+  "previousCounterSeconds": null
+}

--- a/shared-fixtures/attention-classifier/auto-mode-red-stall-persistent.expected.json
+++ b/shared-fixtures/attention-classifier/auto-mode-red-stall-persistent.expected.json
@@ -1,0 +1,5 @@
+{
+  "class": "thinking-stalled",
+  "spinnerGlyph": "✳",
+  "counterSeconds": 45
+}

--- a/shared-fixtures/attention-classifier/auto-mode-red-stall-persistent.input.json
+++ b/shared-fixtures/attention-classifier/auto-mode-red-stall-persistent.input.json
@@ -1,0 +1,12 @@
+{
+  "description": "CC v2.1.126+ auto-mode red-stalled spinner, persistent case: the permission check has been stalled long enough that the glyph has not rotated for ≥30s AND the paren-wrapped counter is frozen at the same value as the prior tick (CC stops emitting progress while the check hangs). The red color itself is invisible here (ANSI-stripped input) — what the classifier keys on is the absence of cross-tick progress, which correctly yields thinking-stalled. This is the intended state for the scenario in youcoded#87: CC signals a stall, and the classifier agrees via its rotation+counter logic rather than via color.",
+  "bufferTail": [
+    "⏺ Bash(npm publish)",
+    "  ⎿  Running…",
+    "✳ Effervescing… (45s · ↓ 1.2k tokens)",
+    ""
+  ],
+  "previousSpinnerGlyph": "✳",
+  "secondsSincePreviousGlyph": 31,
+  "previousCounterSeconds": 45
+}


### PR DESCRIPTION
Works issues #85 and #87 (both filed against CC v2.1.126). The installed CC is now **v2.1.211**, so the CHANGELOG gap v2.1.117 (the lists' previous anchor) → v2.1.211 was reviewed in full, not just the v2.1.126 entry.

## Issue #85 — CC built-in command lists

Both hand-maintained lists (`desktop/src/main/cc-builtin-commands.ts` and the `CC_BUILTIN_COMMANDS` block in `app/src/main/kotlin/com/youcoded/app/runtime/CommandProvider.kt`) updated in lockstep:

- **`claude project purge` intentionally excluded, with a comment in both files** — it is a top-level CLI subcommand, not an in-session slash command, so it can never work from the CommandDrawer (typing `/project purge` into the PTY does nothing), and it's destructive besides. Same rationale recorded for `claude ultrareview` (v2.1.120).
- **Gap additions:** `/cd` (v2.1.169), `/goal` (v2.1.139), `/reload-skills` (v2.1.152), `/scroll-speed` (v2.1.139). Descriptions lifted from the v2.1.211 binary's own command definitions.
- **Rename:** `/extra-usage` → `/usage-credits` (v2.1.144; old alias still accepted by CC).
- **Removal:** `/agents` — CC v2.1.198 deleted the wizard; the v2.1.211 binary now only prints "The /agents wizard has been removed." so surfacing it in search would point users at a stub.
- Version anchors bumped to **v2.1.211 — 2026-07-15** in both files.

Pre-existing omissions that predate the v2.1.117 anchor (`/rewind`, `/btw`, `/skills`, `/login`, `/upgrade`) were left out of scope.

## Issue #87 — auto-mode red-stalled spinner fixtures

Two new fixture pairs under `shared-fixtures/attention-classifier/`:

- `auto-mode-red-stall-first-tick` — pins that CC's red stall coloring is SGR-only: the ANSI-stripped buffer the classifier sees is byte-identical to a healthy spinner line, so `SPINNER_RE` still matches and a first observation classifies `thinking-active` (benefit of the doubt; stall detection is cross-tick by design).
- `auto-mode-red-stall-persistent` — glyph frozen ≥30s AND paren-counter frozen across ticks → `thinking-stalled`. This is what `classifyBuffer` actually returns for the stalled buffer (verified by running it), and it is the intended state: the classifier reaches the same conclusion as CC's red signal via rotation+counter logic, without needing color.

## Verification

- `npx vitest run tests/attention-classifier.test.ts tests/attention-classifier-parity.test.ts` — 63/63 green, including both new fixtures.
- `npx tsc --noEmit` — clean.
- Kotlin change is comment + list-literal entries using the existing `ccBuiltin` helper (no Gradle build run; mirrors the TS file 1:1).

Closes #85
Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)