### PR TITLE
fix(sync): stop surfacing a transient watcher EPERM as "Couldn't sync"

### DIFF
--- a/desktop/src/main/sync-spaces/engine.ts
+++ b/desktop/src/main/sync-spaces/engine.ts
@@ -35,7 +35,15 @@ interface SpaceState {
 // DEFAULT_IGNORES, which stays authoritative about what actually syncs. Each
 // regex means: "this directory name appears anywhere in the path, with either
 // slash style" (Windows \ or POSIX /).
-const WATCH_IGNORED = [/(^|[\\/])\.youcoded([\\/]|$)/, /(^|[\\/])node_modules([\\/]|$)/, /(^|[\\/])\.git([\\/]|$)/];
+// Lock dirs (`<file>.json.lock`) are the mkdir-based lock cas-write.ts takes
+// around every conversation/registry write — created and removed within
+// milliseconds. Watching them is pointless (always empty; git can't track an
+// empty dir) and actively harmful: on Windows chokidar racing the lock's own
+// rmdir throws `EPERM: operation not permitted, watch '…json.lock'`, which
+// surfaced to the user as a red "Couldn't sync" on a sync that was working
+// fine. Scoped to `.json.lock` — NOT bare `.lock` — so real lockfiles a user
+// syncs (Cargo.lock, Gemfile.lock, poetry.lock) still trigger an instant sync.
+const WATCH_IGNORED = [/(^|[\\/])\.youcoded([\\/]|$)/, /(^|[\\/])node_modules([\\/]|$)/, /(^|[\\/])\.git([\\/]|$)/, /\.json\.lock([\\/]|$)/];
 
 export class SpaceSyncEngine {
   private states = new Map<string, SpaceState>();

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -21,6 +21,7 @@ import { useEscClose } from '../hooks/use-esc-close';
 import ConnectGithubModal from './ConnectGithubModal';
 import type { PastSession } from '../../shared/types';
 import SettingsRow from './SettingsRow';
+import { latestUnresolvedError, type SyncStatusData } from './sync-dot-state';
 
 // --- Explainer content (updated for V2 multi-instance model) ---
 
@@ -699,6 +700,11 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
   // flag whether it resolved or failed. Used by the box's "Sync now" and "Try again".
   const runSpacesSyncNow = useCallback(() => {
     setSpacesSyncing(true);
+    // Clear the PREVIOUS attempt's error before retrying. Without this, the
+    // "Try again" button could never turn the header green again: a failure set
+    // spacesError and nothing ever cleared it, so a succeeding retry still read
+    // as "Couldn't sync". A retry that fails again re-sets it in the catch.
+    setSpacesError(null);
     void (window as any).claude.syncSpaces.syncNow()
       .catch((err: any) => setSpacesError(String(err?.message ?? err)))
       .finally(() => setSpacesSyncing(false));
@@ -831,7 +837,13 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                 (Replaces the old primary section, the secondary backups block, and
                 the standalone "Back up now" row.) */}
             {(() => {
-              const engineError = [...visibleSpaceEvents].reverse().find((e: any) => e.type === 'error');
+              // An error only counts while it's UNRESOLVED — i.e. no later
+              // 'synced' for that same space. The old scan took the newest error
+              // in the never-cleared last-50 buffer, so a single transient
+              // watcher hiccup kept this header red for ~100 minutes while syncs
+              // succeeded behind it. Ordering + per-space scoping live in the
+              // pure helper the project dots already use (sync-dot-state.ts).
+              const engineError = latestUnresolvedError(spacesStatus as unknown as SyncStatusData | null);
               const errorMsg = spacesError ?? engineError?.message;
               const enabled = !!spacesStatus?.enabled;
               const githubUnauthed = !!(githubStatus && !githubStatus.authed);

--- a/desktop/src/renderer/components/sync-dot-state.ts
+++ b/desktop/src/renderer/components/sync-dot-state.ts
@@ -54,6 +54,41 @@ export function syncDotFor(folderPath: string, status: SyncStatusData | null): S
   return { color: 'green', label: 'Syncs across your devices' };
 }
 
+/**
+ * The latest 'error' event that a later successful 'synced' for the SAME space
+ * hasn't already superseded — i.e. "sync is broken right now", not "sync
+ * hiccuped once an hour ago". Returns null once every error has been followed
+ * by a success.
+ *
+ * WHY: `recentEvents` is an append-only last-50 buffer that nothing ever
+ * clears, so a naive "newest error wins" scan pins a one-off transient failure
+ * on screen (red "Couldn't sync") for ~50 events — roughly 100 minutes on the
+ * idle poll — while syncs succeed every 2 minutes behind it. A genuinely broken
+ * sync re-emits an error every cycle, so it stays surfaced.
+ *
+ * Ordering + per-space scoping mirror `latestEventFor()` above (which the
+ * project dots already use): another space's success must NEVER clear this
+ * space's error. Sentinel events ('hub-status'/'projects-changed') are excluded
+ * for free — they're neither 'error' nor 'synced'. A 'notice' is informational,
+ * not a success, so it can't clear an error either.
+ */
+export function latestUnresolvedError(
+  status: SyncStatusData | null,
+): SyncStatusData['recentEvents'][number] | null {
+  if (!status) return null;
+  const events = status.recentEvents;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type !== 'error') continue;
+    let superseded = false;
+    for (let j = i + 1; j < events.length; j++) {
+      if (events[j].type === 'synced' && events[j].spaceId === e.spaceId) { superseded = true; break; }
+    }
+    if (!superseded) return e;
+  }
+  return null;
+}
+
 /** "just now" / "N minutes ago" / "N hours ago" / null when unknown.
  *  `now` is injectable for tests. */
 export function lastSyncedLabel(spaceId: string, status: SyncStatusData | null, now: number = Date.now()): string | null {

--- a/desktop/tests/sync-dot-state.test.ts
+++ b/desktop/tests/sync-dot-state.test.ts
@@ -1,6 +1,6 @@
 // desktop/tests/sync-dot-state.test.ts
 import { describe, it, expect } from 'vitest';
-import { syncDotFor, findSpaceFor, lastSyncedLabel, type SyncStatusData } from '../src/renderer/components/sync-dot-state';
+import { syncDotFor, findSpaceFor, lastSyncedLabel, latestUnresolvedError, type SyncStatusData } from '../src/renderer/components/sync-dot-state';
 
 const status = (over: Partial<SyncStatusData> = {}): SyncStatusData => ({
   enabled: true,
@@ -81,6 +81,65 @@ describe('syncDotFor', () => {
       ],
     }));
     expect(d?.color).toBe('red');
+  });
+});
+
+describe('latestUnresolvedError', () => {
+  it('returns null when status is unavailable', () => {
+    expect(latestUnresolvedError(null)).toBeNull();
+  });
+  it('returns null when no error has ever fired', () => {
+    expect(latestUnresolvedError(status({
+      recentEvents: [{ type: 'synced', spaceId: 'personal' }],
+    }))).toBeNull();
+  });
+  it('surfaces an error that no later synced has superseded', () => {
+    const e = latestUnresolvedError(status({
+      recentEvents: [
+        { type: 'synced', spaceId: 'personal' },
+        { type: 'error', spaceId: 'personal', message: 'EPERM: operation not permitted, watch' },
+      ],
+    }));
+    expect(e?.message).toMatch(/EPERM/);
+  });
+  it('clears a transient error once the SAME space syncs successfully after it', () => {
+    // The reported bug: a one-off watcher EPERM kept the panel red ("Couldn't
+    // sync") for ~50 events while syncs succeeded every 2 minutes behind it.
+    expect(latestUnresolvedError(status({
+      recentEvents: [
+        { type: 'error', spaceId: 'personal', message: 'EPERM: operation not permitted, watch' },
+        { type: 'synced', spaceId: 'personal' },
+      ],
+    }))).toBeNull();
+  });
+  it('does NOT let another space\'s success clear an error (per-space, not global)', () => {
+    const e = latestUnresolvedError(status({
+      recentEvents: [
+        { type: 'error', spaceId: 'project:budget-app', message: 'real breakage' },
+        { type: 'synced', spaceId: 'personal' },
+      ],
+    }));
+    expect(e?.message).toBe('real breakage');
+    expect(e?.spaceId).toBe('project:budget-app');
+  });
+  it('keeps surfacing a genuinely broken sync that re-errors every cycle', () => {
+    const e = latestUnresolvedError(status({
+      recentEvents: [
+        { type: 'error', spaceId: 'personal', message: 'auth failed' },
+        { type: 'synced', spaceId: 'personal' },
+        { type: 'error', spaceId: 'personal', message: 'auth failed' },
+      ],
+    }));
+    expect(e?.message).toBe('auth failed');
+  });
+  it('ignores a notice landing after the error (a notice is not a success)', () => {
+    const e = latestUnresolvedError(status({
+      recentEvents: [
+        { type: 'error', spaceId: 'personal', message: 'boom' },
+        { type: 'notice', spaceId: 'personal', message: 'history is large' },
+      ],
+    }));
+    expect(e?.message).toBe('boom');
   });
 });
 

--- a/desktop/tests/sync-spaces-engine.test.ts
+++ b/desktop/tests/sync-spaces-engine.test.ts
@@ -51,6 +51,31 @@ describe('SpaceSyncEngine', () => {
     await engine.stop();
   });
 
+  it('ignores the ephemeral *.json.lock dirs cas-write creates', async () => {
+    const t = fakeTransport();
+    const engine = new SpaceSyncEngine(t, { debounceMs: 100, pollMs: 0, onEvent: () => {} });
+    await engine.addSpace({ id: 'personal', kind: 'personal', root: tmp });
+    // cas-write.ts takes a mkdir-based lock (`<file>.json.lock`) around every
+    // conversation/registry write and removes it milliseconds later. Chokidar
+    // racing that rmdir on Windows throws EPERM, which surfaced to the user as
+    // a red "Couldn't sync" on a sync that was working fine.
+    fs.mkdirSync(path.join(tmp, 'e4b946bb-f310-4499-b677-e6c890453ca5.json.lock'), { recursive: true });
+    await new Promise(r => setTimeout(r, 500));
+    expect(t.pushes.length).toBe(0);
+    await engine.stop();
+  });
+
+  it('still syncs real lockfiles a user keeps in a project (Cargo.lock)', async () => {
+    const t = fakeTransport();
+    const engine = new SpaceSyncEngine(t, { debounceMs: 100, pollMs: 0, onEvent: () => {} });
+    await engine.addSpace({ id: 'project:x', kind: 'project', root: tmp });
+    // The lock-dir ignore is scoped to `.json.lock` precisely so real lockfiles
+    // (Cargo.lock, Gemfile.lock, poetry.lock) keep triggering an instant sync.
+    fs.writeFileSync(path.join(tmp, 'Cargo.lock'), 'x');
+    await vi.waitFor(() => expect(t.pushes.length).toBe(1), { timeout: 5000 });
+    await engine.stop();
+  });
+
   it('poll timer pulls without local changes', async () => {
     const t = fakeTransport();
     const engine = new SpaceSyncEngine(t, { debounceMs: 5000, pollMs: 120, onEvent: () => {} });


### PR DESCRIPTION
## The report

A red **"Couldn't sync — EPERM: operation not permitted, watch `'…e4b946bb-….json.lock'`"** on a sync that was actually working fine. Reported as "confusing and unhelpful error."

It's three bugs producing one symptom.

## 1. Root cause — chokidar was watching the CAS lock dirs

`cas-write.ts` takes a **mkdir-based lock** (`<file>.json.lock`) around every conversation/registry write and removes it milliseconds later. The engine's `WATCH_IGNORED` only filtered `.youcoded`, `node_modules`, and `.git` — so chokidar tried to attach a watcher to each ephemeral lock dir. On Windows, racing the lock's own `rmdir` throws `EPERM`.

Verified empirically, not theorized: the new engine test **reproduced the bug before the fix** — a bare `.json.lock` mkdir triggered a real sync (`pushes.length` 1, expected 0), proving those dirs were watched.

Scoped to `.json.lock` and **not** bare `.lock` on purpose: real lockfiles a user syncs (`Cargo.lock`, `Gemfile.lock`, `poetry.lock`) must keep triggering an instant sync. All four lock call sites (conversations, tags, project + device registries) write `.json` targets, so the narrow pattern covers every one. Pinned by a `Cargo.lock` test.

The git layer's `DEFAULT_IGNORES` stays authoritative about what actually syncs — this only gates what *triggers* a sync, and no signal is lost (the `.tmp`→target rename still fires).

## 2. The error was sticky — the misleading part

`recentEvents` is an append-only **last-50 buffer nothing ever clears**, and the panel took the newest error from it without checking whether a later sync had succeeded. One transient hiccup pinned the header red for **~100 minutes** on the idle poll while syncs succeeded every 2 minutes behind it.

Now derived via `latestUnresolvedError()`, which applies the same ordering + **per-space** scoping that `latestEventFor()` already gives the project dots (another space's success must never clear this space's error). This isn't new semantics — the panel header was the one consumer ignoring event order.

## 3. "Try again" could never go green

`runSpacesSyncNow` set `spacesError` on failure and **never cleared it** — so the button in the screenshot couldn't return the header to green even when the retry succeeded. Now cleared at the start of each attempt; a re-failure re-sets it.

## Deliberately not done

**Not swallowing transient watcher errors.** The sync-spaces rule pins that a watcher which genuinely dies (inotify exhaustion, permissions) must surface as a sync error, and reliably separating "benign EPERM race" from "watcher is dead" is guesswork. Fix 2 gets the same user-visible benefit safely: a real breakage re-errors every cycle and stays red.

## Verification

- New tests fail on the old code (red) and pass on the new (green) — 34/34 in the two touched files.
- `tsc --noEmit` clean.
- Full suite: 2375 passed. Two `sync-spaces` files timed out under parallel load — **investigated, not assumed**: the clean base's full suite fails a *different* file (`subagent-watcher.test.ts`, untouched here), all failures are 30s timeouts, and all three pass in isolation with these changes applied. Pre-existing contention flakes, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)