### PR TITLE
UI consistency: tranche 0 (foundations + primitives) + tranche 1 (buttons)

### DIFF
--- a/desktop/scripts/audit-theme-contrast.mjs
+++ b/desktop/scripts/audit-theme-contrast.mjs
@@ -17,7 +17,10 @@
 // Run from anywhere: node scripts/audit-theme-contrast.mjs
 
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 
 // ────────────────────────────────────────────────────────────────────────────
 // Color math — standard sRGB → linear luminance → WCAG contrast ratio.
@@ -45,36 +48,58 @@ function contrast(hexA, hexB) {
   return (hi + 0.05) / (lo + 0.05);
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Built-in themes (defined in desktop/src/renderer/styles/globals.css).
-// Keep in sync with the :root / [data-theme=...] blocks there.
+/** Euclidean RGB distance — the accent-vs-fg guard the engine uses to decide
+ *  whether accent is usable as a link color. */
+function rgbDistance(hexA, hexB) {
+  const pa = hexA?.replace('#', '').match(/^([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})/i);
+  const pb = hexB?.replace('#', '').match(/^([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})/i);
+  if (!pa || !pb) return null;
+  return Math.sqrt(
+    [1, 2, 3].reduce((sum, i) => sum + (parseInt(pa[i], 16) - parseInt(pb[i], 16)) ** 2, 0),
+  );
+}
 
-const builtIn = {
-  light: {
-    canvas: '#F2F2F2', panel: '#EAEAEA', inset: '#E0E0E0', well: '#F7F7F7',
-    accent: '#1A1A1A', 'on-accent': '#F2F2F2',
-    fg: '#1A1A1A', 'fg-2': '#444444', 'fg-dim': '#666666', 'fg-muted': '#888888', 'fg-faint': '#AAAAAA',
-    edge: '#CFCFCF', link: '#2563EB',
-  },
-  dark: {
-    canvas: '#111111', panel: '#191919', inset: '#222222', well: '#1C1C1C',
-    accent: '#D4D4D4', 'on-accent': '#111111',
-    fg: '#E0E0E0', 'fg-2': '#B0B0B0', 'fg-dim': '#999999', 'fg-muted': '#666666', 'fg-faint': '#444444',
-    edge: '#2E2E2E', link: '#66AAFF',
-  },
-  midnight: {
-    canvas: '#0D1117', panel: '#161B22', inset: '#21262D', well: '#0D1117',
-    accent: '#B1BAC4', 'on-accent': '#0D1117',
-    fg: '#C9D1D9', 'fg-2': '#A0AAB4', 'fg-dim': '#8B949E', 'fg-muted': '#6E7681', 'fg-faint': '#484F58',
-    edge: '#30363D', link: '#58A6FF',
-  },
-  creme: {
-    canvas: '#F0E6D6', panel: '#EBE1D1', inset: '#DDD1BE', well: '#F5ECDE',
-    accent: '#3D3229', 'on-accent': '#F0E6D6',
-    fg: '#2C2418', 'fg-2': '#5C4F3E', 'fg-dim': '#7A6E5D', 'fg-muted': '#9E9283', 'fg-faint': '#BEB3A4',
-    edge: '#CBBFAD', link: '#5B4A1E',
-  },
-};
+// Mirrors computeOverlayTokens() in src/renderer/themes/theme-engine.ts — the
+// audit has to check the colors that actually RENDER, and link/destructive/
+// on-destructive are derived at runtime rather than declared by most packs.
+// The two must agree; tests/theme-builtin-sources.test.ts pins them together.
+function withDerivedTokens(data) {
+  const t = { ...data.tokens };
+  const destructive = data.overlay?.destructive ?? '#DD4444';
+  t.destructive = destructive;
+  t['on-destructive'] =
+    contrast('#FFFFFF', destructive) >= contrast('#1A1A1A', destructive) ? '#FFFFFF' : '#1A1A1A';
+  if (!t.link) {
+    const dist = rgbDistance(t.accent, t.fg);
+    t.link = dist != null && dist > 40 ? t.accent : t['fg-2'];
+  }
+  return t;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Built-in themes — read straight from src/renderer/themes/builtin/*.json,
+// which is the single source of truth (it is what the theme engine actually
+// applies at runtime). This used to be a hand-maintained copy and it drifted:
+// creme's fg-muted/fg-faint were fixed in globals.css but not here or in the
+// JSON, so the audit passed values the app never rendered. Reading the JSON
+// removes that failure mode by construction. The globals.css [data-theme]
+// blocks are anti-FOUC only and are pinned against these files by
+// tests/theme-builtin-sources.test.ts.
+
+const builtinRoot = resolve(scriptDir, '..', 'src', 'renderer', 'themes', 'builtin');
+
+function loadBuiltinThemes() {
+  const out = {};
+  for (const file of readdirSync(builtinRoot)) {
+    if (!file.endsWith('.json')) continue;
+    const data = JSON.parse(readFileSync(join(builtinRoot, file), 'utf-8'));
+    if (!data.tokens) continue;
+    out[data.slug || file.replace(/\.json$/, '')] = withDerivedTokens(data);
+  }
+  return out;
+}
+
+const builtIn = loadBuiltinThemes();
 
 // ────────────────────────────────────────────────────────────────────────────
 // Load community themes from wecoded-themes/themes/*/manifest.json.
@@ -92,7 +117,7 @@ function loadCommunityThemes() {
     if (!existsSync(manifest)) continue;
     const data = JSON.parse(readFileSync(manifest, 'utf-8'));
     if (!data.tokens) continue;
-    out[data.slug || dir] = data.tokens;
+    out[data.slug || dir] = withDerivedTokens(data);
   }
   return out;
 }
@@ -111,6 +136,10 @@ const pairs = [
   { name: 'fg/inset',         a: 'fg',         b: 'inset',  min: 4.5,  label: 'primary text on bubbles (AA)' },
   { name: 'on-accent/accent', a: 'on-accent',  b: 'accent', min: 4.5,  label: 'user-bubble text (AA)' },
   { name: 'link/canvas',      a: 'link',       b: 'canvas', min: 4.5,  label: 'link on content (AA)' },
+  // Danger-button label. --destructive is pack-overridable with no guard, and
+  // --on-destructive derives to whichever of white/near-black reads better —
+  // this catches mid-tone destructives where NEITHER label clears AA.
+  { name: 'on-destructive/destructive', a: 'on-destructive', b: 'destructive', min: 4.5, label: 'danger button label (AA)' },
 ];
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -124,23 +153,11 @@ function auditTheme(name, tokens) {
   return results;
 }
 
-// Proposed fixes — added alongside originals so we can confirm thresholds pass.
-const proposed = {
-  'creme (proposed)': {
-    ...builtIn.creme,
-    'fg-muted': '#8A7E6E',  // was #9E9283 → 2.47:1; new target ≥ 3:1
-    'fg-faint': '#B0A595',  // was #BEB3A4 → 1.67:1; new target ≥ 1.8:1
-  },
-  'strawberry-kitty (proposed)': (() => {
-    const community = loadCommunityThemes();
-    return {
-      ...community['strawberry-kitty'],
-      accent: '#CC4060',  // was #D94E6B → 4.00:1; new target ≥ 4.5:1
-    };
-  })(),
-};
+// (A `proposed` staging block used to live here for two in-flight fixes —
+// creme's fg-muted/fg-faint and strawberry-kitty's accent. Both have since
+// landed in their source files, so the synthetic entries were removed.)
 
-const themes = { ...builtIn, ...loadCommunityThemes(), ...proposed };
+const themes = { ...builtIn, ...loadCommunityThemes() };
 const ordered = Object.keys(themes).sort();
 const overallFails = [];
 

--- a/desktop/src/renderer/components/AccountSection.tsx
+++ b/desktop/src/renderer/components/AccountSection.tsx
@@ -6,6 +6,7 @@ import { useAccount } from '../state/account-context';
 import type { MarketplaceUser } from '../../main/marketplace-auth-store';
 import type { BlockRow } from '../state/marketplace-api-client';
 import SettingsRow from './SettingsRow';
+import { Button } from './ui';
 
 // Settings → Account section. One self-contained row-button + popup, mounted in
 // both the Desktop and Android settings stacks. Auth-token state and mutations
@@ -144,7 +145,11 @@ function SignedOutBody({
       <p className="text-[11px] text-fg-dim leading-relaxed">
         One sign-in for the marketplace and games — GitHub only sees your public profile.
       </p>
-      <button
+      {/* Page-level CTA -> lg. Also drops hover:brightness-110, which was
+          invisible on Light/Creme (their accent is already near-black), and
+          gains the focus ring it never had. */}
+      <Button
+        size="lg"
         onClick={() => {
           setSignInError(null);
           startSignIn().catch((e) =>
@@ -152,11 +157,10 @@ function SignedOutBody({
           );
         }}
         disabled={signInPending}
-        className="flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
       >
         <GitHubIcon />
         {signInPending ? 'Signing in…' : 'Sign in with GitHub'}
-      </button>
+      </Button>
       {signInError && <p className="text-[10px] text-red-500">{signInError}</p>}
     </div>
   );
@@ -595,12 +599,11 @@ function EditAccountBody({
       <section className="space-y-2">
         <h4 className="text-[10px] font-medium text-red-500 uppercase tracking-wider">Danger zone</h4>
         {!deleteExpanded ? (
-          <button
-            onClick={() => setDeleteExpanded(true)}
-            className="w-full text-xs font-medium py-2.5 rounded-lg border border-red-500/50 text-red-500 hover:bg-red-500/10 transition-colors"
-          >
+          // Arming step -> danger-outline. red-500 becomes the --destructive
+          // token so packs can restyle it (identical #DD4444 today).
+          <Button variant="danger-outline" onClick={() => setDeleteExpanded(true)} className="w-full">
             Delete account
-          </button>
+          </Button>
         ) : (
           <div className="space-y-2">
             <p className="text-[11px] text-fg-dim leading-relaxed">
@@ -625,19 +628,27 @@ function EditAccountBody({
               className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-red-500"
             />
             <div className="flex gap-2">
-              <button
+              {/* This Cancel earns its place next to the ✕ rule: it collapses the
+                  danger-zone confirm rather than closing the popup, so it does
+                  something the ✕ doesn't. */}
+              <Button
+                variant="secondary"
                 onClick={() => { setDeleteExpanded(false); setDeleteConfirm(''); setDeleteError(null); }}
-                className="flex-1 text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
+                className="flex-1"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              {/* text-white becomes the derived --on-destructive: --destructive is
+                  pack-overridable with no contrast guard, so white can vanish on a
+                  pale red. */}
+              <Button
+                variant="danger"
                 onClick={() => void confirmDelete()}
                 disabled={deleteConfirm.trim() !== 'delete' || deleting}
-                className="flex-1 text-xs font-medium py-2.5 rounded-lg bg-red-500 text-white hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1"
               >
                 {deleting ? 'Deleting…' : 'Delete my account'}
-              </button>
+              </Button>
             </div>
             {deleteError && <p className="text-[10px] text-red-500">{deleteError}</p>}
           </div>

--- a/desktop/src/renderer/components/ConnectGithubModal.tsx
+++ b/desktop/src/renderer/components/ConnectGithubModal.tsx
@@ -12,6 +12,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 import { getPlatform } from '../platform';
+import { Button } from './ui';
 
 type Stage = 'checking' | 'gh-missing' | 'code' | 'done' | 'error';
 
@@ -223,14 +224,23 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
             {installNote?.kind === 'manual' && (
               <div className="space-y-1">
                 <div className="text-[11px] text-fg-muted">Run this in your terminal, then choose “Check again”:</div>
-                <div className="flex items-center gap-2">
-                  <code className="flex-1 font-mono text-xs text-fg-dim bg-inset px-2 py-1.5 rounded break-all">{installNote.text}</code>
-                  <button
+                {/* copy-inside-container: the Copy button docks INSIDE the code
+                    block instead of floating beside it as a second surface.
+                    hover:bg-edge overrides ghost's hover:bg-inset, which would be
+                    invisible sitting on an inset container. */}
+                <div
+                  className="flex items-center gap-2 bg-inset rounded"
+                  style={{ padding: '4px 4px 4px 8px' }}
+                >
+                  <code className="flex-1 font-mono text-xs text-fg-dim break-all">{installNote.text}</code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="hover:bg-edge shrink-0"
                     onClick={() => navigator.clipboard?.writeText(installNote.text).catch(() => {})}
-                    className="text-xs px-2 py-1 rounded bg-inset hover:bg-edge text-fg-dim shrink-0"
                   >
                     Copy
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}
@@ -238,27 +248,17 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
               <div role="alert" className="text-xs text-red-500">{installNote.text}</div>
             )}
 
+            {/* "Never mind" removed: it called the same handleClose as the ✕ in
+                the header, so it was a second way to do one thing. Dialogs with
+                an ✕ get no redundant text cancel. */}
             <div className="flex justify-end gap-2 pt-1">
-              <button
-                onClick={handleClose}
-                className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors"
-              >
-                Never mind
-              </button>
-              <button
-                onClick={() => void runCheck()}
-                disabled={installBusy}
-                className="text-sm px-3 py-1 rounded border border-edge-dim text-fg-2 hover:bg-inset disabled:opacity-50"
-              >
+              <Button variant="secondary" onClick={() => void runCheck()} disabled={installBusy}>
                 Check again
-              </button>
-              <button
-                onClick={() => void handleInstallGh()}
-                disabled={installBusy}
-                className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50"
-              >
+              </Button>
+              {/* This primary had NO hover state at all before. */}
+              <Button onClick={() => void handleInstallGh()} disabled={installBusy}>
                 {installBusy ? 'Installing…' : 'Install GitHub CLI'}
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/desktop/src/renderer/components/FirstRunView.tsx
+++ b/desktop/src/renderer/components/FirstRunView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import type { FirstRunState, PrerequisiteState } from '../../shared/first-run-types';
 import BrailleSpinner from './BrailleSpinner';
 import { describeStep } from './first-run/describe-step';
+import { Button } from './ui';
 
 /* ------------------------------------------------------------------ */
 /*  StatusIcon                                                        */
@@ -98,12 +99,12 @@ function AuthScreen({
         Sign in with your Claude Pro or Max plan — no API key or credit card needed.
       </p>
 
-      <button
-        onClick={onOAuth}
-        className="px-6 py-3 rounded-full bg-accent text-on-accent font-semibold text-base hover:opacity-90 transition-opacity"
-      >
+      {/* Documented pill exception: first-run hero CTAs keep rounded-full and
+          their own larger padding. Only the hover and the focus ring normalize —
+          hover:opacity-90 faded the label along with the fill. */}
+      <Button onClick={onOAuth} className="px-6 py-3 rounded-full font-semibold text-base">
         Log in with Claude
-      </button>
+      </Button>
 
       {!showApiKey ? (
         <button
@@ -125,13 +126,13 @@ function AuthScreen({
             Your key is passed directly to Claude Code and stored in its secure config.
             YouCoded never stores, logs, or backs up your key.
           </p>
-          <button
+          <Button
             onClick={() => onApiKey(apiKey)}
             disabled={!apiKey.trim()}
-            className="px-4 py-2 rounded-full bg-accent text-on-accent text-sm font-medium hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+            className="px-4 py-2 rounded-full text-sm"
           >
             Verify &amp; Continue
-          </button>
+          </Button>
         </div>
       )}
     </div>
@@ -149,12 +150,9 @@ function DevModeScreen({ onEnable }: { onEnable: () => void }) {
         Windows Developer Mode allows YouCoded to create symbolic links, which
         the toolkit uses for configuration files. This is a one-time system setting.
       </p>
-      <button
-        onClick={onEnable}
-        className="px-5 py-2.5 rounded-full bg-accent text-on-accent font-medium hover:opacity-90 transition-opacity"
-      >
+      <Button onClick={onEnable} className="px-5 py-2.5 rounded-full">
         Enable Developer Mode
-      </button>
+      </Button>
       <p className="text-xs text-fg-muted leading-relaxed">
         If the button doesn't work, open{' '}
         <span className="font-mono text-fg-dim">

--- a/desktop/src/renderer/components/LocalModelsSection.tsx
+++ b/desktop/src/renderer/components/LocalModelsSection.tsx
@@ -9,6 +9,7 @@
 // plain-word status (never ●◐○ glyphs), consequence-gated destructive actions.
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import EngineCard from './EngineCard';
+import { Button } from './ui';
 import type {
   CuratedModel, QuantOption, FitEstimate, DownloadProgress,
   InstalledLocalModel, DetectedEndpoint, HFSearchHit,
@@ -456,12 +457,9 @@ function InstalledRow({ model, onRefresh }: { model: InstalledLocalModel; onRefr
           </p>
         </div>
         {!confirming && (
-          <button
-            onClick={() => setConfirming(true)}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-red-500/40 text-red-500 hover:bg-red-500/10 transition-colors shrink-0"
-          >
+          <Button variant="danger-outline" onClick={() => setConfirming(true)} className="shrink-0">
             Delete
-          </button>
+          </Button>
         )}
       </div>
 
@@ -472,19 +470,19 @@ function InstalledRow({ model, onRefresh }: { model: InstalledLocalModel; onRefr
             This removes the model file ({gb(model.sizeBytes)}) from this computer. Re-downloading it later will take a while.
           </p>
           <div className="flex gap-2">
-            <button
-              onClick={() => setConfirming(false)}
-              className="flex-1 text-xs font-medium py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-            >
+            {/* Keep collapses the confirm rather than closing anything, so it
+                survives the "no redundant text cancel" rule. */}
+            <Button variant="secondary" onClick={() => setConfirming(false)} className="flex-1">
               Keep
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="danger"
               onClick={() => void doDelete()}
               disabled={busy}
-              className="flex-1 text-xs font-medium py-2 rounded-lg bg-red-500 text-white hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1"
             >
               {busy ? 'Deleting…' : 'Delete model'}
-            </button>
+            </Button>
           </div>
           {delError && <p className="text-[10px] text-red-500">{delError}</p>}
         </div>

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -25,6 +25,7 @@ import AccountSection from './AccountSection';
 import ModelProvidersSection from './ModelProvidersPopup';
 import SettingsRow from './SettingsRow';
 import { formatVersionLine } from '../../shared/version-line';
+import { Button } from './ui';
 
 // Both are Vite `define` substitutions, so they're constants at module scope.
 // The typeof guard covers paths where the define isn't applied (unit tests).
@@ -915,8 +916,11 @@ function RemoteButton({
                   <>
                     {/* Setup banner — shown when no clients connected */}
                     {!hasClients && (
-                      <div className="bg-blue-500/10 border border-blue-500/25 rounded-lg p-3">
-                        <p className="text-xs text-blue-400 mb-2">
+                      // Info callouts are accent-tinted, warnings are amber. The
+                      // amber "setup required" boxes below stay amber — they're a
+                      // true warning status, not information.
+                      <div className="bg-accent/10 border border-accent/25 rounded-lg p-3">
+                        <p className="text-xs text-fg-2 mb-2">
                           Remote access lets you use YouCoded from any device — phone, tablet, or another computer.
                         </p>
 
@@ -933,12 +937,9 @@ function RemoteButton({
                                 <QRCodeSVG value={tailscale.url} size={140} />
                               </div>
                               <p className="text-[10px] text-fg-muted mt-2 text-center font-mono">{tailscale.url}</p>
-                              <button
-                                onClick={onCopyLink}
-                                className="w-full mt-2 px-3 py-1 rounded-sm bg-inset hover:bg-edge text-[10px] text-fg-dim"
-                              >
+                              <Button variant="secondary" size="sm" onClick={onCopyLink} className="w-full mt-2">
                                 {copied ? 'Copied!' : 'Copy link'}
-                              </button>
+                              </Button>
                             </div>
                           ) : (
                             <div className="space-y-2">
@@ -947,20 +948,20 @@ function RemoteButton({
                                 <p className="text-[10px] text-amber-400 font-medium mb-0.5">Other device setup required:</p>
                                 <p className="text-[10px] text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running before scanning. The page won't load without it.</p>
                               </div>
-                              <button
-                                onClick={() => onSetShowSetupQR(true)}
-                                className="w-full px-3 py-1.5 rounded-sm bg-blue-600 hover:bg-blue-500 text-xs font-medium"
-                              >
+                              {/* Was bg-blue-600 with NO text-color class, so the
+                                  label inherited the theme fg — near-black on blue
+                                  on Creme. Button primary carries text-on-accent. */}
+                              <Button onClick={() => onSetShowSetupQR(true)} className="w-full">
                                 Set Up Remote Access
-                              </button>
+                              </Button>
                             </div>
                           )
                         ) : setupStatus === 'confirm' ? (
                           <div className="space-y-2">
                             <p className="text-[10px] text-fg-2 text-center">This will download and install Tailscale (~50MB) for secure remote access.</p>
                             <div className="flex gap-2">
-                              <button onClick={onCancelSetup} className="flex-1 px-3 py-1.5 rounded-sm bg-inset hover:bg-edge text-xs">Cancel</button>
-                              <button onClick={onConfirmSetup} className="flex-1 px-3 py-1.5 rounded-sm bg-blue-600 hover:bg-blue-500 text-xs font-medium">Install</button>
+                              <Button variant="secondary" onClick={onCancelSetup} className="flex-1">Cancel</Button>
+                              <Button onClick={onConfirmSetup} className="flex-1">Install</Button>
                             </div>
                           </div>
                         ) : setupStatus === 'installing' ? (
@@ -978,7 +979,7 @@ function RemoteButton({
                         ) : setupStatus === 'error' ? (
                           <div className="space-y-2">
                             <p className="text-xs text-red-400 text-center">{setupError || 'Setup failed'}</p>
-                            <button onClick={onRunSetup} className="w-full px-3 py-1.5 rounded-sm bg-blue-600 hover:bg-blue-500 text-xs font-medium">Retry</button>
+                            <Button onClick={onRunSetup} className="w-full">Retry</Button>
                           </div>
                         ) : tailscale?.installed && !tailscale.connected ? (
                           // Fix: Tailscale is installed but VPN is off — tailscale.url is null in this state,
@@ -993,12 +994,9 @@ function RemoteButton({
                             Set a password below to finish enabling remote access.
                           </p>
                         ) : (
-                          <button
-                            onClick={onRunSetup}
-                            className="w-full px-3 py-1.5 rounded-sm bg-blue-600 hover:bg-blue-500 text-xs font-medium"
-                          >
+                          <Button onClick={onRunSetup} className="w-full">
                             Set Up Remote Access
-                          </button>
+                          </Button>
                         )}
                       </div>
                     )}
@@ -1868,18 +1866,14 @@ function ConnectToDesktopButton() {
                   )}
                   {!showConnectForm ? (
                     <div className="space-y-2">
-                      <button
-                        onClick={handleScanQr}
-                        className="w-full px-3 py-2 rounded-sm bg-accent text-on-accent text-xs font-medium active:brightness-110"
-                      >
+                      {/* Both only had an active: state, so on desktop nothing
+                          happened on hover at all. */}
+                      <Button onClick={handleScanQr} className="w-full">
                         Scan QR Code
-                      </button>
-                      <button
-                        onClick={() => setShowConnectForm(true)}
-                        className="w-full px-3 py-2 rounded-sm border border-edge text-fg-dim text-xs active:bg-inset"
-                      >
+                      </Button>
+                      <Button variant="secondary" onClick={() => setShowConnectForm(true)} className="w-full">
                         Enter Manually
-                      </button>
+                      </Button>
                     </div>
                   ) : (
                     <div className="space-y-3 bg-inset/50 rounded-lg p-3">
@@ -1924,19 +1918,14 @@ function ConnectToDesktopButton() {
                         />
                       </div>
                       <div className="flex gap-2">
-                        <button
-                          onClick={() => setShowConnectForm(false)}
-                          className="px-3 py-1.5 rounded-sm bg-inset hover:bg-edge text-xs text-fg-2"
-                        >
+                        {/* Collapses the add-device form rather than closing the
+                            panel, so it isn't a redundant text cancel. */}
+                        <Button variant="secondary" onClick={() => setShowConnectForm(false)}>
                           Cancel
-                        </button>
-                        <button
-                          onClick={handleSaveDevice}
-                          disabled={!formHost.trim()}
-                          className="flex-1 px-3 py-1.5 rounded-sm bg-accent text-on-accent text-xs font-medium disabled:opacity-50 active:brightness-110"
-                        >
-                          Save & Connect
-                        </button>
+                        </Button>
+                        <Button onClick={handleSaveDevice} disabled={!formHost.trim()} className="flex-1">
+                          Save &amp; Connect
+                        </Button>
                       </div>
                     </div>
                   )}

--- a/desktop/src/renderer/components/marketplace/MarketplaceDetailOverlay.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceDetailOverlay.tsx
@@ -18,6 +18,7 @@ import RatingSubmitModal from "./RatingSubmitModal";
 import ReviewList from "./ReviewList";
 import LikeButton from "./LikeButton";
 import FileViewerOverlay, { type FileViewerTarget } from "./FileViewerOverlay";
+import { Button } from "../ui";
 
 export type DetailTarget =
   | { kind: "skill"; id: string }
@@ -279,26 +280,31 @@ function SkillBody({
             (() => {
               const bundled = isBundledPlugin(entry.id);
               return (
-                <button
-                  type="button"
+                // Was a FILLED inset button, which read as a second primary
+                // sitting next to Install. Bordered secondary makes the hierarchy
+                // obvious.
+                <Button
+                  variant="secondary"
+                  size="lg"
                   onClick={onUninstall}
                   disabled={bundled}
                   title={bundled ? BUNDLED_REASON : undefined}
-                  className="px-4 py-2 rounded-md bg-inset text-fg border border-edge hover:border-edge-dim disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-edge"
                 >
                   Uninstall
-                </button>
+                </Button>
               );
             })()
           ) : (
-            <button
-              type="button"
+            <Button
+              size="lg"
               onClick={onInstall}
-              className={`px-4 py-2 rounded-md bg-accent text-on-accent hover:opacity-90 ${installError ? 'ring-2 ring-red-500' : ''}`}
+              // ring-red-500 -> the destructive token: identical #DD4444 today,
+              // but theme-overridable now.
+              className={installError ? 'ring-2 ring-destructive' : ''}
               title={installError || undefined}
             >
               {installError ? 'Retry Install' : 'Install'}
-            </button>
+            </Button>
           )}
         </div>
       </header>
@@ -545,31 +551,35 @@ function ThemeBody({
               Installing…
             </button>
           ) : !installed ? (
-            <button
-              type="button"
+            <Button
+              size="lg"
               onClick={onInstall}
-              className={`px-4 py-2 rounded-md bg-accent text-on-accent hover:opacity-90 ${installError ? 'ring-2 ring-red-500' : ''}`}
+              // ring-red-500 -> the destructive token: identical #DD4444 today,
+              // but theme-overridable now.
+              className={installError ? 'ring-2 ring-destructive' : ''}
               title={installError || undefined}
             >
               {installError ? 'Retry Install' : 'Install'}
-            </button>
+            </Button>
           ) : isActive ? (
             <>
-              <button type="button" disabled className="px-4 py-2 rounded-md bg-inset text-fg-dim border border-edge cursor-default">
+              {/* "Active" is a disabled state marker, not an action — secondary
+                  reads as the inert sibling of the ghost Uninstall beside it. */}
+              <Button variant="secondary" size="lg" disabled>
                 Active
-              </button>
-              <button type="button" onClick={handleUninstall} className="px-3 py-2 rounded-md text-fg-dim hover:text-fg text-sm">
+              </Button>
+              <Button variant="ghost" size="lg" onClick={handleUninstall}>
                 Uninstall
-              </button>
+              </Button>
             </>
           ) : (
             <>
-              <button type="button" onClick={onApply} className="px-4 py-2 rounded-md bg-accent text-on-accent hover:opacity-90">
+              <Button size="lg" onClick={onApply}>
                 Apply theme
-              </button>
-              <button type="button" onClick={handleUninstall} className="px-3 py-2 rounded-md text-fg-dim hover:text-fg text-sm">
+              </Button>
+              <Button variant="ghost" size="lg" onClick={handleUninstall}>
                 Uninstall
-              </button>
+              </Button>
             </>
           )}
         </div>

--- a/desktop/src/renderer/components/marketplace/MarketplaceHero.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceHero.tsx
@@ -6,6 +6,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import type { FeaturedHeroSlot, SkillEntry } from "../../../shared/types";
+import { Button } from "../ui";
 
 const ROTATION_MS = 6000;
 // Minimum horizontal travel to count as a swipe, in pixels. Below this, the
@@ -76,13 +77,12 @@ export default function MarketplaceHero({ slots, lookup, onOpen }: Props) {
           {entry?.displayName || slot.id}
         </h2>
         <p className="text-sm text-fg-2 max-w-xl mt-1 line-clamp-1 sm:line-clamp-none">{slot.blurb}</p>
-        <button
-          type="button"
-          onClick={() => onOpen(slot.id)}
-          className="mt-3 self-start px-3 py-1.5 rounded-md bg-accent text-on-accent text-sm font-medium hover:opacity-90 transition-opacity"
-        >
+        {/* Page-level CTA -> lg. hover:opacity-90 faded the whole button, LABEL
+            included; the fill now fades toward the surface and the text stays
+            crisp. */}
+        <Button size="lg" onClick={() => onOpen(slot.id)} className="mt-3 self-start">
           View details
-        </button>
+        </Button>
       </div>
       {slots.length > 1 && (
         <div className="absolute bottom-3 right-4 flex gap-1.5 z-10">

--- a/desktop/src/renderer/components/ui/AnchorTip.tsx
+++ b/desktop/src/renderer/components/ui/AnchorTip.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { OverlayPanel } from '../overlays/Overlay';
+import { useEscClose } from '../../hooks/use-esc-close';
+
+/**
+ * Anchored info bubble (change 28, §1.7).
+ *
+ * Replaces the two hand-rolled `fixed z-[9999]` / `bg-panel border rounded-lg
+ * shadow-lg` boxes — InfoPopover and SkipPermissionsInfoTooltip — with one
+ * .layer-surface at L4, so Overlay.tsx stays the only z-index authority
+ * (design rule 11).
+ *
+ * L4 on purpose: these explain L2 popups, so they must float above z-61 or the
+ * bubble gets trapped behind the panel it's describing.
+ *
+ * NOTE — the spec described SkipPermissionsInfoTooltip as "a copy of"
+ * InfoPopover. It isn't. They share the (i) glyph and the panel styling, but
+ * their interaction models differ: InfoPopover is click-toggled and dismissible,
+ * SkipPermissionsInfoTooltip is hover/focus-shown and pointer-events-none. Both
+ * modes are supported here rather than forcing one call site to change behavior.
+ *
+ * Native `title=` hover hints are NOT this component — they stay as-is
+ * (~231 across 63 files). AnchorTip is for rich/click-open info; `title` is for
+ * plain hover hints. Two tools, one documented policy.
+ */
+
+export type AnchorTipTrigger = 'click' | 'hover';
+export type AnchorTipPlacement = 'top' | 'bottom';
+
+export type AnchorTipProps = {
+  /** Accessible name for the trigger, e.g. "About OpenRouter". */
+  label: string;
+  /** Optional bold heading inside the bubble. */
+  title?: string;
+  children: React.ReactNode;
+  /** click (default) = toggled + dismissible. hover = transient, non-interactive. */
+  trigger?: AnchorTipTrigger;
+  placement?: AnchorTipPlacement;
+  /** Tailwind width class for the bubble. */
+  widthClass?: string;
+  className?: string;
+};
+
+export function AnchorTip({
+  label,
+  title,
+  children,
+  trigger = 'click',
+  placement = 'bottom',
+  widthClass = 'w-72',
+  className = '',
+}: AnchorTipProps) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const measure = () => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setPos({
+      x: rect.left + rect.width / 2,
+      y: placement === 'bottom' ? rect.bottom + 6 : rect.top - 10,
+    });
+  };
+
+  useLayoutEffect(() => {
+    if (open) measure();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, placement]);
+
+  /**
+   * Esc goes through the shared dismissal stack rather than a hand-rolled
+   * capture-phase listener.
+   *
+   * The spec said to keep the capture-phase Esc "because it must beat the parent
+   * popup's Esc". It doesn't need to: useEscClose is a LIFO stack, and the tip
+   * pushes AFTER the popup that hosts it, so Esc pops the tip first by
+   * construction — which is the exact behavior the capture-phase hack was
+   * hand-rolling. Going through the stack also means the tip responds to
+   * Android's hardware-back button, which the raw listener never did.
+   */
+  useEscClose(open && trigger === 'click', () => setOpen(false));
+
+  // Outside-click dismissal (click mode only — a hover tip has no pointer events).
+  useEffect(() => {
+    if (!open || trigger !== 'click') return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (triggerRef.current?.contains(t) || panelRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    window.addEventListener('mousedown', onDown, true);
+    return () => window.removeEventListener('mousedown', onDown, true);
+  }, [open, trigger]);
+
+  // These live inside scrollable settings panels, so a bubble measured once on
+  // open detaches from its trigger the moment the panel scrolls. Capture-phase
+  // catches scrolls on ANY ancestor, not just window.
+  useEffect(() => {
+    if (!open) return;
+    const reposition = () => measure();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, placement]);
+
+  const hoverProps =
+    trigger === 'hover'
+      ? {
+          onMouseEnter: () => setOpen(true),
+          onMouseLeave: () => setOpen(false),
+          onFocus: () => setOpen(true),
+          onBlur: () => setOpen(false),
+        }
+      : {};
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={label}
+        aria-expanded={trigger === 'click' ? open : undefined}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (trigger === 'click') setOpen((v) => !v);
+        }}
+        {...hoverProps}
+        className={`inline-flex items-center justify-center shrink-0 text-fg-muted hover:text-fg transition-colors ${className}`.trim()}
+      >
+        <svg
+          className="w-3.5 h-3.5 opacity-60 hover:opacity-100 transition-opacity"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="9" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 11v5" />
+          <circle cx="12" cy="8" r="0.5" fill="currentColor" />
+        </svg>
+      </button>
+
+      {open &&
+        createPortal(
+          <OverlayPanel
+            ref={panelRef}
+            layer={4}
+            role={trigger === 'hover' ? 'tooltip' : 'dialog'}
+            className={`fixed p-3 text-left max-w-[calc(100vw-1.5rem)] ${widthClass} ${
+              trigger === 'hover' ? 'pointer-events-none' : ''
+            }`}
+            style={{
+              left: pos.x,
+              top: pos.y,
+              transform: placement === 'bottom' ? 'translateX(-50%)' : 'translate(-50%, -100%)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {title && <p className="text-xs font-semibold text-fg mb-1.5">{title}</p>}
+            <div className="text-2xs text-fg-2 leading-snug space-y-2">{children}</div>
+          </OverlayPanel>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+export default AnchorTip;

--- a/desktop/src/renderer/components/ui/Button.tsx
+++ b/desktop/src/renderer/components/ui/Button.tsx
@@ -85,21 +85,68 @@ type SizeProps =
 
 export type ButtonProps = CommonProps & SizeProps;
 
+/**
+ * Utility groups where a caller's className must REPLACE the base rather than
+ * pile on next to it.
+ *
+ * This is not optional politeness — Tailwind resolves two competing utilities by
+ * CSS SOURCE ORDER, not by the order you list them in the class attribute, and
+ * the order is Tailwind's, not ours. Measured in our own bundle: `.rounded-full`
+ * is emitted at 26057 and `.rounded-lg` at 26104, so `<Button className="rounded-full">`
+ * silently renders ROUNDED-LG. Same trap for `.text-base` (51062) vs `.text-sm`
+ * (51252). The spec's documented pill exception (change 7: "first-run hero CTAs
+ * keep rounded-full + their own larger padding via className override") would
+ * have quietly produced rounded rectangles.
+ *
+ * The usual fix is tailwind-merge. This is a deliberately tiny stand-in: we own
+ * every class in BUTTON_BASE/VARIANT/SIZE, so we only need to resolve the few
+ * groups we actually emit, and adding a dependency for that is not worth it.
+ * Patterns match RAW tokens, so variant-prefixed classes (`hover:bg-inset`,
+ * `disabled:opacity-50`) never match and are always kept.
+ */
+const CONFLICT_GROUPS: readonly RegExp[] = [
+  /^rounded(-|$)/,
+  // Font SIZE only — must not swallow text-on-accent / text-fg-2 (colors).
+  /^text-(4xs|3xs|2xs|xs|sm|base|lg|xl)$/,
+  /^p[xytrbl]?-/,
+  /^w-/,
+  /^h-/,
+  /^gap-/,
+  /^font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)$/,
+];
+
+/** Drops base tokens whose group the caller has overridden, then appends theirs. */
+export function mergeClasses(base: string, override: string): string {
+  const overrides = override.split(/\s+/).filter(Boolean);
+  if (overrides.length === 0) return base;
+
+  const kept = base
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((token) => {
+      const group = CONFLICT_GROUPS.find((re) => re.test(token));
+      if (!group) return true;
+      return !overrides.some((o) => group.test(o));
+    });
+
+  return [...kept, ...overrides].join(' ');
+}
+
 export function buttonClasses(
   variant: ButtonVariant = 'primary',
   size: ButtonSize = 'md',
   className = '',
 ): string {
-  return [
+  const base = [
     BUTTON_BASE,
     BUTTON_VARIANT[variant],
     BUTTON_SIZE[size],
     NEEDS_COARSE_HIT.has(size) ? 'coarse-hit' : '',
-    className,
   ]
     .filter(Boolean)
-    .join(' ')
-    .trim();
+    .join(' ');
+
+  return mergeClasses(base, className).trim();
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(

--- a/desktop/src/renderer/components/ui/Button.tsx
+++ b/desktop/src/renderer/components/ui/Button.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+/**
+ * The one button. Every button in the app goes through this — never hand-roll
+ * `bg-accent text-on-accent` (design rule 1).
+ *
+ * Before this existed the renderer had ~15 button treatments across ~50 files:
+ * 5 radii, 4 hover idioms, a hardcoded-blue family, and ~80% with no focus ring.
+ *
+ * Recipes below are the ones approved 2026-07-16 — see
+ * docs/active/specs/2026-07-16-ui-consistency-design-spec.md §1.1. Each was an
+ * explicit pick among rendered alternatives; the rejected ones are noted so they
+ * don't get reintroduced as "improvements".
+ */
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'danger-outline';
+export type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
+
+/** The one focus ring — every interactive control shares it (design rule 4),
+ *  so it lives here and Toggle/Checkbox/Radio/Select/SegmentedTabs import it.
+ *
+ *  The canvas offset was challenged post-approval: it's a solid fill, so on a
+ *  panel or popup surface it paints a canvas-colored halo rather than a
+ *  transparent gap, and no such ring existed anywhere in the codebase before.
+ *  Destin reviewed both variants rendered in a real popup footer on 2026-07-16
+ *  and KEPT the offset — the halo is known and accepted. Don't "fix" it.
+ *  Community custom_css focus styles still override by specificity, on purpose:
+ *  packs keep that power. */
+export const FOCUS_RING =
+  'focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canvas';
+
+/** Always applied.
+ *  rounded-lg is the one control radius (12px built-in / 24px on big-radius
+ *  packs, since --radius-lg is a theme token). Rejected: sm, md, full-everywhere.
+ *  Pills survive only as a documented exception (first-run hero CTAs), via
+ *  className override. */
+export const BUTTON_BASE =
+  'inline-flex items-center justify-center gap-1.5 font-medium rounded-lg transition-colors ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed ' +
+  FOCUS_RING;
+
+/** Hover is ALWAYS a background fade toward the surface — the label stays crisp.
+ *  Rejected: `hover:brightness-110` (invisible on Light/Crème's near-black accent)
+ *  and `hover:opacity-90` (fades the label too, and on glow themes like Halftone
+ *  the fill fades out from under the theme's own box-shadow glow).
+ *
+ *  danger uses text-on-destructive, NOT text-white: --destructive is
+ *  pack-overridable with no contrast guard, so hardcoded white can go
+ *  white-on-pale. The engine derives the label color per theme. */
+export const BUTTON_VARIANT: Record<ButtonVariant, string> = {
+  primary: 'bg-accent text-on-accent hover:bg-accent/90',
+  secondary: 'border border-edge-dim text-fg-2 hover:bg-inset',
+  ghost: 'text-fg-dim hover:text-fg hover:bg-inset',
+  danger: 'bg-destructive text-on-destructive hover:bg-destructive/90',
+  'danger-outline': 'border border-destructive/50 text-destructive hover:bg-destructive/10',
+};
+
+/** sm  — inline row actions (EngineCard, provider rows, chips)
+ *  md  — forms, popup footers, most actions
+ *  lg  — page-level CTAs (sign-in, marketplace hero)
+ *  icon— icon-only square; aria-label is required by the type signature */
+export const BUTTON_SIZE: Record<ButtonSize, string> = {
+  sm: 'text-2xs px-2.5 py-1',
+  md: 'text-xs px-3 py-1.5',
+  lg: 'text-sm px-4 py-2',
+  icon: 'w-7 h-7 p-0',
+};
+
+/** sm (~22px tall) and icon (28px) are under the ~44dp touch guideline, and this
+ *  renderer is also the Android UI. `.coarse-hit` expands the tap target on
+ *  touch devices only — no visual change. See globals.css. */
+const NEEDS_COARSE_HIT: ReadonlySet<ButtonSize> = new Set<ButtonSize>(['sm', 'icon']);
+
+type NativeButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+type CommonProps = NativeButtonProps & {
+  variant?: ButtonVariant;
+};
+
+/** Icon buttons have no text, so aria-label isn't optional — the type enforces
+ *  what a lint rule otherwise would (design rule 16). */
+type SizeProps =
+  | { size?: Exclude<ButtonSize, 'icon'> }
+  | { size: 'icon'; 'aria-label': string };
+
+export type ButtonProps = CommonProps & SizeProps;
+
+export function buttonClasses(
+  variant: ButtonVariant = 'primary',
+  size: ButtonSize = 'md',
+  className = '',
+): string {
+  return [
+    BUTTON_BASE,
+    BUTTON_VARIANT[variant],
+    BUTTON_SIZE[size],
+    NEEDS_COARSE_HIT.has(size) ? 'coarse-hit' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', className = '', type, ...rest },
+  ref,
+) {
+  const size = (rest as { size?: ButtonSize }).size ?? 'md';
+  const { size: _omit, ...domProps } = rest as NativeButtonProps & { size?: ButtonSize };
+
+  return (
+    <button
+      ref={ref}
+      // Default to "button" so a Button inside a <form> can't accidentally submit it.
+      // Callers that DO want submit pass type="submit" explicitly.
+      type={type ?? 'button'}
+      className={buttonClasses(variant, size, className)}
+      {...domProps}
+    />
+  );
+});
+
+export default Button;

--- a/desktop/src/renderer/components/ui/Checkbox.tsx
+++ b/desktop/src/renderer/components/ui/Checkbox.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { FOCUS_RING } from './Button';
+
+/**
+ * Consent checkbox (§1.4).
+ *
+ * Narrow by design: Toggle owns settings/state, chips own filters, Radio owns
+ * option lists (design rule 8). After the migration this has essentially one
+ * call site — ProjectView's delete-consent checkbox — plus whatever future
+ * consent gates appear.
+ */
+
+export type CheckboxProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> & {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+};
+
+export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(function Checkbox(
+  { checked, onChange, className = '', disabled, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      // 14px is well under the ~44dp touch guideline and this renderer is also
+      // the Android UI, so coarse-hit expands the tap target on touch only.
+      className={
+        'inline-flex items-center justify-center w-3.5 h-3.5 shrink-0 transition-colors coarse-hit ' +
+        'disabled:opacity-50 disabled:cursor-not-allowed ' +
+        FOCUS_RING +
+        ' ' +
+        (checked ? 'bg-accent border border-accent' : 'bg-inset border border-edge-dim') +
+        ' ' +
+        className
+      }
+      // Literal 4px, deliberately NOT rounded-sm. Radii are theme tokens, and on a
+      // big-radius pack (--radius-sm up to 24px) a 14px box would render as a
+      // circle — i.e. indistinguishable from a Radio. The shape carries meaning
+      // here, so it can't be themeable.
+      style={{ borderRadius: 4 }}
+      {...rest}
+    >
+      {checked && (
+        <svg
+          className="w-full h-full text-on-accent"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={3}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="m5 13 4 4 10-11" />
+        </svg>
+      )}
+    </button>
+  );
+});
+
+export default Checkbox;

--- a/desktop/src/renderer/components/ui/CloseButton.tsx
+++ b/desktop/src/renderer/components/ui/CloseButton.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Button } from './Button';
+
+/**
+ * The popup ✕ (change 41, §1.8).
+ *
+ * The same `w-7 h-7 rounded-sm hover:bg-inset` + copy-pasted SVG was duplicated
+ * across at least 8 files (AccountSection, ModelPickerPopup x2, PreferencesPopup,
+ * AboutPopup, ModelProvidersPopup x2, ContextPopup, PerformancePopup). This is
+ * that button, once, on the approved Button icon+ghost recipe.
+ *
+ * Documented exception: the terminal scroll buttons keep w-10 h-10 via className.
+ */
+
+export type CloseButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'aria-label'
+> & {
+  /** Override when "Close" is ambiguous — e.g. "Close settings", "Dismiss toast". */
+  label?: string;
+};
+
+export const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>(
+  function CloseButton({ label, ...rest }, ref) {
+    return (
+      <Button ref={ref} size="icon" variant="ghost" aria-label={label ?? 'Close'} {...rest}>
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </Button>
+    );
+  },
+);
+
+export default CloseButton;

--- a/desktop/src/renderer/components/ui/ProgressBar.tsx
+++ b/desktop/src/renderer/components/ui/ProgressBar.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+/**
+ * Determinate progress (change 46, §1.8).
+ *
+ * Unifies three near-misses: ModelLoadingBar (bg-well track), FirstRunView
+ * (already matched), and LocalModelsSection (unrounded fill). Track is always
+ * bg-inset — never bg-well.
+ */
+
+export type ProgressBarProps = {
+  /** 0-100. Clamped, so callers can pass raw ratios without guarding. */
+  percent: number;
+  /** Status hue for the fill (UsageCard's thresholds). Omit for bg-accent. */
+  color?: string;
+  /** Right-aligned percent readout. */
+  showLabel?: boolean;
+  'aria-label'?: string;
+  className?: string;
+};
+
+export function ProgressBar({
+  percent,
+  color,
+  showLabel = false,
+  className = '',
+  'aria-label': ariaLabel,
+}: ProgressBarProps) {
+  const pct = Math.max(0, Math.min(100, Number.isFinite(percent) ? percent : 0));
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`.trim()}>
+      <div
+        className="flex-1 h-1.5 rounded-full bg-inset overflow-hidden"
+        role="progressbar"
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={ariaLabel}
+      >
+        <div
+          // transition only width — animating a generic `all` here also animates
+          // background-color, which makes UsageCard's status-hue changes smear.
+          className={`h-full rounded-full transition-[width] duration-300 ease-out ${color ? '' : 'bg-accent'}`}
+          style={{ width: `${pct}%`, backgroundColor: color }}
+        />
+      </div>
+      {showLabel && (
+        // tabular-nums so the readout doesn't jitter horizontally as digits change
+        <span className="text-xs text-fg-muted tabular-nums shrink-0">{Math.round(pct)}%</span>
+      )}
+    </div>
+  );
+}
+
+export default ProgressBar;

--- a/desktop/src/renderer/components/ui/Radio.tsx
+++ b/desktop/src/renderer/components/ui/Radio.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { FOCUS_RING } from './Button';
+
+/**
+ * Option lists (§1.4, change 39). Replaces the native radios at
+ * PreferencesPopup's permission-mode list and SyncSetupWizard's two groups.
+ *
+ * Use RadioGroup rather than bare Radios — a radio group is ONE tab stop with
+ * arrow-key navigation between options, which is what screen-reader and
+ * keyboard users expect and what native radios gave us for free. Bare Radios
+ * would make every option its own tab stop.
+ */
+
+export type RadioProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> & {
+  checked: boolean;
+  onChange: () => void;
+};
+
+export const Radio = React.forwardRef<HTMLButtonElement, RadioProps>(function Radio(
+  { checked, onChange, className = '', disabled, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={onChange}
+      className={
+        'inline-flex items-center justify-center w-3.5 h-3.5 shrink-0 rounded-full transition-colors coarse-hit ' +
+        'disabled:opacity-50 disabled:cursor-not-allowed ' +
+        FOCUS_RING +
+        ' ' +
+        (checked ? 'bg-inset border border-accent' : 'bg-inset border border-edge-dim') +
+        ' ' +
+        className
+      }
+      {...rest}
+    >
+      {checked && <span className="w-1.5 h-1.5 rounded-full bg-accent" aria-hidden="true" />}
+    </button>
+  );
+});
+
+export type RadioGroupProps = {
+  /** Stable option ids in visual order — arrow keys walk this list. */
+  options: readonly string[];
+  value: string;
+  onChange: (next: string) => void;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  className?: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Wraps a set of Radios as one roving-focus group.
+ *
+ * Arrow keys move selection and wrap at the ends, matching native radio
+ * behavior. Only the selected Radio is tabbable (roving tabindex), so Tab
+ * enters and leaves the whole group in one stop.
+ */
+export function RadioGroup({
+  options,
+  value,
+  onChange,
+  className = '',
+  children,
+  ...aria
+}: RadioGroupProps) {
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const delta = e.key === 'ArrowDown' || e.key === 'ArrowRight' ? 1
+      : e.key === 'ArrowUp' || e.key === 'ArrowLeft' ? -1
+      : 0;
+    if (delta === 0) return;
+    e.preventDefault();
+    const i = options.indexOf(value);
+    if (i === -1) return;
+    // Wrap, like native radios.
+    onChange(options[(i + delta + options.length) % options.length]);
+  };
+
+  return (
+    <div role="radiogroup" className={className} onKeyDown={onKeyDown} {...aria}>
+      {children}
+    </div>
+  );
+}
+
+export default Radio;

--- a/desktop/src/renderer/components/ui/SegmentedTabs.tsx
+++ b/desktop/src/renderer/components/ui/SegmentedTabs.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { FOCUS_RING } from './Button';
+
+/**
+ * Tab rows (change 45, §1.8).
+ *
+ * One active-state recipe. Today Library tabs and BugReportPopup's Bug/Feature
+ * share the active style but disagree on inactive (Library tints it bg-inset,
+ * BugReport leaves it bare).
+ *
+ * DECIDED 2026-07-16: inactive is option B — transparent, hover reveals the
+ * tint. Option A (always-tinted inactive) was rendered and not taken.
+ *
+ * Filters are NOT tabs — marketplace filter Chips stay chips (design rule 8).
+ */
+
+export type SegmentedTab = {
+  id: string;
+  label: React.ReactNode;
+};
+
+export type SegmentedTabsProps = {
+  tabs: readonly SegmentedTab[];
+  value: string;
+  onChange: (id: string) => void;
+  /** bare = a plain row (Library). contained = tabs share an inset trough and
+   *  split the width evenly (BugReportPopup). */
+  variant?: 'bare' | 'contained';
+  'aria-label'?: string;
+  className?: string;
+};
+
+const TAB_BASE = `px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${FOCUS_RING}`;
+const TAB_ACTIVE = 'bg-accent text-on-accent';
+const TAB_INACTIVE = 'text-fg-2 hover:bg-inset';
+
+export function SegmentedTabs({
+  tabs,
+  value,
+  onChange,
+  variant = 'bare',
+  className = '',
+  'aria-label': ariaLabel,
+}: SegmentedTabsProps) {
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const delta = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+    if (delta === 0) return;
+    e.preventDefault();
+    const i = tabs.findIndex((t) => t.id === value);
+    if (i === -1) return;
+    onChange(tabs[(i + delta + tabs.length) % tabs.length].id);
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      onKeyDown={onKeyDown}
+      className={[
+        variant === 'contained' ? 'flex gap-1 p-1 bg-inset/50 rounded-lg' : 'flex gap-2',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {tabs.map((tab) => {
+        const active = tab.id === value;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            // Roving tabindex: the row is one tab stop, arrows move within it.
+            tabIndex={active ? 0 : -1}
+            onClick={() => onChange(tab.id)}
+            className={[
+              TAB_BASE,
+              active ? TAB_ACTIVE : TAB_INACTIVE,
+              variant === 'contained' ? 'flex-1' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default SegmentedTabs;

--- a/desktop/src/renderer/components/ui/Select.tsx
+++ b/desktop/src/renderer/components/ui/Select.tsx
@@ -1,0 +1,272 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { OverlayPanel } from '../overlays/Overlay';
+import { useEscClose } from '../../hooks/use-esc-close';
+import { fieldClasses, type FieldSize } from './field';
+
+/**
+ * The one dropdown (change 21, §1.3). NO native <select> anywhere.
+ *
+ * Styling the trigger alone is not enough and that's the whole point: a native
+ * <select>'s option list stays OS-rendered, so you get the OS blue-highlight menu
+ * dropping out of a themed app. This renders the list itself.
+ *
+ * Six call sites: ThemeScreen particles, RuntimeBinding provider + model,
+ * ProvidersSection add-provider type, SkillEditor category. (SessionDrawer's sort
+ * select folds into FileFilterPopover instead — change 38.)
+ */
+
+export type SelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export type SelectProps = {
+  options: readonly SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  size?: FieldSize;
+  placeholder?: string;
+  disabled?: boolean;
+  'aria-label'?: string;
+  className?: string;
+  /** Tailwind class for the menu width. Defaults to matching the trigger. */
+  menuClassName?: string;
+};
+
+export function Select({
+  options,
+  value,
+  onChange,
+  size = 'md',
+  placeholder = 'Select…',
+  disabled,
+  className = '',
+  menuClassName = '',
+  'aria-label': ariaLabel,
+}: SelectProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [rect, setRect] = useState<{ left: number; top: number; width: number } | null>(null);
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLDivElement>(null);
+  // First-character typeahead ("g" jumps to the next option starting with g).
+  const typeahead = useRef({ buffer: '', at: 0 });
+
+  const selected = options.find((o) => o.value === value);
+
+  const measure = () => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    setRect({ left: r.left, top: r.bottom + 4, width: r.width });
+  };
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    measure();
+    // Open with focus on the current value, not the top of the list.
+    const i = options.findIndex((o) => o.value === value);
+    setActiveIndex(i === -1 ? 0 : i);
+  }, [open, options, value]);
+
+  // The selected option can be dozens deep — RuntimeBinding's model select
+  // renders whatever a provider's catalog returns, and OpenRouter-style
+  // providers return a lot. Without this the menu opens scrolled to the top with
+  // the current value nowhere in sight.
+  useLayoutEffect(() => {
+    if (open) activeRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [open, activeIndex]);
+
+  // All six call sites live inside scrollable settings panels, so a menu
+  // positioned once on open drifts away from its trigger as soon as the panel
+  // scrolls. Capture-phase catches scrolls on any ancestor, not just window.
+  useEffect(() => {
+    if (!open) return;
+    const reposition = () => measure();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [open]);
+
+  useEscClose(open, () => setOpen(false));
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (triggerRef.current?.contains(t) || menuRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    window.addEventListener('mousedown', onDown, true);
+    return () => window.removeEventListener('mousedown', onDown, true);
+  }, [open]);
+
+  const commit = (i: number) => {
+    const opt = options[i];
+    if (!opt || opt.disabled) return;
+    onChange(opt.value);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  /** Next selectable index in `dir`, skipping disabled options and wrapping. */
+  const step = (from: number, dir: 1 | -1) => {
+    for (let n = 1; n <= options.length; n++) {
+      const i = (from + dir * n + options.length * n) % options.length;
+      if (!options[i]?.disabled) return i;
+    }
+    return from;
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open) {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setOpen(true);
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => step(i, 1));
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => step(i, -1));
+        return;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(step(options.length - 1, 1));
+        return;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(step(0, -1));
+        return;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        commit(activeIndex);
+        return;
+      case 'Tab':
+        setOpen(false);
+        return;
+      default:
+        break;
+    }
+
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      const now = Date.now();
+      const ta = typeahead.current;
+      // Keystrokes within 500ms accumulate ("mo" -> "model-b"); after that the
+      // buffer resets so a new letter starts a fresh jump.
+      ta.buffer = now - ta.at < 500 ? ta.buffer + e.key.toLowerCase() : e.key.toLowerCase();
+      ta.at = now;
+      const hit = options.findIndex(
+        (o) => !o.disabled && o.label.toLowerCase().startsWith(ta.buffer),
+      );
+      if (hit !== -1) setActiveIndex(hit);
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((v) => !v)}
+        onKeyDown={onKeyDown}
+        className={fieldClasses(size, `flex items-center justify-between gap-2 w-full text-left ${className}`)}
+      >
+        <span className={`truncate ${selected ? '' : 'text-fg-faint'}`}>
+          {selected?.label ?? placeholder}
+        </span>
+        <svg
+          className="w-3 h-3 shrink-0 text-fg-muted"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {open &&
+        rect &&
+        createPortal(
+          // L4 so a menu opened from inside an L2 popup (z-61) isn't trapped
+          // behind the panel that owns it.
+          <OverlayPanel
+            ref={menuRef}
+            layer={4}
+            className={`fixed ${menuClassName}`}
+            style={{
+              left: rect.left,
+              top: rect.top,
+              minWidth: rect.width,
+              borderRadius: 'var(--radius-lg)',
+            }}
+          >
+            {/* The scroll lives on this inner div, NOT on the OverlayPanel.
+                .layer-surface sets `overflow: hidden` as unlayered CSS, and
+                Tailwind emits overflow-y-auto inside @layer utilities — unlayered
+                beats layered, so an overflow-y-auto on the panel itself would be
+                silently ignored and the menu would clip instead of scroll. */}
+            <div
+              role="listbox"
+              aria-label={ariaLabel}
+              className="p-1 max-h-64 overflow-y-auto"
+              onKeyDown={onKeyDown}
+            >
+              {options.map((opt, i) => {
+                const isSelected = opt.value === value;
+                const isActive = i === activeIndex;
+                return (
+                  <div
+                    key={opt.value}
+                    ref={isActive ? activeRef : undefined}
+                    role="option"
+                    aria-selected={isSelected}
+                    aria-disabled={opt.disabled || undefined}
+                    onMouseEnter={() => !opt.disabled && setActiveIndex(i)}
+                    onClick={() => commit(i)}
+                    className={[
+                      // coarse-roomy grows the row on touch. Options sit flush
+                      // against each other, so they can't use coarse-hit's
+                      // overflowing box — it would steal the neighbour's taps.
+                      'px-2.5 py-1.5 coarse-roomy rounded-md text-2xs cursor-pointer truncate',
+                      opt.disabled ? 'opacity-50 cursor-not-allowed' : '',
+                      isSelected
+                        ? 'bg-accent text-on-accent font-medium'
+                        : `text-fg-2 ${isActive && !opt.disabled ? 'bg-inset' : ''}`,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                  >
+                    {opt.label}
+                  </div>
+                );
+              })}
+            </div>
+          </OverlayPanel>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+export default Select;

--- a/desktop/src/renderer/components/ui/TextInput.tsx
+++ b/desktop/src/renderer/components/ui/TextInput.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { fieldClasses, type FieldSize } from './field';
+
+/**
+ * Text entry on the shared FIELD surface (§1.3).
+ *
+ * Deliberately NOT restricted to type="text" — password, search, and number all
+ * route through here and keep their native type. The only text-entry element
+ * that stays hand-rolled is the chat composer (InputBar), which is a transparent
+ * textarea over a mirror overlay and is sui generis.
+ */
+
+export type TextInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+  /** md (default) for forms; sm for inline row actions and filter bars. */
+  size?: FieldSize;
+};
+
+export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(function TextInput(
+  { size = 'md', className = '', type = 'text', ...rest },
+  ref,
+) {
+  return <input ref={ref} type={type} className={fieldClasses(size, className)} {...rest} />;
+});
+
+export default TextInput;

--- a/desktop/src/renderer/components/ui/Textarea.tsx
+++ b/desktop/src/renderer/components/ui/Textarea.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { fieldClasses, type FieldSize } from './field';
+
+/**
+ * Multi-line entry on the shared FIELD surface (§1.3, change 42).
+ *
+ * The 12 textareas across 11 files split across at least two conflicting
+ * recipes — e.g. ContextPopup's `border-edge rounded-sm focus:ring-1` vs
+ * BugReportPopup's `border-edge-dim rounded-lg focus:border-accent`. This is the
+ * second one, which is FIELD.
+ *
+ * Excluded on purpose: the chat composer textarea (InputBar) — transparent text
+ * over a mirror overlay, its own species.
+ */
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  size?: FieldSize;
+  /** Escape hatch for the rare textarea that should be user-resizable.
+   *  Default off: drag-resize inside popups fights the popup's own layout. */
+  resizable?: boolean;
+};
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { size = 'md', className = '', resizable = false, ...rest },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      className={fieldClasses(size, `${resizable ? '' : 'resize-none'} ${className}`.trim())}
+      {...rest}
+    />
+  );
+});
+
+export default Textarea;

--- a/desktop/src/renderer/components/ui/Toast.tsx
+++ b/desktop/src/renderer/components/ui/Toast.tsx
@@ -50,13 +50,17 @@ export function Toast({
       role="status"
       aria-live="polite"
       className={[
-        // rounded-lg overrides .layer-surface's radius-xl — a toast is a control-
-        // sized surface, not a panel.
-        'flex items-center gap-2 px-4 py-2 rounded-lg text-sm text-fg pointer-events-none',
+        'flex items-center gap-2 px-4 py-2 text-sm text-fg pointer-events-none',
         variant === 'global'
           ? 'fixed bottom-16 left-1/2 -translate-x-1/2'
           : 'absolute bottom-full right-0 mb-1 whitespace-nowrap',
       ].join(' ')}
+      // A toast is a control-sized surface, not a panel, so it wants radius-lg
+      // rather than .layer-surface's radius-xl. Set inline, NOT via a rounded-lg
+      // class: .layer-surface's border-radius is unlayered CSS and Tailwind emits
+      // utilities inside @layer utilities, so the class would lose and the toast
+      // would silently keep the panel radius.
+      style={{ borderRadius: 'var(--radius-lg)' }}
     >
       {tone === 'error' && (
         // The state family's failure mark (§1.6) — same dot ErrorState uses.

--- a/desktop/src/renderer/components/ui/Toast.tsx
+++ b/desktop/src/renderer/components/ui/Toast.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { OverlayPanel } from '../overlays/Overlay';
+
+/**
+ * Transient feedback (change 44, §1.8).
+ *
+ * Replaces three uncoordinated systems: the App-global toast (hand-rolled
+ * bg-panel/border-edge/shadow-lg with a manual setTimeout at EVERY call site),
+ * LikeButton's local mini-toast (different size, radius, and z), and the
+ * marketplace role="status" strips.
+ *
+ * The dismiss timer lives here on purpose — call sites kept re-implementing it,
+ * and each one was a chance to leak a timer across unmount.
+ *
+ * Border/shadow/background all come from .layer-surface via OverlayPanel, which
+ * also owns the z-index (design rule 11 — Overlay.tsx is the only z authority).
+ */
+
+export type ToastTone = 'default' | 'error';
+
+export type ToastProps = {
+  message: React.ReactNode;
+  onDismiss: () => void;
+  tone?: ToastTone;
+  /** global = centered above the input bar. anchored = pinned above its
+   *  relatively-positioned parent (LikeButton). */
+  variant?: 'global' | 'anchored';
+  /** Auto-dismiss delay. Pass null to require an explicit dismiss. */
+  durationMs?: number | null;
+};
+
+export function Toast({
+  message,
+  onDismiss,
+  tone = 'default',
+  variant = 'global',
+  durationMs = 3000,
+}: ToastProps) {
+  useEffect(() => {
+    if (durationMs == null) return;
+    const id = setTimeout(onDismiss, durationMs);
+    return () => clearTimeout(id);
+    // Re-arm when the message changes so a second toast gets its own full
+    // window rather than inheriting the first one's remaining time.
+  }, [message, durationMs, onDismiss]);
+
+  return (
+    <OverlayPanel
+      layer={4}
+      role="status"
+      aria-live="polite"
+      className={[
+        // rounded-lg overrides .layer-surface's radius-xl — a toast is a control-
+        // sized surface, not a panel.
+        'flex items-center gap-2 px-4 py-2 rounded-lg text-sm text-fg pointer-events-none',
+        variant === 'global'
+          ? 'fixed bottom-16 left-1/2 -translate-x-1/2'
+          : 'absolute bottom-full right-0 mb-1 whitespace-nowrap',
+      ].join(' ')}
+    >
+      {tone === 'error' && (
+        // The state family's failure mark (§1.6) — same dot ErrorState uses.
+        <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" aria-hidden="true" />
+      )}
+      {message}
+    </OverlayPanel>
+  );
+}
+
+export default Toast;

--- a/desktop/src/renderer/components/ui/Toggle.tsx
+++ b/desktop/src/renderer/components/ui/Toggle.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { FOCUS_RING } from './Button';
+
+/**
+ * The one toggle (change 15, §1.2).
+ *
+ * ONE geometry — 36x20, which was SyncPanel's. It's the largest of the four that
+ * existed (32x16, 32x18, 28x16, 36x20) and therefore the best touch target,
+ * which matters because this renderer is also the Android UI.
+ *
+ * Also fixes a11y: only 2 of the ~14 switches in the app had any aria at all.
+ *
+ * Use Toggle for settings/state, Checkbox for consent, chips for filters,
+ * Radio for option lists (design rule 8).
+ */
+
+export type ToggleTone = 'default' | 'danger';
+
+const TRACK_ON: Record<ToggleTone, string> = {
+  // was green-600 in settings/sync — the app's accent is the on-state now (change 16)
+  default: 'bg-accent',
+  // was a raw #DD4444 hex; danger toggles (Skip Permissions, approve-all) ride
+  // the theme's destructive token so packs can restyle them (change 17)
+  danger: 'bg-destructive',
+};
+
+/**
+ * Track geometry.
+ *
+ * The border is present in BOTH states — visible when off, transparent when on.
+ * That is load-bearing, not decoration: `absolute` children position against the
+ * PADDING box, so a border that exists in only one state shifts the knob by 1px
+ * when you flip it. (The spec flagged this as risk 3 and asked for the 18px/2px
+ * knob positions to be "visually verified on both states" — keeping the border
+ * constant means there's nothing to verify: the two states are geometrically
+ * identical by construction.)
+ */
+const TRACK_BASE =
+  'relative w-9 h-5 rounded-full border transition-colors shrink-0 ' +
+  'disabled:opacity-60 disabled:cursor-not-allowed ' +
+  FOCUS_RING;
+
+/**
+ * Knob offsets, in px, relative to the track's PADDING box (inset 1px by the
+ * border above). 1 -> 17 renders as a symmetric 2px gap on each end with a 16px
+ * travel, which is the approved 36x20 / 16px-knob geometry.
+ *
+ * The spec wrote these as 2 -> 18 because it measured against a border-less
+ * track; with the constant border those same numbers would push the knob 1px
+ * past center. Same rendered result, corrected for the box it actually lives in.
+ */
+const KNOB_LEFT_OFF = 1;
+const KNOB_LEFT_ON = 17;
+
+export type ToggleProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> & {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  tone?: ToggleTone;
+};
+
+export const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(function Toggle(
+  { checked, onChange, tone = 'default', className = '', disabled, ...rest },
+  ref,
+) {
+  const track = checked
+    ? `${TRACK_ON[tone]} border-transparent`
+    : 'bg-inset border-edge-dim';
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`${TRACK_BASE} ${track} ${className}`.trim()}
+      {...rest}
+    >
+      {/* Knob. The border is not decoration either: bare bg-white sits at ~1.2:1
+          against Creme's off-state track (--inset #DDD1BE), where shadow-sm was
+          doing all the work of separating knob from track. The ring keeps it
+          legible on light themes and is invisible on dark ones. */}
+      <span
+        className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border border-edge-dim shadow-sm transition-all"
+        style={{ left: checked ? KNOB_LEFT_ON : KNOB_LEFT_OFF }}
+      />
+    </button>
+  );
+});
+
+export default Toggle;

--- a/desktop/src/renderer/components/ui/field.ts
+++ b/desktop/src/renderer/components/ui/field.ts
@@ -1,0 +1,37 @@
+/**
+ * The one field surface — shared by TextInput, Textarea, and the Select trigger.
+ *
+ * Replaces 3 focus paradigms x 3 backgrounds x 4 radii across ~25 inputs.
+ * Retires: `focus:border-fg-muted` (gray focus), `focus:ring-*` focus,
+ * `bg-canvas`/`bg-well` field surfaces, and `rounded`/`rounded-sm`/`rounded-md`
+ * field radii.
+ *
+ * FIELD covers ALL text entry, not just type="text": password (the 6 API-key
+ * sites), search, number (keeps type="number"), and <textarea>.
+ * ProvidersSection's key input already WAS this baseline — it's the reference.
+ *
+ * Known and accepted: inputs on `bg-inset/50` cards now sit closer to their
+ * background than before. The alternative (bg-well inside inset cards) was
+ * offered during review and not taken.
+ *
+ * Spec: docs/active/specs/2026-07-16-ui-consistency-design-spec.md §1.3
+ */
+
+/** Focus is a border color change, never a ring — the ring belongs to buttons. */
+export const FIELD =
+  'bg-inset border border-edge-dim rounded-lg text-fg placeholder:text-fg-faint ' +
+  'focus:outline-none focus:border-accent ' +
+  // Disabled fields already exist (EngineCard's context-length input, InputBar's
+  // composer, ReportReviewButton) and would otherwise lose their affordance.
+  'disabled:opacity-50 disabled:cursor-not-allowed';
+
+export type FieldSize = 'sm' | 'md';
+
+export const FIELD_SIZE: Record<FieldSize, string> = {
+  md: 'text-xs px-3 py-2',
+  sm: 'text-2xs px-2.5 py-1.5',
+};
+
+export function fieldClasses(size: FieldSize = 'md', className = ''): string {
+  return [FIELD, FIELD_SIZE[size], className].filter(Boolean).join(' ').trim();
+}

--- a/desktop/src/renderer/components/ui/index.ts
+++ b/desktop/src/renderer/components/ui/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared UI primitives. Import from here: `import { Button } from '../ui'`.
+ *
+ * These are the app's control vocabulary — every button, toggle, field, tab row,
+ * and state surface goes through them (design rules 1-18). Hand-rolling
+ * `bg-accent text-on-accent` or a fifth toggle geometry is what this directory
+ * exists to prevent.
+ *
+ * Full recipes and the reasoning behind each decision:
+ * docs/active/specs/2026-07-16-ui-consistency-design-spec.md
+ */
+
+export { Button, buttonClasses, BUTTON_BASE, BUTTON_VARIANT, BUTTON_SIZE, FOCUS_RING } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+
+export { CloseButton } from './CloseButton';
+export type { CloseButtonProps } from './CloseButton';
+
+export { Toggle } from './Toggle';
+export type { ToggleProps, ToggleTone } from './Toggle';
+
+export { FIELD, FIELD_SIZE, fieldClasses } from './field';
+export type { FieldSize } from './field';
+
+export { TextInput } from './TextInput';
+export type { TextInputProps } from './TextInput';
+
+export { Textarea } from './Textarea';
+export type { TextareaProps } from './Textarea';
+
+export { Select } from './Select';
+export type { SelectProps, SelectOption } from './Select';
+
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps } from './Checkbox';
+
+export { Radio, RadioGroup } from './Radio';
+export type { RadioProps, RadioGroupProps } from './Radio';
+
+export { LoadingState, EmptyState, ErrorState, FieldError } from './states';
+export type { LoadingStateProps, EmptyStateProps, ErrorStateProps, FieldErrorProps, StateVariant } from './states';
+
+export { AnchorTip } from './AnchorTip';
+export type { AnchorTipProps, AnchorTipTrigger, AnchorTipPlacement } from './AnchorTip';
+
+export { Toast } from './Toast';
+export type { ToastProps, ToastTone } from './Toast';
+
+export { SegmentedTabs } from './SegmentedTabs';
+export type { SegmentedTabsProps, SegmentedTab } from './SegmentedTabs';
+
+export { ProgressBar } from './ProgressBar';
+export type { ProgressBarProps } from './ProgressBar';

--- a/desktop/src/renderer/components/ui/states.tsx
+++ b/desktop/src/renderer/components/ui/states.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import BrailleSpinner from '../BrailleSpinner';
+import { Button } from './Button';
+
+/**
+ * The loading / empty / error family (changes 31-34, §1.6).
+ *
+ * Shared anatomy: [mark] message [action].
+ * Marks carry meaning — braille spinner = working, nothing = empty,
+ * destructive dot = failed.
+ *
+ * Two variants everywhere:
+ *   block  — list surfaces, text-sm, vertical breathing room
+ *   inline — inside sections, text-2xs, tight
+ */
+
+export type StateVariant = 'block' | 'inline';
+
+export type LoadingStateProps = {
+  /** What is loading. Always name it — "Loading sessions…", not "Loading…". */
+  what: string;
+  variant?: StateVariant;
+  className?: string;
+};
+
+export function LoadingState({ what, variant = 'block', className = '' }: LoadingStateProps) {
+  const block = variant === 'block';
+  return (
+    <div
+      className={[
+        block
+          ? 'flex items-center justify-center gap-2 py-8 text-sm text-fg-muted'
+          : 'flex items-center gap-2 px-1 text-2xs text-fg-muted',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <BrailleSpinner size={block ? 'sm' : 'xs'} />
+      <span>Loading {what}…</span>
+    </div>
+  );
+}
+
+export type EmptyStateProps = {
+  message: React.ReactNode;
+  /** Optional way out — "Clear filters", "Browse themes". */
+  action?: { label: string; onClick: () => void };
+  variant?: StateVariant;
+  className?: string;
+};
+
+export function EmptyState({ message, action, variant = 'block', className = '' }: EmptyStateProps) {
+  const block = variant === 'block';
+  return (
+    <div
+      className={[
+        // No mark: absence IS the empty state's mark.
+        block ? 'flex flex-col items-center gap-2 py-8' : 'flex items-center gap-3 px-1',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <span className={block ? 'text-sm text-fg-muted text-center' : 'text-2xs text-fg-muted'}>
+        {message}
+      </span>
+      {action && (
+        <Button variant="secondary" size="sm" onClick={action.onClick}>
+          {action.label}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** The failure mark. Shared with Toast's error tone. */
+function ErrorDot() {
+  return <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" aria-hidden="true" />;
+}
+
+type ErrorStateRecoverable = {
+  mode?: 'recoverable';
+  /** Specific and accurate — the real detail, never a guessed cause. */
+  message: React.ReactNode;
+  onRetry: () => void;
+  variant?: StateVariant;
+  className?: string;
+};
+
+type ErrorStateGeneral = {
+  mode: 'general';
+  title: React.ReactNode;
+  explainer: React.ReactNode;
+  onReportBug: () => void;
+  onDiagnose: () => void;
+  className?: string;
+};
+
+export type ErrorStateProps = ErrorStateRecoverable | ErrorStateGeneral;
+
+/**
+ * Option C, chosen explicitly over A ("quiet inline") and B ("destructive-tinted
+ * callout"): the container is NEUTRAL, and the destructive dot alone carries the
+ * failure. Errors are not red boxes (design rule 6).
+ *
+ * The `general` mode IS the two-action fallback component that
+ * docs/error-message-standards.md schedules for v1.3.1 — every user-facing error
+ * is either specific+Retry or general+two-actions.
+ */
+export function ErrorState(props: ErrorStateProps) {
+  const container = `bg-inset/50 rounded-lg p-3 ${props.className ?? ''}`.trim();
+
+  if (props.mode === 'general') {
+    return (
+      <div className={container} role="alert">
+        <div className="flex items-start gap-2">
+          <span className="mt-1.5">
+            <ErrorDot />
+          </span>
+          <div className="flex flex-col gap-2 min-w-0">
+            <span className="text-sm font-medium text-fg">{props.title}</span>
+            <span className="text-2xs text-fg-dim leading-relaxed">{props.explainer}</span>
+            <div className="flex items-center gap-2">
+              <Button variant="secondary" size="sm" onClick={props.onReportBug}>
+                Report bug
+              </Button>
+              <Button variant="primary" size="sm" onClick={props.onDiagnose}>
+                Diagnose with Claude
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const block = (props.variant ?? 'block') === 'block';
+  return (
+    <div className={container} role="alert">
+      <div className="flex items-center gap-2">
+        <ErrorDot />
+        <span className={`flex-1 min-w-0 text-fg-2 ${block ? 'text-sm' : 'text-2xs'}`}>
+          {props.message}
+        </span>
+        {/* Retry is FILLED primary — an explicit review correction from secondary,
+            because secondary reads as a dim outline on dark themes. */}
+        <Button variant="primary" size="sm" onClick={props.onRetry}>
+          Retry
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export type FieldErrorProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+/** Field-level errors stay short lines under the input — not cards. */
+export function FieldError({ children, className = '' }: FieldErrorProps) {
+  return (
+    <span className={`text-3xs text-destructive ${className}`.trim()} role="alert">
+      {children}
+    </span>
+  );
+}

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -892,6 +892,45 @@ body[data-mode="buddy-chat"] #theme-bg {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   Coarse-pointer hit expansion
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* This renderer is ALSO the Android UI — the same React bundle runs in the
+   WebView — so every control here is a phone control. Several are far below the
+   ~44-48dp touch guideline: sm buttons are ~22px tall, icon buttons 28px,
+   Checkbox/Radio 14px. This paints an invisible, centered hit target of at
+   least 44x44 on touch devices only.
+   Zero visual change anywhere: the pseudo-element has no paint, and the whole
+   rule is behind pointer:coarse so desktop never sees it. Clicks on the
+   pseudo-element hit the control because it's the control's own child. */
+@media (pointer: coarse) {
+  .coarse-hit {
+    position: relative;
+  }
+  .coarse-hit::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 100%;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* For list rows that can't use an overflowing hit box because they sit
+     shoulder-to-shoulder (Select options) — an expanded ::after would overlap
+     its neighbours and steal their taps. Grow the row itself instead.
+     Unlike everywhere else in this file, unlayered-beats-@layer-utilities is
+     working FOR us here: this deliberately overrides the py-1.5 utility. */
+  .coarse-roomy {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    Window chrome — title bar integration
    ═══════════════════════════════════════════════════════════════════════════ */
 

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -207,6 +207,20 @@
   --color-red-500: #DD4444;
   --color-amber-700: #FF9800;
 
+  /* Type scale below Tailwind's text-xs (12px). The renderer had ~538 raw
+     `text-[11px]` / `text-[10px]` / `text-[9px]` sites; these name the three
+     real sizes so the scale is enumerable and greppable. Same pixel values —
+     naming them is a no-op visually. New rule: no arbitrary `text-[Npx]`. */
+  --text-2xs: 11px;
+  --text-3xs: 10px;
+  --text-4xs: 9px;
+
+  /* Label color for filled --destructive surfaces (danger buttons/toggles).
+     Derived per-theme in theme-engine.ts rather than hardcoded white, because
+     --destructive is community-overridable with no contrast guard — a pack can
+     set a pale red that white text disappears against. */
+  --color-on-destructive: var(--on-destructive);
+
   /* All-monospace typography (matches YouCoded's Cascadia Mono everywhere) */
   --font-sans: 'Cascadia Mono', 'Cascadia Code', 'Fira Code', monospace;
   --font-mono: 'Cascadia Mono', 'Cascadia Code', 'Fira Code', monospace;
@@ -730,13 +744,18 @@ body[data-mode="buddy-chat"] #theme-bg {
 }
 
 /* Inside glass overlays, children use opaque backgrounds so the
-   blurred wallpaper doesn't leak through nested elements */
+   blurred wallpaper doesn't leak through nested elements.
+   Same unlayered-beats-layered hover carve-out as the .layer-surface
+   protection cascade below — see the long comment there for why. */
 .glass-overlay .bg-inset {
   background-color: var(--inset);
 }
 
-.glass-overlay .bg-accent {
+.glass-overlay .bg-accent:not(:hover) {
   background-color: var(--accent);
+}
+.glass-overlay .bg-accent:hover {
+  background-color: color-mix(in oklab, var(--accent) 90%, var(--panel));
 }
 
 /* Chat bubbles — solid themes: plain opaque tokens. Wallpaper themes:
@@ -822,8 +841,16 @@ body[data-mode="buddy-chat"] #theme-bg {
 [data-wallpaper] .panel-glass.bg-inset {
   background-color: color-mix(in srgb, var(--inset) calc(var(--panels-opacity, 1) * 100%), transparent);
 }
-[data-wallpaper] .panel-glass.bg-accent {
+/* Same unlayered-vs-@layer-utilities hover carve-out as the protection cascade
+   (see the .layer-surface comment). panel-glass elements ARE the surface, so
+   their base stays translucent at panels-opacity and the hover fades by scaling
+   that alpha to 90% — the same 10% fade toward the backdrop that
+   `hover:bg-accent/90` gives on solid themes. */
+[data-wallpaper] .panel-glass.bg-accent:not(:hover) {
   background-color: color-mix(in srgb, var(--accent) calc(var(--panels-opacity, 1) * 100%), transparent);
+}
+[data-wallpaper] .panel-glass.bg-accent:hover {
+  background-color: color-mix(in srgb, var(--accent) calc(var(--panels-opacity, 1) * 90%), transparent);
 }
 
 /* Destructive variant — danger-tinted border + ring for delete/clear dialogs */
@@ -836,13 +863,32 @@ body[data-mode="buddy-chat"] #theme-bg {
 /* Protection cascade: inside any popup/overlay, nested .bg-inset / .bg-accent
    elements stay opaque so the blurred background and bubble-opacity setting
    don't leak through soft buttons, dividers, or inline chips. Unconditional
-   (was gated on [data-panels-blur] before the refactor). */
+   (was gated on [data-panels-blur] before the refactor).
+
+   The :not(:hover) carve-out below is load-bearing — do not "simplify" it away.
+   These rules are UNLAYERED, and Tailwind v4 emits every utility inside
+   `@layer utilities`. Unlayered beats layered no matter the specificity, so a
+   plain `.layer-surface .bg-accent` silently overrode `hover:bg-accent/90` and
+   left every primary button in every popup with a dead hover. Splitting the
+   rule hands the hovered state back, and the companion re-states the hover as
+   an opaque color-mix so wallpaper themes don't get double translucency.
+
+   Only .bg-accent needs this. Of the ui/Button variants, primary is the only
+   one with BOTH a base background and a background hover: secondary/ghost/
+   danger-outline hover up from a transparent base (no base class to collide
+   with), and danger uses .bg-destructive — which has no wallpaper-translucency
+   rule, so it needs no protection at all. Adding a `.layer-surface
+   .bg-destructive` rule would not fix anything; it would newly BREAK
+   `hover:bg-destructive/90` the same way this bug worked. */
 .layer-surface .bg-inset {
   background-color: var(--inset);
 }
 
-.layer-surface .bg-accent {
+.layer-surface .bg-accent:not(:hover) {
   background-color: var(--accent);
+}
+.layer-surface .bg-accent:hover {
+  background-color: color-mix(in oklab, var(--accent) 90%, var(--panel));
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/desktop/src/renderer/themes/builtin/creme.json
+++ b/desktop/src/renderer/themes/builtin/creme.json
@@ -13,11 +13,13 @@
     "fg": "#2C2418",
     "fg-2": "#5C4F3E",
     "fg-dim": "#7A6E5D",
-    "fg-muted": "#9E9283",
-    "fg-faint": "#BEB3A4",
+    "fg-muted": "#8A7E6E",
+    "fg-faint": "#B0A595",
     "edge": "#CBBFAD",
     "edge-dim": "#D4C8B580",
     "scrollbar-thumb": "#CBBFB0",
-    "scrollbar-hover": "#A89A8A"
+    "scrollbar-hover": "#A89A8A",
+    "link": "#5B4A1E",
+    "link-hover": "#3D3219"
   }
 }

--- a/desktop/src/renderer/themes/builtin/dark.json
+++ b/desktop/src/renderer/themes/builtin/dark.json
@@ -18,6 +18,8 @@
     "edge": "#2E2E2E",
     "edge-dim": "#37373780",
     "scrollbar-thumb": "#333333",
-    "scrollbar-hover": "#555555"
+    "scrollbar-hover": "#555555",
+    "link": "#66AAFF",
+    "link-hover": "#88CCFF"
   }
 }

--- a/desktop/src/renderer/themes/builtin/light.json
+++ b/desktop/src/renderer/themes/builtin/light.json
@@ -18,6 +18,8 @@
     "edge": "#CFCFCF",
     "edge-dim": "#DCDCDC80",
     "scrollbar-thumb": "#C0C0C0",
-    "scrollbar-hover": "#999999"
+    "scrollbar-hover": "#999999",
+    "link": "#2563EB",
+    "link-hover": "#1D4ED8"
   }
 }

--- a/desktop/src/renderer/themes/builtin/midnight.json
+++ b/desktop/src/renderer/themes/builtin/midnight.json
@@ -18,6 +18,8 @@
     "edge": "#30363D",
     "edge-dim": "#30363D80",
     "scrollbar-thumb": "#30363D",
-    "scrollbar-hover": "#484F58"
+    "scrollbar-hover": "#484F58",
+    "link": "#58A6FF",
+    "link-hover": "#79C0FF"
   }
 }

--- a/desktop/src/renderer/themes/theme-engine.ts
+++ b/desktop/src/renderer/themes/theme-engine.ts
@@ -170,6 +170,16 @@ function rgbLuminance(r: number, g: number, b: number): number {
   return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
 }
 
+/** WCAG 2.0 contrast ratio between two hex colors (1:1 … 21:1).
+ *  Mirrors scripts/audit-theme-contrast.mjs so runtime derivation and the CI
+ *  audit agree on what "readable" means. */
+function contrastRatio(hexA: string, hexB: string): number {
+  const lA = rgbLuminance(...parseHex(hexA));
+  const lB = rgbLuminance(...parseHex(hexB));
+  const [hi, lo] = lA > lB ? [lA, lB] : [lB, lA];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
 /** Computes overlay CSS custom properties from existing theme tokens.
  *  After the glassmorphism refactor, overlay surfaces consume --panels-blur /
  *  --panels-opacity directly (set globally in applyThemeToDom), so this helper
@@ -207,13 +217,42 @@ export function computeOverlayTokens(
   );
   const code = accentFgDistance > 40 ? tokens.accent : tokens['fg-2'];
 
+  // Link color — same accent-vs-fg guard as --code above, for the same reason:
+  // themes that set accent == fg would otherwise render links invisible against
+  // prose. Packs may declare `link` explicitly to opt out of the derivation.
+  // Built-ins all declare their own, so this branch only runs for community packs.
+  const link = tokens.link ?? (accentFgDistance > 40 ? tokens.accent : tokens['fg-2']);
+  const linkHover = tokens['link-hover'] ?? `color-mix(in oklab, ${link} 85%, ${tokens.fg})`;
+
+  // Label color for filled --destructive surfaces (danger buttons, danger toggles).
+  // --destructive is pack-overridable with NO contrast guard, so hardcoding white
+  // can render white-on-pale-pink. Pick whichever of white / near-black reads
+  // better against the theme's actual destructive.
+  //
+  // NOTE: this is a max-contrast pick, NOT the "white if >= 4.5, else near-black"
+  // threshold the UI spec asked for. That rule was written believing white on the
+  // default #DD4444 scored 4.7:1; it actually scores 4.213:1, so the threshold
+  // would fail for EVERY theme and flip every danger button to near-black — which
+  // is both a visible regression and lower contrast than the white it replaced
+  // (near-black on #DD4444 is 4.131:1). Picking the better of the two delivers
+  // what the spec intended: white everywhere today, near-black only for packs
+  // whose destructive is genuinely too light to carry it.
+  const destructive = overlay?.destructive ?? '#DD4444';
+  const onDestructive =
+    contrastRatio('#FFFFFF', destructive) >= contrastRatio('#1A1A1A', destructive)
+      ? '#FFFFFF'
+      : '#1A1A1A';
+
   const result: Record<string, string> = {
     '--scrim': overlay?.scrim ?? `rgba(${scrimR}, ${scrimG}, ${scrimB}, 0.5)`,
     '--scrim-heavy': overlay?.['scrim-heavy'] ?? `rgba(${scrimR}, ${scrimG}, ${scrimB}, 0.7)`,
     '--shadow-strength': String(shadowStrength),
-    '--destructive': overlay?.destructive ?? '#DD4444',
-    '--destructive-dim': `rgba(${parseHex(overlay?.destructive ?? '#DD4444').join(', ')}, 0.15)`,
+    '--destructive': destructive,
+    '--destructive-dim': `rgba(${parseHex(destructive).join(', ')}, 0.15)`,
+    '--on-destructive': onDestructive,
     '--code': code,
+    '--link': link,
+    '--link-hover': linkHover,
   };
 
   return result;
@@ -450,14 +489,4 @@ export function applyThemeToDom(theme: ThemeDefinition, reducedEffects = false):
   applyEffects(reducedEffects ? undefined : theme.effects);
 }
 
-const TOKEN_CSS_PROPS = [
-  '--canvas', '--panel', '--inset', '--well', '--accent', '--on-accent',
-  '--fg', '--fg-2', '--fg-dim', '--fg-muted', '--fg-faint',
-  '--edge', '--edge-dim', '--scrollbar-thumb', '--scrollbar-hover',
-  // Overlay tokens (computed by theme engine from color tokens)
-  '--scrim', '--scrim-heavy',
-  '--shadow-strength', '--destructive', '--destructive-dim',
-  // Glassmorphism vars — always present with safe defaults (blur 0, opacity 1)
-  '--panels-blur', '--panels-opacity', '--bubble-blur', '--bubble-opacity',
-] as const;
 

--- a/desktop/src/renderer/themes/theme-types.ts
+++ b/desktop/src/renderer/themes/theme-types.ts
@@ -14,6 +14,14 @@ export interface ThemeTokens {
   'edge-dim': string;
   'scrollbar-thumb': string;
   'scrollbar-hover': string;
+  /** Hyperlink color. OPTIONAL — the engine derives it from accent/fg-2 when a
+   *  pack omits it (see computeOverlayTokens). Before this was derivable, packs
+   *  had no way to set it and silently inherited the Light theme's #2563EB from
+   *  :root, so every community theme rendered light-blue links. The four
+   *  built-ins declare their own hand-picked values. */
+  link?: string;
+  /** Hover state for `link`. Derived as link mixed 85% toward fg when omitted. */
+  'link-hover'?: string;
 }
 
 export interface ThemeShape {

--- a/desktop/tests/theme-builtin-sources.test.ts
+++ b/desktop/tests/theme-builtin-sources.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * Built-in theme colors exist in two places and MUST agree:
+ *
+ *   1. src/renderer/themes/builtin/<slug>.json  — the source of truth. The theme
+ *      engine applies these at runtime, so these are the values users actually see.
+ *   2. styles/globals.css [data-theme="<slug>"] — anti-FOUC only. Applied before
+ *      React mounts so the first paint isn't unstyled; overwritten moments later
+ *      by the engine.
+ *
+ * They drifted before, and it shipped: creme's fg-muted (#9E9283, 2.47:1) and
+ * fg-faint (#BEB3A4, 1.67:1) were corrected in globals.css but not in the JSON.
+ * Because the JSON is what renders, users kept seeing the failing values while
+ * the CSS and the contrast audit both claimed they were fixed.
+ *
+ * A third copy used to live in scripts/audit-theme-contrast.mjs; it now reads the
+ * JSON directly, so this test only has two sources left to reconcile.
+ */
+
+const builtinDir = resolve(__dirname, '..', 'src', 'renderer', 'themes', 'builtin');
+const globalsCss = readFileSync(
+  resolve(__dirname, '..', 'src', 'renderer', 'styles', 'globals.css'),
+  'utf-8',
+);
+
+/** Pulls the CSS custom properties out of the `[data-theme="<slug>"]` block. */
+function parseThemeBlock(slug: string): Record<string, string> {
+  const re = new RegExp(`\\[data-theme="${slug}"\\][^{]*\\{([^}]*)\\}`);
+  const match = globalsCss.match(re);
+  if (!match) throw new Error(`globals.css has no [data-theme="${slug}"] block`);
+
+  const vars: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const decl = line.match(/^\s*(--[\w-]+)\s*:\s*([^;]+);/);
+    if (decl) vars[decl[1]] = decl[2].trim();
+  }
+  return vars;
+}
+
+function loadBuiltins() {
+  return readdirSync(builtinDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(readFileSync(join(builtinDir, f), 'utf-8')));
+}
+
+describe('built-in theme sources agree', () => {
+  const builtins = loadBuiltins();
+
+  it('finds the four built-in themes', () => {
+    expect(builtins.map((t) => t.slug).sort()).toEqual(['creme', 'dark', 'light', 'midnight']);
+  });
+
+  for (const theme of loadBuiltins()) {
+    describe(theme.slug, () => {
+      const cssVars = parseThemeBlock(theme.slug);
+
+      for (const [token, value] of Object.entries(theme.tokens as Record<string, string>)) {
+        it(`--${token} matches globals.css`, () => {
+          // Hex is case-insensitive in CSS, so compare case-folded — we care
+          // about the color drifting, not the letter casing.
+          expect(cssVars[`--${token}`]?.toLowerCase()).toBe(value.toLowerCase());
+        });
+      }
+    });
+  }
+});
+
+describe('creme legibility fix stays fixed', () => {
+  // The exact values that shipped broken. Guards against a revert restoring
+  // sub-threshold text colors (fg-muted needs >= 3:1, fg-faint >= 1.8:1 vs canvas).
+  it('does not reintroduce the failing fg-muted / fg-faint', () => {
+    const creme = loadBuiltins().find((t) => t.slug === 'creme')!;
+    expect(creme.tokens['fg-muted']).not.toBe('#9E9283');
+    expect(creme.tokens['fg-faint']).not.toBe('#BEB3A4');
+    expect(creme.tokens['fg-muted']).toBe('#8A7E6E');
+    expect(creme.tokens['fg-faint']).toBe('#B0A595');
+  });
+});
+
+describe('built-ins declare their own link colors', () => {
+  // link/link-hover are optional pack tokens the engine derives when absent.
+  // The four built-ins have hand-picked values that must NOT fall back to
+  // derivation, or their links would visibly change color.
+  it('every built-in sets link and link-hover', () => {
+    for (const theme of loadBuiltins()) {
+      expect(theme.tokens.link, `${theme.slug} link`).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      expect(theme.tokens['link-hover'], `${theme.slug} link-hover`).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+});

--- a/desktop/tests/theme-engine.test.ts
+++ b/desktop/tests/theme-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTokenCSS, buildShapeCSS, buildBackgroundStyle, buildLayoutAttrs, buildPatternStyle } from '../src/renderer/themes/theme-engine';
+import { buildTokenCSS, buildShapeCSS, buildBackgroundStyle, buildLayoutAttrs, buildPatternStyle, computeOverlayTokens } from '../src/renderer/themes/theme-engine';
 
 const TOKENS = {
   canvas: '#0D0F1A', panel: '#141726', inset: '#1F2440', well: '#0D0F1A',
@@ -89,5 +89,91 @@ describe('buildPatternStyle', () => {
 
   it('returns null when pattern is undefined', () => {
     expect(buildPatternStyle(undefined, 0.06)).toBeNull();
+  });
+});
+
+describe('computeOverlayTokens — --on-destructive', () => {
+  const derive = (destructive?: string) =>
+    computeOverlayTokens(TOKENS, undefined, destructive ? { destructive } : undefined, false)[
+      '--on-destructive'
+    ];
+
+  it('derives white for the default #DD4444 (no visual change from the shipped text-white)', () => {
+    // Guards a real spec bug: change 43 was written believing white-on-#DD4444
+    // scored 4.7:1 and so specified "white if >= 4.5, else near-black". White
+    // actually scores 4.213:1, so that rule would have flipped EVERY danger
+    // button to near-black — which is also LOWER contrast (4.131:1). We pick the
+    // better of the two instead. If this ever returns #1A1A1A, danger buttons
+    // across every built-in theme just silently changed.
+    expect(derive()).toBe('#FFFFFF');
+  });
+
+  it('derives near-black when a pack overrides destructive with a pale color', () => {
+    // The entire point of the token: --destructive is pack-overridable with no
+    // contrast guard, so hardcoded white can vanish against a pastel red.
+    expect(derive('#FFD1D1')).toBe('#1A1A1A');
+    expect(derive('#F8A5A5')).toBe('#1A1A1A');
+  });
+
+  it('derives white when a pack overrides destructive with a deep color', () => {
+    expect(derive('#7A0000')).toBe('#FFFFFF');
+  });
+
+  it('always picks whichever label actually reads better', () => {
+    // Property check across the spectrum — never return the worse of the two.
+    const lum = (hex: string) => {
+      const ch = (i: number) => {
+        const c = parseInt(hex.slice(1 + i * 2, 3 + i * 2), 16) / 255;
+        return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+      };
+      return 0.2126 * ch(0) + 0.7152 * ch(1) + 0.0722 * ch(2);
+    };
+    const ratio = (a: string, b: string) => {
+      const [hi, lo] = lum(a) > lum(b) ? [lum(a), lum(b)] : [lum(b), lum(a)];
+      return (hi + 0.05) / (lo + 0.05);
+    };
+
+    for (const d of ['#DD4444', '#FFD1D1', '#7A0000', '#C62828', '#FF8080', '#101010']) {
+      const picked = derive(d);
+      const other = picked === '#FFFFFF' ? '#1A1A1A' : '#FFFFFF';
+      expect(ratio(picked, d), `${d} picked ${picked}`).toBeGreaterThanOrEqual(ratio(other, d));
+    }
+  });
+});
+
+describe('computeOverlayTokens — --link / --link-hover', () => {
+  const derive = (tokens: typeof TOKENS) =>
+    computeOverlayTokens(tokens, undefined, undefined, false);
+
+  it('honors a link declared by the theme instead of deriving one', () => {
+    // The four built-ins declare hand-picked links; derivation must not stomp them.
+    const result = derive({ ...TOKENS, link: '#2563EB', 'link-hover': '#1D4ED8' } as typeof TOKENS);
+    expect(result['--link']).toBe('#2563EB');
+    expect(result['--link-hover']).toBe('#1D4ED8');
+  });
+
+  it('derives link from accent when accent is far enough from fg', () => {
+    // Community packs declare no link and used to inherit :root's #2563EB —
+    // light-blue links on every pack regardless of palette.
+    expect(derive(TOKENS)['--link']).toBe(TOKENS.accent);
+  });
+
+  it('falls back to fg-2 when accent is too close to fg to read as a link', () => {
+    // Themes that set accent == fg for high-contrast buttons would otherwise
+    // render links invisible against prose. Same guard as --code.
+    const flat = { ...TOKENS, accent: TOKENS.fg };
+    expect(derive(flat)['--link']).toBe(TOKENS['fg-2']);
+  });
+
+  it('derives link-hover as link mixed 85% toward fg', () => {
+    expect(derive(TOKENS)['--link-hover']).toBe(
+      `color-mix(in oklab, ${TOKENS.accent} 85%, ${TOKENS.fg})`,
+    );
+  });
+
+  it('never leaves link undefined for any theme', () => {
+    // Rule 15: nothing a component consumes may fall back to :root.
+    expect(derive(TOKENS)['--link']).toBeTruthy();
+    expect(derive(TOKENS)['--link-hover']).toBeTruthy();
   });
 });

--- a/desktop/tests/ui-primitives.test.tsx
+++ b/desktop/tests/ui-primitives.test.tsx
@@ -119,6 +119,59 @@ describe('Button', () => {
     render(<Button className="rounded-full px-8">Get started</Button>);
     expect(screen.getByRole('button')).toHaveClass('rounded-full', 'px-8');
   });
+
+  // A className override has to REPLACE the base class, not sit beside it.
+  // Tailwind resolves competing utilities by CSS source order, not by attribute
+  // order — and measured in our bundle, .rounded-full (26057) is emitted BEFORE
+  // .rounded-lg (26104), so both-present means rounded-lg wins and the pill
+  // silently isn't a pill. Same for .text-base (51062) vs .text-sm (51252).
+  describe('className override actually overrides', () => {
+    it('drops the base radius when the caller supplies one (change 7 pills)', () => {
+      const cls = buttonClasses('primary', 'lg', 'rounded-full');
+      expect(cls).toContain('rounded-full');
+      expect(cls).not.toContain('rounded-lg');
+    });
+
+    it('drops the base font size when the caller supplies one', () => {
+      const cls = buttonClasses('primary', 'lg', 'text-base');
+      expect(cls).toContain('text-base');
+      expect(cls.split(/\s+/)).not.toContain('text-sm');
+    });
+
+    it('drops the base padding when the caller supplies its own', () => {
+      const cls = buttonClasses('primary', 'lg', 'px-6 py-3');
+      expect(cls).toContain('px-6');
+      expect(cls).toContain('py-3');
+      expect(cls.split(/\s+/)).not.toContain('px-4');
+      expect(cls.split(/\s+/)).not.toContain('py-2');
+    });
+
+    it('lets the terminal scroll buttons keep w-10 h-10 over icon size (change 41)', () => {
+      const cls = buttonClasses('ghost', 'icon', 'w-10 h-10');
+      expect(cls).toContain('w-10');
+      expect(cls).toContain('h-10');
+      expect(cls.split(/\s+/)).not.toContain('w-7');
+      expect(cls.split(/\s+/)).not.toContain('h-7');
+    });
+
+    it('never mistakes a text COLOR for a text size', () => {
+      // text-on-accent / text-fg-2 must survive a text-base override.
+      expect(buttonClasses('primary', 'md', 'text-base')).toContain('text-on-accent');
+      expect(buttonClasses('secondary', 'md', 'text-base')).toContain('text-fg-2');
+    });
+
+    it('keeps variant-prefixed classes, which never conflict', () => {
+      const cls = buttonClasses('primary', 'md', 'rounded-full');
+      expect(cls).toContain('hover:bg-accent/90');
+      expect(cls).toContain('disabled:opacity-50');
+      expect(cls).toContain('focus-visible:ring-2');
+    });
+
+    it('leaves the base untouched when nothing is overridden', () => {
+      expect(buttonClasses('primary', 'lg')).toContain('rounded-lg');
+      expect(buttonClasses('primary', 'lg')).toContain('text-sm');
+    });
+  });
 });
 
 describe('CloseButton', () => {

--- a/desktop/tests/ui-primitives.test.tsx
+++ b/desktop/tests/ui-primitives.test.tsx
@@ -1,0 +1,514 @@
+// @vitest-environment jsdom
+// ui-primitives.test.tsx — pinning tests for components/ui.
+//
+// These lock the recipes approved 2026-07-16 (see
+// docs/active/specs/2026-07-16-ui-consistency-design-spec.md). They are
+// deliberately assertions about CLASS OUTPUT and ARIA, not snapshots: the point
+// is that a specific rejected idiom can never quietly come back. Each test that
+// guards a rejected alternative says which one and why.
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { Button, buttonClasses } from '../src/renderer/components/ui/Button';
+import { CloseButton } from '../src/renderer/components/ui/CloseButton';
+import { Toggle } from '../src/renderer/components/ui/Toggle';
+import { Checkbox } from '../src/renderer/components/ui/Checkbox';
+import { Radio, RadioGroup } from '../src/renderer/components/ui/Radio';
+import { TextInput } from '../src/renderer/components/ui/TextInput';
+import { Textarea } from '../src/renderer/components/ui/Textarea';
+import { Select } from '../src/renderer/components/ui/Select';
+import { SegmentedTabs } from '../src/renderer/components/ui/SegmentedTabs';
+import { ProgressBar } from '../src/renderer/components/ui/ProgressBar';
+import { Toast } from '../src/renderer/components/ui/Toast';
+import { LoadingState, EmptyState, ErrorState, FieldError } from '../src/renderer/components/ui/states';
+import { FIELD } from '../src/renderer/components/ui/field';
+
+// jsdom does not implement scrollIntoView. Select uses it to bring the current
+// value into view when a long catalog opens; every real browser and the Android
+// WebView have it, so this is a test-environment gap, not a product guard.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(cleanup);
+
+describe('Button', () => {
+  it('primary uses the accent fill with a background-fade hover', () => {
+    const cls = buttonClasses('primary');
+    expect(cls).toContain('bg-accent');
+    expect(cls).toContain('text-on-accent');
+    expect(cls).toContain('hover:bg-accent/90');
+  });
+
+  it('never uses the rejected hover idioms', () => {
+    // brightness-110 is imperceptible on Light/Creme's near-black accent;
+    // opacity-90 fades the LABEL too, and on glow themes (Halftone) the fill
+    // fades out from under the theme's own box-shadow. Both were rendered and
+    // rejected — this stops either coming back as a "polish" tweak.
+    for (const v of ['primary', 'secondary', 'ghost', 'danger', 'danger-outline'] as const) {
+      expect(buttonClasses(v)).not.toContain('brightness');
+      expect(buttonClasses(v)).not.toMatch(/(^|\s|:)opacity-90/);
+    }
+  });
+
+  it('danger takes its label from the derived token, never hardcoded white', () => {
+    // --destructive is pack-overridable with NO contrast guard, so text-white
+    // can render white-on-pale. Rule 15: every color is settable or derived.
+    const cls = buttonClasses('danger');
+    expect(cls).toContain('bg-destructive');
+    expect(cls).toContain('text-on-destructive');
+    expect(cls).not.toContain('text-white');
+  });
+
+  it('every variant carries the focus ring', () => {
+    // ~80% of buttons had no focus-visible style before this existed (rule 4).
+    for (const v of ['primary', 'secondary', 'ghost', 'danger', 'danger-outline'] as const) {
+      expect(buttonClasses(v)).toContain('focus-visible:ring-2');
+      expect(buttonClasses(v)).toContain('focus-visible:ring-accent');
+    }
+  });
+
+  it('uses one control radius', () => {
+    // Rule 2. Pills survive only as a documented className override.
+    expect(buttonClasses('primary')).toContain('rounded-lg');
+    expect(buttonClasses('primary')).not.toContain('rounded-sm');
+    expect(buttonClasses('primary')).not.toContain('rounded-full');
+  });
+
+  it('maps each size to its approved scale', () => {
+    expect(buttonClasses('primary', 'sm')).toContain('text-2xs');
+    expect(buttonClasses('primary', 'md')).toContain('text-xs');
+    expect(buttonClasses('primary', 'lg')).toContain('text-sm');
+    expect(buttonClasses('primary', 'icon')).toContain('w-7 h-7');
+  });
+
+  it('expands the tap target only for the sizes below the touch guideline', () => {
+    // This renderer is also the Android UI. sm is ~22px tall, icon is 28px.
+    expect(buttonClasses('primary', 'sm')).toContain('coarse-hit');
+    expect(buttonClasses('primary', 'icon')).toContain('coarse-hit');
+    expect(buttonClasses('primary', 'md')).not.toContain('coarse-hit');
+    expect(buttonClasses('primary', 'lg')).not.toContain('coarse-hit');
+  });
+
+  it('defaults to type=button so it cannot submit a surrounding form', () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <Button>Save</Button>
+      </form>,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    fireEvent.click(screen.getByRole('button'));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('still allows an explicit submit button', () => {
+    render(<Button type="submit">Go</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+
+  it('carries the disabled affordance', () => {
+    expect(buttonClasses('primary')).toContain('disabled:opacity-50');
+    expect(buttonClasses('primary')).toContain('disabled:cursor-not-allowed');
+  });
+
+  it('forwards className so documented exceptions (first-run pills) can override', () => {
+    render(<Button className="rounded-full px-8">Get started</Button>);
+    expect(screen.getByRole('button')).toHaveClass('rounded-full', 'px-8');
+  });
+});
+
+describe('CloseButton', () => {
+  it('is an icon-size ghost with an accessible name', () => {
+    render(<CloseButton />);
+    const btn = screen.getByRole('button', { name: 'Close' });
+    expect(btn).toHaveClass('w-7', 'h-7');
+  });
+
+  it('accepts a more specific label', () => {
+    render(<CloseButton label="Close settings" />);
+    expect(screen.getByRole('button', { name: 'Close settings' })).toBeInTheDocument();
+  });
+});
+
+describe('Toggle', () => {
+  it('is a switch with state, which only 2 of ~14 toggles used to be', () => {
+    render(<Toggle checked={false} onChange={() => {}} />);
+    const sw = screen.getByRole('switch');
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('uses accent for the on-state, not green', () => {
+    // Settings/sync toggles were green-600 (change 16).
+    render(<Toggle checked onChange={() => {}} />);
+    expect(screen.getByRole('switch').className).toContain('bg-accent');
+    expect(screen.getByRole('switch').className).not.toContain('green');
+  });
+
+  it('uses the destructive token for danger toggles, not a raw hex', () => {
+    // Skip Permissions / approve-all were a literal bg-[#DD4444] (change 17).
+    render(<Toggle checked tone="danger" onChange={() => {}} />);
+    const cls = screen.getByRole('switch').className;
+    expect(cls).toContain('bg-destructive');
+    expect(cls).not.toContain('#DD4444');
+  });
+
+  it('keeps the border in BOTH states so the knob cannot shift', () => {
+    // Risk 3: absolutely-positioned children resolve against the PADDING box, so
+    // a border that exists in only one state moves the knob 1px on flip. The
+    // on-state border is transparent, not absent.
+    const { rerender } = render(<Toggle checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('switch').className).toContain('border-edge-dim');
+    rerender(<Toggle checked onChange={() => {}} />);
+    expect(screen.getByRole('switch').className).toContain('border-transparent');
+  });
+
+  it('travels the knob 16px between symmetric ends', () => {
+    const { rerender } = render(<Toggle checked={false} onChange={() => {}} />);
+    const knob = () => screen.getByRole('switch').querySelector('span')!;
+    expect(knob()).toHaveStyle({ left: '1px' });
+    rerender(<Toggle checked onChange={() => {}} />);
+    expect(knob()).toHaveStyle({ left: '17px' });
+  });
+
+  it('rings the knob so it stays visible on light tracks', () => {
+    // Bare bg-white is ~1.2:1 against Creme's off-state track (--inset #DDD1BE).
+    render(<Toggle checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('switch').querySelector('span')!.className).toContain('border-edge-dim');
+  });
+
+  it('reports the flipped value', () => {
+    const onChange = vi.fn();
+    render(<Toggle checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('Checkbox', () => {
+  it('is a checkbox with state', () => {
+    render(<Checkbox checked onChange={() => {}} />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('keeps a literal 4px radius so it can never render as a circle', () => {
+    // Radii are theme tokens; a big-radius pack would round a 14px box into a
+    // Radio. The shape carries meaning, so it is not themeable.
+    render(<Checkbox checked={false} onChange={() => {}} />);
+    // Asserted via the style attribute rather than toHaveStyle: jsdom's CSSOM
+    // doesn't expose the border-radius shorthand through getComputedStyle, so
+    // toHaveStyle reports it as absent even when it renders.
+    expect(screen.getByRole('checkbox').getAttribute('style')).toContain('border-radius: 4px');
+  });
+
+  it('expands its tap target on touch', () => {
+    render(<Checkbox checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('checkbox').className).toContain('coarse-hit');
+  });
+});
+
+describe('Radio / RadioGroup', () => {
+  const Group = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <RadioGroup options={['a', 'b', 'c']} value={value} onChange={onChange} aria-label="Modes">
+      {['a', 'b', 'c'].map((id) => (
+        <Radio key={id} checked={value === id} onChange={() => onChange(id)} aria-label={id} />
+      ))}
+    </RadioGroup>
+  );
+
+  it('exposes radio semantics', () => {
+    render(<Group value="a" onChange={() => {}} />);
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+  });
+
+  it('moves selection with arrow keys, like the native radios it replaces', () => {
+    const onChange = vi.fn();
+    render(<Group value="a" onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowDown' });
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('wraps at the ends', () => {
+    const onChange = vi.fn();
+    render(<Group value="a" onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowUp' });
+    expect(onChange).toHaveBeenCalledWith('c');
+  });
+});
+
+describe('field surface', () => {
+  it('focuses by border color, not a ring or a gray', () => {
+    // Retires focus:border-fg-muted (gray focus) and focus:ring-* focus.
+    expect(FIELD).toContain('focus:border-accent');
+    expect(FIELD).not.toContain('focus:ring');
+    expect(FIELD).not.toContain('focus:border-fg-muted');
+  });
+
+  it('sits on inset, never canvas or well', () => {
+    expect(FIELD).toContain('bg-inset');
+    expect(FIELD).not.toContain('bg-canvas');
+    expect(FIELD).not.toContain('bg-well');
+  });
+
+  it('keeps a disabled affordance', () => {
+    // Disabled fields already exist (EngineCard, InputBar, ReportReviewButton).
+    expect(FIELD).toContain('disabled:opacity-50');
+  });
+
+  it('applies to non-text inputs too, keeping their native type', () => {
+    // Password/search/number all route through FIELD (change 20 + §9.I).
+    const { container } = render(<TextInput type="password" defaultValue="k" />);
+    const input = container.querySelector('input')!;
+    expect(input).toHaveAttribute('type', 'password');
+    expect(input.className).toContain('bg-inset');
+  });
+
+  it('Textarea defaults to non-resizable', () => {
+    const { container } = render(<Textarea />);
+    expect(container.querySelector('textarea')!.className).toContain('resize-none');
+  });
+
+  it('Textarea can opt back into resizing', () => {
+    const { container } = render(<Textarea resizable />);
+    expect(container.querySelector('textarea')!.className).not.toContain('resize-none');
+  });
+});
+
+describe('Select', () => {
+  const OPTS = [
+    { value: 'a', label: 'Alpha' },
+    { value: 'b', label: 'Beta' },
+    { value: 'c', label: 'Gamma' },
+  ];
+
+  it('renders NO native select — that is the entire point', () => {
+    // A styled trigger alone leaves the OS-rendered option list (the blue
+    // highlight menu) dropping out of a themed app.
+    const { container } = render(<Select options={OPTS} value="a" onChange={() => {}} aria-label="Pick" />);
+    expect(container.querySelector('select')).toBeNull();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-haspopup', 'listbox');
+  });
+
+  it('opens a listbox of options', () => {
+    render(<Select options={OPTS} value="a" onChange={() => {}} aria-label="Pick" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('marks the selected option', () => {
+    render(<Select options={OPTS} value="b" onChange={() => {}} aria-label="Pick" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('option', { name: 'Beta' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('scrolls rather than clips a long catalog', () => {
+    // RuntimeBinding's model select renders a provider's whole catalog; the
+    // scroll MUST be on an inner element, because .layer-surface's
+    // `overflow: hidden` is unlayered and would beat an overflow-y-auto utility.
+    render(<Select options={OPTS} value="a" onChange={() => {}} aria-label="Pick" />);
+    fireEvent.click(screen.getByRole('button'));
+    const list = screen.getByRole('listbox');
+    expect(list.className).toContain('overflow-y-auto');
+    expect(list.className).toContain('max-h-64');
+  });
+
+  it('selects with the keyboard', () => {
+    const onChange = vi.fn();
+    render(<Select options={OPTS} value="a" onChange={onChange} aria-label="Pick" />);
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' }); // opens
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' }); // a -> b
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('jumps by first character', () => {
+    const onChange = vi.fn();
+    render(<Select options={OPTS} value="a" onChange={onChange} aria-label="Pick" />);
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+    fireEvent.keyDown(trigger, { key: 'g' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('c');
+  });
+
+  it('skips disabled options when navigating', () => {
+    const onChange = vi.fn();
+    const opts = [
+      { value: 'a', label: 'Alpha' },
+      { value: 'b', label: 'Beta', disabled: true },
+      { value: 'c', label: 'Gamma' },
+    ];
+    render(<Select options={opts} value="a" onChange={onChange} aria-label="Pick" />);
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('c');
+  });
+});
+
+describe('SegmentedTabs', () => {
+  const TABS = [
+    { id: 'x', label: 'X' },
+    { id: 'y', label: 'Y' },
+  ];
+
+  it('exposes tab semantics', () => {
+    render(<SegmentedTabs tabs={TABS} value="x" onChange={() => {}} aria-label="Sections" />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'X' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('uses option B for inactive tabs — transparent, tint on hover', () => {
+    // DECIDED 2026-07-16. Option A (always-tinted inactive) was rendered and
+    // not taken; Library tabs tinted inactive with bg-inset before this.
+    render(<SegmentedTabs tabs={TABS} value="x" onChange={() => {}} aria-label="Sections" />);
+    const inactive = screen.getByRole('tab', { name: 'Y' });
+    expect(inactive.className).toContain('hover:bg-inset');
+    expect(inactive.className).not.toMatch(/(^|\s)bg-inset(\s|$)/);
+  });
+
+  it('is one tab stop with arrow navigation', () => {
+    const onChange = vi.fn();
+    render(<SegmentedTabs tabs={TABS} value="x" onChange={onChange} aria-label="Sections" />);
+    expect(screen.getByRole('tab', { name: 'Y' })).toHaveAttribute('tabindex', '-1');
+    fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('y');
+  });
+});
+
+describe('ProgressBar', () => {
+  it('exposes progress semantics', () => {
+    render(<ProgressBar percent={42} aria-label="Download" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '42');
+  });
+
+  it('clamps nonsense input instead of overflowing its track', () => {
+    const { rerender } = render(<ProgressBar percent={999} aria-label="p" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    rerender(<ProgressBar percent={-5} aria-label="p" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    rerender(<ProgressBar percent={NaN} aria-label="p" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('tracks on inset, never well', () => {
+    render(<ProgressBar percent={50} aria-label="p" />);
+    const track = screen.getByRole('progressbar');
+    expect(track.className).toContain('bg-inset');
+    expect(track.className).not.toContain('bg-well');
+  });
+
+  it('rounds the fill and lets a status hue override the accent', () => {
+    render(<ProgressBar percent={50} color="rgb(255, 0, 0)" aria-label="p" />);
+    const fill = screen.getByRole('progressbar').firstElementChild as HTMLElement;
+    expect(fill.className).toContain('rounded-full');
+    expect(fill).toHaveStyle({ backgroundColor: 'rgb(255, 0, 0)' });
+  });
+});
+
+describe('Toast', () => {
+  it('announces politely without stealing focus', () => {
+    render(<Toast message="Copied" onDismiss={() => {}} />);
+    const toast = screen.getByRole('status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+    expect(toast).toHaveTextContent('Copied');
+  });
+
+  it('owns its dismiss timer so call sites stop re-implementing it', () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<Toast message="Saved" onDismiss={onDismiss} durationMs={3000} />);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3000);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('does not fire its timer after unmount', () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    const { unmount } = render(<Toast message="Saved" onDismiss={onDismiss} />);
+    unmount();
+    vi.advanceTimersByTime(5000);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('can require an explicit dismiss', () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<Toast message="Stay" onDismiss={onDismiss} durationMs={null} />);
+    vi.advanceTimersByTime(60_000);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+
+describe('state family', () => {
+  it('loading always names what is loading', () => {
+    // "Loading sessions…", never a bare "Loading…".
+    render(<LoadingState what="sessions" />);
+    expect(screen.getByText(/Loading sessions/)).toBeInTheDocument();
+  });
+
+  it('empty offers a way out when given one', () => {
+    const onClick = vi.fn();
+    render(<EmptyState message="No themes match" action={{ label: 'Clear filters', onClick }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('errors are NEUTRAL cards, not red-tinted boxes', () => {
+    // Option C, chosen explicitly over B ("destructive-tinted callout").
+    // The dot carries the failure; the container does not (rule 6).
+    const { container } = render(<ErrorState message="Fetch failed" onRetry={() => {}} />);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain('bg-inset/50');
+    expect(card.className).not.toContain('bg-destructive');
+    expect(card.querySelector('.bg-destructive')).not.toBeNull(); // the mark
+  });
+
+  it('Retry is a FILLED primary', () => {
+    // Explicit review correction from secondary — secondary reads as a dim
+    // outline on dark themes.
+    render(<ErrorState message="Fetch failed" onRetry={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Retry' }).className).toContain('bg-accent');
+  });
+
+  it('general errors ship the two documented actions', () => {
+    // This IS the reusable two-action component docs/error-message-standards.md
+    // schedules for v1.3.1.
+    const onReportBug = vi.fn();
+    const onDiagnose = vi.fn();
+    render(
+      <ErrorState
+        mode="general"
+        title="Unable to run local models"
+        explainer="Something went wrong."
+        onReportBug={onReportBug}
+        onDiagnose={onDiagnose}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Report bug' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Diagnose with Claude' }));
+    expect(onReportBug).toHaveBeenCalled();
+    expect(onDiagnose).toHaveBeenCalled();
+  });
+
+  it('field errors use the destructive token at the named size', () => {
+    // Change 34 (text-red-500 -> text-destructive) and rule 14 (§9.H fixed the
+    // spec's own text-[10px] here).
+    render(<FieldError>Required</FieldError>);
+    const el = screen.getByText('Required');
+    expect(el.className).toContain('text-destructive');
+    expect(el.className).toContain('text-3xs');
+    expect(el.className).not.toContain('text-red-500');
+  });
+});


### PR DESCRIPTION
Implements **tranche 0** and **tranche 1** of `docs/active/specs/2026-07-16-ui-consistency-design-spec.md` (the 51 changes approved 2026-07-16).

Three commits, each self-contained:

| | |
|---|---|
| `4424c7d8` | tranche 0 foundations — tokens, engine derivation, Crème fix, protection cascade |
| `8321bc4f` | the 14 `components/ui/` primitives + 56 pinning tests |
| `cfe1d1f0` | tranche 1 — buttons, changes 1–14 |

## What this actually fixes

Not only restyling — these were live bugs:

- **SettingsPanel's four `bg-blue-600` buttons had no text-color class at all.** The label inherited the theme foreground, so it rendered near-black on blue on Crème.
- **Crème shipped failing text colors.** `fg-muted` (2.47:1, needs ≥3) and `fg-faint` (1.67:1, needs ≥1.8) were fixed in `globals.css` but never in `creme.json` — and the JSON is what the engine applies, so users saw the broken values while the CSS and the audit both claimed otherwise.
- **Every primary button inside every popup had a dead hover.** `globals.css` is Tailwind v4, which emits utilities inside `@layer utilities`, while `.layer-surface .bg-accent` is unlayered — and unlayered beats layered regardless of specificity. `hover:bg-accent/90` never fired. Verified against the compiled bundle: `@layer utilities` spans 9654–81014; the protection rule sits at 101357.
- **Community themes rendered light-blue links regardless of palette** — packs had no way to set `link`, so they silently inherited `:root`'s `#2563EB`.
- ConnectGithubModal's primary had no hover; Scan QR / Save & Connect only reacted to `active:`, so desktop hover did nothing.

## Where the spec was wrong

Each deviation is documented at the edit site and in its commit message.

- **Change 43's arithmetic.** The spec asserts white-on-`#DD4444` is ~4.7:1; it's **4.213:1**. Its `white if ≥4.5, else near-black` rule would have failed for every theme and flipped every danger button to near-black — which is *lower* contrast (4.131:1) than the white it replaced. Ships as a max-contrast pick, which delivers the spec's stated intent (white today, near-black only for genuinely pale pack reds).
- **§9.K's missing `.bg-destructive` protection rule.** Would have *created* a bug, not fixed one: protection rules exist to defeat the `[data-wallpaper]` translucency rules, and none exists for destructive — it's already opaque. Adding it would newly kill `hover:bg-destructive/90`.
- **Change 7's pill exception didn't work.** Tailwind resolves competing utilities by CSS *source order*, not attribute order: `.rounded-full` is emitted at 26057, `.rounded-lg` at 26104, so `<Button className="rounded-full">` rendered rounded-lg. The pills would have shipped as rounded rectangles with nothing failing. `buttonClasses()` now resolves the conflict groups it owns.
- **Toggle's knob positions** assumed a border-less track; the border exists only in the off state and absolutely-positioned children resolve against the padding box, so the approved 2→18 would sit 1px off-center. Holding the border constant (transparent when on) makes both states geometrically identical — which also retires risk 3's "verify both states visually" task.
- **AnchorTip's capture-phase Esc is unnecessary.** `useEscClose` is a LIFO stack; the tip pushes after its host popup, so Esc pops it first by construction. Going through the stack also gets Android hardware-back for free. Relatedly, the two tooltips the spec called copies of each other aren't — one is click-toggled, the other hover-shown and `pointer-events-none`; both modes are supported.

## Scope notes

- **Nothing imports the primitives except tranche 1's surfaces**, so visual risk is contained. The intended visual changes are Crème's muted/faint text and the buttons in changes 1–14.
- **One side effect worth knowing:** hand-rolled accent buttons inside popups previously had a *dead* hover and now get the approved fade (`GameLobby`, `GameOverlay`; `SyncSetupWizard:552` asked for 80% and gets 90%). All move toward the approved recipe, and tranches 1/8 convert them to `Button` anyway.
- **Change 11 (ToolCard's Yes/Always Allow/No trio) is deliberately untouched** — it keeps its semantic colors and arrow-key roving focus.
- The spec's *"~50 files — the grep returns the worklist"* framing is misleading: of 53 matches, 17 belong to other tranches, and several aren't buttons at all (`UserMessage:72` is the **user chat bubble**, `StatusBar:546/:630` are theme swatches, `HeaderBar:268` is an active-state indicator). The remaining ~25–30 genuine hand-rolled buttons were never individually rendered and are left for a follow-up pass with an explicit triage list.

## Follow-ups filed

Two pre-existing theme-contrast bugs surfaced here and were deliberately kept out (each needs a new color on a built-in theme — a visual decision wanting its own render). Filed in `youcoded-dev` `2a96243`:
- Crème `panel/canvas` 1.048:1 (min 1.07) — the last remaining Crème audit failure.
- Default `--destructive` `#DD4444` can't carry an AA label at any text color (4.213:1 white / 4.131:1 near-black); only darkening the red fixes it.

## Verification

- `npx tsc --noEmit` — clean
- `npx vite build` — clean
- **2501 tests pass.** 3 fail: `sync-spaces-git-transport` / `sync-spaces-project-discovery`, the documented load-dependent flake. Evidence they're not from this branch: they import nothing it touches, they failed on a clean `origin/master` baseline before any change, and the whole file passes **16/16 when run alone** (134s — each test eats most of the 30s budget, so any parallel load blows it).
- Cascade fixes verified against the **compiled bundle**, not just reasoning — layer boundaries and rule offsets checked directly.

Android needs no work: the renderer is shared, and there are no IPC changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)