### PR TITLE
feat(renderer): chat flick-scroll + right-click context menu

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -83,6 +83,7 @@ import { RootErrorBoundary } from './components/RootErrorBoundary';
 import ThemeEffects from './components/ThemeEffects';
 import { ZoomOverlay } from './components/ZoomOverlay';
 import { RemoteSnapshotExporter } from './components/RemoteSnapshotExporter';
+import { ContextMenuHost } from './components/context-menu/ContextMenuHost';
 import { BuddyMascotApp } from './components/buddy/BuddyMascotApp';
 import { BuddyChatApp } from './components/buddy/BuddyChatApp';
 import { BuddyBarApp } from './components/buddy/BuddyBarApp';
@@ -2478,6 +2479,10 @@ function AppInner() {
       {/* Mount-only: listens for chat:export-snapshot from main, serializes
           ChatState, and sends the snapshot back for remote-browser hydration. */}
       <RemoteSnapshotExporter />
+      {/* Mount-only: app-wide right-click menu for chat content + the composer
+          (copy/paste, Ask about this, file-pill actions). Opens only over
+          surfaces it owns; leaves the terminal and other chrome untouched. */}
+      <ContextMenuHost />
       {/* Main area — relative so bottom-float chrome can position against it.
           When a Phase-2 full-screen destination is active, hide the chat
           chrome entirely. Unmounting via `hidden` is cleaner than z-index

--- a/desktop/src/renderer/components/ChatView.tsx
+++ b/desktop/src/renderer/components/ChatView.tsx
@@ -341,19 +341,25 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
     return () => window.removeEventListener('keydown', onKey, true);
   }, [visible]);
 
-  // Wheel scroll acceleration: rapid successive touchpad/mousewheel flicks
-  // compound — the 5th flick in a row scrolls farther than the 1st. A pause
-  // (~350ms) resets the multiplier so an intentional small scroll stays small.
-  // Mirrors the arrow-key acceleration pattern above but for wheel input.
+  // Wheel scroll: burst acceleration + momentum ("flick") glide.
   //
-  // Important: a single touchpad flick fires ~20-30 wheel events (initial
-  // input + OS momentum tail). We only bump the multiplier at the START of a
-  // new burst (gap > BURST_GAP since last bump) so one flick stays at 1x;
-  // only a SECOND deliberate flick within RESET_MS compounds.
+  // Burst acceleration: rapid successive flicks compound — the 5th flick in a
+  // row scrolls farther than the 1st. A pause (~350ms) resets the multiplier so
+  // an intentional small scroll stays small.
+  //
+  // Momentum glide: on macOS the OS appends a ~20-30-event momentum tail to a
+  // flick, so scrolling coasts for free. Linux/libinput emits NO such tail —
+  // the wheel events stop the instant the finger lifts, so scrolling died
+  // immediately (Destin's report). We fix that ourselves: sample the recent
+  // wheel velocity and, once events stop, keep scrolling under exponential
+  // friction until it decays away. A single mouse-wheel notch (one isolated
+  // event) never reaches flick velocity, so discrete mouse scrolling stays
+  // snappy — only a fast multi-event trackpad flick coasts.
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
+    // — Burst acceleration state (unchanged behavior) —
     let multiplier = 1;
     let lastWheelTime = 0;
     let lastBumpTime = 0;
@@ -362,9 +368,87 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
     const STEP = 0.25;
     const MAX = 4;
 
+    // — Momentum glide state —
+    let velocity = 0; // px/ms, signed; the speed the glide coasts at
+    let momentumRaf: number | null = null;
+    let gliding = false; // true only while coasting on inertia (finger is OFF the pad)
+    let lastFrameTime = 0;
+    const samples: { d: number; t: number }[] = []; // recent applied deltas
+    const VELOCITY_WINDOW = 90; // ms window the velocity estimate averages over
+    const IDLE_GAP = 28; // ms with no wheel event ⇒ finger lifted, start coasting
+    const FRICTION = 0.0021; // per-ms exponential decay — controls deceleration rate
+    const MIN_VELOCITY = 0.03; // px/ms ⇒ glide has effectively stopped
+    const MIN_FLICK_VELOCITY = 0.35; // px/ms ⇒ fast enough to coast at all
+
+    const stopMomentum = () => {
+      if (momentumRaf !== null) {
+        cancelAnimationFrame(momentumRaf);
+        momentumRaf = null;
+      }
+      velocity = 0;
+      gliding = false;
+      samples.length = 0;
+    };
+
+    // Estimate current velocity as total recent scroll ÷ its time span. A lone
+    // event (one sample) can't establish a velocity, so it never coasts.
+    const estimateVelocity = (now: number): number => {
+      while (samples.length && now - samples[0].t > VELOCITY_WINDOW) samples.shift();
+      if (samples.length < 2) return 0;
+      const span = Math.max(now - samples[0].t, 16);
+      const total = samples.reduce((sum, s) => sum + s.d, 0);
+      return total / span;
+    };
+
+    const glide = (now: number) => {
+      const dt = Math.min(now - lastFrameTime, 32); // clamp tab-switch jumps
+      lastFrameTime = now;
+
+      // Finger still down (events still arriving): the direct scroll in onWheel
+      // is driving. Idle, so the hand-off to inertia is seamless.
+      if (now - lastWheelTime < IDLE_GAP) {
+        gliding = false; // an OS momentum tail (macOS) is still feeding us
+        momentumRaf = requestAnimationFrame(glide);
+        return;
+      }
+
+      // Past the idle gap ⇒ the finger is off and we're coasting on our own
+      // inertia. A touch/tap now should "catch" and freeze it (see onWheel).
+      gliding = true;
+      velocity *= Math.exp(-FRICTION * dt);
+      if (Math.abs(velocity) < MIN_VELOCITY) {
+        stopMomentum();
+        return;
+      }
+
+      const before = container.scrollTop;
+      container.scrollTop = before + velocity * dt;
+      // Hit the top/bottom and couldn't move ⇒ nothing left to coast into.
+      if (Math.abs(container.scrollTop - before) < 0.5) {
+        stopMomentum();
+        return;
+      }
+      momentumRaf = requestAnimationFrame(glide);
+    };
+
     const onWheel = (e: WheelEvent) => {
       // Let browser zoom (Ctrl+wheel) pass through untouched
       if (e.ctrlKey) return;
+
+      // "Catch the glide": while we're coasting on inertia, ANY new wheel input —
+      // including the sub-pixel jitter of just resting fingers on the pad — means
+      // the user touched the pad to stop it. Freeze in place and swallow this
+      // event (don't scroll by it), so a tap parks the view exactly where it is;
+      // the next real scroll then fine-tunes from there. Runs BEFORE the small-
+      // delta guard because a tap's delta is often < 1px. Only fires during our
+      // own inertia (gliding), never mid-flick or during a macOS momentum tail.
+      if (gliding) {
+        e.preventDefault();
+        stopMomentum();
+        lastWheelTime = performance.now();
+        return;
+      }
+
       if (Math.abs(e.deltaY) < 1) return;
 
       const now = performance.now();
@@ -383,13 +467,41 @@ export default function ChatView({ sessionId, visible, resumeInfo, cwd, gamePane
       // else: mid-burst momentum events — leave multiplier alone
       lastWheelTime = now;
 
+      const applied = e.deltaY * multiplier;
+
+      // Feed the velocity estimator with the delta we actually apply, so the
+      // glide coasts at the speed the content was visibly moving.
+      samples.push({ d: applied, t: now });
+      velocity = estimateVelocity(now);
+
       e.preventDefault();
-      container.scrollBy({ top: e.deltaY * multiplier, behavior: 'auto' });
+      // Direct 1:1 scroll while the finger is down (zero latency); the glide
+      // loop takes over only once events stop.
+      container.scrollBy({ top: applied, behavior: 'auto' });
+
+      // Arm the glide loop once the gesture is fast enough to be a real flick.
+      if (momentumRaf === null && Math.abs(velocity) >= MIN_FLICK_VELOCITY) {
+        lastFrameTime = now;
+        momentumRaf = requestAnimationFrame(glide);
+      }
+    };
+
+    // Any deliberate interaction cancels an in-flight glide (standard "grab to
+    // stop" behavior): a click, a touch, or a key (incl. the arrow-key scroll).
+    const cancelOnInput = () => {
+      if (momentumRaf !== null) stopMomentum();
     };
 
     // Non-passive so preventDefault() works and our delta replaces native scroll
     container.addEventListener('wheel', onWheel, { passive: false });
-    return () => container.removeEventListener('wheel', onWheel);
+    window.addEventListener('pointerdown', cancelOnInput, true);
+    window.addEventListener('keydown', cancelOnInput, true);
+    return () => {
+      container.removeEventListener('wheel', onWheel);
+      window.removeEventListener('pointerdown', cancelOnInput, true);
+      window.removeEventListener('keydown', cancelOnInput, true);
+      stopMomentum();
+    };
   }, []);
 
   const handlePromptSelect = useCallback(

--- a/desktop/src/renderer/components/FilepathToken.tsx
+++ b/desktop/src/renderer/components/FilepathToken.tsx
@@ -35,6 +35,17 @@ function FileGlyph({ ext }: { ext: string }) {
   );
 }
 
+// Best-effort absolute path for the right-click menu's View-in-folder / Open /
+// Copy-as-path actions. Claude often writes a project-relative path; join it with
+// the session cwd so shell.showItemInFolder/openPath get a real target. Already-
+// absolute paths (POSIX, Windows drive, or ~) pass through untouched.
+function resolveForMenu(p: string, cwd?: string): string {
+  const norm = p.replace(/\\/g, '/');
+  if (/^([a-zA-Z]:\/|\/|~)/.test(norm)) return p;
+  if (cwd) return cwd.replace(/[\\/]+$/, '') + '/' + norm.replace(/^\.\//, '');
+  return p;
+}
+
 export function FilepathToken({ path, sessionId }: Props) {
   // Optional: the buddy window / sandbox render this without ArtifactProvider.
   // When absent, the pill still renders (so prose isn't disrupted) but the
@@ -44,6 +55,8 @@ export function FilepathToken({ path, sessionId }: Props) {
   // Basename only inline — the full path lives in the title tooltip. Keeps prose
   // calm when Claude references deep paths mid-sentence.
   const name = path.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? path;
+  // Absolute path for the chat right-click menu (View in folder / Copy as path).
+  const menuPath = resolveForMenu(path, artifactCtx?.state.sessionCwd?.[sessionId]);
 
   const onClick = async () => {
     // No provider (buddy window / sandbox) → nothing to open. Bail quietly.
@@ -132,6 +145,8 @@ export function FilepathToken({ path, sessionId }: Props) {
       className="group inline-flex items-center gap-1.5 align-middle px-2 py-0.5 rounded-md bg-well border border-edge hover:border-fg-muted transition-colors"
       onClick={onClick}
       title={path}
+      // Right-click menu recovers the path here (left-click still opens the drawer).
+      data-file-path={menuPath || undefined}
     >
       <FileGlyph ext={ext} />
       <span className="font-mono text-[0.85em] text-fg group-hover:underline underline-offset-2 decoration-fg-muted">

--- a/desktop/src/renderer/components/InputBar.tsx
+++ b/desktop/src/renderer/components/InputBar.tsx
@@ -223,6 +223,27 @@ const InputBar = forwardRef<InputBarHandle, Props>(function InputBar({ sessionId
     return () => window.removeEventListener('buddy:attach-file', listener);
   }, [addFiles]);
 
+  // External "insert into composer" entry point — the chat right-click menu's
+  // "Ask about this" action dispatches this window CustomEvent with a pre-built
+  // quote + follow-up scaffold. Mirrors buddy:attach-file so no prop threading
+  // is needed. We PREPEND the scaffold and drop the caret right after it, so any
+  // draft the user was already typing survives as the follow-up text.
+  useEffect(() => {
+    const listener = (e: Event) => {
+      const insert = (e as CustomEvent<{ text?: string }>).detail?.text;
+      if (!insert) return;
+      setText((prev) => insert + prev);
+      requestAnimationFrame(() => {
+        const el = inputRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(insert.length, insert.length);
+      });
+    };
+    window.addEventListener('youcoded:compose-insert', listener);
+    return () => window.removeEventListener('youcoded:compose-insert', listener);
+  }, []);
+
   const removeAttachment = useCallback((path: string) => {
     setAttachments((prev) => prev.filter((a) => a.path !== path));
   }, []);

--- a/desktop/src/renderer/components/context-menu/ContextMenu.tsx
+++ b/desktop/src/renderer/components/context-menu/ContextMenu.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { OverlayPanel } from '../overlays/Overlay';
+import { useEscClose } from '../../hooks/use-esc-close';
+import { MenuIcon } from './menu-icons';
+import type { MenuEntry } from './build-menu';
+
+// The themed right-click menu itself. Portalled to document.body on the app's
+// .layer-surface popover (L4, like the Select dropdown) so it re-themes and
+// glasses automatically. The host owns which entries + where; this owns look,
+// edge-flip positioning, keyboard nav, and dismissal.
+
+const VIEWPORT_PAD = 8;
+
+export function ContextMenu({
+  x,
+  y,
+  entries,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  entries: MenuEntry[];
+  onClose: () => void;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const menuElRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ left: x, top: y });
+
+  // Indices of focusable (enabled) items, for arrow-key navigation.
+  const enabledIndices = useMemo(
+    () => entries.map((e, i) => (e.type === 'item' && !e.disabled ? i : -1)).filter((i) => i >= 0),
+    [entries],
+  );
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  // Flip left / up when the menu would overflow the viewport (open near an edge).
+  useLayoutEffect(() => {
+    const el = panelRef.current;
+    if (!el) return;
+    const { width, height } = el.getBoundingClientRect();
+    let left = x;
+    let top = y;
+    if (left + width > window.innerWidth - VIEWPORT_PAD) left = Math.max(VIEWPORT_PAD, x - width);
+    if (top + height > window.innerHeight - VIEWPORT_PAD) top = Math.max(VIEWPORT_PAD, y - height);
+    setPos({ left, top });
+  }, [x, y, entries]);
+
+  // Focus the menu CONTAINER (not the first item) so keydown reaches us for
+  // arrow-key nav, but nothing looks pre-selected on open — the first item only
+  // highlights once the user hovers or arrows onto it.
+  useEffect(() => {
+    menuElRef.current?.focus();
+  }, []);
+
+  useEscClose(true, onClose);
+
+  // Dismiss on outside pointer-down, scroll, resize, or focus loss. The listener
+  // is added after this paint, so the right-click that opened the menu (its own
+  // mousedown already fired) can't immediately close it.
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (!panelRef.current?.contains(e.target as Node)) onClose();
+    };
+    const onScroll = () => onClose();
+    window.addEventListener('mousedown', onDown, true);
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onClose);
+    window.addEventListener('blur', onClose);
+    return () => {
+      window.removeEventListener('mousedown', onDown, true);
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onClose);
+      window.removeEventListener('blur', onClose);
+    };
+  }, [onClose]);
+
+  const run = (entry: MenuEntry) => {
+    if (entry.type !== 'item' || entry.disabled) return;
+    // Close first so focus/selection side-effects of the action (e.g. focusing
+    // the composer, mutating the selection) aren't fighting the open menu.
+    onClose();
+    void entry.run();
+  };
+
+  const moveFocus = (dir: 1 | -1) => {
+    if (enabledIndices.length === 0) return;
+    const active = document.activeElement;
+    const current = enabledIndices.findIndex((i) => itemRefs.current[i] === active);
+    const next = current === -1 ? (dir === 1 ? 0 : enabledIndices.length - 1) : (current + dir + enabledIndices.length) % enabledIndices.length;
+    itemRefs.current[enabledIndices[next]]?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveFocus(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveFocus(-1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        itemRefs.current[enabledIndices[0]]?.focus();
+        break;
+      case 'End':
+        e.preventDefault();
+        itemRefs.current[enabledIndices[enabledIndices.length - 1]]?.focus();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return createPortal(
+    <OverlayPanel
+      ref={panelRef}
+      layer={4}
+      className="fixed select-none"
+      style={{ left: pos.left, top: pos.top, minWidth: 200, borderRadius: 'var(--radius-lg)' }}
+    >
+      {/* Keyboard handling lives on this inner div — OverlayPanel's typed props
+          don't include onKeyDown, and the menu shouldn't scroll (no overflow on
+          the surface). */}
+      <div ref={menuElRef} role="menu" tabIndex={-1} className="p-1 outline-none" onKeyDown={onKeyDown}>
+      {entries.map((entry, i) => {
+        if (entry.type === 'sep') {
+          return <div key={`sep-${i}`} className="h-px my-1 mx-1.5" style={{ background: 'var(--edge-dim)' }} role="separator" />;
+        }
+        return (
+          <button
+            key={entry.id}
+            ref={(el) => {
+              itemRefs.current[i] = el;
+            }}
+            type="button"
+            role="menuitem"
+            disabled={entry.disabled}
+            aria-disabled={entry.disabled || undefined}
+            tabIndex={-1}
+            onClick={() => run(entry)}
+            className={[
+              'flex items-center gap-2.5 w-full text-left px-2.5 py-1.5 rounded-md text-2xs coarse-roomy',
+              entry.disabled
+                ? 'opacity-50 cursor-not-allowed'
+                : entry.primary
+                  ? 'text-fg font-medium hover:bg-inset focus:bg-inset'
+                  : 'text-fg-2 hover:bg-inset focus:bg-inset',
+            ].join(' ')}
+          >
+            <span
+              className={entry.primary && !entry.disabled ? '' : 'text-fg-muted'}
+              style={entry.primary && !entry.disabled ? { color: 'var(--accent)' } : undefined}
+            >
+              <MenuIcon name={entry.icon} />
+            </span>
+            <span className="flex-1 truncate">{entry.label}</span>
+            {entry.kbd && <span className="text-fg-faint text-[10px] tracking-wide">{entry.kbd}</span>}
+          </button>
+        );
+      })}
+      </div>
+    </OverlayPanel>,
+    document.body,
+  );
+}

--- a/desktop/src/renderer/components/context-menu/ContextMenuHost.tsx
+++ b/desktop/src/renderer/components/context-menu/ContextMenuHost.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { buildContextMenu, type MenuEntry } from './build-menu';
+import { ContextMenu } from './ContextMenu';
+
+// Single app-wide right-click host. Listens for `contextmenu` (capture) on the
+// document, asks build-menu what (if anything) applies to the target, and — only
+// when there's something actionable — suppresses the default menu and opens ours.
+// Targets outside chat content / the composer are left untouched (terminal,
+// settings, remote-browser native menu, etc.). Mounted once from App.
+
+type MenuState = { x: number; y: number; entries: MenuEntry[] };
+
+export function ContextMenuHost() {
+  const [menu, setMenu] = useState<MenuState | null>(null);
+
+  useEffect(() => {
+    const onContextMenu = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const entries = buildContextMenu(target);
+      if (!entries) return; // not our surface — leave the default behavior alone
+      e.preventDefault();
+      setMenu({ x: e.clientX, y: e.clientY, entries });
+    };
+    document.addEventListener('contextmenu', onContextMenu, true);
+    return () => document.removeEventListener('contextmenu', onContextMenu, true);
+  }, []);
+
+  if (!menu) return null;
+  return <ContextMenu x={menu.x} y={menu.y} entries={menu.entries} onClose={() => setMenu(null)} />;
+}

--- a/desktop/src/renderer/components/context-menu/build-menu.ts
+++ b/desktop/src/renderer/components/context-menu/build-menu.ts
@@ -1,0 +1,201 @@
+import { isAndroid, isRemoteMode } from '../../platform';
+import { copyText, readText } from './clipboard';
+import type { MenuIconName } from './menu-icons';
+
+// Builds the chat right-click menu for a given DOM target. Pure inspection of
+// the DOM + current selection → a list of entries; the host owns positioning,
+// open/close, and rendering. Returns null when the target isn't a surface we
+// own (or has nothing actionable), so the host leaves the event alone.
+
+export type MenuEntry =
+  | {
+      type: 'item';
+      id: string;
+      label: string;
+      icon: MenuIconName;
+      kbd?: string;
+      primary?: boolean;
+      disabled?: boolean;
+      run: () => void | Promise<void>;
+    }
+  | { type: 'sep' };
+
+const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform);
+const mod = (key: string) => (isMac ? `⌘${key}` : `Ctrl+${key}`);
+// Reveal-in-folder / open-in-OS only do anything on the Electron desktop; on
+// Android and remote-browser the shell IPC is a no-op, so we hide those items.
+const isDesktop = () => !isAndroid() && !isRemoteMode();
+
+// window.claude is the shared IPC surface (preload on desktop, remote-shim on
+// Android/remote). Typed loosely here to avoid coupling to the ambient global.
+const shell = () => (window as { claude?: { shell?: any } }).claude?.shell;
+
+function selectionText(): string {
+  return window.getSelection()?.toString() ?? '';
+}
+
+function closestBubble(el: Element): Element | null {
+  return el.closest('.assistant-bubble, .user-bubble');
+}
+
+function baseName(p: string): string {
+  return p.replace(/\\/g, '/').split('/').pop() || p;
+}
+
+function selectElementContents(el: Element): void {
+  const sel = window.getSelection();
+  if (!sel) return;
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+// "Ask about this" drops a quoted reference + follow-up scaffold into the
+// composer (InputBar listens for this CustomEvent — see InputBar.tsx). Simple v1
+// per Destin (2026-07-17): plain prompt text, no new plumbing. The caret lands
+// right after the scaffold so any existing draft becomes the follow-up.
+function askAboutThis(text: string): void {
+  window.dispatchEvent(new CustomEvent('youcoded:compose-insert', { detail: { text } }));
+}
+
+function scaffold(lead: string, body: string, fenced: boolean): string {
+  const quoted = fenced ? '```\n' + body + '\n```' : `"${body}"`;
+  return `${lead}\n${quoted}\n\nThe user has a follow-up: `;
+}
+
+// Copy + Select all — shared tail for every read-only chat menu.
+function textBasics(bubble: Element | null): MenuEntry[] {
+  const sel = selectionText();
+  return [
+    {
+      type: 'item',
+      id: 'copy',
+      label: 'Copy',
+      icon: 'copy',
+      kbd: mod('C'),
+      disabled: !sel && !bubble,
+      run: () => void copyText(sel || (bubble?.textContent ?? '')),
+    },
+    {
+      type: 'item',
+      id: 'select-all',
+      label: 'Select all',
+      icon: 'select-all',
+      kbd: mod('A'),
+      disabled: !bubble,
+      run: () => {
+        if (bubble) selectElementContents(bubble);
+      },
+    },
+  ];
+}
+
+function editableMenu(el: HTMLTextAreaElement | HTMLInputElement): MenuEntry[] {
+  // Capture the selection NOW (at right-click), because auto-focusing the menu
+  // blurs the textarea; we restore this range before each op so cut/copy/paste
+  // act on what the user actually had selected.
+  const selStart = el.selectionStart ?? 0;
+  const selEnd = el.selectionEnd ?? 0;
+  const hasSelection = selStart !== selEnd;
+  const empty = (el.value ?? '').length === 0;
+  const restore = () => {
+    el.focus();
+    el.setSelectionRange(selStart, selEnd);
+  };
+  return [
+    // execCommand cut/paste fire the native 'input' event, so React's controlled
+    // onChange stays in sync — a manual value set would not.
+    { type: 'item', id: 'cut', label: 'Cut', icon: 'cut', kbd: mod('X'), disabled: !hasSelection, run: () => { restore(); document.execCommand('cut'); } },
+    { type: 'item', id: 'copy', label: 'Copy', icon: 'copy', kbd: mod('C'), disabled: !hasSelection, run: () => { restore(); document.execCommand('copy'); } },
+    { type: 'item', id: 'paste', label: 'Paste', icon: 'paste', kbd: mod('V'), run: async () => { restore(); const t = await readText(); if (t) document.execCommand('insertText', false, t); } },
+    { type: 'sep' },
+    { type: 'item', id: 'select-all', label: 'Select all', icon: 'select-all', kbd: mod('A'), disabled: empty, run: () => { el.focus(); el.select(); } },
+  ];
+}
+
+function filePillMenu(el: HTMLElement): MenuEntry[] {
+  const abs = el.getAttribute('data-file-path') || '';
+  const name = baseName(abs);
+  const entries: MenuEntry[] = [];
+  if (isDesktop()) {
+    entries.push(
+      { type: 'item', id: 'open-file', label: 'Open file', icon: 'open', primary: true, run: () => shell()?.openPath(abs) },
+      { type: 'item', id: 'reveal', label: 'View in folder', icon: 'folder', run: () => shell()?.showItemInFolder(abs) },
+      { type: 'sep' },
+    );
+  }
+  entries.push(
+    { type: 'item', id: 'copy-name', label: 'Copy file name', icon: 'copy', run: () => void copyText(name) },
+    { type: 'item', id: 'copy-path', label: 'Copy as path', icon: 'path', run: () => void copyText(abs) },
+  );
+  return entries;
+}
+
+function linkMenu(a: HTMLAnchorElement, target: HTMLElement): MenuEntry[] {
+  const href = a.href || a.getAttribute('href') || '';
+  return [
+    { type: 'item', id: 'open-link', label: 'Open link', icon: 'open', primary: true, disabled: !href, run: () => { if (href) shell()?.openExternal(href); } },
+    { type: 'item', id: 'copy-link', label: 'Copy link address', icon: 'link', disabled: !href, run: () => void copyText(href) },
+    { type: 'sep' },
+    ...textBasics(closestBubble(target)),
+  ];
+}
+
+function codeMenu(pre: HTMLElement, target: HTMLElement): MenuEntry[] {
+  const code = pre.innerText.replace(/\n+$/, '');
+  return [
+    { type: 'item', id: 'ask', label: 'Ask about this', icon: 'ask', primary: true, disabled: !code, run: () => askAboutThis(scaffold('Earlier, you shared this code:', code, true)) },
+    { type: 'item', id: 'copy-code', label: 'Copy code block', icon: 'code', disabled: !code, run: () => void copyText(code) },
+    { type: 'sep' },
+    ...textBasics(closestBubble(target)),
+  ];
+}
+
+function textMenu(target: HTMLElement): MenuEntry[] {
+  const bubble = closestBubble(target);
+  const quote = (selectionText().trim() || bubble?.textContent?.trim()) ?? '';
+  // "you said" reads right for an assistant message; flip it for the user's own
+  // bubble, and stay neutral if we can't tell.
+  const lead = bubble?.classList.contains('assistant-bubble')
+    ? 'In an earlier message, you said:'
+    : bubble?.classList.contains('user-bubble')
+      ? 'Earlier I wrote:'
+      : 'Regarding this:';
+  const entries: MenuEntry[] = [];
+  if (quote) {
+    entries.push({ type: 'item', id: 'ask', label: 'Ask about this', icon: 'ask', primary: true, run: () => askAboutThis(scaffold(lead, quote, false)) });
+  }
+  entries.push(...textBasics(bubble));
+  return entries;
+}
+
+export function buildContextMenu(target: HTMLElement): MenuEntry[] | null {
+  // The editable composer (Cut/Copy/Paste/Select all) lives outside .chat-scroll.
+  const composer = target.closest('.input-bar-textarea');
+  if (composer instanceof HTMLTextAreaElement || composer instanceof HTMLInputElement) {
+    return finalize(editableMenu(composer));
+  }
+
+  // Everything else is scoped to chat content — never hijack the terminal, the
+  // settings panels, or other chrome.
+  if (!target.closest('.chat-scroll')) return null;
+
+  const filePill = target.closest('[data-file-path]');
+  if (filePill instanceof HTMLElement && filePill.getAttribute('data-file-path')) {
+    return finalize(filePillMenu(filePill));
+  }
+  const link = target.closest('a[href]');
+  if (link instanceof HTMLAnchorElement) return finalize(linkMenu(link, target));
+
+  const pre = target.closest('pre');
+  if (pre instanceof HTMLElement) return finalize(codeMenu(pre, target));
+
+  return finalize(textMenu(target));
+}
+
+// Drop a menu with no actionable (enabled) item — e.g. a right-click on empty
+// chat gutter — so the host doesn't pop an all-greyed shell.
+function finalize(entries: MenuEntry[]): MenuEntry[] | null {
+  return entries.some((e) => e.type === 'item' && !e.disabled) ? entries : null;
+}

--- a/desktop/src/renderer/components/context-menu/clipboard.ts
+++ b/desktop/src/renderer/components/context-menu/clipboard.ts
@@ -1,0 +1,48 @@
+// Clipboard helpers for the chat context menu.
+//
+// navigator.clipboard requires a secure context (https / localhost). The remote
+// browser access mode serves the UI over plain http to a LAN/Tailscale IP, where
+// the async Clipboard API is unavailable — so writes fall back to a hidden
+// textarea + execCommand('copy'), the same fallback ShareSheet.tsx already uses.
+
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to the execCommand path (insecure origin / denied permission)
+  }
+  return legacyCopy(text);
+}
+
+function legacyCopy(text: string): boolean {
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    // Keep it out of view and out of the layout while still selectable.
+    ta.style.position = 'fixed';
+    ta.style.top = '-9999px';
+    ta.style.opacity = '0';
+    ta.setAttribute('readonly', '');
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+// Read clipboard text for Paste. Returns null when unavailable (insecure origin,
+// denied permission) — the caller then no-ops rather than inserting garbage.
+export async function readText(): Promise<string | null> {
+  try {
+    if (navigator.clipboard?.readText) return await navigator.clipboard.readText();
+  } catch {
+    // insecure origin or permission denied
+  }
+  return null;
+}

--- a/desktop/src/renderer/components/context-menu/menu-icons.tsx
+++ b/desktop/src/renderer/components/context-menu/menu-icons.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+// Icon set for the chat context menu. Same visual language as the app's other
+// inline icons (24×24 viewBox, stroke: currentColor, stroke-width 2, round
+// caps/joins) so they inherit theme color from the menu row. The sparkle for
+// "Ask about this" was Destin's pick (2026-07-17 icon review).
+
+export type MenuIconName =
+  | 'copy'
+  | 'cut'
+  | 'paste'
+  | 'select-all'
+  | 'ask'
+  | 'code'
+  | 'open'
+  | 'link'
+  | 'folder'
+  | 'path';
+
+const PATHS: Record<MenuIconName, React.ReactNode> = {
+  copy: (
+    <>
+      <rect x="9" y="9" width="11" height="11" rx="2" />
+      <path d="M5 15V5a2 2 0 0 1 2-2h8" />
+    </>
+  ),
+  cut: (
+    <>
+      <circle cx="6" cy="6" r="2.5" />
+      <circle cx="6" cy="18" r="2.5" />
+      <path d="M20 4 8.5 15.5M14.5 14.5 20 20M8 8l4 4" />
+    </>
+  ),
+  paste: (
+    <>
+      <rect x="8" y="4" width="8" height="4" rx="1" />
+      <path d="M16 6h2a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h2" />
+    </>
+  ),
+  'select-all': (
+    <>
+      <path d="M4 8V6a2 2 0 0 1 2-2h2M16 4h2a2 2 0 0 1 2 2v2M20 16v2a2 2 0 0 1-2 2h-2M8 20H6a2 2 0 0 1-2-2v-2" />
+      <rect x="9" y="9" width="6" height="6" rx="1" />
+    </>
+  ),
+  ask: (
+    <>
+      <path d="M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8z" />
+      <path d="M18.5 14.5l.6 1.8 1.8.6-1.8.6-.6 1.8-.6-1.8-1.8-.6 1.8-.6z" />
+    </>
+  ),
+  code: <path d="m8 8-4 4 4 4M16 8l4 4-4 4M13 6l-2 12" />,
+  open: <path d="M14 4h6v6M20 4l-9 9M18 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h5" />,
+  link: (
+    <>
+      <path d="M9 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1" />
+      <path d="M15 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1" />
+    </>
+  ),
+  folder: <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />,
+  path: (
+    <>
+      <path d="M9 5h9a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-2" />
+      <path d="M4 15l3-3-3-3" />
+      <path d="M12 9h4M12 13h4" />
+    </>
+  ),
+};
+
+export function MenuIcon({ name }: { name: MenuIconName }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {PATHS[name]}
+    </svg>
+  );
+}

--- a/desktop/src/renderer/components/tool-views/ToolBody.tsx
+++ b/desktop/src/renderer/components/tool-views/ToolBody.tsx
@@ -68,7 +68,9 @@ function CollapsibleBlock({ children, maxLines = 20, className = '' }: { childre
 function PathHeader({ fp, extra }: { fp: string; extra?: React.ReactNode }) {
   const dir = parentDir(fp);
   return (
-    <div className="flex items-center gap-1.5 text-[11px] font-mono">
+    // data-file-path carries the absolute path so the chat right-click menu can
+    // offer View in folder / Copy as path (the DOM otherwise only has display labels).
+    <div className="flex items-center gap-1.5 text-[11px] font-mono" data-file-path={fp || undefined}>
       {dir && <span className="text-fg-muted">{dir}/</span>}
       <span className="text-fg-2 font-medium">{basename(fp)}</span>
       {extra}
@@ -150,6 +152,10 @@ function ToolFilePreview({ fp, sessionId, chips }: { fp: string; sessionId?: str
         type="button"
         onClick={open}
         title={`Open ${name}`}
+        // data-file-path (absolute) lets the chat right-click menu recover the
+        // real path for View in folder / Copy as path — left-click still opens
+        // the in-app artifact drawer.
+        data-file-path={fp || undefined}
         className="group flex items-center gap-3 w-full p-2 rounded-lg bg-inset border border-edge hover:border-fg-muted text-left transition-colors"
       >
         <ArtifactThumbnail


### PR DESCRIPTION
Two chat-view features Destin requested, both verified in a dev instance.

## 1. Momentum "flick" scroll
Linux/libinput sends no OS momentum tail, so a trackpad flick died on finger-lift. The wheel handler now samples recent velocity and coasts under exponential friction after input stops. A single mouse-wheel notch never reaches flick velocity (discrete scrolling stays snappy). **Tap to catch:** any touch while coasting freezes the view in place (handles sub-pixel resting-finger jitter too).

## 2. Custom themed right-click menu
Previously right-click did nothing anywhere. New `components/context-menu/` module: one document-level capture listener opens a themed `.layer-surface` popover, scoped to chat content + the composer (terminal/chrome untouched). Context-aware:
- selected text → **Ask about this** · Copy · Select all
- code block → Ask about this · Copy code block · Copy · Select all
- link → Open link · Copy link address · Copy · Select all
- file pill → Open file · View in folder · Copy file name · Copy as path
- composer → Cut · Copy · Paste · Select all

"Ask about this" quotes the target into the composer via a new `youcoded:compose-insert` event. File pills got `data-file-path` (tool-card + inline chip); left-click still opens the drawer. Reuses existing `shell` IPC (desktop-gated); clipboard falls back to `execCommand` on insecure remote. Opens with nothing preselected — highlight on hover/arrow only.

Shared renderer code; the wheel handler is inert on Android (no wheel events), and the menu also serves Android long-press + remote browser. Image sub-menu (copy/save image) deferred — needs new IPC; tracked in the workspace ROADMAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)