### PR TITLE
fix(buddy): self-heal peek position + cap chat pop-in at the window edge

### DIFF
--- a/desktop/src/main/buddy-window-manager.ts
+++ b/desktop/src/main/buddy-window-manager.ts
@@ -111,6 +111,29 @@ export class BuddyWindowManager {
   private syncEngagement(): void {
     const engaged = this.barVisibility.wantsVisible() || this.attentionNeeded;
     this.dispatchDock({ type: engaged ? 'engage' : 'disengage' });
+    // Self-heal the peek position. `peeking` is only guaranteed flush-to-edge
+    // when moveMascot's live drag-peek enters it (it sets the window flush in
+    // the same step). Reaching `peeking` via disengage — chat closed, or
+    // attention cleared — only changes the POSE; if opening the chat had
+    // pushed the mascot off his edge to make room (computeGroupLayout tier-3
+    // bounce), he'd otherwise lean + grip in mid-air with no screen edge under
+    // him (Destin 2026-07-17: "peek occasionally hangs off of nothing").
+    this.reconcilePeekPosition();
+  }
+
+  /** Glide a peeking mascot flush against his dock edge if he isn't already.
+   *  No-op unless the state is `peeking` (free/docked own their positions) and
+   *  he's actually off the edge — the common left-edge case opens the chat to
+   *  his free side and never moves him, so this costs nothing there. */
+  private reconcilePeekPosition(): void {
+    const { mode, edge } = this.dockState;
+    if (mode !== 'peeking' || !edge) return;
+    if (!this.mascot || this.mascot.isDestroyed()) return;
+    const mb = this.mascot.getBounds();
+    const display = screen.getDisplayMatching(mb) ?? screen.getPrimaryDisplay();
+    const flush = dockPosition(edge, { x: mb.x, y: mb.y }, MASCOT_SIZE, display.workArea);
+    if (Math.round(mb.x) === Math.round(flush.x) && Math.round(mb.y) === Math.round(flush.y)) return;
+    this.glideGroup(flush);
   }
 
   private pushMascotState(): void {
@@ -175,7 +198,11 @@ export class BuddyWindowManager {
     const win = this.mascot;
     if (!win || win.isDestroyed()) return;
 
-    const chatVisible = !!(this.chat && !this.chat.isDestroyed() && this.chat.isVisible());
+    // Gate on the INTENT to have the chat open, not live isVisible() — during
+    // the 140ms close fade the window is still shown but chatOpenIntent is
+    // already false, and a reconcile-to-peek glide must move ONLY the mascot
+    // (leaving the fading chat to fade in place), not chase it to layout.mascot.
+    const chatVisible = !!(this.chatOpenIntent && this.chat && !this.chat.isDestroyed() && this.chat.isVisible());
     const layout = this.layoutFor({ ...mascotTarget, ...MASCOT_SIZE });
     // The mascot only gets pushed back to the pinned distance while the chat is
     // OPEN. With the chat closed the buddy is free to sit anywhere, including

--- a/desktop/src/renderer/styles/buddy.css
+++ b/desktop/src/renderer/styles/buddy.css
@@ -426,15 +426,24 @@ body[data-mode="buddy-mascot"] .mascot-sink[data-swing="left"] .mascot-lean { ro
    from there reads as the panel dropping out of the buddy.
 
    Open is deliberately springy (Destin 2026-07-16 — the old 120ms ease-out
-   read as a flat fade): an ease-out-back curve carries the panel past 100%
-   and settles it back, and the small upward offset in the `from` frame starts
-   it tucked against the mascot. The overshoot is entirely in the timing
-   function, so the track stays two-stop.
+   read as a flat fade), but the panel fills the window edge-to-edge and
+   Electron clips anything past the window bounds. The earlier
+   cubic-bezier(…1.56…) overshoot carried the panel PAST scale(1) — ~7% over,
+   ~11px each side / ~17px top+bottom on the 320×480 window — so the peak
+   frame's edges got clipped off (Destin 2026-07-17: "too large for its
+   container, edges briefly disappear").
+
+   Fix: the spring now PEAKS at scale(1) — the window edge — and the bounce
+   lives INWARD (a slight dip below full size, then settle back up). The eye
+   still reads a spring arriving and settling, but the panel never exceeds the
+   window, so nothing clips. The bounce is carried by the keyframe stops, so
+   the timing function must NOT overshoot (a back-out curve would blow past a
+   1.0 stop mid-segment and re-introduce the clip) — plain ease-out.
 
    Close stays quick and non-bouncy: main hides the window 140ms after cueing
    the exit, and anything longer would just get truncated mid-animation. */
 body[data-mode="buddy-chat"] .buddy-chat-enter {
-  animation: buddy-chat-in 340ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  animation: buddy-chat-in 360ms ease-out;
   transform-origin: 50% 0%;
 }
 body[data-mode="buddy-chat"] .buddy-chat-exit {
@@ -442,8 +451,13 @@ body[data-mode="buddy-chat"] .buddy-chat-exit {
   transform-origin: 50% 0%;
 }
 @keyframes buddy-chat-in {
-  from { opacity: 0; transform: scale(0.82) translateY(-12px); }
-  to { opacity: 1; transform: scale(1) translateY(0); }
+  /* scale is capped at 1.0 (the window edge); the 68%/84% dip-and-recover is
+     the spring settle, staying safely inside the window the whole time. */
+  0% { opacity: 0; transform: scale(0.84) translateY(-10px); }
+  52% { opacity: 1; transform: scale(1) translateY(0); }
+  68% { transform: scale(0.972) translateY(0); }
+  84% { transform: scale(0.994) translateY(0); }
+  100% { transform: scale(1) translateY(0); }
 }
 @keyframes buddy-chat-out {
   from { opacity: 1; transform: scale(1); }


### PR DESCRIPTION
Two buddy-floater bug fixes from the 2026-07-17 tuning loop.

## 1. Peek "hangs off of nothing"
`peeking` is only guaranteed flush-to-edge when `moveMascot`'s live drag-peek enters it (it sets the window flush in the same step). But `peeking` is also reachable via `disengage` — chat closed, or attention cleared — which changes only the **pose**. If opening the chat had pushed the mascot off his edge to fit the 320px panel (`computeGroupLayout` tier-3 bounce — hence *occasional*: mostly right/top/bottom edges + corners), closing it left him leaning + gripping in **mid-air** with no screen edge under the mittens.

**Fix:** `syncEngagement` self-heals via a new `reconcilePeekPosition()` — any resolution to `peeking` glides the window flush to its edge (no-op when already flush, the common left-edge case). `glideGroup` now gates on `chatOpenIntent` instead of live `isVisible()`, so the reconcile glide during the 140ms chat fade-out moves only the mascot and lets the chat fade in place. Also covers the attention-clear variant of the same bug.

## 2. Chat pop-in clipped its own edges
The entrance spring `cubic-bezier(0.34, 1.56, 0.64, 1)` carried the panel ~7% **past** `scale(1)`; since the panel fills the transparent window edge-to-edge, Electron clipped the overflow at the peak frame ("too large for its container, edges briefly disappear").

**Fix:** the spring now peaks exactly at `scale(1)` (the window edge) and the bounce lives **inward** (a slight dip-and-settle), carried by keyframe stops with a non-overshooting ease-out so nothing exceeds the window. Resting chat is pixel-identical.

## Verification
Typecheck clean; **49 buddy tests pass** (dock reducer, bar geometry, bar visibility, edge clamp). Renderer #2 hot-verified; #1 is a main-process change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)