### PR TITLE
Mascot rig core: sanitizer, poses/springs, MascotRig + default rig

### DIFF
--- a/desktop/src/renderer/components/mascot/MascotRig.tsx
+++ b/desktop/src/renderer/components/mascot/MascotRig.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { sanitizeRigSvg } from './sanitize-rig-svg';
+import { DEFAULT_BUDDY_RIG } from './default-buddy-rig';
+import {
+  POSES, LIMB_IDS, parsePivot, defaultPivot, stepSpring, isSettled, dragTargets,
+  type PoseName, type FaceName, type SpringState, type RigPartId,
+} from './mascot-poses';
+
+export interface RigMotion { vx: number; vy: number; dragging: boolean; }
+
+interface MascotRigProps {
+  /** theme-asset:// URL of the theme's rig, or null → first-party default rig. */
+  svgUrl: string | null;
+  pose: PoseName;
+  /** Mutable drag-velocity ref written by the drag handler (BuddyMascot).
+   *  A ref, not state — pointermove-rate re-renders would defeat the point.
+   *  Velocity must arrive normalized to the 80px window scale (k = 80/size × 2.4). */
+  motionRef: React.MutableRefObject<RigMotion>;
+  /** Disables blink + limb springs (reduced-effects mode). Pose changes remain. */
+  reducedEffects: boolean;
+}
+
+interface Parts {
+  byId: Map<RigPartId, SVGGElement>;
+  // The six expression groups + blink, indexed by face name; absent groups
+  // simply don't swap (graceful degradation per spec §3.2).
+  faces: Partial<Record<FaceName | 'blink', SVGGElement>>;
+}
+
+// Parts the drag springs act on: the four limbs plus the tail, which trails
+// off the left-leg target (Kuromi's tail wags when carried).
+const SPRING_IDS = [...LIMB_IDS, 'rig-tail'] as const;
+type SpringId = (typeof SPRING_IDS)[number];
+
+/**
+ * Renders a rigged mascot SVG and animates it (spec §3).
+ * - Fetches + sanitizes the theme rig (or uses the bundled default).
+ * - Applies poses as transforms on named part groups (CSS-transitioned; the
+ *   unified pose/sway spring loop + motion styles land with the buddy
+ *   integration — see the workbench prototype in youcoded-dev
+ *   docs/active/prototypes/2026-07-16-buddy-rig-workbench.html).
+ * - Runs per-limb rotation springs during drag for the trailing-limbs feel.
+ * - Blinks by swapping the face group every 6–12s (per-motion-style cadence
+ *   arrives with the integration pass).
+ */
+export function MascotRig({ svgUrl, pose, motionRef, reducedEffects }: MascotRigProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [svgHtml, setSvgHtml] = useState<string | null>(null);
+  const partsRef = useRef<Parts | null>(null);
+  const springsRef = useRef<Map<SpringId, SpringState>>(new Map());
+  const poseRef = useRef<PoseName>(pose);
+  poseRef.current = pose;
+  const [blinking, setBlinking] = useState(false);
+
+  // ── Load + sanitize ──
+  useEffect(() => {
+    let alive = true;
+    if (!svgUrl) {
+      setSvgHtml(sanitizeRigSvg(DEFAULT_BUDDY_RIG));
+      return;
+    }
+    // theme-asset:// is registered with supportFetchAPI:true (main.ts), so
+    // fetch works. Sanitization is the security boundary — see sanitize-rig-svg.
+    fetch(svgUrl)
+      .then((r) => r.text())
+      .then((text) => { if (alive) setSvgHtml(sanitizeRigSvg(text) ?? sanitizeRigSvg(DEFAULT_BUDDY_RIG)); })
+      .catch(() => { if (alive) setSvgHtml(sanitizeRigSvg(DEFAULT_BUDDY_RIG)); });
+    return () => { alive = false; };
+  }, [svgUrl]);
+
+  // ── Index parts + set pivots after the SVG lands in the DOM ──
+  useEffect(() => {
+    if (!svgHtml || !hostRef.current) { partsRef.current = null; return; }
+    const svg = hostRef.current.querySelector('svg');
+    if (!svg) { partsRef.current = null; return; }
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', '100%');
+    const byId = new Map<RigPartId, SVGGElement>();
+    const allIds: RigPartId[] = [...LIMB_IDS, 'rig-tail', 'rig-body'];
+    for (const id of allIds) {
+      const el = svg.querySelector<SVGGElement>(`#${id}`);
+      if (!el) continue;
+      byId.set(id, el);
+      if (id === 'rig-body') continue;
+      const pivot = parsePivot(el.getAttribute('data-pivot'))
+        ?? (() => { try { return defaultPivot(id, el.getBBox()); } catch { return null; } })();
+      if (pivot) {
+        // transform-box:view-box makes transform-origin viewBox-relative,
+        // matching the data-pivot coordinate space.
+        (el.style as unknown as Record<string, string>).transformBox = 'view-box';
+        el.style.transformOrigin = `${pivot.x}px ${pivot.y}px`;
+      }
+    }
+    const faces: Parts['faces'] = {};
+    for (const name of ['idle', 'welcome', 'curious', 'shocked', 'dizzy', 'blink'] as const) {
+      const el = svg.querySelector<SVGGElement>(`#rig-face-${name}`);
+      if (el) faces[name] = el;
+    }
+    partsRef.current = { byId, faces };
+    springsRef.current = new Map();
+    applyPose(partsRef.current, poseRef.current, blinking, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [svgHtml]);
+
+  // ── Pose + face application ──
+  useEffect(() => {
+    if (partsRef.current) applyPose(partsRef.current, pose, blinking, false);
+  }, [pose, blinking]);
+
+  // ── Blink loop ──
+  useEffect(() => {
+    if (reducedEffects) return;
+    let closeTimer: NodeJS.Timeout | null = null;
+    let openTimer: NodeJS.Timeout | null = null;
+    let stopped = false;
+    const schedule = () => {
+      if (stopped) return;
+      closeTimer = setTimeout(() => {
+        // Skip blinks mid-drag and while shocked — eyes-wide states.
+        if (!motionRef.current.dragging && poseRef.current !== 'shocked' && partsRef.current?.faces.blink) {
+          setBlinking(true);
+          openTimer = setTimeout(() => { setBlinking(false); schedule(); }, 120);
+        } else {
+          schedule();
+        }
+      }, 6000 + Math.random() * 6000);
+    };
+    schedule();
+    return () => {
+      stopped = true;
+      if (closeTimer) clearTimeout(closeTimer);
+      if (openTimer) clearTimeout(openTimer);
+      setBlinking(false);
+    };
+  }, [reducedEffects, motionRef]);
+
+  // ── Limb springs (drag trailing) ──
+  useEffect(() => {
+    if (reducedEffects) return;
+    let raf = 0;
+    let last = performance.now();
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      const dt = now - last;
+      last = now;
+      const parts = partsRef.current;
+      if (!parts) return;
+      const m = motionRef.current;
+      const limbTargets = m.dragging ? dragTargets(m.vx, m.vy) : ZERO_TARGETS;
+      // The tail trails off the left-leg lean, softened — a wag, not a flail.
+      const targetFor = (id: SpringId) =>
+        id === 'rig-tail' ? limbTargets['rig-leg-left'] * 0.8 : limbTargets[id];
+      let anyActive = m.dragging;
+      for (const id of SPRING_IDS) {
+        const el = parts.byId.get(id);
+        if (!el) continue;
+        let s = springsRef.current.get(id) ?? { value: 0, velocity: 0 };
+        if (!m.dragging && isSettled(s, 0) && s.value === 0) continue;
+        s = stepSpring(s, targetFor(id), dt);
+        if (!m.dragging && isSettled(s, 0)) s = { value: 0, velocity: 0 };
+        else anyActive = true;
+        springsRef.current.set(id, s);
+        const base = POSES[poseRef.current].parts[id]?.rotate ?? 0;
+        // Direct per-frame write — disable the pose transition while springing.
+        el.style.transition = 'none';
+        el.style.transform = `rotate(${base + s.value}deg)`;
+      }
+      if (!anyActive) {
+        // Springs settled — restore transition-driven pose transforms.
+        for (const id of SPRING_IDS) {
+          const el = parts.byId.get(id);
+          if (el) el.style.transition = '';
+        }
+        applyPose(parts, poseRef.current, blinking, false);
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reducedEffects]);
+
+  return (
+    <div
+      ref={hostRef}
+      style={{ width: '100%', height: '100%', pointerEvents: 'none' }}
+      // Sanitized upstream — sanitizeRigSvg is the security boundary.
+      dangerouslySetInnerHTML={svgHtml ? { __html: svgHtml } : undefined}
+    />
+  );
+}
+
+const ZERO_TARGETS: Record<(typeof LIMB_IDS)[number], number> = {
+  'rig-arm-left': 0, 'rig-arm-right': 0, 'rig-leg-left': 0, 'rig-leg-right': 0,
+};
+
+function applyPose(parts: Parts, pose: PoseName, blinking: boolean, instant: boolean): void {
+  const def = POSES[pose];
+  for (const [id, el] of parts.byId) {
+    if (id === 'rig-body') continue;
+    const p = def.parts[id] ?? {};
+    el.style.transition = instant ? 'none' : 'transform 180ms ease-out';
+    el.style.transform = `translate(${p.tx ?? 0}px, ${p.ty ?? 0}px) rotate(${p.rotate ?? 0}deg)`;
+  }
+  // Blink overlays whichever face is showing (except eyes-wide shocked).
+  const want: FaceName | 'blink' =
+    blinking && parts.faces.blink && def.face !== 'shocked' ? 'blink' : def.face;
+  for (const [name, el] of Object.entries(parts.faces)) {
+    (el as SVGGElement).style.display = name === want ? '' : 'none';
+  }
+}

--- a/desktop/src/renderer/components/mascot/default-buddy-rig.ts
+++ b/desktop/src/renderer/components/mascot/default-buddy-rig.ts
@@ -1,0 +1,113 @@
+/**
+ * First-party default buddy (spec §3.6) — the capsule character in the
+ * approved 2.5D-soft skin, ported from wecoded-themes/mascots/skins/
+ * 2-5d-soft.svg. Ships as a rig so every user gets the full experience
+ * (trailing limbs, six faces, peek hands) out of the box, and doubles as
+ * the rig contract's reference implementation.
+ *
+ * Tinting: body/limbs use var(--rig-accent), face/sockets var(--rig-on-accent)
+ * (the buddy renderer maps these from the theme's accent/on-accent tokens,
+ * whose contrast rules guarantee ≥4.5:1). The skin's amber-derived highlight/
+ * shade colors are replaced with white/black overlays at matching opacities so
+ * the lighting works on ANY accent color, not just amber. Fallbacks keep the
+ * demo palette so the SVG previews standalone.
+ * NOT currentColor — that renders black through the legacy <img> path.
+ *
+ * Limbs are drawn HANGING DOWN from their data-pivot (the pose-data
+ * convention) and painted before the body so they sit behind it.
+ */
+export const DEFAULT_BUDDY_RIG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -5 30 30">
+  <defs>
+    <radialGradient id="g-hi" cx="33%" cy="20%" r="80%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.42"/>
+      <stop offset="55%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="g-lo" x1="0" y1="0" x2="0.22" y2="1">
+      <stop offset="52%" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.34"/>
+    </linearGradient>
+    <linearGradient id="g-limb-shade" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#000000" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.32"/>
+    </linearGradient>
+    <radialGradient id="g-spec" cx="30%" cy="16%" r="26%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="f-soft" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="0.45"/>
+    </filter>
+  </defs>
+  <g id="rig-root">
+    <g id="rig-arm-left" data-pivot="2.5 9">
+      <path d="M1.8 9 L3.2 9 A0.8 0.8 0 0 1 4 9.8 L4 12.2 A0.8 0.8 0 0 1 3.2 13 L1.8 13 A0.8 0.8 0 0 1 1 12.2 L1 9.8 A0.8 0.8 0 0 1 1.8 9 Z" fill="var(--rig-accent, #f0a828)"/>
+      <path d="M1.8 9 L3.2 9 A0.8 0.8 0 0 1 4 9.8 L4 12.2 A0.8 0.8 0 0 1 3.2 13 L1.8 13 A0.8 0.8 0 0 1 1 12.2 L1 9.8 A0.8 0.8 0 0 1 1.8 9 Z" fill="url(#g-limb-shade)"/>
+    </g>
+    <g id="rig-arm-right" data-pivot="21.5 9">
+      <path d="M20.8 9 L22.2 9 A0.8 0.8 0 0 1 23 9.8 L23 12.2 A0.8 0.8 0 0 1 22.2 13 L20.8 13 A0.8 0.8 0 0 1 20 12.2 L20 9.8 A0.8 0.8 0 0 1 20.8 9 Z" fill="var(--rig-accent, #f0a828)"/>
+      <path d="M20.8 9 L22.2 9 A0.8 0.8 0 0 1 23 9.8 L23 12.2 A0.8 0.8 0 0 1 22.2 13 L20.8 13 A0.8 0.8 0 0 1 20 12.2 L20 9.8 A0.8 0.8 0 0 1 20.8 9 Z" fill="url(#g-limb-shade)"/>
+      <g id="slot-item"/>
+    </g>
+    <g id="rig-leg-left" data-pivot="8.95 17">
+      <rect x="7.2" y="17" width="3.5" height="4" rx="1.2" fill="var(--rig-accent, #f0a828)"/>
+      <rect x="7.2" y="17" width="3.5" height="4" rx="1.2" fill="url(#g-limb-shade)"/>
+    </g>
+    <g id="rig-leg-right" data-pivot="15.05 17">
+      <rect x="13.3" y="17" width="3.5" height="4" rx="1.2" fill="var(--rig-accent, #f0a828)"/>
+      <rect x="13.3" y="17" width="3.5" height="4" rx="1.2" fill="url(#g-limb-shade)"/>
+    </g>
+    <g id="rig-body">
+      <path d="M9 4 L15 4 A4 4 0 0 1 19 8 L19 12 A4 4 0 0 1 15 16 L9 16 A4 4 0 0 1 5 12 L5 8 A4 4 0 0 1 9 4 Z" fill="var(--rig-accent, #f0a828)"/>
+      <path d="M9 4 L15 4 A4 4 0 0 1 19 8 L19 12 A4 4 0 0 1 15 16 L9 16 A4 4 0 0 1 5 12 L5 8 A4 4 0 0 1 9 4 Z" fill="url(#g-lo)"/>
+      <path d="M9 4 L15 4 A4 4 0 0 1 19 8 L19 12 A4 4 0 0 1 15 16 L9 16 A4 4 0 0 1 5 12 L5 8 A4 4 0 0 1 9 4 Z" fill="url(#g-hi)"/>
+      <ellipse cx="9.6" cy="6.4" rx="3.4" ry="1.9" fill="url(#g-spec)" transform="rotate(-14 9.6 6.4)"/>
+      <path d="M5 10.5 L5 8 A4 4 0 0 1 9 4 L11 4" fill="none" stroke="#ffffff" stroke-opacity="0.55" stroke-width="0.32" filter="url(#f-soft)"/>
+      <g id="rig-face-idle">
+        <path fill="var(--rig-on-accent, #2a1004)" d="M8.5 8 L10.5 10 L8.5 12 L9.5 12 L11.5 10 L9.5 8 Z"/>
+        <path fill="var(--rig-on-accent, #2a1004)" d="M15.5 8 L13.5 10 L15.5 12 L14.5 12 L12.5 10 L14.5 8 Z"/>
+      </g>
+      <g id="rig-face-welcome" style="display:none">
+        <ellipse cx="9.3" cy="9.55" rx="1.6" ry="2.2" fill="var(--rig-on-accent, #2a1004)"/>
+        <ellipse cx="14.7" cy="9.25" rx="1.6" ry="2.2" fill="var(--rig-on-accent, #2a1004)"/>
+        <circle cx="10" cy="10.25" r="0.28" fill="var(--rig-accent, #ffc030)"/><circle cx="9.35" cy="10.85" r="0.2" fill="var(--rig-accent, #ffe090)" fill-opacity="0.8"/><circle cx="10.3" cy="10.85" r="0.14" fill="var(--rig-accent, #ffd060)" fill-opacity="0.65"/>
+        <circle cx="15.4" cy="9.95" r="0.28" fill="var(--rig-accent, #ffc030)"/><circle cx="14.75" cy="10.55" r="0.2" fill="var(--rig-accent, #ffe090)" fill-opacity="0.8"/><circle cx="15.65" cy="10.55" r="0.14" fill="var(--rig-accent, #ffd060)" fill-opacity="0.65"/>
+        <g transform="rotate(-2 12 13.3)"><path d="M10.8 13.3 Q10.8 13 12 13 Q13.2 13 13.2 13.3 A1.1 1 0 0 1 10.8 13.3 Z" fill="var(--rig-on-accent, #2a1004)"/></g>
+      </g>
+      <g id="rig-face-curious" style="display:none">
+        <ellipse cx="9.3" cy="9.55" rx="1.7" ry="2.3" fill="var(--rig-on-accent, #2a1004)"/>
+        <ellipse cx="14.7" cy="9.25" rx="1.7" ry="2.3" fill="var(--rig-on-accent, #2a1004)"/>
+        <g class="pupil"><circle cx="9.75" cy="9.2" r="0.42" fill="var(--rig-accent, #ffc030)"/><circle cx="9" cy="10.3" r="0.22" fill="var(--rig-accent, #ffe090)" fill-opacity="0.8"/><circle cx="9.95" cy="10.15" r="0.14" fill="var(--rig-accent, #ffd060)" fill-opacity="0.65"/></g>
+        <g class="pupil"><circle cx="15.15" cy="8.9" r="0.42" fill="var(--rig-accent, #ffc030)"/><circle cx="14.4" cy="10" r="0.22" fill="var(--rig-accent, #ffe090)" fill-opacity="0.8"/><circle cx="15.35" cy="9.85" r="0.14" fill="var(--rig-accent, #ffd060)" fill-opacity="0.65"/></g>
+        <path d="M13.5 6.1 Q14.7 5.55 15.9 6.1" fill="none" stroke="var(--rig-on-accent, #2a1004)" stroke-width="0.45" stroke-linecap="round"/>
+        <ellipse cx="12.1" cy="13.1" rx="0.55" ry="0.65" fill="var(--rig-on-accent, #2a1004)"/>
+      </g>
+      <g id="rig-face-shocked" style="display:none">
+        <circle cx="9.3" cy="9.8" r="2.1" fill="var(--rig-on-accent, #2a1004)"/>
+        <circle cx="14.7" cy="9.8" r="2.1" fill="var(--rig-on-accent, #2a1004)"/>
+        <circle cx="9.9" cy="9.2" r="0.5" fill="var(--rig-accent, #ffe090)"/><circle cx="15.3" cy="9.2" r="0.5" fill="var(--rig-accent, #ffe090)"/>
+        <ellipse cx="12" cy="13.6" rx="1" ry="1.25" fill="var(--rig-on-accent, #2a1004)"/>
+      </g>
+      <g id="rig-face-dizzy" style="display:none">
+        <g stroke="var(--rig-on-accent, #2a1004)" stroke-width="1" stroke-linecap="round">
+          <line x1="8" y1="8.6" x2="10.6" y2="11.4"/><line x1="10.6" y1="8.6" x2="8" y2="11.4"/>
+          <line x1="13.4" y1="8.6" x2="16" y2="11.4"/><line x1="16" y1="8.6" x2="13.4" y2="11.4"/>
+        </g>
+        <path d="M10.4 13.6 L11.2 13 L12 13.6 L12.8 13 L13.6 13.6" fill="none" stroke="var(--rig-on-accent, #2a1004)" stroke-width="0.8" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M5.4 3.6 Q6.4 2.6 7.4 3.6 Q6.4 4.6 5.4 3.6" fill="none" stroke="var(--rig-accent, #ffc030)" stroke-width="0.5" stroke-linecap="round"/>
+        <path d="M16.6 3.6 Q17.6 2.6 18.6 3.6 Q17.6 4.6 16.6 3.6" fill="none" stroke="var(--rig-accent, #ffc030)" stroke-width="0.5" stroke-linecap="round"/>
+      </g>
+      <g id="rig-face-blink" style="display:none">
+        <path d="M8 10 Q9.3 11 10.6 10" fill="none" stroke="var(--rig-on-accent, #2a1004)" stroke-width="0.9" stroke-linecap="round"/>
+        <path d="M13.4 10 Q14.7 11 16 10" fill="none" stroke="var(--rig-on-accent, #2a1004)" stroke-width="0.9" stroke-linecap="round"/>
+      </g>
+      <g id="slot-eyewear"/>
+    </g>
+    <g id="slot-hat"/>
+    <g id="rig-hand-peek-right" style="display:none">
+      <rect x="20.7" y="8.3" width="2.6" height="3.4" rx="1.17" fill="var(--rig-accent, #f0a828)" stroke="#000000" stroke-opacity="0.4" stroke-width="0.34"/>
+    </g>
+    <g id="rig-hand-peek-left" style="display:none">
+      <rect x="0.7" y="8.3" width="2.6" height="3.4" rx="1.17" fill="var(--rig-accent, #f0a828)" stroke="#000000" stroke-opacity="0.4" stroke-width="0.34"/>
+    </g>
+  </g>
+</svg>`;

--- a/desktop/src/renderer/components/mascot/mascot-poses.ts
+++ b/desktop/src/renderer/components/mascot/mascot-poses.ts
@@ -1,0 +1,96 @@
+/**
+ * Pose + physics data for rigged mascots (spec §3.3, §5 — youcoded-dev
+ * docs/active/specs/2026-07-10-buddy-floater-upgrades-design.md).
+ *
+ * Poses are DATA acting on named rig parts — themes author parts once, the
+ * app defines behaviors centrally. New poses/animations ship in app updates
+ * and apply to every existing rig with no re-authoring. Reference behavior:
+ * youcoded-dev docs/active/prototypes/2026-07-16-buddy-rig-workbench.html.
+ */
+
+export const LIMB_IDS = ['rig-arm-left', 'rig-arm-right', 'rig-leg-left', 'rig-leg-right'] as const;
+export type LimbId = (typeof LIMB_IDS)[number];
+// The tail springs like a limb (drag target = left-leg lean × 0.8) but has no
+// pose entries of its own today, so it stays out of LIMB_IDS.
+export type RigPartId = LimbId | 'rig-tail' | 'rig-body';
+export type FaceName = 'idle' | 'welcome' | 'curious' | 'shocked' | 'dizzy';
+export type PoseName = 'idle' | 'welcome' | 'curious' | 'shocked' | 'dizzy' | 'peek' | 'peek-right' | 'peek-left';
+
+export interface PartPose { rotate?: number; tx?: number; ty?: number; }
+export interface PoseDef { parts: Partial<Record<RigPartId, PartPose>>; face: FaceName; wave?: boolean; }
+
+// Rotation values assume limbs drawn HANGING DOWN from their pivot (the
+// rig-contract convention, wecoded-themes/mascots/README.md).
+// SIGN CONVENTION (2026-07-16 workbench, verified visually): positive =
+// clockwise, so raising the RIGHT arm OUTWARD is NEGATIVE and the LEFT arm
+// outward is POSITIVE. +160 on the right arm waves ACROSS THE FACE — an
+// earlier sketch had it backwards; the unit tests pin the corrected signs.
+export const POSES: Record<PoseName, PoseDef> = {
+  idle:    { parts: {}, face: 'idle' },
+  welcome: { parts: { 'rig-arm-right': { rotate: -160 } }, face: 'welcome', wave: true },
+  curious: { parts: {}, face: 'curious' },
+  shocked: { parts: { 'rig-arm-left': { rotate: 130 }, 'rig-arm-right': { rotate: -130 } }, face: 'shocked' },
+  dizzy:   { parts: { 'rig-arm-left': { rotate: -14 }, 'rig-arm-right': { rotate: 14 } }, face: 'dizzy' },
+  // Bottom/top peek: arms curled INWARD = little hands gripping the screen
+  // edge while the body sinks past it (BuddyMascot applies the sink transform).
+  peek:    { parts: { 'rig-arm-left': { rotate: -160 }, 'rig-arm-right': { rotate: 160 } }, face: 'idle' },
+  // Side peek: arms parked via translate (the edge-pinned mittens do the
+  // gripping — see spec §6.2 "75° wider"), one leg cocked, curious face.
+  'peek-right': { parts: { 'rig-arm-left': { rotate: 0, tx: 4.5 }, 'rig-arm-right': { rotate: 0 }, 'rig-leg-left': { rotate: -10 } }, face: 'curious' },
+  'peek-left':  { parts: { 'rig-arm-right': { rotate: 0, tx: -4.5 }, 'rig-arm-left': { rotate: 0 }, 'rig-leg-right': { rotate: 10 } }, face: 'curious' },
+};
+
+/** Parse a data-pivot="x y" attribute (viewBox coordinates). */
+export function parsePivot(attr: string | null): { x: number; y: number } | null {
+  if (!attr) return null;
+  const parts = attr.trim().split(/[\s,]+/).map(Number);
+  if (parts.length !== 2 || parts.some(Number.isNaN)) return null;
+  return { x: parts[0], y: parts[1] };
+}
+
+/** Fallback pivot when a part declares no data-pivot: limbs hinge at
+ *  top-center (shoulder/hip) — they hang down from it. Canonical capsule
+ *  rigs declare explicit pivots: arms (2.5 9)/(21.5 9), legs (8.95 17)/
+ *  (15.05 17), tail (19 14). */
+export function defaultPivot(
+  partId: RigPartId,
+  bbox: { x: number; y: number; width: number; height: number },
+): { x: number; y: number } {
+  void partId; // reserved — future part kinds may hinge elsewhere
+  return { x: bbox.x + bbox.width / 2, y: bbox.y };
+}
+
+// ── Spring physics (limb trailing during drag) ──
+export interface SpringState { value: number; velocity: number; }
+
+// Underdamped on purpose: the release overshoot IS the "carried soft toy"
+// wobble. dt clamped so a backgrounded rAF resuming with a huge delta can't
+// explode the integration.
+export function stepSpring(s: SpringState, target: number, dtMs: number, stiffness = 170, damping = 16): SpringState {
+  const dt = Math.min(dtMs, 64) / 1000;
+  const accel = stiffness * (target - s.value) - damping * s.velocity;
+  const velocity = s.velocity + accel * dt;
+  return { value: s.value + velocity * dt, velocity };
+}
+
+export function isSettled(s: SpringState, target: number): boolean {
+  return Math.abs(s.value - target) < 0.15 && Math.abs(s.velocity) < 0.15;
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+/** Per-limb rotation targets (degrees) from smoothed drag velocity.
+ *  Velocity must be normalized to the 80px buddy-window scale by the caller
+ *  (k = 80/renderSize × 2.4) so trailing feels identical at any size.
+ *  Limbs trail OPPOSITE the motion — body leads, extremities lag. */
+export function dragTargets(vx: number, vy: number): Record<LimbId, number> {
+  const lean = clamp(-vx * 1.6, -28, 28);
+  const lift = clamp(vy * 0.8, -10, 10);
+  const z = (v: number) => v + 0; // normalize -0 → +0 (vx=0 yields -0 through the negation)
+  return {
+    'rig-arm-left': z(clamp(lean * 1.4 + lift, -45, 45)),
+    'rig-arm-right': z(clamp(lean * 1.4 - lift, -45, 45)),
+    'rig-leg-left': z(clamp(lean * 1.1, -45, 45)),
+    'rig-leg-right': z(clamp(lean * 1.1, -45, 45)),
+  };
+}

--- a/desktop/src/renderer/components/mascot/sanitize-rig-svg.ts
+++ b/desktop/src/renderer/components/mascot/sanitize-rig-svg.ts
@@ -1,0 +1,51 @@
+/**
+ * Sanitizes a theme-provided rig SVG before it is inlined into the buddy DOM.
+ *
+ * SECURITY BOUNDARY: themes are third-party content, and inline SVG executes
+ * in our renderer with access to window.claude. Everything that can run
+ * script or reach the network is stripped; only static drawing content,
+ * same-document references (#id) and embedded data:image/* rasters survive.
+ * Registry-side CI validation is a follow-up — THIS function is the guarantee.
+ *
+ * Pure (DOMParser is available in the renderer and jsdom tests). Returns the
+ * serialized sanitized SVG, or null when the input isn't a parseable SVG.
+ */
+const BLOCKED_TAGS = ['script', 'foreignObject', 'iframe', 'object', 'embed', 'link', 'meta', 'style', 'animate', 'animateTransform', 'animateMotion', 'set'];
+
+export function sanitizeRigSvg(svgText: string): string | null {
+  let doc: Document;
+  try {
+    doc = new DOMParser().parseFromString(svgText, 'image/svg+xml');
+  } catch {
+    return null;
+  }
+  const root = doc.documentElement;
+  if (!root || root.tagName.toLowerCase() !== 'svg' || doc.querySelector('parsererror')) return null;
+
+  for (const tag of BLOCKED_TAGS) {
+    // SVG is case-sensitive but sloppy authors aren't — match both spellings.
+    doc.querySelectorAll(`${tag}, ${tag.toLowerCase()}`).forEach((el) => el.remove());
+  }
+
+  const scrub = (el: Element): void => {
+    // Array.from, not spread — the repo tsconfig lacks DOM.Iterable.
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.trim();
+      if (name.startsWith('on')) {
+        el.removeAttribute(attr.name);
+      } else if (name === 'href' || name === 'xlink:href') {
+        if (!(value.startsWith('#') || value.toLowerCase().startsWith('data:image/'))) {
+          el.removeAttribute(attr.name);
+        }
+      } else if (name === 'style' && /url\s*\(\s*['"]?\s*(?!#|data:image\/)/i.test(value)) {
+        // fill:url(https://…) can exfiltrate via fetch — allow only #refs/data images.
+        el.removeAttribute(attr.name);
+      }
+    }
+    for (const child of Array.from(el.children)) scrub(child);
+  };
+  scrub(root);
+
+  return new XMLSerializer().serializeToString(root);
+}

--- a/desktop/src/renderer/themes/theme-types.ts
+++ b/desktop/src/renderer/themes/theme-types.ts
@@ -87,7 +87,14 @@ export type ThemeIcons = Partial<Record<IconSlot, string>>;
 
 export type MascotVariant = 'idle' | 'welcome' | 'inquisitive' | 'shocked';
 
-export type ThemeMascot = Partial<Record<MascotVariant, string>>;
+export type ThemeMascot = Partial<Record<MascotVariant, string>> & {
+  /** Optional rigged SVG (named part groups + data-pivot attrs) — the
+   *  preferred mascot format; the flat variants above are the legacy tier.
+   *  Full authoring contract: wecoded-themes mascots/README.md.
+   *  Resolved to theme-asset:// by theme-asset-resolver like the flat variants
+   *  (its Object.entries loop is key-agnostic — no resolver change needed). */
+  rig?: string;
+};
 
 export interface ThemeScrollbar {
   'thumb-image'?: string;

--- a/desktop/tests/mascot-poses.test.ts
+++ b/desktop/tests/mascot-poses.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePivot, defaultPivot, POSES, stepSpring, isSettled, dragTargets,
+  LIMB_IDS,
+} from '../src/renderer/components/mascot/mascot-poses';
+
+describe('parsePivot', () => {
+  it('parses "x y" and "x,y"', () => {
+    expect(parsePivot('18 38')).toEqual({ x: 18, y: 38 });
+    expect(parsePivot('18,38')).toEqual({ x: 18, y: 38 });
+    expect(parsePivot(' 18.5  38 ')).toEqual({ x: 18.5, y: 38 });
+  });
+  it('rejects malformed input', () => {
+    expect(parsePivot(null)).toBeNull();
+    expect(parsePivot('')).toBeNull();
+    expect(parsePivot('18')).toBeNull();
+    expect(parsePivot('a b')).toBeNull();
+  });
+});
+
+describe('defaultPivot', () => {
+  const bbox = { x: 10, y: 20, width: 8, height: 20 };
+  it('limbs pivot at top-center (shoulder/hip — limbs hang down)', () => {
+    expect(defaultPivot('rig-arm-left', bbox)).toEqual({ x: 14, y: 20 });
+    expect(defaultPivot('rig-leg-right', bbox)).toEqual({ x: 14, y: 20 });
+  });
+});
+
+describe('POSES', () => {
+  it('every pose names only known part ids and a valid face', () => {
+    for (const pose of Object.values(POSES)) {
+      expect(['idle', 'welcome', 'curious', 'shocked', 'dizzy']).toContain(pose.face);
+      for (const id of Object.keys(pose.parts)) {
+        expect([...LIMB_IDS, 'rig-tail', 'rig-body']).toContain(id);
+      }
+    }
+  });
+  // SIGN-CONVENTION PINS (2026-07-16 workbench): limbs hang down from their
+  // pivot, positive = clockwise. These caught a real bug — the original plan
+  // sketch had the wave crossing the face.
+  it('welcome raises the right arm OUTWARD (negative rotation)', () => {
+    expect(POSES.welcome.parts['rig-arm-right']!.rotate!).toBeLessThan(0);
+  });
+  it('shocked flails both arms OUTWARD (left positive, right negative)', () => {
+    expect(POSES.shocked.parts['rig-arm-left']!.rotate!).toBeGreaterThan(0);
+    expect(POSES.shocked.parts['rig-arm-right']!.rotate!).toBeLessThan(0);
+  });
+  it('bottom-peek curls both arms INWARD to grip the edge', () => {
+    expect(POSES.peek.parts['rig-arm-left']!.rotate!).toBeLessThan(0);
+    expect(POSES.peek.parts['rig-arm-right']!.rotate!).toBeGreaterThan(0);
+  });
+});
+
+describe('stepSpring', () => {
+  it('converges to the target and settles', () => {
+    let s = { value: 0, velocity: 0 };
+    for (let i = 0; i < 300; i++) s = stepSpring(s, 20, 16);
+    expect(s.value).toBeCloseTo(20, 0);
+    expect(isSettled(s, 20)).toBe(true);
+  });
+  it('overshoots on the way (underdamped wobble)', () => {
+    let s = { value: 0, velocity: 0 };
+    let maxV = 0;
+    for (let i = 0; i < 300; i++) { s = stepSpring(s, 20, 16); maxV = Math.max(maxV, s.value); }
+    expect(maxV).toBeGreaterThan(20); // the wobble is the feature
+  });
+  it('clamps huge dt so a paused rAF cannot explode the spring', () => {
+    let s = { value: 0, velocity: 0 };
+    s = stepSpring(s, 20, 5000);
+    expect(Number.isFinite(s.value)).toBe(true);
+    expect(Math.abs(s.value)).toBeLessThan(100);
+  });
+});
+
+describe('dragTargets', () => {
+  it('limbs trail opposite the direction of horizontal motion', () => {
+    const t = dragTargets(10, 0); // moving right → limbs lag left (negative rotation)
+    expect(t['rig-arm-left']).toBeLessThan(0);
+    expect(t['rig-leg-left']).toBeLessThan(0);
+  });
+  it('is clamped', () => {
+    const t = dragTargets(10000, 10000);
+    for (const v of Object.values(t)) expect(Math.abs(v)).toBeLessThanOrEqual(45);
+  });
+  it('zero velocity → zero targets', () => {
+    const t = dragTargets(0, 0);
+    for (const v of Object.values(t)) expect(v).toBe(0);
+  });
+});

--- a/desktop/tests/sanitize-rig-svg.test.tsx
+++ b/desktop/tests/sanitize-rig-svg.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { sanitizeRigSvg } from '../src/renderer/components/mascot/sanitize-rig-svg';
+
+const wrap = (inner: string) => `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -5 30 30">${inner}</svg>`;
+
+describe('sanitizeRigSvg', () => {
+  it('returns null for non-SVG and unparseable input', () => {
+    expect(sanitizeRigSvg('<div>nope</div>')).toBeNull();
+    expect(sanitizeRigSvg('<<<garbage')).toBeNull();
+  });
+
+  it('preserves rig groups, data-pivot, and shapes', () => {
+    const out = sanitizeRigSvg(wrap('<g id="rig-arm-left" data-pivot="2.5 9"><rect x="1" y="2" width="3" height="4"/></g>'));
+    expect(out).toContain('rig-arm-left');
+    expect(out).toContain('data-pivot="2.5 9"');
+    expect(out).toContain('<rect');
+  });
+
+  it('strips script, foreignObject, and style tags', () => {
+    const out = sanitizeRigSvg(wrap('<script>alert(1)</script><foreignObject><body/></foreignObject><style>@import url(http://evil)</style><g id="rig-body"/>'));
+    expect(out).not.toContain('script');
+    expect(out).not.toContain('foreignObject');
+    expect(out).not.toContain('style>');
+    expect(out).toContain('rig-body');
+  });
+
+  it('strips SMIL animation tags (all animation is app-side)', () => {
+    const out = sanitizeRigSvg(wrap('<g id="rig-body"><animate attributeName="x" from="0" to="9"/><animateTransform attributeName="transform"/></g>'));
+    expect(out).not.toContain('<animate');
+    expect(out).toContain('rig-body');
+  });
+
+  it('strips on* event handler attributes', () => {
+    const out = sanitizeRigSvg(wrap('<g id="rig-body" onclick="evil()" onload="evil()"/>'));
+    expect(out).not.toContain('onclick');
+    expect(out).not.toContain('onload');
+  });
+
+  it('strips external hrefs but keeps same-document refs and data: images', () => {
+    const out = sanitizeRigSvg(wrap(
+      '<use href="#part"/><image href="data:image/png;base64,AAAA"/><image href="https://evil.example/x.png"/>'
+    ));
+    expect(out).toContain('href="#part"');
+    expect(out).toContain('data:image/png');
+    expect(out).not.toContain('evil.example');
+  });
+
+  it('strips style attributes containing external url()', () => {
+    const out = sanitizeRigSvg(wrap('<g id="rig-body" style="fill: url(http://evil.example/f.svg#x)"/>'));
+    expect(out).not.toContain('evil.example');
+  });
+
+  it('keeps benign style attributes (display:none face groups, var() tints)', () => {
+    const out = sanitizeRigSvg(wrap('<g id="rig-face-blink" style="display:none"><path d="M1 1h2"/></g>'));
+    expect(out).toContain('display:none');
+    const tinted = sanitizeRigSvg(wrap('<stop style="stop-color:var(--rig-accent, #f0a828)"/>'));
+    expect(tinted).toContain('--rig-accent');
+  });
+
+  it('keeps gradients, filters, and internal url(#ref) paints', () => {
+    const out = sanitizeRigSvg(wrap(
+      '<defs><radialGradient id="g-hi"><stop offset="0"/></radialGradient></defs><g id="rig-body"><path d="M1 1h2" fill="url(#g-hi)"/></g>'
+    ));
+    expect(out).toContain('radialGradient');
+    expect(out).toContain('url(#g-hi)');
+  });
+});


### PR DESCRIPTION
Implements the rig-format foundation (buddy-floater plan Tasks 7–9, as revised by the 2026-07-16 mascot-rig-workbench fold-back — youcoded-dev `docs/active/handoffs/2026-07-16-mascot-rig-workbench-handoff.md`).

- **`sanitize-rig-svg.ts`** — the security boundary for third-party theme rigs: strips scripts/foreignObject/`<style>`/SMIL/`on*`/external URLs; only `#refs` and `data:image/*` survive. Unit-tested.
- **`mascot-poses.ts`** — pose data (six faces, eight poses incl. side-peek), pivot parsing, underdamped spring physics, drag-trailing targets. The corrected workbench sign convention (welcome right arm −160° outward) is pinned by test.
- **`MascotRig.tsx`** — fetch → sanitize → inline → index parts → apply poses; per-limb (+tail) drag-trailing springs; blink loop; reduced-effects support.
- **`default-buddy-rig.ts`** — the capsule buddy in the approved 2.5D-soft skin, ported from wecoded-themes `mascots/skins/2-5d-soft.svg`, retinted via `--rig-accent`/`--rig-on-accent` with neutral white/black overlay shading so it works on any accent.
- **`theme-types.ts`** — `mascot.rig` key (resolver's `Object.entries` loop is key-agnostic — verified, no resolver change).

Nothing consumes `MascotRig` yet — BuddyMascot integration (motion styles, companions, peek staging) is the next task and needs the action-bar IPC work. `tsc --noEmit` clean; new suites pass (22 tests). Pre-existing unrelated failures on master: `src/main/harness` tsc errors (fixed by `npm install` — new native-tools deps) and the sync-spaces-project-discovery test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)