### PR TITLE
fix(hooks): bundled write-guard must exit 2 + stderr to actually block

### DIFF
--- a/app/src/main/assets/write-guard.sh
+++ b/app/src/main/assets/write-guard.sh
@@ -126,6 +126,13 @@ fi
 
 echo "$(date): WRITE BLOCKED: '$FILE_PATH' last modified by PID $REG_PID at $WRITE_TIME — blocking write from PID $PPID ($BLOCK_REASON)" >> "$LOG"
 
-# Exit non-zero to block the write, with message for Claude session
-echo "WRITE BLOCKED: $(basename "$FILE_PATH") was last modified by $BLOCK_REASON (PID $REG_PID) at $WRITE_TIME. Re-read the file to see the current version, then retry your edit."
-exit 1
+# Exit code 2 is Claude Code's PreToolUse BLOCKING contract: stderr is fed
+# back to Claude and the tool call is denied. The previous version exited 1
+# with the message on stdout — CC treats non-2 exit codes as NON-blocking,
+# so the "block" was a no-op and the write went through in every permission
+# mode. Verified empirically against CC v2.1.211 on 2026-07-15 (sandboxed
+# `claude -p` probes, incl. --dangerously-skip-permissions): exit 1 + stdout
+# → write succeeds; exit 2 + stderr → write blocked and Claude receives the
+# message verbatim. Mirrors youcoded-core PR #119; see itsdestin/youcoded#86.
+echo "WRITE BLOCKED: $(basename "$FILE_PATH") was last modified by $BLOCK_REASON (PID $REG_PID) at $WRITE_TIME. Re-read the file to see the current version, then retry your edit." >&2
+exit 2

--- a/desktop/hook-scripts/write-guard.sh
+++ b/desktop/hook-scripts/write-guard.sh
@@ -126,6 +126,13 @@ fi
 
 echo "$(date): WRITE BLOCKED: '$FILE_PATH' last modified by PID $REG_PID at $WRITE_TIME — blocking write from PID $PPID ($BLOCK_REASON)" >> "$LOG"
 
-# Exit non-zero to block the write, with message for Claude session
-echo "WRITE BLOCKED: $(basename "$FILE_PATH") was last modified by $BLOCK_REASON (PID $REG_PID) at $WRITE_TIME. Re-read the file to see the current version, then retry your edit."
-exit 1
+# Exit code 2 is Claude Code's PreToolUse BLOCKING contract: stderr is fed
+# back to Claude and the tool call is denied. The previous version exited 1
+# with the message on stdout — CC treats non-2 exit codes as NON-blocking,
+# so the "block" was a no-op and the write went through in every permission
+# mode. Verified empirically against CC v2.1.211 on 2026-07-15 (sandboxed
+# `claude -p` probes, incl. --dangerously-skip-permissions): exit 1 + stdout
+# → write succeeds; exit 2 + stderr → write blocked and Claude receives the
+# message verbatim. Mirrors youcoded-core PR #119; see itsdestin/youcoded#86.
+echo "WRITE BLOCKED: $(basename "$FILE_PATH") was last modified by $BLOCK_REASON (PID $REG_PID) at $WRITE_TIME. Re-read the file to see the current version, then retry your edit." >&2
+exit 2

--- a/desktop/tests/write-guard-contract.test.ts
+++ b/desktop/tests/write-guard-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// Pins the write-guard PreToolUse BLOCKING contract discovered via issue #86:
+// Claude Code only denies a tool call when a PreToolUse hook exits with code 2
+// and puts its message on STDERR. An earlier version exited 1 with the message
+// on stdout — CC treated that as non-blocking, so the same-machine concurrency
+// guard was silently a no-op in every permission mode (verified empirically
+// against CC v2.1.211, 2026-07-15; fixed in youcoded-core PR #119 and mirrored
+// into both bundled copies here). These pins keep the contract from regressing
+// and keep the two platform copies from drifting apart.
+
+const desktopCopy = path.resolve(__dirname, '..', 'hook-scripts', 'write-guard.sh');
+const androidCopy = path.resolve(__dirname, '..', '..', 'app', 'src', 'main', 'assets', 'write-guard.sh');
+
+describe('bundled write-guard.sh blocking contract', () => {
+  it('desktop and Android copies are byte-identical (bundled-hook parity)', () => {
+    expect(fs.readFileSync(desktopCopy, 'utf8')).toBe(fs.readFileSync(androidCopy, 'utf8'));
+  });
+
+  it('the block path exits 2 with the message on stderr (CC PreToolUse deny contract)', () => {
+    const script = fs.readFileSync(desktopCopy, 'utf8');
+    // The user-facing WRITE BLOCKED line must go to stderr…
+    expect(script).toMatch(/echo "WRITE BLOCKED: .*retry your edit\." >&2/);
+    // …followed by exit 2 (the ONLY exit code CC treats as a block).
+    expect(script).toMatch(/>&2\nexit 2/);
+    // And no return to the old non-blocking shape.
+    expect(script).not.toMatch(/\nexit 1\s*$/);
+  });
+});


### PR DESCRIPTION
The issue #86 verification (write-guard under `--dangerously-skip-permissions`) uncovered a worse defect: **the bundled write-guard never blocked anything on current CC**. Claude Code's PreToolUse deny contract is exit code 2 with the message on stderr; both bundled copies exited 1 with the message on stdout, which CC treats as non-blocking — in every permission mode, not just the skip flag.

This mirrors the fix already merged to the source copy (youcoded-core PR #119, verified there with sandboxed `claude -p` probes against CC v2.1.211: exit 1 + stdout → write goes through; exit 2 + stderr → write blocked, Claude receives the WRITE BLOCKED message verbatim) into:

- `desktop/hook-scripts/write-guard.sh`
- `app/src/main/assets/write-guard.sh` (byte-identical mirror)

and adds `desktop/tests/write-guard-contract.test.ts` pinning (1) desktop/Android byte-parity and (2) the stderr + exit-2 block shape.

Verification: new test 2/2 green.

Note: installed copies on user machines update through the normal bundle-deploy path on next app launch (install-hooks.js / Bootstrap.installHooks re-deploy from the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)