### PR TITLE
fix(sync): surface push-retry merge results + merge failures; dedupe oversize excludes

### DIFF
--- a/desktop/src/main/sync-spaces/engine.ts
+++ b/desktop/src/main/sync-spaces/engine.ts
@@ -120,8 +120,14 @@ export class SpaceSyncEngine {
         const pull = await this.transport.pull(space);
         if (pull.conflictCopies.length) this.onEvent({ type: 'conflict', spaceId: space.id, copies: pull.conflictCopies });
         const push = await this.transport.push(space, `sync from ${space.id}`);
+        // A rejected push recovers by pulling + retrying (a peer pushed first).
+        // Fold that recovery pull's outcome into THIS cycle's events — without
+        // it, the peer's changes land on disk with updated:false and nothing
+        // downstream (conversation materialize sweep, project discovery,
+        // conflict notice) ever reacts to them.
+        if (push.conflictCopies?.length) this.onEvent({ type: 'conflict', spaceId: space.id, copies: push.conflictCopies });
         if (push.oversize.length) this.onEvent({ type: 'oversize', spaceId: space.id, files: push.oversize });
-        this.onEvent({ type: 'synced', spaceId: space.id, pushed: push.pushed, updated: pull.updated });
+        this.onEvent({ type: 'synced', spaceId: space.id, pushed: push.pushed, updated: pull.updated || !!push.updated });
         // Post-sync maintenance (spec §7). Wrapped so a repack/probe failure can
         // NEVER break a sync — the sync already succeeded above.
         try {

--- a/desktop/src/main/sync-spaces/git-transport.ts
+++ b/desktop/src/main/sync-spaces/git-transport.ts
@@ -127,9 +127,14 @@ export class GitTransport implements SyncTransport {
     const p = await this.git(space, ['push', '-u', 'origin', 'main']);
     if (p.code !== 0) {
       // Non-fast-forward: another device pushed first. Merge, then push again.
-      await this.pull(space);
+      // The recovery pull's outcome MUST be surfaced on the result: it applies
+      // the peer's changes, and discarding it made those changes invisible to
+      // the engine's event (updated:false → no materialize sweep, no discovery,
+      // no conflict notice) until some unrelated later pull — a stale-resume /
+      // forked-transcript hazard on conversations (2026-07-15 review finding).
+      const recovery = await this.pull(space);
       const retry = await this.git(space, ['push', '-u', 'origin', 'main']);
-      return { pushed: retry.code === 0, commit, oversize };
+      return { pushed: retry.code === 0, commit, oversize, updated: recovery.updated, conflictCopies: recovery.conflictCopies };
     }
     return { pushed: true, commit, oversize };
   }
@@ -145,9 +150,15 @@ export class GitTransport implements SyncTransport {
     }
     if (oversize.length) {
       await this.git(space, ['reset', '--', ...oversize]);
-      // Persist the exclusion so the watcher doesn't re-stage it every cycle.
-      fs.appendFileSync(path.join(this.gitDir(space), 'info', 'exclude'),
-        oversize.map(o => `/${o}`).join('\n') + '\n');
+      // Persist the exclusion so the watcher doesn't re-stage it every cycle —
+      // DEDUPED, because exclude only silences UNTRACKED files: a TRACKED file
+      // that grew past the cap is re-staged by `git add -A` on every sync, and
+      // an unconditional append grew info/exclude without bound at poll cadence.
+      const excludePath = path.join(this.gitDir(space), 'info', 'exclude');
+      let have = new Set<string>();
+      try { have = new Set(fs.readFileSync(excludePath, 'utf8').split('\n')); } catch { /* fresh file */ }
+      const fresh = oversize.map(o => `/${o}`).filter(line => !have.has(line));
+      if (fresh.length) fs.appendFileSync(excludePath, fresh.join('\n') + '\n');
     }
     return oversize;
   }
@@ -215,9 +226,13 @@ export class GitTransport implements SyncTransport {
     }
     const commit = await this.git(space, ['commit', '--no-edit']);
     if (commit.code !== 0) {
-      // Merge could not complete — bail out rather than leave a wedged repo.
+      // Merge could not complete — abort rather than leave a wedged repo, then
+      // THROW so the engine emits an error event (red dot + message). The old
+      // silent {updated:false} made a persistently unmergeable space look
+      // healthy while it quietly stopped converging (2026-07-15 review finding).
+      // The abort restores the pre-merge state, so the next sync retries clean.
       await this.git(space, ['merge', '--abort']);
-      return { updated: false, conflictCopies: [] };
+      throw new Error(`Sync merge could not complete for ${space.id}: ${commit.stderr.trim() || 'git commit failed'}`);
     }
     return { updated: true, conflictCopies: copies };
   }

--- a/desktop/src/main/sync-spaces/types.ts
+++ b/desktop/src/main/sync-spaces/types.ts
@@ -14,6 +14,13 @@ export interface PushResult {
   pushed: boolean;          // false when nothing changed or no remote configured
   commit?: string;          // HEAD sha after commit, when one was made
   oversize: string[];       // rel paths excluded for exceeding MAX_SYNC_FILE_BYTES
+  // Present when a rejected push ran a RECOVERY pull (a peer pushed first).
+  // That pull applies the peer's changes, so its outcome must ride the push
+  // result — swallowing it left changes on disk with no synced/updated event,
+  // so the conversation materialize sweep, project discovery, and conflict
+  // notices never fired for them (2026-07-15 review finding).
+  updated?: boolean;        // the recovery pull applied remote changes
+  conflictCopies?: string[];// conflict copies the recovery pull wrote
 }
 
 export interface PullResult {

--- a/desktop/tests/sync-spaces-engine.test.ts
+++ b/desktop/tests/sync-spaces-engine.test.ts
@@ -124,6 +124,30 @@ describe('SpaceSyncEngine', () => {
     await engine.stop();
   });
 
+  it('folds a push-retry recovery pull into the synced event (updated) and emits its conflicts', async () => {
+    const t = fakeTransport();
+    // The caller-visible pull sees nothing new; the peer's changes arrive via
+    // the PUSH's internal recovery pull (concurrent-push race). The engine must
+    // OR the flags and emit the recovery conflicts — otherwise the materialize
+    // sweep / discovery / conflict notice never fire for changes that ARE on disk.
+    (t.push as any).mockImplementation(async (s: SyncSpace) => {
+      t.pushes.push(s.id);
+      return { pushed: true, oversize: [], updated: true, conflictCopies: ['doc (from Other, 2026-07-15).md'] };
+    });
+    const events: SpaceSyncEvent[] = [];
+    const engine = new SpaceSyncEngine(t, { debounceMs: 50, pollMs: 0, onEvent: e => events.push(e) });
+    const space: SyncSpace = { id: 'personal', kind: 'personal', root: tmp };
+    await engine.addSpace(space);
+    await engine.syncSpace(space);
+    const synced = events.find(e => e.type === 'synced') as Extract<SpaceSyncEvent, { type: 'synced' }>;
+    expect(synced).toBeDefined();
+    expect(synced.updated).toBe(true);
+    const conflict = events.find(e => e.type === 'conflict') as Extract<SpaceSyncEvent, { type: 'conflict' }>;
+    expect(conflict).toBeDefined();
+    expect(conflict.copies).toEqual(['doc (from Other, 2026-07-15).md']);
+    await engine.stop();
+  });
+
   it('emits error events instead of throwing (never-block, spec §13)', async () => {
     const t = fakeTransport();
     (t.push as any).mockImplementation(async () => { throw new Error('boom'); });

--- a/desktop/tests/sync-spaces-git-transport.test.ts
+++ b/desktop/tests/sync-spaces-git-transport.test.ts
@@ -47,6 +47,56 @@ describe('GitTransport specifics', () => {
     await h.cleanup();
   }, 30000);
 
+  it('a tracked file that grows past the cap is excluded ONCE, not re-appended every sync', async () => {
+    const h = await makeHarness();
+    const a = await h.makeDeviceSpace();
+    const small = new GitTransport({ deviceName: 'T', maxFileBytes: 10 });
+    fs.writeFileSync(path.join(a.root, 'log.txt'), 'tiny'); // under cap → gets tracked
+    await small.push(a, 'small');
+    fs.writeFileSync(path.join(a.root, 'log.txt'), 'x'.repeat(11)); // grows past cap
+    const r1 = await small.push(a, 'grew');
+    expect(r1.oversize).toEqual(['log.txt']);
+    // info/exclude only silences UNTRACKED files, so `git add -A` re-stages the
+    // tracked file's growth on EVERY sync — each cycle must not re-append its
+    // exclude line (unbounded info/exclude growth at poll cadence).
+    const r2 = await small.push(a, 'again');
+    expect(r2.oversize).toEqual(['log.txt']);
+    const exclude = fs.readFileSync(path.join(a.root, '.youcoded', 'sync.git', 'info', 'exclude'), 'utf8');
+    expect(exclude.split('\n').filter(l => l === '/log.txt').length).toBe(1);
+    await h.cleanup();
+  }, 30000);
+
+  it('a merge that cannot complete surfaces an error instead of silently reporting no update', async () => {
+    const h = await makeHarness();
+    const a = await h.makeDeviceSpace();
+    const b = await h.makeDeviceSpace();
+    const t = h.transport;
+    // Divergent same-file edits → the conflict-resolution path runs on pull.
+    fs.writeFileSync(path.join(a.root, 'plan.md'), 'base\n');
+    await t.push(a, 'base');
+    await t.pull(b);
+    fs.writeFileSync(path.join(a.root, 'plan.md'), 'A version\n');
+    await t.push(a, 'A edit');
+    fs.writeFileSync(path.join(b.root, 'plan.md'), 'B version\n');
+    // Force the merge-conclusion commit to fail (stands in for lock contention /
+    // disk hiccups). Silent {updated:false} here left a non-converging space
+    // LOOKING healthy — it must throw so the engine emits an error event.
+    const origGit = (t as any).git.bind(t);
+    (t as any).git = async (space: SyncSpace, args: string[]) => {
+      if (args[0] === 'commit' && args.includes('--no-edit')) return { code: 1, stdout: '', stderr: 'simulated: cannot commit' };
+      return origGit(space, args);
+    };
+    await expect(t.pull(b)).rejects.toThrow(/could not complete/i);
+    // The abort left the repo un-wedged: with git healthy again, the next pull
+    // converges normally (remote wins canonical + local kept as conflict copy).
+    (t as any).git = origGit;
+    const retry = await t.pull(b);
+    expect(retry.updated).toBe(true);
+    expect(retry.conflictCopies.length).toBe(1);
+    expect(fs.readFileSync(path.join(b.root, 'plan.md'), 'utf8')).toBe('A version\n');
+    await h.cleanup();
+  }, 30000);
+
   it('maybeGc advances the persisted counter and gc actually repacks on the Nth sync', async () => {
     const h = await makeHarness();
     const a = await h.makeDeviceSpace();

--- a/desktop/tests/sync-transport-contract.ts
+++ b/desktop/tests/sync-transport-contract.ts
@@ -152,6 +152,50 @@ export function describeTransportContract(name: string, makeHarness: () => Promi
       expect(fs.readFileSync(path.join(b.root, pull.conflictCopies[0]), 'utf8')).toBe(bContent);
     });
 
+    it('a push rejected by a concurrent peer push reports the recovery pull (updated)', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      // Shared base so both devices have a local main.
+      fs.writeFileSync(path.join(a.root, 'doc.md'), 'base\n');
+      await h.transport.push(a, 'base');
+      await h.transport.pull(b);
+      // A pushes first; B commits locally and pushes second → non-fast-forward.
+      // B's push must recover (merge + retry) AND report that the recovery pull
+      // applied A's changes — swallowing `updated` here left peers' data on disk
+      // with no downstream reaction (materialize sweep, discovery) until some
+      // unrelated later pull. (2026-07-15 review finding.)
+      fs.writeFileSync(path.join(a.root, 'a-file.md'), 'from A\n');
+      await h.transport.push(a, 'A change');
+      fs.writeFileSync(path.join(b.root, 'b-file.md'), 'from B\n');
+      const push = await h.transport.push(b, 'B change');
+      expect(push.pushed).toBe(true);
+      expect(push.updated).toBe(true);
+      expect(fs.readFileSync(path.join(b.root, 'a-file.md'), 'utf8')).toBe('from A\n');
+    });
+
+    it('conflict copies created by the push-retry merge are reported on the push result', async () => {
+      const a = await h.makeDeviceSpace();
+      const b = await h.makeDeviceSpace();
+      await h.transport.init(a); await h.transport.init(b);
+      fs.writeFileSync(path.join(a.root, 'doc.md'), 'base\n');
+      await h.transport.push(a, 'base');
+      await h.transport.pull(b);
+      // Same-file divergence, but the merge happens inside B's PUSH retry, not
+      // a caller-visible pull — the copies must still surface on the result so
+      // the engine can emit its conflict event.
+      fs.writeFileSync(path.join(a.root, 'doc.md'), 'A version\n');
+      await h.transport.push(a, 'A edit');
+      fs.writeFileSync(path.join(b.root, 'doc.md'), 'B version\n');
+      const push = await h.transport.push(b, 'B edit');
+      expect(push.pushed).toBe(true);
+      expect(push.conflictCopies?.length).toBe(1);
+      // Convergent rule holds inside the retry merge too: remote (A) wins the
+      // canonical name, B's content is preserved as the visible copy.
+      expect(fs.readFileSync(path.join(b.root, 'doc.md'), 'utf8')).toBe('A version\n');
+      expect(fs.readFileSync(path.join(b.root, push.conflictCopies![0]), 'utf8')).toBe('B version\n');
+    });
+
     it('conflict copies preserve binary content exactly', async () => {
       const a = await h.makeDeviceSpace();
       const b = await h.makeDeviceSpace();


### PR DESCRIPTION
Three fixes from the 2026-07-15 sync-system pre-release review (workspace handoff: `docs/active/handoffs/2026-07-10-sync-completion-handoff.md`).

## 1. Concurrent-push race swallowed pulled changes (HIGH)
`GitTransport.push()` recovers a rejected push (peer pushed first) with an internal pull + retry — but discarded that pull's `updated`/`conflictCopies`. The engine's `synced` event then said `updated:false` for peer changes that WERE applied to the space, so the conversation materialize sweep, project discovery, and conflict notices never fired for them. A peer's conversation turn could sit invisibly in the local space: the Resume Browser row resumed a stale transcript, and continuing it could fork/overwrite the durable copy. The peer's own hub signal could not rescue this — by the time it arrived the merge was already local, so the re-pull saw "0 behind".

**Fix:** `push()` returns the recovery pull's outcome (optional `PushResult.updated`/`conflictCopies`); the engine ORs `updated` into the synced event and emits the recovery conflicts. Pinned by two new **sync-transport-contract** tests (this is engine-load-bearing, so future transports must satisfy it) + one engine test.

## 2. Silent non-convergence looked healthy (MED)
`pull()`'s merge-conclusion commit failure aborted the merge and returned `{updated:false}` with **no event** — a persistently unmergeable space kept a green dot while it quietly stopped converging. It now throws after the abort (repo restored, next sync retries clean), routing through the engine's error event: red dot + the real git stderr per the error-message standards.

## 3. info/exclude unbounded growth (LOW)
`info/exclude` only silences UNTRACKED files, so a tracked file that grew past the 50MB cap was re-staged by `git add -A` on every sync and its exclude line re-appended every cycle. Appends are now deduped.

## Verification
- tsc clean; **full desktop suite 2027 passed / 0 failed**; vite + electron-builder build clean
- 5 new tests (2 contract, 2 transport-specific, 1 engine) — all red before the fix, green after
- Consumer audit: `pull`/`push` are only called inside `engine.syncSpace`'s try/catch (throw → error event; `syncSpace` still never rejects); SyncPanel's conflict check uses `.some()` (tolerant of the second conflict emit); sync-dot derivation keys only on `error`/`synced`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)