### PR TITLE
fix(dev): self-heal window loads + pre-warm Vite dep cache (first-launch crash)

### DIFF
--- a/desktop/scripts/run-dev.js
+++ b/desktop/scripts/run-dev.js
@@ -1,10 +1,11 @@
-// Dev-mode orchestrator: starts Vite renderer, waits for it, then starts Electron main.
+// Dev-mode orchestrator: pre-warms Vite's dependency cache, starts the Vite
+// renderer, waits for it, then starts Electron main.
 // Reads YOUCODED_PORT_OFFSET to stay in sync with src/shared/ports.ts so dev can
 // coexist with a running built app (see docs/local-dev.md in the workspace repo).
 //
 // Replaces the previous one-liner that hardcoded `wait-on http://localhost:5173` —
 // with a port offset the wait-on URL must shift too, or Electron hangs forever.
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 const offset = Number(process.env.YOUCODED_PORT_OFFSET ?? 0);
 const vitePort = 5173 + (Number.isFinite(offset) ? offset : 0);
@@ -28,6 +29,22 @@ function run(cmd, args, label) {
 }
 
 console.log(`[run-dev] Vite → ${viteUrl}`);
+
+// Pre-warm Vite's dependency cache BEFORE Electron ever loads the page.
+// On a cold/invalidated cache (fresh clone, lockfile changed by a pull or an
+// npm install), the first window load otherwise triggers dependency
+// optimization mid-load — a storm of unbundled module requests plus a
+// full-reload — which has crashed Chromium's network service and left a dead
+// window ("dev crashes on first launch, restart fixes it", 2026-07-16).
+// `vite optimize` bakes node_modules/.vite ahead of time so the first load is
+// as calm as a second launch. Near-instant when the cache is already warm.
+// Non-fatal on failure: the in-app dev-recovery reload (main.ts
+// wireDevLoadRecovery) is the safety net either way.
+console.log('[run-dev] pre-warming Vite dependency cache…');
+const optimize = spawnSync(npxCmd, ['vite', 'optimize'], { stdio: 'inherit', env: process.env, shell: true });
+if (optimize.status !== 0) {
+  console.warn('[run-dev] vite optimize failed (non-fatal) — first load may re-optimize mid-boot');
+}
 
 const renderer = run(npmCmd, ['run', 'dev:renderer'], 'dev:renderer');
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -388,6 +388,55 @@ const debouncedBroadcastAttention = (() => {
 // windows spawned by the detach subsystem. Keeps webPreferences, security
 // hardening, and fullscreen relay consistent across every window so renderers
 // don't have to guess which features are available.
+/**
+ * Dev-only self-healing for Vite-served windows (recurring first-launch
+ * failure, diagnosed 2026-07-16): on a cold Vite dependency cache the first
+ * window load fires a storm of unbundled module requests plus a mid-load
+ * full-reload; Chromium's network service has crashed under it ("Network
+ * service crashed or was terminated"), aborting every in-flight request and
+ * leaving a permanently blank window — the only remedy was restarting dev.
+ * Three recovery paths, because the failure shows up three ways:
+ *  - did-fail-load: the main document itself failed to load (also covers
+ *    "Electron reached the URL before Vite was actually serving");
+ *  - render-process-gone: the renderer process died outright;
+ *  - blank-mount watchdog: the document loaded but its module scripts were
+ *    aborted mid-boot, so React never mounted and NO failure event fires —
+ *    this is the network-service-crash signature.
+ * Prod loads local files and is deliberately untouched (callers gate on
+ * !app.isPackaged).
+ */
+function wireDevLoadRecovery(win: BrowserWindow, devUrl: string): void {
+  let attempts = 0;
+  const retry = (why: string) => {
+    if (win.isDestroyed() || attempts >= 5) return;
+    attempts += 1;
+    console.warn(`[dev-recovery] renderer load failed (${why}) — retry ${attempts}/5 in ${attempts}s`);
+    setTimeout(() => {
+      if (!win.isDestroyed()) win.loadURL(devUrl);
+    }, attempts * 1000);
+  };
+  win.webContents.on('did-fail-load', (_e, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+    // -3 = ERR_ABORTED: fired by Vite's own full-reloads and by a loadURL
+    // superseding an in-flight load — retrying on it would loop forever.
+    if (isMainFrame && errorCode !== -3) retry(`did-fail-load ${errorCode} ${errorDescription}`);
+  });
+  win.webContents.on('render-process-gone', (_e, details) => {
+    if (details.reason !== 'clean-exit') retry(`render-process-gone: ${details.reason}`);
+  });
+  win.webContents.on('did-finish-load', () => {
+    setTimeout(() => {
+      if (win.isDestroyed()) return;
+      win.webContents
+        .executeJavaScript('!!document.getElementById("root")?.childElementCount')
+        .then((mounted) => {
+          if (mounted) attempts = 0; // healthy — future incidents get a fresh retry budget
+          else retry('blank renderer — React never mounted');
+        })
+        .catch(() => { /* window closed or JS context torn down — nothing to heal */ });
+    }, 8000);
+  });
+}
+
 function createAppWindow(opts?: { x?: number; y?: number; width?: number; height?: number; maximize?: boolean; inactive?: boolean; buddy?: 'mascot' | 'chat' | 'capture' }): BrowserWindow {
   const iconPath = path.join(__dirname, '../../assets/icon.png');
   const icon = nativeImage.createFromPath(iconPath);
@@ -523,7 +572,9 @@ function createAppWindow(opts?: { x?: number; y?: number; width?: number; height
     // ?mode=buddy-* routing so the override can't hijack them. Prod (file://)
     // is untouched because this whole branch runs under `!app.isPackaged`.
     const devUrlOverride = !opts?.buddy ? process.env.YOUCODED_DEV_URL : undefined;
-    win.loadURL(devUrlOverride || `${DEV_SERVER_URL}${modeQuery}`);
+    const devUrl = devUrlOverride || `${DEV_SERVER_URL}${modeQuery}`;
+    win.loadURL(devUrl);
+    wireDevLoadRecovery(win, devUrl);
   } else {
     win.loadFile(path.join(__dirname, '../renderer/index.html'), {
       // loadFile expects search string WITHOUT the leading '?'


### PR DESCRIPTION
Fixes the recurring "dev crashes on first launch, restart fixes it" failure.

**Diagnosis:** on a cold/invalidated Vite dependency cache (fresh clone, lockfile changed by a pull or `npm install`), the first window load triggers dependency optimization *mid-load* — a storm of unbundled module requests plus a full-reload — under which Chromium's network service crashes (`Network service crashed or was terminated`, captured in today's crash log). Every in-flight request aborts and the window is left permanently blank; `main.ts` had no load-failure handling, so only a manual restart (now warm-cached) recovered.

**Fix 1 — `wireDevLoadRecovery` (main.ts, dev-only, wired in `createAppWindow` so buddy windows are covered too):** retries `loadURL` on `did-fail-load` (ignoring `ERR_ABORTED` from Vite's own reloads) and `render-process-gone`, plus a blank-mount watchdog that catches the network-service signature — document loaded, module scripts aborted, React never mounted, **no failure event fires**. 5 attempts with linear backoff; the budget resets once the renderer mounts. Prod (`app.isPackaged`) untouched.

**Fix 2 — pre-warm (run-dev.js):** runs `vite optimize` before starting the dev server, so the dependency cache is baked before Electron ever loads the page. A cold first launch now behaves like a warm second one. Near-instant when already warm; non-fatal if it fails (fix 1 is the safety net). Vite 8 prints a deprecation note for the command — cosmetic.

**Verified:** deleted `node_modules/.vite` and booted — 18 deps pre-bundled ahead of Electron, no mid-load re-optimization, no crash, no recovery retries. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)