### PR TITLE
perf(renderer): skip re-render of unchanged assistant turns during streaming

### DIFF
--- a/desktop/src/renderer/components/AssistantTurnBubble.test.tsx
+++ b/desktop/src/renderer/components/AssistantTurnBubble.test.tsx
@@ -1,12 +1,30 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { ChatProvider } from '../state/chat-context';
 import AssistantTurnBubble from './AssistantTurnBubble';
 import type { AssistantTurn } from '../state/chat-types';
 import type { ToolCallState, ToolGroupState } from '../../shared/types';
+
+// Mock MarkdownContent with a render-counting probe. AssistantTurnBubble renders
+// one <MarkdownContent> per text bubble, so counting its renders tells us whether
+// the memo comparator let a turn skip re-rendering. The real markdown pipeline
+// (react-markdown + highlight.js) is the expensive thing the memo exists to avoid
+// re-running on every streaming frame — counting its invocation is the most direct
+// observable of the perf invariant.
+vi.mock('./MarkdownContent', () => {
+  const renders: string[] = [];
+  const Mock = ({ content }: { content: string }) => {
+    renders.push(content);
+    return <div data-testid="md-probe">{content}</div>;
+  };
+  Mock.__renders = renders;
+  return { default: Mock };
+});
+import MarkdownContent from './MarkdownContent';
+const mdRenders = (MarkdownContent as any).__renders as string[];
 
 // Helpers for synthesizing minimal test fixtures. The reducer is untouched
 // in this task — these objects bypass it entirely and feed AssistantTurnBubble
@@ -126,5 +144,132 @@ describe('AssistantTurnBubble — Skill extraction', () => {
     expect(twoIdx).toBeGreaterThanOrEqual(0);
     expect(bashIdx).toBeLessThan(oneIdx);
     expect(oneIdx).toBeLessThan(twoIdx);
+  });
+});
+
+describe('AssistantTurnBubble — memo comparator (streaming perf)', () => {
+  beforeEach(() => {
+    cleanup();
+    mdRenders.length = 0;
+  });
+
+  // A turn with a text segment (renders MarkdownContent) plus one tool group.
+  function makeTextTurn(id: string, text: string, groupId: string): AssistantTurn {
+    return {
+      id,
+      segments: [
+        { type: 'text' as const, content: text, messageId: `${id}-msg` },
+        { type: 'tool-group' as const, groupId },
+      ],
+      timestamp: 0,
+      stopReason: null,
+      model: null,
+      usage: null,
+      anthropicRequestId: null,
+    };
+  }
+
+  it('does NOT re-render when an unrelated tool changes in the shared Maps', () => {
+    // This is the core streaming-perf invariant: the reducer hands every turn a
+    // fresh toolCalls/toolGroups Map reference whenever ANY tool updates. The
+    // memo comparator must see that THIS turn's own tools are unchanged and skip
+    // the re-render (and its markdown re-parse).
+    const turn = makeTextTurn('turn_a', 'hello world', 'g1');
+    const toolGroups = new Map<string, ToolGroupState>([
+      ['g1', { id: 'g1', toolIds: ['b1'] }],
+    ]);
+    const toolCalls = new Map<string, ToolCallState>([
+      ['b1', bashTool('b1', 'git status')],
+    ]);
+
+    const props = { turn, toolGroups, toolCalls, sessionId: 'test', showTimestamps: false };
+    const { rerender } = render(
+      <ChatProvider>
+        <AssistantTurnBubble {...props} />
+      </ChatProvider>
+    );
+    const rendersAfterMount = mdRenders.length;
+    expect(rendersAfterMount).toBeGreaterThan(0);
+
+    // Simulate a reducer dispatch for a DIFFERENT turn's tool: brand-new Map
+    // references, but turn_a's own group/tool entries are referentially intact.
+    const toolGroups2 = new Map(toolGroups);
+    const toolCalls2 = new Map(toolCalls);
+    toolGroups2.set('g2', { id: 'g2', toolIds: ['b2'] });
+    toolCalls2.set('b2', bashTool('b2', 'npm test'));
+
+    rerender(
+      <ChatProvider>
+        <AssistantTurnBubble {...props} toolGroups={toolGroups2} toolCalls={toolCalls2} />
+      </ChatProvider>
+    );
+
+    // Memo gate held → MarkdownContent did not re-run for the unchanged turn.
+    expect(mdRenders.length).toBe(rendersAfterMount);
+  });
+
+  it('DOES re-render when its own tool entry changes', () => {
+    // Guard against over-blocking: if this turn's OWN tool updates (e.g. its
+    // Bash result lands), the comparator must let the re-render through.
+    const turn = makeTextTurn('turn_b', 'hello world', 'g1');
+    const toolGroups = new Map<string, ToolGroupState>([
+      ['g1', { id: 'g1', toolIds: ['b1'] }],
+    ]);
+    const toolCalls = new Map<string, ToolCallState>([
+      ['b1', { toolUseId: 'b1', toolName: 'Bash', input: { command: 'git status' }, status: 'running' }],
+    ]);
+
+    const props = { turn, toolGroups, toolCalls, sessionId: 'test', showTimestamps: false };
+    const { rerender } = render(
+      <ChatProvider>
+        <AssistantTurnBubble {...props} />
+      </ChatProvider>
+    );
+    const rendersAfterMount = mdRenders.length;
+
+    // b1 transitions running → complete (new ToolCallState object, new Map).
+    const toolCalls2 = new Map(toolCalls);
+    toolCalls2.set('b1', { toolUseId: 'b1', toolName: 'Bash', input: { command: 'git status' }, status: 'complete', response: 'ok' });
+
+    rerender(
+      <ChatProvider>
+        <AssistantTurnBubble {...props} toolCalls={toolCalls2} />
+      </ChatProvider>
+    );
+
+    expect(mdRenders.length).toBeGreaterThan(rendersAfterMount);
+  });
+
+  it('DOES re-render when the turn object itself changes', () => {
+    // The comparator keys on `turn` by reference — a new turn object (e.g. the
+    // reducer appended a streaming text delta) must always re-render.
+    const turn = makeTextTurn('turn_c', 'hello', 'g1');
+    const toolGroups = new Map<string, ToolGroupState>([
+      ['g1', { id: 'g1', toolIds: ['b1'] }],
+    ]);
+    const toolCalls = new Map<string, ToolCallState>([
+      ['b1', bashTool('b1', 'git status')],
+    ]);
+
+    const props = { turn, toolGroups, toolCalls, sessionId: 'test', showTimestamps: false };
+    const { rerender } = render(
+      <ChatProvider>
+        <AssistantTurnBubble {...props} />
+      </ChatProvider>
+    );
+    const rendersAfterMount = mdRenders.length;
+
+    // New turn object with appended text (what the reducer produces per delta).
+    const turn2 = { ...turn, segments: [
+      { type: 'text' as const, content: 'hello world', messageId: 'turn_c-msg' },
+      turn.segments[1],
+    ] };
+    rerender(
+      <ChatProvider>
+        <AssistantTurnBubble {...props} turn={turn2} />
+      </ChatProvider>
+    );
+
+    expect(mdRenders.length).toBeGreaterThan(rendersAfterMount);
   });
 });

--- a/desktop/src/renderer/components/AssistantTurnBubble.tsx
+++ b/desktop/src/renderer/components/AssistantTurnBubble.tsx
@@ -272,11 +272,74 @@ function collectTurnSkills(
   return skills;
 }
 
+/**
+ * Returns the IDs of every tool group this turn renders (its own `tool-group`
+ * segments). A turn's rendered output depends ONLY on its own segments plus
+ * the tool/group entries reachable from these IDs — not on the rest of the
+ * session-lifetime `toolCalls`/`toolGroups` Maps. This set is the basis for
+ * the memo comparator below.
+ */
+function turnGroupIds(turn: AssistantTurn): string[] {
+  const ids: string[] = [];
+  for (const seg of turn.segments) {
+    if (seg.type === 'tool-group') ids.push(seg.groupId);
+  }
+  return ids;
+}
+
+/**
+ * Custom equality for React.memo.
+ *
+ * WHY: `toolCalls` and `toolGroups` are session-lifetime Maps shared by EVERY
+ * turn in the conversation. The reducer hands ChatView a fresh Map reference
+ * whenever ANY tool updates, so React's default shallow compare (which treats
+ * two Maps with identical contents as different) re-renders every assistant
+ * turn on every streaming frame — even completed turns whose tools never
+ * changed. Each of those re-renders re-runs splitIntoBubbles() and re-parses
+ * the turn's markdown (react-markdown + highlight.js), which was the dominant
+ * per-frame cost while Claude types.
+ *
+ * A turn's rendered output is a pure function of:
+ *   - `turn` (its segments/metadata) — compared by reference; the reducer
+ *     replaces the turn object only when that turn actually changes.
+ *   - the tool/group entries REACHABLE from the turn's own tool-group segments.
+ * So we compare those entries individually. If none of THIS turn's tools or
+ * groups changed, a sibling turn's activity must not re-render this one.
+ *
+ * The primitives (sessionId/provider/showTimestamps) are compared by value.
+ *
+ * Returns true when the component can skip re-rendering.
+ */
+function assistantTurnPropsAreEqual(prev: Props, next: Props): boolean {
+  if (prev.turn !== next.turn) return false;
+  if (prev.sessionId !== next.sessionId) return false;
+  if (prev.provider !== next.provider) return false;
+  if (prev.showTimestamps !== next.showTimestamps) return false;
+
+  // Same turn object (checked above) ⇒ same segments ⇒ same group IDs. We only
+  // need to walk one side's IDs.
+  const groupIds = turnGroupIds(next.turn);
+  for (const gid of groupIds) {
+    const prevGroup = prev.toolGroups.get(gid);
+    const nextGroup = next.toolGroups.get(gid);
+    if (prevGroup !== nextGroup) return false;
+    if (!nextGroup) continue;
+    for (const toolId of nextGroup.toolIds) {
+      if (prev.toolCalls.get(toolId) !== next.toolCalls.get(toolId)) return false;
+    }
+  }
+  return true;
+}
+
 export default React.memo(function AssistantTurnBubble({ turn, toolGroups, toolCalls, sessionId, provider, showTimestamps }: Props) {
   // Read opt-in metadata preference here so the strip below only renders when
   // the user has explicitly turned it on in PreferencesPopup (default false).
   const { showTurnMetadata } = useTheme();
-  const bubbles = splitIntoBubbles(turn);
+  // splitIntoBubbles is pure over `turn`, so cache it and only recompute when
+  // the turn object itself changes — not on every parent re-render. Combined
+  // with the memo comparator below, completed turns no longer re-split (and
+  // re-parse their markdown) on every streaming frame.
+  const bubbles = React.useMemo(() => splitIntoBubbles(turn), [turn]);
   // Skills are reordered to the end of the turn's last bubble (view-layer only).
   // ToolGroupInline filters Skills out of their groups; this list backs the
   // trailing standalone-card row below.
@@ -355,7 +418,7 @@ export default React.memo(function AssistantTurnBubble({ turn, toolGroups, toolC
       })}
     </>
   );
-});
+}, assistantTurnPropsAreEqual);
 
 /**
  * Renders a plan-mode plan (from ExitPlanMode tool input) as a distinct section


### PR DESCRIPTION
## What

`toolCalls`/`toolGroups` are session-lifetime Maps shared by **every** assistant turn. The reducer hands `ChatView` fresh Map references whenever *any* tool updates, so `React.memo`'s default shallow compare re-rendered **every** assistant turn on **every** streaming frame — re-running `splitIntoBubbles()` and re-parsing each turn's markdown (react-markdown + highlight.js) even for completed turns whose tools never changed. This was the dominant per-frame render cost while the model types.

## Fix (internal only — no UI/UX change)

1. **Custom `arePropsEqual`** for `AssistantTurnBubble`. A turn's rendered output depends only on its own segments plus the tool/group entries reachable from its own `tool-group` segments — so compare those entries individually instead of the shared Map references. A sibling turn's tool activity no longer re-renders this one; the turn still re-renders when its *own* tool entry or its `turn` object changes.
2. **Cache `splitIntoBubbles(turn)`** with `useMemo` keyed on `[turn]` — it's pure, so it only recomputes when the turn actually changes.

## Verification

- `chat-reducer.test.ts` (25) + `AssistantTurnBubble.test.tsx` (6) all green.
- New memo test suite pins the invariant with a render-counting `MarkdownContent` mock:
  - unrelated tool change → **no** re-render (**mutation-verified**: fails if the comparator is removed),
  - own-tool change → re-renders (guards against over-blocking),
  - turn-object change → re-renders.
- `tsc --noEmit`: error set is byte-identical to unmodified `master` (5 pre-existing errors in `src/main/harness/tools/` from uninstalled optional deps — none in the renderer).

## Note

This is the shallow half of a two-depth fix discussed in-session. The structural follow-up — making each `AssistantTurn` own its tool calls so referential equality becomes a *correct* render gate — is intentionally deferred; this change carries forward regardless.