### PR TITLE
ci(test-build): upload the deb/rpm/pacman a beta already builds

### DIFF
--- a/.github/workflows/desktop-test-build.yml
+++ b/.github/workflows/desktop-test-build.yml
@@ -26,7 +26,16 @@ jobs:
             artifact: desktop/release/*.dmg
             name: macos
           - os: ubuntu-latest
-            artifact: desktop/release/*.AppImage
+            # Mirrors desktop-release.yml. electron-builder.yml has built all
+            # four Linux targets since #98, but this workflow kept globbing only
+            # the AppImage — so a beta silently discarded the deb/rpm/pacman it
+            # had just built, and they were untestable before a release carried
+            # them (#98 postdates the v1.2.4 tag, so none ever has).
+            artifact: |
+              desktop/release/*.AppImage
+              desktop/release/*.deb
+              desktop/release/*.rpm
+              desktop/release/*.pacman
             name: linux
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What

Mirror `desktop-release.yml`'s Linux artifact glob into `desktop-test-build.yml`, so a beta uploads the `.deb` / `.rpm` / `.pacman` it already builds instead of discarding them.

## Why

`electron-builder.yml` has built all four Linux targets since #98, and `desktop-release.yml` collects all four. This workflow was never updated to match — it globbed `desktop/release/*.AppImage` alone, so every beta produced the three native packages and dropped them at the upload step.

That mattered more than it looks:

- **They've never been testable.** #98 landed 2026-05-20, two days *after* the v1.2.4 tag (05-18), so no release has ever carried a deb/rpm/pacman. The beta build was the only path that could produce them — and it was the one path throwing them away.
- **The download picker from #153 routes to them.** It builds its distro options from the assets a release actually carries, so exercising it end-to-end needs a build that has the packages.
- **The workspace ROADMAP tracks it as open work** — "test the deb/rpm/pacman artifacts when v1.3 ships them" is still outstanding under the VM-testing item.
- The `.deb` also sidesteps the FUSE failure the AppImage hits on stock Ubuntu 24.04 (`dlopen(): error loading libfuse.so.2`), verified in a clean VM 2026-07-16.

## Risk

Low. No new build dependencies — #101 already installs `rpm` + `libarchive-tools` on this workflow's Linux runner, which is exactly what produces the packages today. The change is the artifact glob only; build, test, and smoke-test steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)