### PR TITLE
feat(docs): route Linux downloads to the right native package

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2364,6 +2364,42 @@
     line-height: 1.55;
   }
   .install-modal-section + .install-modal-section { margin-top: 20px; }
+
+  /* --- Distro picker (Linux only) ---
+     A browser can't tell Ubuntu from Fedora from Arch — the user agent is
+     just "X11; Linux x86_64" — so the Linux modal asks once and hands over
+     the matching native package instead of making everyone use the AppImage
+     (which needs libfuse2 on stock Ubuntu 24.04 and has no menu entry). */
+  .distro-picker { margin: 0 0 16px; padding: 0; border: 0; }
+  .distro-picker legend {
+    padding: 0;
+    margin-bottom: 10px;
+    font-size: 0.92rem;
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+  .distro-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .distro-option + .distro-option { margin-top: 8px; }
+  .distro-option:hover { background: var(--bg-card-hover); }
+  /* :has() lets the whole row react to its radio — no JS class toggling. */
+  .distro-option:has(input:checked) {
+    border-color: var(--border-accent);
+    background: var(--accent-subtle);
+  }
+  .distro-option input { margin: 3px 0 0; accent-color: var(--accent); flex: none; }
+  .distro-option-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .distro-option-label { font-size: 0.9rem; color: var(--text-primary); }
+  .distro-option-hint { font-size: 0.8rem; color: var(--text-dim); }
+
   .install-modal-section ol {
     margin: 0 0 0 18px;
     padding: 0;
@@ -3909,11 +3945,24 @@
       var CACHE_VERSION = 2;
       var CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
       var API_URL = 'https://api.github.com/repos/itsdestin/youcoded/releases/latest';
+      // Keys that match a card id set that card's href too; the dl-linux-*
+      // keys have no card on purpose — they only populate
+      // __youcodedReleaseAssets so the Linux modal's distro picker can offer
+      // them. applyAssets already no-ops the href when getElementById misses.
+      //
+      // Anything absent from the release is simply never recorded, and the
+      // picker only offers what it finds — so releases that predate the
+      // native packages (they landed in #98, AFTER the v1.2.4 tag) degrade to
+      // AppImage-only with no picker, and light up on their own once a
+      // release carries them. No coordinated change needed at ship time.
       var matchers = {
-        'dl-windows': function(n) { return /\.exe$/i.test(n); },
-        'dl-macos':   function(n) { return /\.dmg$/i.test(n); },
-        'dl-linux':   function(n) { return /\.AppImage$/i.test(n); },
-        'dl-android': function(n) { return /\.apk$/i.test(n); }
+        'dl-windows':      function(n) { return /\.exe$/i.test(n); },
+        'dl-macos':        function(n) { return /\.dmg$/i.test(n); },
+        'dl-linux':        function(n) { return /\.AppImage$/i.test(n); },
+        'dl-linux-deb':    function(n) { return /\.deb$/i.test(n); },
+        'dl-linux-rpm':    function(n) { return /\.rpm$/i.test(n); },
+        'dl-linux-pacman': function(n) { return /\.pacman$/i.test(n); },
+        'dl-android':      function(n) { return /\.apk$/i.test(n); }
       };
 
       // Per-platform lookup the install modal reads on open.
@@ -4066,23 +4115,72 @@
           ],
           note: null
         },
+        // Linux is the one platform where the right file depends on the
+        // distro, and the browser can't tell us which one it is. So this entry
+        // carries `variants` instead of `steps`/`note`: the modal renders a
+        // picker (see renderVariantPicker) and swaps in that variant's steps
+        // and download URL. Ordered most-common-first; the first AVAILABLE one
+        // is the default, so Debian-family users — the majority — get the
+        // right file without touching the picker.
         'dl-linux': {
           platformLabel: 'Linux',
-          intro: 'The download button gives you the <strong>AppImage</strong> &mdash; a single self-contained file that runs on any distribution with no installer. If you\'d rather install YouCoded as a permanent, pinnable app, native packages for the major distros are listed at the bottom.',
-          steps: [
-            'Open the AppImage you just downloaded &mdash; most file managers run it on a double-click.',
-            'If double-clicking does nothing, the file needs permission to run. In your file manager: right-click the file → <strong>Properties → Permissions</strong> → tick <strong>"Allow executing file as program"</strong> (the wording varies by desktop). From a terminal instead: <code>chmod +x YouCoded-*.AppImage</code>, then launch it with <code>./YouCoded-*.AppImage</code>.',
-            'YouCoded opens straight from the file &mdash; nothing is copied into your system.',
-            '<strong>To keep it around:</strong> move the AppImage somewhere permanent (such as a <code>~/Applications</code> folder) before you rely on it &mdash; if it sits in <code>~/Downloads</code> and you clear that folder, your launcher breaks. For a real menu entry you can pin to your taskbar, install <a href="https://github.com/TheAssassin/AppImageLauncher" target="_blank" rel="noopener">AppImageLauncher</a>: it adds an icon and menu entry for any AppImage automatically the first time you run it.'
-          ],
-          note: '<strong>If the app doesn\'t start:</strong> some distributions need the FUSE library the AppImage depends on. Install it with your package manager &mdash; <code>sudo apt install libfuse2</code> (Debian/Ubuntu/Mint), <code>sudo dnf install fuse-libs</code> (Fedora/RHEL), <code>sudo pacman -S fuse2</code> (Arch/CachyOS/Manjaro), or <code>sudo zypper install fuse</code> (openSUSE). Still nothing? Launch the AppImage from a terminal &mdash; it will print the underlying error.',
-          altPaths: '<p><strong>Prefer a native install?</strong> Packages that install to a fixed location and add a pinnable menu entry &mdash; like any other app &mdash; are on the <a href="https://github.com/itsdestin/youcoded/releases/latest" target="_blank" rel="noopener">latest release</a> page. Download the one for your distribution and install it from a terminal:</p>' +
-            '<ol>' +
-              '<li><strong>Debian, Ubuntu, Linux Mint, Pop!_OS</strong> &mdash; the <code>.deb</code> file: <code>sudo apt install ./youcoded_*.deb</code></li>' +
-              '<li><strong>Fedora, RHEL, openSUSE</strong> &mdash; the <code>.rpm</code> file: <code>sudo dnf install ./youcoded-*.rpm</code> (openSUSE: <code>sudo zypper install ./youcoded-*.rpm</code>)</li>' +
-              '<li><strong>Arch, CachyOS, Manjaro</strong> &mdash; the <code>.pacman</code> file: <code>sudo pacman -U youcoded-*.pacman</code></li>' +
-            '</ol>' +
-            '<p>Once it\'s installed, launch YouCoded from your application menu and pin it to your taskbar.</p>'
+          intro: 'Linux packages come in a few flavours. Pick your distribution and you\'ll get the one that installs like any other app &mdash; with a menu entry you can pin.',
+          variants: [
+            {
+              key: 'dl-linux-deb',
+              label: 'Ubuntu, Debian, Linux Mint, Pop!_OS',
+              hint: 'Installs like any other app, with a menu entry.',
+              steps: [
+                'Open the <code>.deb</code> you just downloaded &mdash; double-clicking hands it to your software centre (GNOME Software, Discover, or similar), which installs it like any other app and pulls in anything it needs.',
+                'If your desktop doesn\'t open it automatically, right-click the file → <strong>Open With → Software Install</strong>. From a terminal instead: <code>sudo apt install ./youcoded_*.deb</code>.',
+                'Launch YouCoded from your applications menu &mdash; and pin it to your dock or taskbar if you want it handy.'
+              ],
+              note: null
+            },
+            {
+              key: 'dl-linux-rpm',
+              label: 'Fedora, RHEL, openSUSE',
+              hint: 'Installs like any other app, with a menu entry.',
+              steps: [
+                'Open the <code>.rpm</code> you just downloaded &mdash; double-clicking hands it to your software centre (GNOME Software, Discover, or similar), which installs it like any other app.',
+                'If your desktop doesn\'t open it automatically, from a terminal: <code>sudo dnf install ./youcoded-*.rpm</code> &mdash; on openSUSE, <code>sudo zypper install ./youcoded-*.rpm</code>.',
+                'Launch YouCoded from your applications menu &mdash; and pin it if you want it handy.'
+              ],
+              note: null
+            },
+            {
+              key: 'dl-linux-pacman',
+              label: 'Arch, CachyOS, Manjaro',
+              hint: 'Native package. Installs with one pacman command.',
+              steps: [
+                'Install the file you just downloaded: <code>sudo pacman -U youcoded-*.pacman</code>',
+                'Launch YouCoded from your applications menu &mdash; and pin it if you want it handy.'
+              ],
+              // Honest about why this one isn't a double-click: Arch simply has
+              // no graphical installer for standalone package files.
+              note: '<strong>Why a command here?</strong> Arch has no graphical installer for standalone package files &mdash; <code>pacman -U</code> is the normal way to install one, and it\'s the same command an AUR helper would run for you.'
+            },
+            {
+              // Always last, always offered: the universal fallback for
+              // distros we don't ship a native package for.
+              key: 'dl-linux',
+              label: 'Something else',
+              hint: 'AppImage &mdash; one file, runs on any distribution.',
+              steps: [
+                'Open the AppImage you just downloaded &mdash; most file managers run it on a double-click.',
+                'If double-clicking does nothing, the file needs permission to run. In your file manager: right-click the file → <strong>Properties → Permissions</strong> → tick <strong>"Allow executing file as program"</strong> (the wording varies by desktop). From a terminal instead: <code>chmod +x YouCoded-*.AppImage</code>, then launch it with <code>./YouCoded-*.AppImage</code>.',
+                'YouCoded opens straight from the file &mdash; nothing is copied into your system.',
+                '<strong>To keep it around:</strong> move the AppImage somewhere permanent (such as a <code>~/Applications</code> folder) before you rely on it &mdash; if it sits in <code>~/Downloads</code> and you clear that folder, your launcher breaks. For a real menu entry you can pin to your taskbar, install <a href="https://github.com/TheAssassin/AppImageLauncher" target="_blank" rel="noopener">AppImageLauncher</a>: it adds an icon and menu entry for any AppImage automatically the first time you run it.'
+              ],
+              // FUSE belongs to the AppImage alone — the native packages don't
+              // depend on it. Verified on a clean Ubuntu 24.04 VM: the AppImage
+              // dies with `dlopen(): error loading libfuse.so.2`, while the .deb
+              // declares zero fuse deps. `libfuse2` is correct here even though
+              // 24.04 renamed the real package to libfuse2t64 — apt resolves it
+              // via Provides, and this spelling also works on Debian/Mint.
+              note: '<strong>If the app doesn\'t start:</strong> some distributions need the FUSE library the AppImage depends on. Install it with your package manager &mdash; <code>sudo apt install libfuse2</code> (Debian/Ubuntu/Mint), <code>sudo dnf install fuse-libs</code> (Fedora/RHEL), <code>sudo pacman -S fuse2</code> (Arch/CachyOS/Manjaro), or <code>sudo zypper install fuse</code> (openSUSE). Still nothing? Launch the AppImage from a terminal &mdash; it will print the underlying error.'
+            }
+          ]
         },
         'dl-android': {
           platformLabel: 'Android',
@@ -4106,41 +4204,103 @@
         return mb < 10 ? mb.toFixed(1) + ' MB' : Math.round(mb) + ' MB';
       }
 
+      // Which variant the user picked, remembered across reopens of the modal
+      // (null = "not chosen yet", so the default below applies).
+      var chosenVariantKey = null;
+
+      // Variants whose asset actually exists in the latest release. The
+      // AppImage entry is kept unconditionally: it's the universal fallback,
+      // and if the release fetch failed we still want a working button
+      // (resetDownloadButton falls back to the /releases/latest page).
+      function availableVariants(p) {
+        if (!p.variants) return [];
+        var have = window.__youcodedReleaseAssets || {};
+        return p.variants.filter(function(v) {
+          return v.key === 'dl-linux' || (have[v.key] && have[v.key].url);
+        });
+      }
+
+      // The variant to render: the user's pick if it's still on offer,
+      // otherwise the first available (most-common distro family first).
+      function activeVariant(p) {
+        var vs = availableVariants(p);
+        if (!vs.length) return null;
+        for (var i = 0; i < vs.length; i++) {
+          if (vs[i].key === chosenVariantKey) return vs[i];
+        }
+        return vs[0];
+      }
+
+      // Radio list of distro choices. Returns '' when there's nothing to
+      // choose between (e.g. a release with only an AppImage) so those users
+      // see exactly the modal they saw before this existed.
+      function renderVariantPicker(p, active) {
+        var vs = availableVariants(p);
+        if (vs.length < 2) return '';
+        var opts = vs.map(function(v) {
+          var size = formatSize(((window.__youcodedReleaseAssets || {})[v.key] || {}).sizeBytes);
+          return '' +
+            '<label class="distro-option">' +
+              '<input type="radio" name="distro" value="' + v.key + '"' +
+                (v.key === active.key ? ' checked' : '') + '>' +
+              '<span class="distro-option-text">' +
+                '<span class="distro-option-label">' + v.label + '</span>' +
+                '<span class="distro-option-hint">' + v.hint + (size ? ' &middot; ' + size : '') + '</span>' +
+              '</span>' +
+            '</label>';
+        }).join('');
+        return '<fieldset class="distro-picker">' +
+          '<legend>Which distribution do you use?</legend>' + opts + '</fieldset>';
+      }
+
       // Build the modal body HTML for a given platform, including the
       // "After install" collapsible and (for Android) the runtime-size note.
+      // Platforms with `variants` (Linux) take their steps/note from the
+      // active variant and get a picker above them.
       function renderPlatform(platformKey) {
         var p = platforms[platformKey];
         if (!p) return '';
-        var stepsHtml = p.steps.map(function(s) { return '<li>' + s + '</li>'; }).join('');
-        var noteHtml = p.note ? '<p class="install-modal-note">' + p.note + '</p>' : '';
-        // Optional extra section for platforms that offer more than one install
-        // route (e.g. Linux: AppImage above, native packages here).
-        var altHtml = p.altPaths ? '<div class="install-modal-section">' + p.altPaths + '</div>' : '';
+        var active = p.variants ? activeVariant(p) : null;
+        var content = active || p;
+        var stepsHtml = content.steps.map(function(s) { return '<li>' + s + '</li>'; }).join('');
+        var noteHtml = content.note ? '<p class="install-modal-note">' + content.note + '</p>' : '';
+        var pickerHtml = active ? renderVariantPicker(p, active) : '';
         var afterInstallHtml = AFTER_INSTALL + (platformKey === 'dl-android' ? ANDROID_AFTER_EXTRA : '');
         return '' +
           '<p class="install-modal-intro">' + p.intro + '</p>' +
+          pickerHtml +
           '<div class="install-modal-section">' +
             '<ol>' + stepsHtml + '</ol>' +
             noteHtml +
           '</div>' +
-          altHtml +
           '<details class="install-modal-details">' +
             '<summary>After install: What to expect on first launch</summary>' +
             '<div class="install-modal-section">' + afterInstallHtml + '</div>' +
           '</details>';
       }
 
+      // The asset key the Download Now button should point at: the chosen
+      // variant for Linux, the platform's own key everywhere else.
+      function downloadKeyFor(platformKey) {
+        var p = platforms[platformKey];
+        var active = p && p.variants ? activeVariant(p) : null;
+        return active ? active.key : platformKey;
+      }
+
       // Reset the Download Now button to its "unclicked" state. Called on
       // every openModal() so reopening the same platform's modal doesn't
       // leave a stale "Download Initiated" label.
-      function resetDownloadButton(platformKey, label) {
+      //
+      // `assetKey` is usually the platform/card id, but for Linux it's the
+      // chosen variant's key (dl-linux-deb/-rpm/-pacman) — see downloadKeyFor.
+      function resetDownloadButton(assetKey, label) {
         downloadBtn.removeAttribute('data-initiated');
         downloadBtn.textContent = label;
 
         // Resolve href + size from whatever the latest-release fetch captured.
         // If the fetch hasn't completed yet (or failed), fall back to the
         // generic /releases/latest page so the button is never broken.
-        var asset = (window.__youcodedReleaseAssets || {})[platformKey];
+        var asset = (window.__youcodedReleaseAssets || {})[assetKey];
         if (asset && asset.url) {
           downloadBtn.href = asset.url;
           var sizeLabel = formatSize(asset.sizeBytes);
@@ -4152,16 +4312,31 @@
         }
       }
 
+      // Which platform's modal is currently open — the picker's change
+      // handler needs it to re-render the right body.
+      var openPlatformKey = null;
+
       function openModal(platformKey) {
         var p = platforms[platformKey];
         if (!p) return;
+        openPlatformKey = platformKey;
         title.textContent = 'Before you install YouCoded on ' + p.platformLabel;
         body.innerHTML = renderPlatform(platformKey);
-        resetDownloadButton(platformKey, 'Download Now');
+        resetDownloadButton(downloadKeyFor(platformKey), 'Download Now');
         modal.setAttribute('data-open', '');
         modal.setAttribute('aria-hidden', 'false');
         document.body.style.overflow = 'hidden';
       }
+
+      // Picking a distro swaps the steps and repoints the download button.
+      // Delegated because the radios are re-created on every render.
+      body.addEventListener('change', function(e) {
+        var t = e.target;
+        if (!t || t.name !== 'distro' || !openPlatformKey) return;
+        chosenVariantKey = t.value;
+        body.innerHTML = renderPlatform(openPlatformKey);
+        resetDownloadButton(downloadKeyFor(openPlatformKey), 'Download Now');
+      });
 
       function closeModal() {
         modal.removeAttribute('data-open');


### PR DESCRIPTION
## Why

The download page hard-coded the AppImage for Linux:

```js
'dl-linux': function(n) { return /\.AppImage$/i.test(n); },
```

So every Linux visitor got the one artifact that **needs libfuse2 and provides no menu entry** — while the native packages added in #98 were mentioned only in a footnote telling people to install them from a terminal.

## Verified on a clean Ubuntu 24.04 VM (not inferred)

| | result |
|---|---|
| Shipped AppImage on stock 24.04 | `dlopen(): error loading libfuse.so.2` — **dead on arrival** |
| Locally-built `.deb` | `Depends:` libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0 — **zero fuse** |
| `apt install ./youcoded_*.deb` | resolves everything itself, installs to `/opt/YouCoded`, registers `youcoded.desktop` |

**The fix for FUSE friction isn't automating the fuse install — it's handing users the package that never needed it.**

## What changed

A browser can't detect the distro (`navigator.userAgent` is just `X11; Linux x86_64`), so the Linux modal asks **once** and swaps in that variant's file + steps:

- Ubuntu/Debian/Mint/Pop → `.deb` · Fedora/RHEL/openSUSE → `.rpm` · Arch/CachyOS/Manjaro → `.pacman` · Something else → AppImage
- The **FUSE note moves onto the AppImage variant alone**, where it actually applies
- Arch keeps one command, honestly explained — there's no graphical installer for standalone package files, and `pacman -U` is what an AUR helper would run anyway

## No coordination needed with the v1.3 ship

Options are built from the assets the release **actually contains**. v1.2.4 predates #98, so today's page renders exactly as before — no picker, AppImage, FUSE note — and the picker **appears on its own** once a release carries the native packages. No follow-up PR, no flag day.

## Verification

jsdom driving the real page code against both release shapes:

```
v1.2.4 — AppImage only     picker: none  href: YouCoded-1.2.4.AppImage  FUSE note: shown
v1.3.0 — native packages   picker: 4     href: youcoded_1.3.0_amd64.deb FUSE note: hidden
  after picking Arch    →  href: youcoded-1.3.0.pacman · 'pacman -U' in steps · note gone
```

Reviewed visually against a simulated v1.3 release. `node --check` clean on the page's JS.

Notes for review — two judgement calls worth a second opinion:
1. **`.deb` is preselected** rather than forcing a choice: fewest clicks for the majority, but a Fedora user who ignores the picker gets a `.deb`.
2. **Selected-row styling uses CSS `:has()`** (no JS class toggling) — widely supported, but it's the newest thing in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)