### PR TITLE
feat(build): mark test builds as "(BETA)" and stamp them a distinct version

### DIFF
--- a/.github/workflows/desktop-test-build.yml
+++ b/.github/workflows/desktop-test-build.yml
@@ -2,6 +2,16 @@ name: Desktop Test Build
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Version to stamp into the build. MUST sort ABOVE the latest published
+          release, or the installed build will offer to "update" itself back to
+          that release (compareVersions in ipc-handlers.ts parses naively:
+          `1.2.4-beta` -> [1,2,0], which is LOWER than 1.2.4). Bump the minor
+          and suffix, e.g. 1.3.0-beta, rather than patching the current version.
+        required: false
+        default: '1.3.0-beta'
 
 jobs:
   build:
@@ -33,6 +43,19 @@ jobs:
           cache: npm
           cache-dependency-path: desktop/package-lock.json
 
+      # Mirrors desktop-release.yml's "Sync version from tag". Without this the
+      # build inherits package.json's version — the LAST RELEASED one — so a test
+      # build is indistinguishable from the real release in Settings → About, in
+      # analytics (analytics-service.ts reports app.getVersion()), and in bug
+      # reports. Both __APP_VERSION__ and app.getVersion() derive from this file,
+      # so stamping it here fixes every surface at once.
+      - name: Stamp beta version
+        shell: bash
+        run: |
+          BETA_VERSION="${{ inputs.version }}"
+          node -e "var p=require('path').resolve('package.json'),pkg=JSON.parse(require('fs').readFileSync(p,'utf8'));pkg.version=process.argv[1];require('fs').writeFileSync(p,JSON.stringify(pkg,null,2)+'\n')" "$BETA_VERSION"
+          echo "Set desktop/package.json version to $BETA_VERSION"
+
       - name: Install dependencies
         run: npm ci
 
@@ -50,6 +73,10 @@ jobs:
         working-directory: .
 
       - name: Build
+        # Vite bakes this into __BUILD_CHANNEL__, which renders the "(BETA)" tag
+        # in Settings → About. Release builds never set it, so they render clean.
+        env:
+          YOUCODED_BUILD_CHANNEL: BETA
         run: npm run build
 
       - name: Install xvfb (Linux)

--- a/desktop/src/renderer/components/AboutPopup.tsx
+++ b/desktop/src/renderer/components/AboutPopup.tsx
@@ -4,6 +4,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import { Toggle } from './SettingsPanel';
+import { formatVersionLine } from '../../shared/version-line';
 
 // Shared About popup for Desktop and Android settings. Previously this was an
 // inline collapsible inside SettingsPanel on both platforms, which didn't match
@@ -17,6 +18,8 @@ interface AboutPopupProps {
   platform: 'desktop' | 'android';
   version: string;
   build?: string;
+  /** Build channel (e.g. 'BETA') — set only by test builds, never by releases. */
+  channel?: string;
 }
 
 const DESKTOP_LIBS: { lib: string; license: string; source: string }[] = [
@@ -75,7 +78,7 @@ function AnalyticsOptInToggle() {
   );
 }
 
-export default function AboutPopup({ open, onClose, platform, version, build }: AboutPopupProps) {
+export default function AboutPopup({ open, onClose, platform, version, build, channel }: AboutPopupProps) {
   const scrollRef = useScrollFade<HTMLDivElement>();
 
   // Escape-to-close, matching PreferencesPopup/ModelPickerPopup convention.
@@ -84,7 +87,7 @@ export default function AboutPopup({ open, onClose, platform, version, build }: 
   if (!open) return null;
 
   const libs = platform === 'desktop' ? DESKTOP_LIBS : ANDROID_LIBS;
-  const versionLine = `YouCoded ${version}${build ? ` · ${build}` : ''}`;
+  const versionLine = formatVersionLine({ version, build, channel });
 
   return createPortal(
     <>

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1,4 +1,7 @@
 declare const __APP_VERSION__: string;
+// Baked in by Vite from YOUCODED_BUILD_CHANNEL. '' for release builds, 'BETA'
+// for desktop-test-build.yml artifacts. See src/shared/version-line.ts.
+declare const __BUILD_CHANNEL__: string;
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { QRCodeSVG } from 'qrcode.react';
@@ -21,6 +24,12 @@ import PerformanceButton from './PerformanceButton';
 import AccountSection from './AccountSection';
 import ModelProvidersSection from './ModelProvidersPopup';
 import SettingsRow from './SettingsRow';
+import { formatVersionLine } from '../../shared/version-line';
+
+// Both are Vite `define` substitutions, so they're constants at module scope.
+// The typeof guard covers paths where the define isn't applied (unit tests).
+const desktopVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '';
+const desktopChannel = typeof __BUILD_CHANNEL__ !== 'undefined' ? __BUILD_CHANNEL__ : '';
 
 // Plain-language explainer for the Remote Access popup. Shown when the user
 // taps the (i) icon in the popup header — see RemoteButton's `showInfo` state.
@@ -2097,7 +2106,7 @@ function AndroidSettings({ open, onClose, onSendInput, onOpenThemeMarketplace, o
                 </svg>
               }
               title="About"
-              subtitle={`YouCoded ${aboutInfo.version}${aboutInfo.build ? ` · ${aboutInfo.build}` : ''}`}
+              subtitle={formatVersionLine({ version: aboutInfo.version, build: aboutInfo.build })}
               onClick={() => setShowAbout(true)}
             />
             <AboutPopup
@@ -2427,14 +2436,15 @@ function DesktopSettings({ open, onClose, onSendInput, hasActiveSession, onOpenT
             </svg>
           }
           title="About"
-          subtitle={`YouCoded ${typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : ''}`}
+          subtitle={formatVersionLine({ version: desktopVersion, channel: desktopChannel })}
           onClick={() => setShowAbout(true)}
         />
         <AboutPopup
           open={showAbout}
           onClose={() => setShowAbout(false)}
           platform="desktop"
-          version={typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : ''}
+          version={desktopVersion}
+          channel={desktopChannel}
         />
       </div>
     </>

--- a/desktop/src/shared/version-line.ts
+++ b/desktop/src/shared/version-line.ts
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for the "YouCoded <version>" line in Settings → About
+ * (the row subtitle and the popup header, on both desktop and Android).
+ *
+ * WHY a channel: test builds are installed over a real install and share its
+ * appId, so nothing else on screen distinguishes a dogfood build from a shipped
+ * one. `desktop-test-build.yml` stamps YOUCODED_BUILD_CHANNEL=BETA, which Vite
+ * bakes in as __BUILD_CHANNEL__, and the line becomes `YouCoded v1.3.0-beta
+ * (BETA)`. Release builds set no channel and render exactly as they did before:
+ * `YouCoded 1.2.4` on desktop, `YouCoded 1.2.1 · 17` on Android (where `build`
+ * is the versionCode — that's why the channel is a separate field and not
+ * folded into `build`).
+ */
+export function formatVersionLine(opts: {
+  version: string;
+  build?: string;
+  channel?: string;
+}): string {
+  const { version, build, channel } = opts;
+  if (channel) return `YouCoded v${version} (${channel})`;
+  return `YouCoded ${version}${build ? ` · ${build}` : ''}`;
+}

--- a/desktop/tests/version-line.test.ts
+++ b/desktop/tests/version-line.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { formatVersionLine } from '../src/shared/version-line';
+
+describe('formatVersionLine', () => {
+  // Release builds must render exactly as they did before the channel existed.
+  it('renders a plain release version with no channel', () => {
+    expect(formatVersionLine({ version: '1.2.4' })).toBe('YouCoded 1.2.4');
+  });
+
+  it('keeps the Android build number as a middot suffix', () => {
+    expect(formatVersionLine({ version: '1.2.1', build: '17' })).toBe('YouCoded 1.2.1 · 17');
+  });
+
+  // The reason this module exists: a beta install must be unmistakable.
+  it('renders a beta build with a v-prefix and parenthesised channel', () => {
+    expect(formatVersionLine({ version: '1.3.0-beta', channel: 'BETA' })).toBe(
+      'YouCoded v1.3.0-beta (BETA)',
+    );
+  });
+
+  // A channel must never be silently dropped just because `build` is also set —
+  // if both ever arrive, the channel is the load-bearing one.
+  it('prefers the channel over the build number when both are present', () => {
+    expect(formatVersionLine({ version: '1.3.0-beta', build: '17', channel: 'BETA' })).toBe(
+      'YouCoded v1.3.0-beta (BETA)',
+    );
+  });
+
+  // Vite's define injects '' (not undefined) for unset env vars, so the empty
+  // string must be treated as "no channel" or every release build says "()".
+  it('treats an empty channel as absent', () => {
+    expect(formatVersionLine({ version: '1.2.4', channel: '' })).toBe('YouCoded 1.2.4');
+  });
+});

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    // Marks non-release builds. desktop-test-build.yml sets this to 'BETA' so
+    // Settings → About reads `YouCoded v1.3.0-beta (BETA)` — a dogfood build
+    // installs over a real one and is otherwise indistinguishable. Empty for
+    // release builds, which render unchanged. See src/shared/version-line.ts.
+    __BUILD_CHANNEL__: JSON.stringify(process.env.YOUCODED_BUILD_CHANNEL ?? ''),
     __PARTYKIT_HOST__: JSON.stringify(process.env.VITE_PARTYKIT_HOST ?? null),
   },
 });


### PR DESCRIPTION
## Why

Test builds install *over* a real install (same `appId` / `productName`) and share its `userData` — so nothing on screen distinguished a dogfood build from the shipped release.

Worse: `desktop-test-build.yml` had **no version-patch step**. Only `desktop-release.yml` patches `package.json` (from the tag). So a test build inherited the **last released** version number and reported it everywhere — Settings → About, analytics (`analytics-service.ts` sends `app.getVersion()`), and bug reports. Dogfooding master looked exactly like running 1.2.4.

This came out of trying to set up a permanent master testing build to work from while finalizing the next release.

## What changed

**1. Stamp the version.** A `Stamp beta version` step mirrors `desktop-release.yml`'s existing `Sync version from tag` and patches `package.json` before the build. Both `__APP_VERSION__` (Vite reads `pkg.version`) and `app.getVersion()` derive from that file, so one step corrects every surface at once. Exposed as a `workflow_dispatch` input, default `1.3.0-beta`.

> ⚠️ The version **must sort above the latest release**. `compareVersions` in `ipc-handlers.ts` parses naively, so `1.2.4-beta` → `Number('4-beta')` → `NaN` → `[1,2,0]`, which is **lower** than `1.2.4` — the build would offer to "update" itself back to the release it's meant to be ahead of. Bump the minor instead. The input description says so.

**2. Label the build.** `YOUCODED_BUILD_CHANNEL=BETA` is baked in by Vite as `__BUILD_CHANNEL__`; About renders `YouCoded v1.3.0-beta (BETA)`. Release builds set no channel and render byte-identically to today.

## Notes

- The channel is a **separate prop**, not a reuse of `AboutPopup`'s existing `build`. Android passes its `versionCode` through `build`, so overloading it would have turned Android's line into `YouCoded 1.2.1 (17)`.
- `formatVersionLine` is extracted to `src/shared/version-line.ts` — the format was duplicated across three call sites (About popup, desktop subtitle, Android subtitle).

## Verification

- Built the renderer **both ways** and grepped the bundle: with the env var the defines bake in as ``_$=`1.2.4`, v$=`BETA` ``; without it the fresh bundle has **zero** `BETA` occurrences.
- `tsc --noEmit` clean.
- 2187 tests pass (217 files). New `tests/version-line.test.ts` pins the release shape, the Android `· <build>` shape, the beta shape, and the empty-string channel Vite injects when the env var is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)