### PR TITLE
feat(drawer): drag-to-resize artifact drawer width (persisted)

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2445,8 +2445,11 @@ function AppInner() {
         hidden={activeView === 'marketplace' || activeView === 'library'}
         // --right-pane-width drives BOTH the framed-shell drawer-pane width and
         // the chrome-glass cutout offset (both descend from here). The game pane
-        // is narrower than the artifact drawer's 480px default.
-        style={{ ['--right-pane-width' as any]: gameState.panelOpen ? '400px' : '480px' }}
+        // stays fixed at 400px; the artifact drawer's width is user-resizable
+        // (youcoded#105) via --drawer-width on <html> — referencing the var here
+        // (instead of a px literal) means mid-drag App re-renders rewrite the
+        // SAME string and can't snap the width back while the user is dragging.
+        style={{ ['--right-pane-width' as any]: gameState.panelOpen ? '400px' : 'var(--drawer-width, 480px)' }}
       >
         {sessions.length > 0 && sessionId && currentSession ? (
           <>

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -9,6 +9,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useArtifact } from '../state/ArtifactContext';
 import { useTheme } from '../state/theme-context';
+import { clampDrawerWidth, applyDrawerWidthVar } from '../state/drawer-width';
 import { useEscClose } from '../hooks/use-esc-close';
 import { ActiveArtifactView, type ActiveArtifactHandle } from './artifact-views/ActiveArtifactView';
 import { ContentFindBar } from './ContentFindBar';
@@ -82,7 +83,7 @@ function IconBtn({ name, title, onClick, active }: { name: string; title: string
 
 export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }: Props) {
   const { state, dispatch } = useArtifact();
-  const { hideCodeAndConfigs, setHideCodeAndConfigs, showDeletedArtifacts, setShowDeletedArtifacts } = useTheme();
+  const { hideCodeAndConfigs, setHideCodeAndConfigs, showDeletedArtifacts, setShowDeletedArtifacts, drawerWidth, setDrawerWidth, resetDrawerWidth } = useTheme();
   const allArtifacts = state.sessionArtifacts[sessionId] ?? [];
   // Drawer open/closed AND the selected artifact are per-session (remembered
   // across switches). This drawer instance belongs to `sessionId`.
@@ -417,15 +418,63 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
     </>
   );
 
+  // Drag-to-resize (youcoded#105). The drawer sits on the RIGHT, so dragging
+  // the LEFT edge left grows it: width = startWidth + (startX - clientX).
+  // Live preview writes the <html> --drawer-width var once per frame (no
+  // React re-render per mousemove); pointer-up commits via setDrawerWidth
+  // (clamp + localStorage). Double-click resets to the 480px default.
+  const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
+  const dragRaf = useRef(0);
+  const [dragging, setDragging] = useState(false);
+
+  const onHandlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    dragState.current = { startX: e.clientX, startWidth: drawerWidth };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    setDragging(true);
+  };
+  const onHandlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = dragState.current;
+    if (!s) return;
+    const next = clampDrawerWidth(s.startWidth + (s.startX - e.clientX), window.innerWidth);
+    cancelAnimationFrame(dragRaf.current);
+    dragRaf.current = requestAnimationFrame(() => applyDrawerWidthVar(next));
+  };
+  const onHandlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = dragState.current;
+    if (!s) return;
+    dragState.current = null;
+    setDragging(false);
+    cancelAnimationFrame(dragRaf.current);
+    setDrawerWidth(s.startWidth + (s.startX - e.clientX)); // setter clamps + persists
+  };
+
+  // Hidden while expanded — there's no width to drag in fill mode. w-1.5 is a
+  // 6px hit area hugging the drawer's left edge; the visible affordance is the
+  // hover/drag accent tint. No new backdrop-filter (react-renderer rule).
+  const resizeHandle = expanded ? null : (
+    <div
+      className={`absolute left-0 inset-y-0 w-1.5 cursor-col-resize z-10 transition-colors ${dragging ? 'bg-accent/50' : 'hover:bg-accent/30'}`}
+      title="Drag to resize · double-click to reset"
+      onPointerDown={onHandlePointerDown}
+      onPointerMove={onHandlePointerMove}
+      onPointerUp={onHandlePointerUp}
+      onPointerCancel={onHandlePointerUp}
+      onDoubleClick={resetDrawerWidth}
+    />
+  );
+
   // Expanded just fills the framed-shell content region (ChatView hides the chat
   // pane via the .drawer-expanded class) — the header/input chrome stay put.
+  // relative: positioning context for the resize handle. Width follows the
+  // same var as the parent .drawer-pane so the two can't drift (youcoded#105).
   const asideClass = expanded
-    ? 'flex-1 min-w-0 h-full flex flex-col bg-inset'
-    : 'w-[480px] h-full flex flex-col bg-inset shrink-0';
+    ? 'relative flex-1 min-w-0 h-full flex flex-col bg-inset'
+    : 'relative w-[var(--right-pane-width,480px)] h-full flex flex-col bg-inset shrink-0';
 
   // No selection → the whole drawer is the list (nothing to view yet).
   if (!active) {
-    return <aside ref={asideRef} className={asideClass}>{listInner}</aside>;
+    return <aside ref={asideRef} className={asideClass}>{resizeHandle}{listInner}</aside>;
   }
 
   const statusWord = statusInfo(active, active.status === 'deleted' || orphanIds.has(active.id));
@@ -433,6 +482,7 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
 
   return (
     <aside ref={asideRef} className={asideClass}>
+      {resizeHandle}
       {/* top bar */}
       <div className="flex items-center gap-1 px-2 py-1.5 border-b border-edge shrink-0">
         <IconBtn name="list" title={listOpen ? 'Hide list' : 'Show list'} active={listOpen} onClick={() => setListOpen((v) => !v)} />

--- a/desktop/src/renderer/state/drawer-width.ts
+++ b/desktop/src/renderer/state/drawer-width.ts
@@ -1,4 +1,3 @@
-// desktop/src/renderer/state/drawer-width.ts
 /** Artifact-drawer width preference (youcoded#105).
  *
  * The drawer's width is distributed to the layout through ONE CSS var,

--- a/desktop/src/renderer/state/drawer-width.ts
+++ b/desktop/src/renderer/state/drawer-width.ts
@@ -1,0 +1,30 @@
+// desktop/src/renderer/state/drawer-width.ts
+/** Artifact-drawer width preference (youcoded#105).
+ *
+ * The drawer's width is distributed to the layout through ONE CSS var,
+ * `--right-pane-width` (see react-renderer rule — the chrome-glass cutout and
+ * .drawer-pane both read it). This module owns the USER-CHOSEN width behind
+ * it: `--drawer-width`, set on <html> by ThemeProvider and referenced by
+ * App.tsx's inline style as `var(--drawer-width, 480px)`. Live drag writes
+ * the <html> var directly (no React re-render per mousemove); pointer-up
+ * commits through ThemeProvider (state + localStorage).
+ */
+
+export const DRAWER_WIDTH_KEY = 'youcoded-drawer-width';
+export const DEFAULT_DRAWER_WIDTH = 480; // matches the pre-resize fixed width
+export const MIN_DRAWER_WIDTH = 320;     // thinner is unreadable
+export const MAX_DRAWER_FRACTION = 0.6;  // leave the chat pane usable
+
+/** Clamp a candidate width to [320, 60% of window], defaulting to 480 for
+ *  non-finite input (e.g. corrupt localStorage). Always returns an integer. */
+export function clampDrawerWidth(width: number, windowWidth: number): number {
+  if (!Number.isFinite(width)) return DEFAULT_DRAWER_WIDTH;
+  const max = Math.max(MIN_DRAWER_WIDTH, Math.floor(windowWidth * MAX_DRAWER_FRACTION));
+  return Math.round(Math.min(max, Math.max(MIN_DRAWER_WIDTH, width)));
+}
+
+/** Write the live width var on <html>. Used by ThemeProvider (committed
+ *  value) AND by the drag handler (per-frame preview). */
+export function applyDrawerWidthVar(px: number): void {
+  document.documentElement.style.setProperty('--drawer-width', `${px}px`);
+}

--- a/desktop/src/renderer/state/theme-context.tsx
+++ b/desktop/src/renderer/state/theme-context.tsx
@@ -9,6 +9,7 @@ import { applyThemeToDom, applyThemeFont, buildBackgroundStyle, buildPatternStyl
 import type { ThemeDefinition, LoadedTheme } from '../themes/theme-types';
 import { resolveAllAssetPaths } from '../themes/theme-asset-resolver';
 import { buildDefaultIconSvg, rasterizeSvgToPngDataUrl } from '../themes/theme-default-icon';
+import { clampDrawerWidth, applyDrawerWidthVar, DRAWER_WIDTH_KEY, DEFAULT_DRAWER_WIDTH } from './drawer-width';
 
 // Built-in themes imported as JSON (Vite handles JSON imports natively)
 import lightJson from '../themes/builtin/light.json';
@@ -74,6 +75,12 @@ interface ThemeContextValue {
   setHideCodeAndConfigs: (v: boolean) => void;
   showDeletedArtifacts: boolean;
   setShowDeletedArtifacts: (v: boolean) => void;
+  /** Artifact drawer width in px (youcoded#105). Committed value — the live
+   *  drag previews via the <html> CSS var and commits here on pointer-up. */
+  drawerWidth: number;
+  setDrawerWidth: (px: number) => void;
+  /** Double-click-the-handle reset: back to 480 and forget the stored pref. */
+  resetDrawerWidth: () => void;
   allThemes: LoadedTheme[];
   activeTheme: LoadedTheme;
   bgStyle: Record<string, string> | null;
@@ -96,6 +103,7 @@ const ThemeContext = createContext<ThemeContextValue>({
   showTurnMetadata: false, setShowTurnMetadata: () => {},
   hideCodeAndConfigs: true, setHideCodeAndConfigs: () => {},
   showDeletedArtifacts: false, setShowDeletedArtifacts: () => {},
+  drawerWidth: DEFAULT_DRAWER_WIDTH, setDrawerWidth: () => {}, resetDrawerWidth: () => {},
   allThemes: BUILTIN_THEMES, activeTheme: BUILTIN_THEMES[0], bgStyle: null, patternStyle: null,
   setGlassOverride: () => {},
   reloadUserThemes: async () => {},
@@ -144,6 +152,40 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // Artifact viewer "Show deleted" toggle. Default OFF — hide both explicit
   // delete versions AND artifacts whose underlying file has gone missing.
   const [showDeletedArtifacts, setShowDeletedArtifactsState] = useState(() => getStored(SHOW_DELETED_ARTIFACTS_KEY, '') === '1');
+  // Artifact drawer width (youcoded#105). Clamped at load so a pref saved on
+  // a big monitor can't overflow a smaller window on next launch.
+  const [drawerWidth, setDrawerWidthState] = useState(() =>
+    clampDrawerWidth(parseInt(getStored(DRAWER_WIDTH_KEY, String(DEFAULT_DRAWER_WIDTH)), 10), window.innerWidth));
+
+  const setDrawerWidth = (px: number) => {
+    const clamped = clampDrawerWidth(px, window.innerWidth);
+    setDrawerWidthState(clamped);
+    try { localStorage.setItem(DRAWER_WIDTH_KEY, String(clamped)); } catch {}
+  };
+
+  const resetDrawerWidth = () => {
+    setDrawerWidthState(DEFAULT_DRAWER_WIDTH);
+    // Remove (don't write 480) so a future default change reaches users who reset.
+    try { localStorage.removeItem(DRAWER_WIDTH_KEY); } catch {}
+  };
+
+  // Keep the <html> var in sync with the committed value…
+  useEffect(() => { applyDrawerWidthVar(drawerWidth); }, [drawerWidth]);
+
+  // …and re-clamp when the window shrinks (debounced via rAF; resize storms
+  // are cheap no-ops when the clamp doesn't change the value).
+  useEffect(() => {
+    let raf = 0;
+    const onResize = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        setDrawerWidthState((w) => clampDrawerWidth(w, window.innerWidth));
+      });
+    };
+    window.addEventListener('resize', onResize);
+    return () => { cancelAnimationFrame(raf); window.removeEventListener('resize', onResize); };
+  }, []);
+
   const [userThemes, setUserThemes] = useState<LoadedTheme[]>([]);
   const [userThemesLoaded, setUserThemesLoaded] = useState(false);
   // Glass overrides for non-user themes — keyed by theme slug, persisted to
@@ -531,6 +573,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     showTurnMetadata, setShowTurnMetadata,
     hideCodeAndConfigs, setHideCodeAndConfigs,
     showDeletedArtifacts, setShowDeletedArtifacts,
+    drawerWidth, setDrawerWidth, resetDrawerWidth,
     allThemes, activeTheme, bgStyle, patternStyle,
     setGlassOverride, reloadUserThemes,
   }), [activeSlug, setTheme, cycleTheme, cycleList, setCycleList, font,
@@ -538,6 +581,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
        showTurnMetadata, setShowTurnMetadata,
        hideCodeAndConfigs, setHideCodeAndConfigs,
        showDeletedArtifacts, setShowDeletedArtifacts,
+       // drawerWidth is the only new dep — the two setters are recreated per
+       // render but close over nothing stale (clamp reads window at call time),
+       // so listing them would defeat the memo for no correctness gain.
+       drawerWidth,
        allThemes, activeTheme, bgStyle, patternStyle, setGlassOverride, reloadUserThemes]);
 
   return (

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -1182,7 +1182,10 @@ body[data-mode="buddy-chat"] #theme-bg {
      The artifact drawer uses the 480px default; App overrides it to a narrower
      value when the game pane is the active right pane. Referenced by both
      .drawer-pane (width) and chrome-glass--drawer-open (cutout offset) so the
-     frosted-chrome cutout always matches the actual pane width. */
+     frosted-chrome cutout always matches the actual pane width.
+     User-resized drawer widths arrive via --drawer-width on <html>
+     (ThemeProvider / drawer-width.ts) — App.tsx points --right-pane-width at
+     it when the artifact drawer is the active right pane. */
   --right-pane-width: 480px;
 }
 

--- a/desktop/tests/drawer-width.test.ts
+++ b/desktop/tests/drawer-width.test.ts
@@ -1,0 +1,31 @@
+// desktop/tests/drawer-width.test.ts
+import { describe, it, expect } from 'vitest';
+import { clampDrawerWidth, DEFAULT_DRAWER_WIDTH, MIN_DRAWER_WIDTH } from '../src/renderer/state/drawer-width';
+
+// Pins the resize guardrails from the 2026-07-16 spec: min 320px, max 60% of
+// the window, non-finite input falls back to the 480px default, and the
+// result is always an integer (CSS px).
+describe('clampDrawerWidth', () => {
+  it('passes through an in-range width, rounded to an integer', () => {
+    expect(clampDrawerWidth(600.4, 1920)).toBe(600);
+  });
+
+  it('clamps below the 320px minimum up to the minimum', () => {
+    expect(clampDrawerWidth(100, 1920)).toBe(MIN_DRAWER_WIDTH);
+    expect(MIN_DRAWER_WIDTH).toBe(320);
+  });
+
+  it('clamps above 60% of the window width down to that ceiling', () => {
+    expect(clampDrawerWidth(2000, 1920)).toBe(Math.floor(1920 * 0.6));
+  });
+
+  it('never lets the ceiling drop below the minimum on tiny windows', () => {
+    // 60% of 400px = 240 < 320 — the min wins so the drawer stays usable.
+    expect(clampDrawerWidth(999, 400)).toBe(MIN_DRAWER_WIDTH);
+  });
+
+  it('falls back to the 480px default for non-finite input (corrupt localStorage)', () => {
+    expect(clampDrawerWidth(NaN, 1920)).toBe(DEFAULT_DRAWER_WIDTH);
+    expect(clampDrawerWidth(Infinity, 1920)).toBe(DEFAULT_DRAWER_WIDTH); // Infinity is non-finite too
+  });
+});


### PR DESCRIPTION
Closes #105.

A slim grab handle on the artifact drawer's left edge: drag to any width (live preview, no per-frame React re-renders), double-click to reset to 480px. The width persists in localStorage (`youcoded-drawer-width`) so it survives restarts and app updates, clamps to [320px, 60% of window] with re-clamp on window resize, and is hidden in expand-to-fill mode. The games panel keeps its fixed 400px.

Architecture per the spec (`youcoded-dev/docs/active/specs/2026-07-16-artifact-drawer-resize-design.md`): a `--drawer-width` var on `<html>` (ThemeProvider-owned) feeds App.tsx's `--right-pane-width`, which stays the single distribution point both right-pane consumers read (react-renderer rule). Referencing the var (not a px literal) in App's inline style means mid-drag App re-renders can't snap the width back.

**Verification**
- New `clampDrawerWidth` unit tests: 5/5.
- Full desktop suite on this branch: 202 files / 2034 tests passed, 0 failures.
- `tsc --noEmit` clean.

**Pending dev-instance visual checks (reviewer/owner):** drag feel + chrome-glass cutout alignment at 100%/125% zoom · restart persistence · double-click reset · clamp limits · window-shrink re-clamp · expand-toggle hides handle · games panel unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)