### PR TITLE
fix(ui): correct announcement widget tooltip cadence (6 hours → hourly)

### DIFF
--- a/desktop/src/renderer/components/StatusBar.tsx
+++ b/desktop/src/renderer/components/StatusBar.tsx
@@ -355,7 +355,7 @@ const WIDGET_CATEGORIES: WidgetCategory[] = [
         id: 'announcement',
         label: 'Announcement',
         defaultVisible: true,
-        description: 'Platform announcements from the YouCoded team — new releases, outages, tips. Pulled every 6 hours from the announcement cache.',
+        description: 'Platform announcements from the YouCoded team — new releases, outages, tips. Pulled every hour from the announcement cache.',
         bestFor: 'Everyone. Hides automatically when there is no active announcement.',
       },
     ],


### PR DESCRIPTION
The StatusBar announcement widget description claimed announcements are "Pulled every 6 hours", but AnnouncementService fetches every hour on both platforms (`REFRESH_MS = 60 * 60 * 1000` in `desktop/src/main/announcement-service.ts` and `app/.../runtime/AnnouncementService.kt`). One-line copy fix; no behavior change.

Found while fact-checking the announce admin skill against the app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)