### PR TITLE
fix(tests): kill the load-dependent flake family (fixed sleeps + 30s ceilings)

### DIFF
--- a/desktop/tests/subagent-watcher.test.ts
+++ b/desktop/tests/subagent-watcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -33,9 +33,21 @@ function toolUseLine(uuid: string, toolUseId: string, toolName: string, input: a
   };
 }
 
+// Fixed sleep. ONLY valid before a NEGATIVE assertion ("nothing was emitted"),
+// where there is no condition to poll for — a too-short sleep there fails safe
+// (the assertion still holds). NEVER sleep before a POSITIVE assertion: the
+// watcher's reads are async and fs.watch delivery is load-dependent (macOS
+// FSEvents coalescing, Windows under vitest's parallel pool), so a fixed budget
+// is a bet that loses as the machine gets busy — that was this file's flake.
+// Use `vi.waitFor(...)` to poll until the condition actually holds instead.
 function wait(ms = 50): Promise<void> {
   return new Promise(r => setTimeout(r, ms));
 }
+
+// Generous ceilings — these only bound the FAILURE case. A passing assertion
+// returns as soon as it holds, so raising them costs nothing on green runs.
+const SETTLE_MS = 5_000;   // in-process: watcher read + emit
+const WATCH_MS = 15_000;   // fs.watch/stat-poll delivery of an external write
 
 describe('SubagentWatcher', () => {
   let tmpRoot: string;
@@ -69,9 +81,8 @@ describe('SubagentWatcher', () => {
 
     index.recordParentAgentToolUse('toolu_parent', 'Find bug', 'Explore');
     watcher.start();
-    await wait(100);
+    await vi.waitFor(() => expect(emitted).toHaveLength(1), { timeout: SETTLE_MS });
 
-    expect(emitted).toHaveLength(1);
     expect(emitted[0].type).toBe('tool-use');
     expect(emitted[0].data.parentAgentToolUseId).toBe('toolu_parent');
     expect(emitted[0].data.agentId).toBe('abc');
@@ -84,10 +95,14 @@ describe('SubagentWatcher', () => {
 
     writeMeta(subagentsDir, 'abc', 'Find bug', 'Explore');
     appendLine(subagentsDir, 'abc', toolUseLine('u1', 'toolu_X', 'Read', { file_path: '/a' }));
-    await wait(1500); // allow fs.watch/poll to fire
 
-    const stamped = emitted.find(e => e.type === 'tool-use');
-    expect(stamped?.data.parentAgentToolUseId).toBe('toolu_parent');
+    // Was `await wait(1500) // allow fs.watch/poll to fire`, which failed every
+    // macOS build: FSEvents coalescing latency exceeds 1500ms under runner load.
+    // Poll for the event instead of betting on a fixed budget.
+    await vi.waitFor(() => {
+      const stamped = emitted.find(e => e.type === 'tool-use');
+      expect(stamped?.data.parentAgentToolUseId).toBe('toolu_parent');
+    }, { timeout: WATCH_MS });
   });
 
   it('streams new lines appended to an existing subagent file', async () => {
@@ -96,11 +111,13 @@ describe('SubagentWatcher', () => {
 
     index.recordParentAgentToolUse('toolu_parent', 'Find bug', 'Explore');
     watcher.start();
-    await wait(100);
-    expect(emitted).toHaveLength(1);
+    await vi.waitFor(() => expect(emitted).toHaveLength(1), { timeout: SETTLE_MS });
 
     appendLine(subagentsDir, 'abc', toolUseLine('u2', 'toolu_Y', 'Grep', { pattern: 'foo' }));
-    await wait(1500);
+    // fs.watch delivery of the append — poll, don't sleep (see wait() above).
+    await vi.waitFor(() => {
+      expect(emitted.find(e => e.data.toolName === 'Grep')).toBeDefined();
+    }, { timeout: WATCH_MS });
 
     expect(emitted.length).toBeGreaterThanOrEqual(2);
     const grep = emitted.find(e => e.data.toolName === 'Grep');
@@ -114,13 +131,19 @@ describe('SubagentWatcher', () => {
 
     watcher.start();
     await wait(100);
+    // Negative assertion, so the fixed sleep is fine: with no parent binding the
+    // watcher CANNOT emit, whether or not its read has landed yet.
     expect(emitted).toHaveLength(0); // buffered
 
     index.recordParentAgentToolUse('toolu_parent', 'Find bug', 'Explore');
-    watcher.flushPendingFor('abc');
-    await wait(50);
-
-    expect(emitted).toHaveLength(1);
+    // Retry the flush rather than flushing once behind a fixed sleep: the read
+    // is async, so under load the single flush ran against an empty buffer and
+    // the assertion below never saw the event. A flush with nothing pending is a
+    // no-op, so retrying is safe.
+    await vi.waitFor(() => {
+      watcher.flushPendingFor('abc');
+      expect(emitted).toHaveLength(1);
+    }, { timeout: SETTLE_MS });
     expect(emitted[0].data.parentAgentToolUseId).toBe('toolu_parent');
   });
 
@@ -130,12 +153,11 @@ describe('SubagentWatcher', () => {
 
     index.recordParentAgentToolUse('toolu_parent', 'Find bug', 'Explore');
     watcher.start();
-    await wait(100);
-    expect(emitted).toHaveLength(1);
+    await vi.waitFor(() => expect(emitted).toHaveLength(1), { timeout: SETTLE_MS });
 
     // Simulate file-size shrink then re-growth (e.g. poll triggers redundant read).
     watcher.forceRereadFor('abc');
-    await wait(50);
+    await wait(50); // negative assertion below — a fixed settle is correct here
     expect(emitted).toHaveLength(1); // no duplicate emit
   });
 
@@ -166,13 +188,18 @@ describe('SubagentWatcher', () => {
 
     watcher.start();
     await wait(100);
+    // Negative — safe as a fixed sleep (no parent binding ⇒ no emit possible).
     expect(emitted).toHaveLength(0); // both lines buffered, no parent yet
 
     index.recordParentAgentToolUse('toolu_parent', 'Find bug', 'Explore');
-    watcher.flushAllPending();
-    await wait(50);
-
-    expect(emitted).toHaveLength(2);
+    // Retry the flush until the async read has buffered both lines. This is the
+    // exact case that failed on Windows under vitest's parallel pool: the read
+    // landed after the fixed 100ms sleep, so flushAllPending() found an empty
+    // buffer and the length-2 assertion below saw nothing.
+    await vi.waitFor(() => {
+      watcher.flushAllPending();
+      expect(emitted).toHaveLength(2);
+    }, { timeout: SETTLE_MS });
     // Preserved order: first buffered event still emits first.
     expect(emitted[0].data.toolName).toBe('Read');
     expect(emitted[1].data.toolName).toBe('Grep');
@@ -238,12 +265,13 @@ describe('SubagentWatcher read integrity', () => {
     await wait(150);
     expect(emitted).toHaveLength(0);
 
-    // Second half completes the line.
+    // Second half completes the line. Poll the reread until the carried bytes
+    // reassemble (was a 20x50ms loop — a 1s ceiling is the same fixed-budget bet).
     fs.appendFileSync(jsonlPath, full.subarray(splitAt));
-    for (let i = 0; i < 20 && emitted.length === 0; i++) {
+    await vi.waitFor(() => {
       watcher.forceRereadFor('utf8');
-      await wait(50);
-    }
+      expect(emitted.length).toBeGreaterThan(0);
+    }, { timeout: SETTLE_MS });
 
     const text = emitted.find(e => e.type === 'assistant-text');
     expect(text).toBeDefined();
@@ -294,9 +322,9 @@ describe('SubagentWatcher timer lifecycle', () => {
     appendLine(subagentsDir, 'kick', toolUseLine('u-kick', 'toolu_K', 'Read', { file_path: '/k' }));
 
     watcher.kickScan();
-    await wait(150);
-
-    expect(emitted.some(e => e.data.agentId === 'kick')).toBe(true);
+    await vi.waitFor(() => {
+      expect(emitted.some(e => e.data.agentId === 'kick')).toBe(true);
+    }, { timeout: SETTLE_MS });
   });
 
   it('settleByParent stops the file poll but keeps fs.watch delivering late writes', async () => {
@@ -306,8 +334,7 @@ describe('SubagentWatcher timer lifecycle', () => {
     appendLine(subagentsDir, 'done', toolUseLine('u-d1', 'toolu_D1', 'Read', { file_path: '/d' }));
 
     watcher.start();
-    await wait(150);
-    expect(emitted.length).toBeGreaterThanOrEqual(1);
+    await vi.waitFor(() => expect(emitted.length).toBeGreaterThanOrEqual(1), { timeout: SETTLE_MS });
     expect(watcher.hasActivePoll('done')).toBe(true);
 
     await watcher.settleByParent('toolu_parent_done');
@@ -317,8 +344,9 @@ describe('SubagentWatcher timer lifecycle', () => {
     // the settle only removes the belt-and-suspenders stat poll).
     const before = emitted.length;
     appendLine(subagentsDir, 'done', toolUseLine('u-d2', 'toolu_D2', 'Grep', { pattern: 'x' }));
-    for (let i = 0; i < 20 && emitted.length === before; i++) await wait(50);
-    expect(emitted.length).toBeGreaterThan(before);
+    // fs.watch delivery of an external append — the old 20x50ms (1s) ceiling was
+    // far under macOS FSEvents coalescing latency on a loaded runner.
+    await vi.waitFor(() => expect(emitted.length).toBeGreaterThan(before), { timeout: WATCH_MS });
   });
 
   it('settleByParent for an unknown parent is a harmless no-op', async () => {

--- a/desktop/tests/sync-spaces-git-transport.test.ts
+++ b/desktop/tests/sync-spaces-git-transport.test.ts
@@ -1,5 +1,5 @@
 // desktop/tests/sync-spaces-git-transport.test.ts
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -7,6 +7,15 @@ import { execFileSync } from 'child_process';
 import { GitTransport } from '../src/main/sync-spaces/git-transport';
 import type { SyncSpace } from '../src/main/sync-spaces/types';
 import { describeTransportContract, TransportHarness } from './sync-transport-contract';
+
+// INTEGRATION test, not a unit test: every case spawns real `git` subprocesses,
+// so its wall-clock scales with machine load — and vitest's parallel pool
+// guarantees load. The 5s default (and even 30s) is a fixed-budget bet that
+// loses on a busy machine, which made this file time out nondeterministically
+// and block release builds (`npm test` gates the Build step). A generous ceiling
+// only bounds the FAILURE case; passing tests return as soon as they finish.
+// Applies to the describeTransportContract() cases below too — verified.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 // Real git, local bare repo as the "GitHub" remote. Needs git on PATH (CI has it).
 async function makeHarness(): Promise<TransportHarness> {
@@ -26,7 +35,11 @@ async function makeHarness(): Promise<TransportHarness> {
       await transport.setRemote(space, bare);
       return space;
     },
-    async cleanup() { fs.rmSync(tmp, { recursive: true, force: true }); },
+    // Windows holds handles briefly after the git subprocesses exit, so a bare
+    // rmSync here threw `EPERM: operation not permitted` under parallel load.
+    // Node retries EPERM/EBUSY/ENOTEMPTY natively with linear backoff — same
+    // pattern sync-spaces-project-discovery.test.ts already uses.
+    async cleanup() { fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }); },
   };
 }
 
@@ -45,7 +58,7 @@ describe('GitTransport specifics', () => {
     expect(r.pushed).toBe(true);
     expect(r.oversize).toEqual(['big.bin']);
     await h.cleanup();
-  }, 30000);
+  });
 
   it('a tracked file that grows past the cap is excluded ONCE, not re-appended every sync', async () => {
     const h = await makeHarness();
@@ -64,7 +77,7 @@ describe('GitTransport specifics', () => {
     const exclude = fs.readFileSync(path.join(a.root, '.youcoded', 'sync.git', 'info', 'exclude'), 'utf8');
     expect(exclude.split('\n').filter(l => l === '/log.txt').length).toBe(1);
     await h.cleanup();
-  }, 30000);
+  });
 
   it('a merge that cannot complete surfaces an error instead of silently reporting no update', async () => {
     const h = await makeHarness();
@@ -95,7 +108,7 @@ describe('GitTransport specifics', () => {
     expect(retry.conflictCopies.length).toBe(1);
     expect(fs.readFileSync(path.join(b.root, 'plan.md'), 'utf8')).toBe('A version\n');
     await h.cleanup();
-  }, 30000);
+  });
 
   it('maybeGc advances the persisted counter and gc actually repacks on the Nth sync', async () => {
     const h = await makeHarness();
@@ -149,7 +162,7 @@ describe('GitTransport specifics', () => {
     await expect(t.maybeGc(a)).resolves.toBeUndefined();
     expect(fs.readFileSync(counterFile, 'utf8').trim()).toBe('1');
     await h.cleanup();
-  }, 30000);
+  });
 
   it('gitDirSizeBytes returns >0 for a real repo and 0 for a missing dir', async () => {
     const h = await makeHarness();
@@ -165,5 +178,5 @@ describe('GitTransport specifics', () => {
     fs.mkdirSync(empty.root, { recursive: true });
     expect(await t.gitDirSizeBytes(empty)).toBe(0);
     await h.cleanup();
-  }, 30000);
+  });
 });

--- a/desktop/tests/sync-spaces-project-discovery.test.ts
+++ b/desktop/tests/sync-spaces-project-discovery.test.ts
@@ -3,7 +3,7 @@
 // 2026-07-12). Two ManagedRoots + real bare remotes, mirroring
 // sync-spaces-two-device.test.ts. Exercises the registry + planner + transport
 // directly (no service/Electron layer) so convergence is provable against git.
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -16,6 +16,11 @@ import {
 } from '../src/main/sync-spaces/project-registry';
 import { planReconcile, activeManagedSpaces } from '../src/main/sync-spaces/materialization-planner';
 import type { SyncSpace } from '../src/main/sync-spaces/types';
+
+// INTEGRATION test: spawns real `git`, and measured 19.6-27.3s in ISOLATION —
+// i.e. 65-90% of the old 30s budget before any parallel load, so vitest's pool
+// reliably pushed it over. A generous ceiling only bounds the FAILURE case.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-disc-')); });
@@ -113,4 +118,7 @@ it('device B discovers, materializes, and (after a stop) detaches a project', as
   expect(plan2.toStop).toEqual([]); // no live space to stop
 
   await lEngine.stop(); await dEngine.stop();
-}, 30_000);
+// Timeout comes from the file-level vi.setConfig above. It used to be an inline
+// `}, 30_000)` third argument, which SILENTLY OVERRIDES vi.setConfig — that's
+// why raising the file config alone didn't fix this test.
+});

--- a/desktop/tests/sync-transport-contract.ts
+++ b/desktop/tests/sync-transport-contract.ts
@@ -20,7 +20,17 @@ export function describeTransportContract(name: string, makeHarness: () => Promi
     // slowest contract test does ~6 sequential git round-trips (~8s on Windows).
     // Own a generous timeout here so bare `vitest run` stays green while the
     // global default stays tight for fast unit tests.
-    vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+    //
+    // 30_000 -> 120_000 (2026-07-17): the old ceiling was sized against that ~8s
+    // ISOLATED measurement, but these tests spawn real `git`, so their wall-clock
+    // scales with machine load — and vitest's parallel pool guarantees load. At
+    // 30s this timed out nondeterministically under a full-suite run and blocked
+    // release builds (`npm test` gates Build). The ceiling only bounds the
+    // FAILURE case: a passing test returns as soon as it finishes, so a higher
+    // number costs nothing on green runs. NOTE this is file-wide (vi.setConfig
+    // is per-file, not per-describe), so it also governs the calling transport
+    // file's own tests.
+    vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
     let h: TransportHarness;
     beforeEach(async () => { h = await makeHarness(); });

--- a/desktop/tests/transcript-watcher.test.ts
+++ b/desktop/tests/transcript-watcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -8,6 +8,18 @@ import {
   TranscriptWatcher,
 } from '../src/main/transcript-watcher';
 import type { TranscriptEvent } from '../src/shared/types';
+
+// Fixed sleep. ONLY valid before a NEGATIVE assertion ("nothing emitted yet") or
+// as a settle that lets a WRONG extra event land before asserting it didn't —
+// a too-short sleep there fails safe. NEVER sleep before a POSITIVE assertion:
+// reads are async and fs.watch delivery is load-dependent, so a fixed budget is
+// a bet that loses as the machine gets busy. Use `vi.waitFor(...)` to poll.
+const wait = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+// Generous ceilings — they only bound the FAILURE case; a passing assertion
+// returns the moment it holds, so raising them costs nothing on green runs.
+const SETTLE_MS = 5_000;   // in-process: watcher read + emit
+const WATCH_MS = 15_000;   // fs.watch/stat-poll delivery of an external write
 
 // ---------------------------------------------------------------------------
 // parseTranscriptLine
@@ -374,8 +386,14 @@ describe('TranscriptWatcher', () => {
     watcher.on('transcript-event', (ev: TranscriptEvent) => events.push(ev));
 
     watcher.startWatching(desktopSessionId, claudeSessionId, cwd);
-    // readNewLines is async — wait for the initial read triggered by startWatching
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // readNewLines is async — poll for the initial read rather than betting on a
+    // fixed 100ms, which lost under vitest's parallel pool.
+    await vi.waitFor(() => expect(events.length).toBeGreaterThanOrEqual(1), { timeout: SETTLE_MS });
+    // Settle before the dedup assertion: both lines were written before the
+    // watch started so they arrive in ONE read, but waiting only for "length is
+    // 1" would let a regression that DOES emit the dup pass at the instant the
+    // count first hits 1.
+    await wait(50);
 
     // Only the first occurrence should be emitted (second uuid-dup is deduplicated)
     expect(events).toHaveLength(1);
@@ -426,14 +444,13 @@ describe('TranscriptWatcher', () => {
     watcher.on('transcript-event', (ev: TranscriptEvent) => events.push(ev));
 
     watcher.startWatching(desktopSessionId, claudeSessionId, cwd);
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await wait(200); // negative assertion below — a fixed settle is correct here
     expect(events).toHaveLength(0); // Incomplete line, no events
 
     // Append the rest with newline — now the full line is parseable
     fs.appendFileSync(jsonlPath, fullLine.substring(50) + '\n');
-    // Wait for fs.watch or polling to pick up the change
-    await new Promise((resolve) => setTimeout(resolve, 2500));
-    expect(events).toHaveLength(1);
+    // fs.watch/poll delivery — poll for it instead of betting 2500ms.
+    await vi.waitFor(() => expect(events).toHaveLength(1), { timeout: WATCH_MS });
     expect(events[0].data.text).toBe('partial test');
   });
 
@@ -463,10 +480,9 @@ describe('TranscriptWatcher', () => {
     watcher.on('transcript-event', (ev: TranscriptEvent) => events.push(ev));
 
     watcher.startWatching(desktopSessionId, claudeSessionId, cwd);
-    // readNewLines is async — wait for the initial read triggered by startWatching
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // readNewLines is async — poll for the initial read, don't bet on 100ms.
+    await vi.waitFor(() => expect(events).toHaveLength(2), { timeout: SETTLE_MS });
 
-    expect(events).toHaveLength(2);
     expect(events[0].type).toBe('assistant-text');
     expect(events[1].type).toBe('turn-complete');
   });
@@ -498,10 +514,10 @@ describe('TranscriptWatcher', () => {
     });
     fs.writeFileSync(jsonlPath, line + '\n');
 
-    // Wait for the poll interval to pick up the file
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // Poll until the watcher's own poll interval picks the file up — a fixed
+    // 1500ms is under the interval's worst case on a loaded machine.
+    await vi.waitFor(() => expect(events.length).toBeGreaterThanOrEqual(1), { timeout: WATCH_MS });
 
-    expect(events.length).toBeGreaterThanOrEqual(1);
     expect(events[0].data.text).toBe('From polling');
   });
 
@@ -548,10 +564,10 @@ describe('TranscriptWatcher', () => {
     });
 
     watcher.startWatching(desktopSessionId, claudeSessionId, cwd);
-    await new Promise((resolve) => setTimeout(resolve, 150));
-
-    expect(received).toContain('msg A');
-    expect(received).toContain('msg C');
+    await vi.waitFor(() => {
+      expect(received).toContain('msg A');
+      expect(received).toContain('msg C');
+    }, { timeout: SETTLE_MS });
   });
 
   it('records Agent tool_use in SubagentIndex for correlation', async () => {
@@ -665,7 +681,14 @@ describe('TranscriptWatcher read integrity', () => {
     watcher.readNewLinesForSession('desktop-race');
     watcher.readNewLinesForSession('desktop-race');
 
-    await new Promise((r) => setTimeout(r, 500));
+    // Poll for the first emit (the read is async — a fixed 500ms raced it under
+    // load), THEN settle so a second, racing emit would have landed before we
+    // assert it didn't. The old single sleep was doing both jobs at once.
+    await vi.waitFor(
+      () => expect(events.filter((e) => e.type === 'user-message').length).toBeGreaterThanOrEqual(1),
+      { timeout: SETTLE_MS },
+    );
+    await wait(200);
 
     const userMessages = events.filter((e) => e.type === 'user-message');
     expect(userMessages.length).toBe(1);


### PR DESCRIPTION
Fixes the three ROADMAP entries that were all one bug: **tests that bet a FIXED time budget on work whose wall-clock scales with machine load.** vitest's parallel pool guarantees load, so the bet loses nondeterministically. `npm test` gates the Build step, so a red run blocks release builds — the macOS `.dmg` never gets produced.

The victim set varies run to run, which is exactly why chasing individual tests never worked. Two mechanisms:

## 1. Fixed sleeps before positive assertions

`await wait(1500) // allow fs.watch/poll to fire` then assert. Replaced with `vi.waitFor(...)` bounded-retry polling — already the idiom in `sync-spaces-engine.test.ts`. A passing assertion returns the moment it holds, so the generous ceilings cost nothing on green runs.

Also converted two hand-rolled `20 x 50ms` loops: a **1s** ceiling for fs.watch delivery is the same losing bet, just spelled as a loop.

**Sleeps before NEGATIVE assertions are kept**, and the `wait()` helper now documents why: there's no condition to poll for, and a too-short sleep there fails safe. Reintroducing polling there would be wrong.

**Two tests assert *exactly one* event** (transcript dedup, and the double-emit race). Naively polling for `length === 1` would pass at the instant the count first hits 1 — masking a regression that emits a second. Those now poll for `>= 1`, then settle before asserting. The old single sleep was silently doing both jobs at once.

## 2. The 30s ceilings on git integration tests

Sized against an ~8s **isolated** measurement. `project-discovery` alone measures 19.6–27.3s isolated — already 65–90% of budget before any parallel load. Raised to 120s.

**Raising the file-level `vi.setConfig` alone did not work** — caught by re-running rather than trusting the first green. Three separate things pinned 30s:
- an inline `}, 30_000)` **third argument**, which silently overrides `vi.setConfig`
- five more inline args in `git-transport`
- the shared contract's own `vi.setConfig(30_000)`, which runs when `describeTransportContract()` is *called* and clobbers the caller's file-level config

Removed the inline args so each file has **one** documented knob. (Verified `vi.setConfig` does reach imported-helper-registered tests with a throwaway probe before relying on it.)

## Verification

Windows, same machine, same branch:

| | Result |
|---|---|
| **Before** | 3/3 full-suite runs failed (2 files, then 2, then 1) |
| **After** | 7 full-suite runs — 6 fully clean (2377 passed, counts reconciling), `tsc` clean |

One run showed a file unaccounted for with **no** test failure — that's the pre-existing `Worker exited unexpectedly` class already noted in the ROADMAP, not a timeout. It did not recur in the 4 runs after. I've left that entry open rather than claim it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)