### PR TITLE
feat(buddy): peek tuning — drag-driven engage, hover peek-out, grip fixes

### DIFF
--- a/desktop/src/main/buddy-dock.ts
+++ b/desktop/src/main/buddy-dock.ts
@@ -4,16 +4,18 @@ import { clampToWorkArea, type Point, type Rect, type Size } from './buddy-windo
  * Edge snap + peek state machine (spec §6). Pure — the BuddyWindowManager
  * drives it with events and owns the windows.
  *
- *   free ──drag-release(near edge)──▶ peeking ──engage──▶ docked
- *     ▲                                  ▲                   │
- *     └──drag-release(elsewhere)/drag-start                  │
- *                                        └─── disengage ─────┘
+ *   free ──drag-peek/drag-release(near edge)──▶ peeking ──engage──▶ docked
+ *     ▲                                            ▲                   │
+ *     └──drag-start / drag-release(elsewhere)      │                  │
+ *                                                  └─── disengage ────┘
  *
- * Peek is DIRECT and has no timer (Destin 2026-07-17). Dropping the buddy on an
- * edge snaps him straight into peek and he stays; dragging him off the edge
- * brings him back out. There used to be an 8s idle timer between `docked` and
- * `peeking`, which made peek feel like something that happened TO you rather
- * than something you did — you couldn't put him away, you could only wait.
+ * Peek is DIRECT and has no timer (Destin 2026-07-17). It engages LIVE, mid-drag:
+ * drag the buddy against an edge and `drag-peek` snaps him into peek while you're
+ * still holding him (he then slides along the edge); pull him away and `drag-start`
+ * frees him again. Releasing at the edge (`drag-release`) just leaves him peeked.
+ * There used to be an 8s idle timer between `docked` and `peeking`, which made
+ * peek feel like something that happened TO you rather than something you did —
+ * you couldn't put him away, you could only wait.
  *
  * `docked` is now the deliberate "out and staying out" state: engage fires when
  * the chat opens or the buddy needs attention, disengage when both are done.
@@ -24,6 +26,7 @@ export type DockEdge = 'left' | 'right' | 'top' | 'bottom';
 export interface DockState { mode: 'free' | 'docked' | 'peeking'; edge: DockEdge | null; }
 export type DockEvent =
   | { type: 'drag-start' }
+  | { type: 'drag-peek'; edge: DockEdge }        // dragged against an edge — peek NOW, still holding
   | { type: 'drag-release'; snapEdge: DockEdge | null }
   | { type: 'engage' }      // chat opened, or attention needed — come out and stay
   | { type: 'disengage' };  // chat closed and nothing needs attention — sink back
@@ -35,6 +38,10 @@ export function dockReducer(state: DockState, event: DockEvent): DockState {
   switch (event.type) {
     case 'drag-start':
       return FREE_DOCK;
+    case 'drag-peek':
+      // Live peek while the drag is still in progress; the same shape a
+      // drag-release near an edge produces, just entered a beat earlier.
+      return { mode: 'peeking', edge: event.edge };
     case 'drag-release':
       return event.snapEdge ? { mode: 'peeking', edge: event.snapEdge } : FREE_DOCK;
     case 'engage':

--- a/desktop/src/main/buddy-window-manager.ts
+++ b/desktop/src/main/buddy-window-manager.ts
@@ -6,7 +6,7 @@ import {
 } from './buddy-bar-geometry';
 import { BarVisibilityTracker } from './buddy-bar-visibility';
 import {
-  dockReducer, detectSnapEdge, dockPosition, FREE_DOCK,
+  dockReducer, detectSnapEdge, dockPosition, FREE_DOCK, SNAP_THRESHOLD_PX,
   type DockState, type DockEvent, type DockEdge,
 } from './buddy-dock';
 
@@ -15,6 +15,12 @@ import {
 const IPC_BAR_STATE = 'buddy:bar-state';
 const IPC_CHAT_STATE = 'buddy:chat-state';
 const IPC_MASCOT_STATE = 'buddy:mascot-state';
+
+// How close (px) the raw drag target must get to a screen edge, WITH the chat
+// open, to read as "put him away" — close the chat and peek. Deliberately much
+// smaller than SNAP_THRESHOLD_PX: the chat-open x-pin already parks the mascot
+// ~17px off the left edge, so a 24px test would fire on ordinary positioning.
+const PEEK_PAST_EDGE_PX = 6;
 
 export interface Rect { x: number; y: number; width: number; height: number; }
 export interface Point { x: number; y: number; }
@@ -127,7 +133,15 @@ export class BuddyWindowManager {
     if (!this.mascot || this.mascot.isDestroyed()) return;
     const mb = this.mascot.getBounds();
     const display = screen.getDisplayMatching(mb) ?? screen.getPrimaryDisplay();
-    const edge = detectSnapEdge({ x: mb.x, y: mb.y }, MASCOT_SIZE, display.workArea);
+    // Peek is a chat-CLOSED state. While the chat is open the mascot is x-pinned
+    // ~17px off the left edge (and y-free on top/bottom), which used to false-
+    // snap into peek at a non-flush spot on release — and that inconsistent
+    // "peeking + chat open" state then survived closing the chat (Destin
+    // 2026-07-17). Putting him away now goes through the shove-past-edge path in
+    // moveMascot, which closes the chat first; so if the chat is STILL open on
+    // release, never peek — just settle the pair back onto its layout.
+    const chatOpen = !!(this.chatOpenIntent && this.chat && !this.chat.isDestroyed());
+    const edge = chatOpen ? null : detectSnapEdge({ x: mb.x, y: mb.y }, MASCOT_SIZE, display.workArea);
     this.dispatchDock({ type: 'drag-release', snapEdge: edge });
     // Glide even when nothing snapped (the mascot then stays put): the
     // satellites still need to settle back onto their anchors. While dragging
@@ -332,24 +346,36 @@ export class BuddyWindowManager {
     this.deps.onStatusChanged(this.getStatus());
   }
 
+  /**
+   * Animated chat close: cue the renderer's fade, hide the window once it plays,
+   * and fade the action bar out alongside it. `chatOpenIntent` flips false
+   * immediately (before the delayed hide) so drag logic treats the chat as gone
+   * at once, and it also guards the timeout against a rapid re-open.
+   *
+   * Does NOT reconcile the dock — callers decide what happens next: toggleChat
+   * syncs engagement (sink back to peek), the drag-to-peek path dispatches
+   * drag-peek itself.
+   */
+  private closeChat(): void {
+    if (!this.chat || this.chat.isDestroyed() || !this.chat.isVisible()) return;
+    this.chatOpenIntent = false;
+    this.chat.webContents.send(IPC_CHAT_STATE, { visible: false });
+    const chatRef = this.chat;
+    setTimeout(() => {
+      if (chatRef && !chatRef.isDestroyed() && chatRef === this.chat && !this.chatOpenIntent) {
+        chatRef.hide();
+      }
+    }, 140);
+    this.barVisibility.setChatOpen(false);
+  }
+
   toggleChat(): void {
     if (!this.chat || this.chat.isDestroyed()) {
       this.createChat();
       return;
     }
     if (this.chat.isVisible()) {
-      this.chatOpenIntent = false;
-      // Exit animation: cue the renderer, let the 120ms fade play, THEN hide
-      // the window. Guarded so a rapid re-toggle inside the delay can't hide
-      // a window the user just re-opened.
-      this.chat.webContents.send(IPC_CHAT_STATE, { visible: false });
-      const chatRef = this.chat;
-      setTimeout(() => {
-        if (chatRef && !chatRef.isDestroyed() && chatRef === this.chat && !this.chatOpenIntent) {
-          chatRef.hide();
-        }
-      }, 140);
-      this.barVisibility.setChatOpen(false);
+      this.closeChat();
       this.syncEngagement(); // chat closed — sink back to peek unless attention holds him
     } else {
       // Re-anchor to current mascot position before showing — the user may
@@ -438,29 +464,59 @@ export class BuddyWindowManager {
    */
   moveMascot(targetX: number, targetY: number): void {
     if (!this.mascot || this.mascot.isDestroyed()) return;
-    // A live drag cancels any in-flight snap glide and pops the mascot out
-    // of its dock (spec §6.1 — dragging always frees).
+    // A live drag cancels any in-flight snap glide.
     if (this.glideTimer) { clearInterval(this.glideTimer); this.glideTimer = null; }
-    if (this.dockState.mode !== 'free') this.dispatchDock({ type: 'drag-start' });
     const [oldX, oldY] = this.mascot.getPosition();
     const raw = { x: targetX, y: targetY };
     const display = screen.getDisplayMatching({ ...raw, ...MASCOT_SIZE }) ?? screen.getPrimaryDisplay();
-    const chatVisible = !!(this.chat && !this.chat.isDestroyed() && this.chat.isVisible());
-    let clamped = clampToWorkArea(raw, MASCOT_SIZE, display.workArea);
-    // With the chat open the pair are horizontally rigid, so the mascot STOPS
-    // once the chat's right (or left) edge reaches the workArea edge, rather
-    // than sliding out from under his own chat window (Destin 2026-07-17).
-    // Anchor-based dragging makes the stop harmless: the cursor can run past
-    // the wall and the mascot picks it straight back up on the way back, with
-    // no accumulated drift.
-    //
-    // Horizontal only. Pinning Y the same way would be a disaster: the chat is
-    // 480 tall against an 852 workArea, so it would shrink the draggable band
-    // to a sliver and fight edge docking. Vertical is reconciled at release by
-    // the tier-3 bounce in computeGroupLayout.
-    if (chatVisible) {
-      const range = mascotXRangeForChat({ ...clamped, ...MASCOT_SIZE }, display.workArea);
+    const wa = display.workArea;
+    // Gate on the INTENT to have the chat open, not the window's live
+    // isVisible() — the exit animation keeps the window shown for 140ms after a
+    // close, and drag logic must treat the chat as already gone the instant it
+    // starts closing (so the shove-to-peek below hands off cleanly).
+    const chatOpen = !!(this.chatOpenIntent && this.chat && !this.chat.isDestroyed());
+    let clamped = clampToWorkArea(raw, MASCOT_SIZE, wa);
+
+    if (chatOpen) {
+      // With the chat open the pair are horizontally rigid, so the mascot is
+      // x-pinned to keep the chat on-screen. But dragging the buddy ALL THE WAY
+      // to a screen edge means "put him away": shoving the cursor past the edge
+      // (the raw target lands within PEEK_PAST_EDGE_PX of it, i.e. essentially
+      // flush) closes the chat + bar (animated) and hands straight off to the
+      // edge-peek — Destin 2026-07-17. A small threshold, NOT SNAP_THRESHOLD_PX:
+      // the left pin already parks the mascot ~17px off the edge, so a 24px test
+      // would false-trigger on ordinary positioning.
+      const shove = detectSnapEdge(clamped, MASCOT_SIZE, wa, PEEK_PAST_EDGE_PX);
+      if (shove) {
+        this.closeChat(); // fades chat + bar out; chatOpenIntent flips false now
+        this.dispatchDock({ type: 'drag-peek', edge: shove });
+        const pos = dockPosition(shove, clamped, MASCOT_SIZE, wa);
+        this.mascot.setPosition(Math.round(pos.x), Math.round(pos.y));
+        return;
+      }
+      if (this.dockState.mode !== 'free') this.dispatchDock({ type: 'drag-start' });
+      // Horizontal pin only. Pinning Y would shrink the draggable band to a
+      // sliver (chat 480 tall vs 852 workArea) and fight edge docking; vertical
+      // is reconciled at release by computeGroupLayout's tier-3 bounce.
+      const range = mascotXRangeForChat({ ...clamped, ...MASCOT_SIZE }, wa);
       clamped = { x: Math.max(range.min, Math.min(clamped.x, range.max)), y: clamped.y };
+    } else {
+      // Chat closed: live edge-peek. Dragging the buddy against an edge snaps
+      // him into peek mid-drag and he slides along it; pulling away past the
+      // threshold frees him (the renderer plays the swing-out on peeking→free).
+      // Hysteresis: enter at SNAP_THRESHOLD_PX, hold until the cursor pulls 2.5×
+      // further away, so a hand at the boundary can't flutter him in and out
+      // (each toggle would fire the 380ms swing).
+      const peeking = this.dockState.mode === 'peeking';
+      const threshold = peeking ? SNAP_THRESHOLD_PX * 2.5 : SNAP_THRESHOLD_PX;
+      const edge = detectSnapEdge(clamped, MASCOT_SIZE, wa, threshold);
+      if (edge) {
+        this.dispatchDock({ type: 'drag-peek', edge });
+        const pos = dockPosition(edge, clamped, MASCOT_SIZE, wa);
+        this.mascot.setPosition(Math.round(pos.x), Math.round(pos.y));
+        return; // flush against the edge; chat closed → no satellites to follow
+      }
+      this.dispatchDock({ type: 'drag-start' }); // in open space → free/idle
     }
     // setPosition requires integer args. Pointer screenX/Y on HiDPI displays
     // can be fractional, so targetX/Y (and therefore clamped.x/y) may be
@@ -483,7 +539,7 @@ export class BuddyWindowManager {
     // of "squishy" drag latency.
     const actualDx = newX - oldX;
     const actualDy = newY - oldY;
-    if ((actualDx !== 0 || actualDy !== 0) && this.chat && !this.chat.isDestroyed() && chatVisible) {
+    if ((actualDx !== 0 || actualDy !== 0) && this.chat && !this.chat.isDestroyed() && chatOpen) {
       const cb = this.chat.getBounds();
       const chatRaw = { x: cb.x + actualDx, y: cb.y + actualDy };
       const chatDisplay = screen.getDisplayMatching({ ...chatRaw, ...CHAT_SIZE }) ?? screen.getPrimaryDisplay();

--- a/desktop/src/renderer/components/buddy/BuddyMascot.tsx
+++ b/desktop/src/renderer/components/buddy/BuddyMascot.tsx
@@ -10,11 +10,6 @@ const DRAG_THRESHOLD_PX = 4;
 // the limb springs (spec §5: k = 80/size × 2.4) so trailing feels identical
 // at any render size (the buddy renders at 112px since the 2026-07-16 bump).
 const DRAG_VELOCITY_GAIN = (80 / 112) * 2.4;
-// Hover-hop dwell. The sink transition is 380ms each way, so this leaves him
-// fully out for a beat before he sinks back — long enough to read as a peek-a-boo
-// rather than a glitch, short enough to still read as "immediately" (Destin).
-const HOP_MS = 700;
-
 // Pointer-driven drag state. Anchor-based: we capture the cursor's offset
 // inside the 80×80 mascot at pointerdown (grabOffsetX/Y from e.clientX/Y)
 // and recompute the absolute target on every pointermove as
@@ -79,25 +74,35 @@ export function BuddyMascot() {
     return off;
   }, [triggerSwing]);
 
-  // Hover hop (Destin 2026-07-17): hovering a peeking buddy pops him out for a
-  // beat and then he sinks straight back — an acknowledgement, not a mode
-  // change, which is why it lives here and not in the dock reducer. Only a
-  // CLICK brings him out for real (it opens the chat, which engages the dock
-  // main-side). Peek itself is now entered by dropping him on an edge; there is
-  // no idle timer any more.
+  // Hover peek-out (Destin 2026-07-17): hovering a peeking buddy swings him OUT
+  // of the edge and stands him up in idle for as long as the cursor stays over
+  // his window; moving away sinks him smoothly back into peek. It's a transient
+  // visual acknowledgement, not a dock-state change (only a CLICK brings him out
+  // for real — that opens the chat, which engages the dock main-side), which is
+  // why `hopping` lives here and not in the dock reducer. Hover-HELD, not timed:
+  // he stays out while you're on him and returns the moment you leave, so it
+  // never yanks him back under a resting cursor.
   const [hopping, setHopping] = useState(false);
-  const hopTimerRef = useRef<NodeJS.Timeout | null>(null);
+  // Hover is only "armed" after a genuine pointer LEAVE. A press disarms it, so
+  // when a drag drops the buddy into peek with the cursor still sitting on him,
+  // the hover-swing-out does NOT fire immediately — otherwise you'd get
+  // drag→peek → (release, cursor still there) → swing-out → (move away) → re-peek
+  // (Destin 2026-07-17). He has to leave and come back before hovering pops him.
+  const hoverArmedRef = useRef(true);
   const onPointerEnter = useCallback(() => {
     if (dock.mode !== 'peeking') return;
+    if (!hoverArmedRef.current) return; // still holding the post-drag/press state
+    // Side peeks whip upright through the lean on the way out; top/bottom slide.
     if (dock.edge === 'left' || dock.edge === 'right') triggerSwing(dock.edge);
     setHopping(true);
-    if (hopTimerRef.current) clearTimeout(hopTimerRef.current);
-    hopTimerRef.current = setTimeout(() => setHopping(false), HOP_MS);
   }, [dock.mode, dock.edge, triggerSwing]);
+  const onPointerLeave = useCallback(() => {
+    hoverArmedRef.current = true; // a real leave — the next enter is a genuine hover
+    setHopping(false);
+  }, []);
   // Any dock change ends a hop — he's somewhere else now.
   useEffect(() => { setHopping(false); }, [dock.mode, dock.edge]);
   useEffect(() => () => {
-    if (hopTimerRef.current) clearTimeout(hopTimerRef.current);
     if (swingTimerRef.current) clearTimeout(swingTimerRef.current);
   }, []);
 
@@ -166,6 +171,10 @@ export function BuddyMascot() {
   }, []);
 
   const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // Disarm hover-swing-out for the duration of this press and until the
+    // cursor next leaves (see hoverArmedRef): a drag that ends in peek must not
+    // immediately pop back out just because the cursor is still on him.
+    hoverArmedRef.current = false;
     // setPointerCapture keeps pointermove/up flowing even if the pointer
     // leaves the 80×80 window during a fast drag.
     try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* ignore */ }
@@ -276,13 +285,20 @@ export function BuddyMascot() {
       onLostPointerCapture={onLostPointerCapture}
       onPointerCancel={onPointerCancel}
       onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
     >
       {/* Sink layer: dock/peek transforms + the side-peek lean (independent
           `rotate` so it composes with the wrapper's hover/grab `scale` and
           the flat-art breathing `translate`). data-attrs → buddy.css. */}
       <div
         className="mascot-sink"
-        data-dock-mode={peeking ? 'peeking' : dock.mode}
+        // During a hover-hop force 'free' so the sink transform RELEASES and he
+        // swings out of the edge — `dock.mode` is still 'peeking' mid-hop (hover
+        // doesn't touch dock state), so the old `peeking ? 'peeking' : dock.mode`
+        // kept him pinned in the sunk position and only the pose changed (Destin
+        // 2026-07-17: "swaps between peek and idle despite staying in the same
+        // position"). The 380ms transform+rotate transitions carry the move.
+        data-dock-mode={hopping ? 'free' : dock.mode}
         data-dock-edge={dock.edge ?? ''}
         data-swing={swing ?? ''}
       >
@@ -314,7 +330,10 @@ export function BuddyMascot() {
           screen edge while the body sags between them (spec §6.2 "75° wider").
           Rig-only; flat art degrades to the sink alone. */}
       {useRig && sidePeek && (
-        <PeekHands side={dock.edge as 'left' | 'right'} rigHostRef={rigHostRef} />
+        // key on the rig URL so a theme switch REMOUNTS the hands (handSvg
+        // resets to null) instead of leaving the new mascot wearing the old
+        // theme's mittens — see PeekHands (Destin 2026-07-17).
+        <PeekHands key={rigUrl ?? 'default'} side={dock.edge as 'left' | 'right'} rigHostRef={rigHostRef} />
       )}
     </div>
   );
@@ -329,29 +348,35 @@ export function BuddyMascot() {
 function PeekHands({ side, rigHostRef }: { side: 'left' | 'right'; rigHostRef: React.RefObject<HTMLDivElement | null> }) {
   const [handSvg, setHandSvg] = useState<string | null>(null);
 
+  // Re-extract the mitten art whenever the rig svg inside the host changes.
+  // A theme switch swaps a whole new rig into rigHostRef WITHOUT this
+  // component's props changing, so the old one-shot extraction left the NEW
+  // mascot wearing the OLD theme's hands (Destin 2026-07-17). A MutationObserver
+  // on the stable host catches BOTH the async first load (boot into a persisted
+  // peek) and every later theme swap. The call site also keys us on rigUrl, so
+  // handSvg resets to null on switch — a new rig that happens to lack peek hands
+  // then degrades to the sink alone instead of bleeding the previous hands.
   useEffect(() => {
-    let timer: NodeJS.Timeout | null = null;
-    let attempts = 0;
-    const tryExtract = () => {
-      const svg = rigHostRef.current?.querySelector('svg');
+    const host = rigHostRef.current;
+    if (!host) return;
+    let cancelled = false;
+    const extract = () => {
+      if (cancelled) return;
+      const svg = host.querySelector('svg');
       const hand = svg?.querySelector<SVGGElement>(`#rig-hand-peek-${side}`) ?? null;
-      if (!svg || !hand) {
-        // The rig fetch/sanitize may not have resolved yet (e.g., the buddy
-        // boots straight into a persisted peek) — retry briefly, then give
-        // up: a rig without peek-hand groups degrades to the sink alone.
-        setHandSvg(null);
-        if (attempts++ < 20) timer = setTimeout(tryExtract, 250);
-        return;
-      }
-      // The hand group ships display:none (only the app's overlay shows it).
-      // getBBox needs a rendered box — flip display on synchronously, measure,
-      // flip back; no paint happens inside one JS task, so nothing flashes.
+      // Rig not landed yet, or this rig has no mittens — leave whatever we have;
+      // the observer fires again on the next DOM change (e.g. the rig landing).
+      if (!svg || !hand) return;
+      // The hand group ships display:none (only this overlay shows it). getBBox
+      // needs a rendered box — flip display on synchronously, measure, flip
+      // back; no paint happens inside one JS task. We observe childList only
+      // (not attributes), so this flip can't re-trigger the observer.
       const prevDisplay = hand.style.display;
       hand.style.display = '';
       let bbox: DOMRect | null = null;
-      try { bbox = hand.getBBox(); } catch { /* detached/unrenderable — degrade */ }
+      try { bbox = hand.getBBox(); } catch { /* detached/unrenderable — skip */ }
       hand.style.display = prevDisplay;
-      if (!bbox || !bbox.width || !bbox.height) { setHandSvg(null); return; }
+      if (!bbox || !bbox.width || !bbox.height) return;
       const clone = hand.cloneNode(true) as SVGGElement;
       clone.style.display = '';
       clone.removeAttribute('id'); // no duplicate ids in the document
@@ -361,32 +386,51 @@ function PeekHands({ side, rigHostRef }: { side: 'left' | 'right'; rigHostRef: R
         `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${bbox.x - pad} ${bbox.y - pad} ${bbox.width + pad * 2} ${bbox.height + pad * 2}" width="100%" height="100%">${clone.outerHTML}</svg>`,
       );
     };
-    tryExtract();
-    return () => { if (timer) clearTimeout(timer); };
+    extract(); // the rig may already be present (peek toggled with a stable rig)
+    const obs = new MutationObserver(extract);
+    obs.observe(host, { childList: true, subtree: true });
+    return () => { cancelled = true; obs.disconnect(); };
   }, [side, rigHostRef]);
 
   if (!handSvg) return null;
-  // Grip geometry in fractions of the 80px window (workbench values / 230):
-  // mitten width 0.15, centers at mid ± gap/2 with gap 0.73.
+  // Grip geometry in fractions of the buddy window. Mittens are ~17% tall
+  // (bumped from 15% — Destin 2026-07-17 wanted them slightly taller); width
+  // stays 15% and the art meet-fits inside, so it reads as a small vertical
+  // grow. Centered on centerFrac; the two centers sit at mid ± gap/2, gap 0.73.
+  const H = 0.17;
   const mitten = (centerFrac: number, tilt: number) => (
     <div
       aria-hidden="true"
       style={{
         position: 'absolute',
         [side]: 0,
-        top: `${(centerFrac - 0.075) * 100}%`,
+        top: `${(centerFrac - H / 2) * 100}%`,
         width: '15%',
-        height: '15%',
+        height: `${H * 100}%`,
         rotate: `${tilt}deg`,
         pointerEvents: 'none',
       }}
       dangerouslySetInnerHTML={{ __html: handSvg }}
     />
   );
+  // Straddle the BODY, not the window. The leaning body's face sits at ~0.39 of
+  // the window height (0.5 minus the -11% peek up-shift in buddy.css), so the
+  // two mittens must center on 0.39 — centering on 0.5 rode the whole grip low
+  // and floated the bottom hand well beneath the compact leaning body (Destin
+  // 2026-07-17: "the body should be right between the hands"). Half-gap pulled
+  // in from 0.365 too: at the old width, re-centering on 0.39 would shove the
+  // top mitten off the top edge (0.39 − 0.365 − H/2 < 0).
+  // Grip center sits a touch BELOW the body's face (~0.39) — Destin wanted the
+  // pair shifted down slightly from dead-centered, so the head leans up and out
+  // over the top hand. Shifting down also buys top-edge headroom, which is what
+  // lets the gap widen past the old 0.30 ceiling without the top mitten
+  // clipping (top edge = GRIP_CENTER − HALF_GAP − H/2 must stay ≥ 0).
+  const GRIP_CENTER = 0.46;
+  const HALF_GAP = 0.34;
   return (
     <>
-      {mitten(0.5 - 0.365, side === 'right' ? -4 : 4)}
-      {mitten(0.5 + 0.365, side === 'right' ? 4 : -4)}
+      {mitten(GRIP_CENTER - HALF_GAP, side === 'right' ? -4 : 4)}
+      {mitten(GRIP_CENTER + HALF_GAP, side === 'right' ? 4 : -4)}
     </>
   );
 }

--- a/desktop/src/renderer/components/mascot/MascotRig.tsx
+++ b/desktop/src/renderer/components/mascot/MascotRig.tsx
@@ -138,6 +138,7 @@ export function MascotRig({
     springsRef.current = new Map();
     // Fresh DOM starts from the authored state — write the full current look.
     applyPose(partsRef.current, poseRef.current, blinking, true);
+    applyLimbVisibility(partsRef.current, poseRef.current);
     applyLoopClass(partsRef.current);
     return partsRef.current;
   };
@@ -169,6 +170,7 @@ export function MascotRig({
     const parts = ensureParts();
     if (!parts) return;
     applyFace(parts, pose, blinking);
+    applyLimbVisibility(parts, pose);
     // Reduced effects: springs don't run — write pose transforms directly.
     if (reducedEffects) applyPose(parts, pose, blinking, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -326,6 +328,18 @@ function applyPose(parts: Parts, pose: PoseName, blinking: boolean, instant: boo
     el.style.transform = `translate(${p.tx ?? 0}px, ${p.ty ?? 0}px) rotate(${p.rotate ?? 0}deg)`;
   }
   applyFace(parts, pose, blinking);
+}
+
+/** Show/hide whole limbs per the pose's `hidden` flags. Not spring-animated —
+ *  visibility is a discrete pose property (side-peek hides the rig arms because
+ *  the edge-pinned mittens stand in for the hands). Set on pose change only;
+ *  the rAF spring loop writes transforms and never touches display. */
+function applyLimbVisibility(parts: Parts, pose: PoseName): void {
+  const def = POSES[pose];
+  for (const id of LIMB_IDS) {
+    const el = parts.byId.get(id);
+    if (el) el.style.display = def.parts[id]?.hidden ? 'none' : '';
+  }
 }
 
 function applyFace(parts: Parts, pose: PoseName, blinking: boolean): void {

--- a/desktop/src/renderer/components/mascot/mascot-poses.ts
+++ b/desktop/src/renderer/components/mascot/mascot-poses.ts
@@ -16,7 +16,7 @@ export type RigPartId = LimbId | 'rig-tail' | 'rig-body';
 export type FaceName = 'idle' | 'welcome' | 'curious' | 'shocked' | 'dizzy';
 export type PoseName = 'idle' | 'pressed' | 'welcome' | 'curious' | 'shocked' | 'dizzy' | 'peek' | 'peek-right' | 'peek-left';
 
-export interface PartPose { rotate?: number; tx?: number; ty?: number; }
+export interface PartPose { rotate?: number; tx?: number; ty?: number; hidden?: boolean; }
 export interface PoseDef { parts: Partial<Record<RigPartId, PartPose>>; face: FaceName; wave?: boolean; }
 
 // Rotation values assume limbs drawn HANGING DOWN from their pivot (the
@@ -41,10 +41,14 @@ export const POSES: Record<PoseName, PoseDef> = {
   // Bottom/top peek: arms curled INWARD = little hands gripping the screen
   // edge while the body sinks past it (BuddyMascot applies the sink transform).
   peek:    { parts: { 'rig-arm-left': { rotate: -160 }, 'rig-arm-right': { rotate: 160 } }, face: 'welcome' },
-  // Side peek: arms parked via translate (the edge-pinned mittens do the
-  // gripping — see spec §6.2 "75° wider"), one leg cocked, curious face.
-  'peek-right': { parts: { 'rig-arm-left': { rotate: 0, tx: 4.5 }, 'rig-arm-right': { rotate: 0 }, 'rig-leg-left': { rotate: -10 } }, face: 'curious' },
-  'peek-left':  { parts: { 'rig-arm-right': { rotate: 0, tx: -4.5 }, 'rig-arm-left': { rotate: 0 }, 'rig-leg-right': { rotate: 10 } }, face: 'curious' },
+  // Side peek: the edge-pinned grip mittens (rig-hand-peek-*, cloned to the
+  // screen edge by BuddyMascot) ARE the hands here, so the rig's OWN arms are
+  // HIDDEN — otherwise the 75°-leaning body shows a stray third arm poking out
+  // past it, alongside the two mittens (Destin 2026-07-17). One leg cocks out,
+  // curious face. (Top/bottom 'peek' above keeps its arms — there the curled
+  // arms themselves are the grip, no mittens.)
+  'peek-right': { parts: { 'rig-arm-left': { hidden: true }, 'rig-arm-right': { hidden: true }, 'rig-leg-left': { rotate: -10 } }, face: 'curious' },
+  'peek-left':  { parts: { 'rig-arm-left': { hidden: true }, 'rig-arm-right': { hidden: true }, 'rig-leg-right': { rotate: 10 } }, face: 'curious' },
 };
 
 /** Parse a data-pivot="x y" attribute (viewBox coordinates). */

--- a/desktop/src/renderer/styles/buddy.css
+++ b/desktop/src/renderer/styles/buddy.css
@@ -401,10 +401,19 @@ body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-
 /* Side peeks: the sink slides the box past the edge (18% visible), shifted up
    so the body sags below the hand line; the LEAN layer inside rotates the
    body ∓75° about its own (already-moved) center, tipping the head back out
-   over the edge — the approved "75° wider" staging. */
-body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-edge="right"] { transform: translate(45%, -22.6%); }
+   over the edge — the approved "75° wider" staging.
+
+   The up-shift IS the head-to-hands relationship, so it's the one number to
+   tune here (Destin 2026-07-17: "the head is slightly too high relative to the
+   hands", twice). The rig's face sits at viewBox y≈10, i.e. dead center of the
+   -5..25 box, and a rotation about that center leaves it there — so the face
+   renders at 50% − shift of the window, against mittens pinned at 13.5%/86.5%.
+   Walked down over two rounds: -22.6% (face at 27.4%, crowding the top mitten)
+   → -16% (34%, still reading high) → -11% (39%, head sitting just under the
+   grip line). */
+body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-edge="right"] { transform: translate(45%, -11%); }
 body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-edge="right"] .mascot-lean { rotate: -75deg; }
-body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-edge="left"] { transform: translate(-45%, -22.6%); }
+body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-edge="left"] { transform: translate(-45%, -11%); }
 body[data-mode="buddy-mascot"] .mascot-sink[data-dock-mode="peeking"][data-dock-edge="left"] .mascot-lean { rotate: 75deg; }
 /* Swing-out whip: leaving a side peek releases the lean THROUGH ±14° past
    vertical (~230ms, set by BuddyMascot), then the transition settles it to 0

--- a/desktop/tests/buddy-dock.test.ts
+++ b/desktop/tests/buddy-dock.test.ts
@@ -34,6 +34,20 @@ describe('dockReducer', () => {
     expect(dockReducer(FREE_DOCK, { type: 'drag-release', snapEdge: 'bottom' }))
       .toEqual({ mode: 'peeking', edge: 'bottom' });
   });
+  // Destin 2026-07-17: peek now engages LIVE, mid-drag — dragging against an
+  // edge snaps him into peek while you're still holding him (moveMascot fires
+  // drag-peek), and sliding along the edge just re-affirms the same edge.
+  it('drag-peek engages peek while the drag is still in progress', () => {
+    expect(dockReducer(FREE_DOCK, { type: 'drag-peek', edge: 'right' }))
+      .toEqual({ mode: 'peeking', edge: 'right' });
+  });
+  it('drag-peek can switch the peeked edge mid-drag (corner cross-over)', () => {
+    expect(dockReducer({ mode: 'peeking', edge: 'right' }, { type: 'drag-peek', edge: 'bottom' }))
+      .toEqual({ mode: 'peeking', edge: 'bottom' });
+  });
+  it('drag-start frees a live-peeking buddy (dragged back off the edge)', () => {
+    expect(dockReducer({ mode: 'peeking', edge: 'right' }, { type: 'drag-start' })).toEqual(FREE_DOCK);
+  });
   it('drag-release away from edges frees', () => {
     expect(dockReducer({ mode: 'peeking', edge: 'left' }, { type: 'drag-release', snapEdge: null }))
       .toEqual(FREE_DOCK);


### PR DESCRIPTION
Interactive visual tuning of the buddy floater's side-edge peek, all eyeballed live in a dev instance with Destin over several rounds.

## Changes
- **Grip geometry** — mittens straddle the leaning body (center 0.46, gap 0.68), slightly taller; head dropped to −11% sink so it sits between the hands.
- **Theme-switch staleness fixed** — peek hands re-extract via `MutationObserver` + a `rigUrl` key, so switching themes mid-peek no longer leaves the new mascot wearing the old theme's mittens.
- **Phantom third arm fixed** — the rig's own arms are hidden in the side-peek pose (new `PartPose.hidden`); the edge-pinned mittens are the hands.
- **Hover peek-out** — hovering a peeking buddy swings him out of the edge into idle and holds while the cursor is on him (sink released via `data-dock-mode`), sinking back on leave. Hover-held, not a fixed timer.
- **Live drag-peek** — new `drag-peek` dock event: dragging to an edge snaps him into peek while still held and slides along the edge, popping back to free when pulled away (with hysteresis).
- **Chat-open drag bug fixed** — `dragEnded()` no longer false-snaps into peek at a non-flush spot while the chat is open. Shoving past the edge with the chat open closes the chat + bar (animated) and hands off to the edge-peek.
- **hoverArmed latch** — a press disarms hover-swing-out until the next genuine pointer-leave, so dropping into peek with the cursor on him doesn't instantly pop back out.

## Testing
- Full desktop suite green: **2609 tests / 238 files**, typecheck clean.
- New guards in `buddy-dock.test.ts` (drag-peek, edge switch, free).
- Verified interactively across rounds in a dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)