### PR TITLE
fix(sync): green the Linux/macOS CI failures + run CI on feat/** branches

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,7 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [master, 'feature/**', 'fix/**']
+    # Same gap as desktop-ci.yml: this repo names branches 'feat/**', which
+    # 'feature/**' does not match, so those pushes ran no Android checks either.
+    branches: [master, 'feat/**', 'feature/**', 'fix/**']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -2,7 +2,11 @@ name: Desktop CI
 
 on:
   push:
-    branches: [master, 'feature/**', 'fix/**']
+    # 'feat/**' is the name this repo actually uses (feat/mascot-rig-core,
+    # feat/beta-build-channel); only 'feature/**' was listed, so those branches
+    # and their PRs got NO checks at all. That's how master stayed red from
+    # 2026-07-14 to 07-16 — 18 failing pushes — without anyone noticing.
+    branches: [master, 'feat/**', 'feature/**', 'fix/**']
   workflow_dispatch:
 
 jobs:

--- a/desktop/tests/sync-spaces-git-transport.test.ts
+++ b/desktop/tests/sync-spaces-git-transport.test.ts
@@ -117,6 +117,16 @@ describe('GitTransport specifics', () => {
     // the gc had a real EFFECT rather than the command silently no-op'ing/failing
     // (both git() and maybeGc swallow failures, so counter-advance alone wouldn't).
     git('config', 'gc.autoPackLimit', '1');
+    // gc.autoDetach defaults to TRUE, so `git gc --auto` forks and returns
+    // immediately wherever git can daemonize() — i.e. Linux/macOS but NOT
+    // Windows. The packCount() assertion below then races the background gc and
+    // reads the pre-gc value, which is why this test passed locally on Windows
+    // and failed on every ubuntu/macos CI run from 2026-07-14 (ffd17fe5) on.
+    // Verified on Linux: with autoDetach default the count is still 2 right
+    // after gc and only drops to 1 ~2s later; with it false it's 1 immediately.
+    // Pinned here rather than in maybeGc because BACKGROUND gc is the behavior
+    // we want in production — a sync must never block on repacking.
+    git('config', 'gc.autoDetach', 'false');
     fs.writeFileSync(path.join(a.root, 'f.md'), 'v1');
     await t.push(a, 'c1');
     git('repack', '-d');                       // pack #1 (packs c1's loose objects)

--- a/desktop/tests/sync-spaces-project-discovery.test.ts
+++ b/desktop/tests/sync-spaces-project-discovery.test.ts
@@ -36,8 +36,22 @@ it('device B discovers, materializes, and (after a stop) detaches a project', as
 
   const lT = new GitTransport({ deviceName: 'Laptop' });
   const dT = new GitTransport({ deviceName: 'Desktop' });
-  const lEngine = new SpaceSyncEngine(lT, { debounceMs: 200, pollMs: 0, onEvent: () => {} });
-  const dEngine = new SpaceSyncEngine(dT, { debounceMs: 200, pollMs: 0, onEvent: () => {} });
+  // debounceMs is deliberately longer than this test's lifetime (the
+  // sync-spaces-engine.test.ts:76 idiom), NOT the 200ms copied from
+  // sync-spaces-two-device — that test wants background syncs (pollMs: 300),
+  // this one drives every sync explicitly below (pollMs: 0).
+  //
+  // WHY it must not fire: addSpace() starts a chokidar watcher on space.root,
+  // so each registry write here schedules a debounced background syncSpace().
+  // syncSpace() is single-flight — if one is already running it sets rerun and
+  // returns IMMEDIATELY (engine.ts:114), so the test's own `await syncSpace()`
+  // could resolve without having synced anything, and the peer then pulled a
+  // stale registry ('active' instead of 'stopped'). A watcher that never fires
+  // makes the explicit awaits the only syncs, which is what this test means.
+  // This raced only under full-suite load — green on Windows and on an idle
+  // Linux box, red on every ubuntu/macos CI run.
+  const lEngine = new SpaceSyncEngine(lT, { debounceMs: 60_000, pollMs: 0, onEvent: () => {} });
+  const dEngine = new SpaceSyncEngine(dT, { debounceMs: 60_000, pollMs: 0, onEvent: () => {} });
 
   // planReconcile takes live project NAMES, not space ids — convert exactly as
   // the service's runDiscovery does (id 'project:app' → name 'app').


### PR DESCRIPTION
## Why

**Desktop CI has been red on master since 2026-07-14** — 18 failing runs on 07-16 alone. It went unnoticed because `desktop-ci.yml` only triggered on `feature/**`, while every branch this repo ships is named `feat/**` (`feat/mascot-rig-core` #150, `feat/beta-build-channel` #151) — so those PRs reported **no checks at all**. Both failures were Linux/macOS-only, and development happens on Windows.

Surfaced while setting up a beta test build: `desktop-test-build.yml` runs `npm test`, so **Linux and macOS installers could not be produced at all** — only Windows.

Both failures are **test bugs, not product defects**. Reproduced on real Linux (WSL, node 22, git 2.53) and fixed there rather than guessed at from CI logs.

## 1. `sync-spaces-git-transport` — "gc actually repacks on the Nth sync"

`gc.autoDetach` defaults to **true**, so `git gc --auto` forks and returns immediately wherever git can `daemonize()` — Linux/macOS, but **not** Windows, where it's unsupported and gc runs inline. The `packCount()` assertion raced the background gc and read the pre-gc value. The assertion landed in `ffd17fe5` on 2026-07-14 — verified on Windows, never passing on Linux/macOS.

Measured on Linux with plain git:

| `gc.autoDetach` | packs immediately after gc | after ~2s |
|---|---|---|
| default (true) | **2** → test asserts 1, fails | 1 |
| `false` | **1** → passes | 1 |

Fixed in the **test**, not `maybeGc`: backgrounded gc is what we want in production — a sync must never block on repacking.

## 2. `sync-spaces-project-discovery` — "expected 'active' to be 'stopped'"

A **load-dependent race**, not a Linux bug — it passes on Windows *and* on an idle Linux box, and only fails under full-suite load.

`addSpace()` starts a chokidar watcher on `space.root`, so each registry write schedules a debounced background `syncSpace()`. `syncSpace()` is single-flight: if one is already running it sets `rerun` and **returns immediately** (`engine.ts:114`) — so the test's own `await syncSpace()` could resolve having synced nothing, and the peer then pulled a stale registry.

The 200ms debounce was copied from `sync-spaces-two-device`, which actually *wants* background syncs (`pollMs: 300`). This test uses `pollMs: 0` and drives all six syncs explicitly, so the watcher is pure interference. Raised to `60_000` — longer than the test's lifetime — matching the existing idiom at `sync-spaces-engine.test.ts:76`.

## 3. CI trigger

Adds `feat/**` to `desktop-ci.yml` and `android-ci.yml` (both had the gap), keeping `feature/**` and `fix/**`.

## Verification

- **`desktop-test-build.yml` on this branch: ubuntu ✅ macos ✅ windows ✅** — all three green, so Linux/macOS installers build again.
- **Desktop CI (ubuntu) on this branch: ✅** — first green run on this path since 07-14.
- Linux full-suite (WSL) before → after: failed tests **3 → 1**; both sync failures gone. The survivor is an artifact of my desktop-only export (`write-guard-contract` checks byte-parity against the Android `app/` tree).
- Windows full suite: **2187 passed, 0 failed** — no regression.

## Flagged, not fixed

`await engine.syncSpace()` resolving without having synced is a real API footgun beyond the tests — a user-driven "Sync now" can resolve early too. Data still converges via `rerun`, but the promise lies. Left alone deliberately: it's release-gating sync code and deserves its own change.

Also left as a decision: the trigger is still a branch-name allowlist, so a future convention can silently re-open the hole. A `pull_request:` trigger would close it by construction, at the cost of double runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)