### PR TITLE
feat(sync): device rows show real sync recency

### DIFF
--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -22,6 +22,9 @@ import ConnectGithubModal from './ConnectGithubModal';
 import type { PastSession } from '../../shared/types';
 import SettingsRow from './SettingsRow';
 import { latestUnresolvedError, type SyncStatusData } from './sync-dot-state';
+// relativeMs is co-located in the pure device-activity-label module (single
+// wording ladder, shared by the device recency label and the fallback below).
+import { deviceActivityLabel, relativeMs } from './device-activity-label';
 import { summarizeSpaceSyncError } from './sync-space-error-summary';
 
 // --- Explainer content (updated for V2 multi-instance model) ---
@@ -99,6 +102,11 @@ interface SyncStatus {
   syncInProgress: boolean;
   syncingBackendId: string | null;
   syncedCategories: string[];
+  // Per-device sync recency: key = device machineId (= the row's `d.id`), value =
+  // epoch-ms of that device's most recent successful sync. Carried over the
+  // SyncHub Durable Object (never git). Optional — an older main process that
+  // doesn't populate it makes device rows fall back to the launch-time value.
+  lastSyncByDevice?: Record<string, number>;
 }
 
 // --- Helpers ---
@@ -112,21 +120,6 @@ function timeAgo(epoch: number): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
-}
-
-// Relative time from a MILLISECOND epoch (the device registry stores lastSeen in
-// ms, unlike the sync backends above which use seconds). Plain words on purpose —
-// the "Your devices" list is spec'd as plain text with no status glyphs.
-function relativeMs(ms: number): string {
-  if (!ms || !Number.isFinite(ms)) return 'unknown';
-  const seconds = Math.floor((Date.now() - ms) / 1000);
-  if (seconds < 45) return 'just now';
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes} min ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
-  const days = Math.round(hours / 24);
-  return `${days} day${days === 1 ? '' : 's'} ago`;
 }
 
 // Map process.platform to a plain, human word. Empty string (unknown platform)
@@ -309,6 +302,9 @@ export default function SyncSection({ autoOpen, onAutoOpenHandled }: SyncSection
           lastSyncEpoch: data.lastSyncEpoch ?? prev.lastSyncEpoch,
           syncInProgress: data.syncInProgress ?? prev.syncInProgress,
           backupMeta: data.backupMeta ?? prev.backupMeta,
+          // Keep per-device recency live between full refetches (same pattern as
+          // lastSyncEpoch). Absent on the push → keep the last-known map.
+          lastSyncByDevice: data.lastSyncByDevice ?? prev.lastSyncByDevice,
         };
       });
     });
@@ -495,6 +491,8 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                 lastSyncEpoch: epoch ?? prev.lastSyncEpoch,
                 syncInProgress: data.syncInProgress ?? prev.syncInProgress,
                 backupMeta: data.backupMeta ?? prev.backupMeta,
+                // Per-device recency rides the same push (feeds the device list).
+                lastSyncByDevice: data.lastSyncByDevice ?? prev.lastSyncByDevice,
               }
             : prev,
         );
@@ -1058,7 +1056,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         })}
                       </div>
                       <div role="tabpanel" className="border-t border-edge-dim px-3 py-2.5">
-                        {countTab === 'dev' && <DevicesTab devices={devices} onRename={handleRenameDevice} onRemove={handleRemoveDevice} />}
+                        {countTab === 'dev' && <DevicesTab devices={devices} onRename={handleRenameDevice} onRemove={handleRemoveDevice} syncInProgress={status?.syncInProgress ?? false} lastSyncByDevice={status?.lastSyncByDevice} />}
                         {countTab === 'proj' && (() => {
                           const projects = ((spacesStatus?.spaces ?? []) as any[]).filter(s => s.kind === 'project');
                           if (projects.length === 0) return <p className="text-[11px] text-fg-muted">Turn on sync for a project folder to add it here.</p>;
@@ -1535,7 +1533,7 @@ interface DeviceRow {
   self: boolean;
 }
 
-function DevicesTab({ devices, onRename, onRemove }: { devices: DeviceRow[] | null; onRename: (id: string, name: string) => void; onRemove: (id: string) => Promise<string | null> }) {
+function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDevice }: { devices: DeviceRow[] | null; onRename: (id: string, name: string) => void; onRemove: (id: string) => Promise<string | null>; syncInProgress: boolean; lastSyncByDevice?: Record<string, number> }) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draft, setDraft] = useState('');
   // Two-step confirm: the id awaiting confirmation, if any. Removal is recoverable
@@ -1573,7 +1571,17 @@ function DevicesTab({ devices, onRename, onRemove }: { devices: DeviceRow[] | nu
     <ul className="space-y-1">
       {(devices ?? []).map(d => {
         const plat = platformLabel(d.platform);
-        const activity = d.self ? 'active now' : `last seen ${relativeMs(d.lastSeen)}`;
+        // Real sync recency instead of the frozen launch-time "last seen":
+        // "Synced just now" (<5 min), "Last synced 12 minutes ago" (older), or —
+        // when there's no sync record (older main process / never-synced peer) —
+        // the launch-time fallback. Self shows a live "Syncing…" mid-sync.
+        // lastSyncByDevice is keyed by machineId, which is exactly `d.id`.
+        const activity = deviceActivityLabel({
+          isSelf: d.self,
+          syncInProgress,
+          lastSyncAt: lastSyncByDevice?.[d.id] ?? null,
+          gitLastSeen: d.lastSeen,
+        }, Date.now());
         const right = plat ? `${plat} · ${activity}` : activity;
         return (
           <li key={d.id}>

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -1056,7 +1056,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         })}
                       </div>
                       <div role="tabpanel" className="border-t border-edge-dim px-3 py-2.5">
-                        {countTab === 'dev' && <DevicesTab devices={devices} onRename={handleRenameDevice} onRemove={handleRemoveDevice} syncInProgress={status?.syncInProgress ?? false} lastSyncByDevice={status?.lastSyncByDevice} />}
+                        {countTab === 'dev' && <DevicesTab devices={devices} onRename={handleRenameDevice} onRemove={handleRemoveDevice} syncInProgress={status?.syncInProgress ?? false} lastSyncByDevice={status?.lastSyncByDevice} lastSyncEpoch={status?.lastSyncEpoch ?? null} />}
                         {countTab === 'proj' && (() => {
                           const projects = ((spacesStatus?.spaces ?? []) as any[]).filter(s => s.kind === 'project');
                           if (projects.length === 0) return <p className="text-[11px] text-fg-muted">Turn on sync for a project folder to add it here.</p>;
@@ -1533,7 +1533,7 @@ interface DeviceRow {
   self: boolean;
 }
 
-function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDevice }: { devices: DeviceRow[] | null; onRename: (id: string, name: string) => void; onRemove: (id: string) => Promise<string | null>; syncInProgress: boolean; lastSyncByDevice?: Record<string, number> }) {
+function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDevice, lastSyncEpoch }: { devices: DeviceRow[] | null; onRename: (id: string, name: string) => void; onRemove: (id: string) => Promise<string | null>; syncInProgress: boolean; lastSyncByDevice?: Record<string, number>; lastSyncEpoch: number | null }) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draft, setDraft] = useState('');
   // Two-step confirm: the id awaiting confirmation, if any. Removal is recoverable
@@ -1576,10 +1576,18 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
         // when there's no sync record (older main process / never-synced peer) —
         // the launch-time fallback. Self shows a live "Syncing…" mid-sync.
         // lastSyncByDevice is keyed by machineId, which is exactly `d.id`.
+        // Self's recency comes from the LOCAL live marker (lastSyncEpoch, in
+        // SECONDS → ms), not the DO map: the SyncHub never echoes a device's own
+        // signal back to it, so self's own map entry only refreshes on reconnect
+        // and would otherwise drift stale (row saying "20 min ago" while the panel
+        // header says "just now"). Peers use the map, updated live from relayed signals.
+        const lastSyncAt = d.self
+          ? (lastSyncEpoch != null ? lastSyncEpoch * 1000 : null)
+          : (lastSyncByDevice?.[d.id] ?? null);
         const activity = deviceActivityLabel({
           isSelf: d.self,
           syncInProgress,
-          lastSyncAt: lastSyncByDevice?.[d.id] ?? null,
+          lastSyncAt,
           gitLastSeen: d.lastSeen,
         }, Date.now());
         const right = plat ? `${plat} · ${activity}` : activity;

--- a/desktop/src/renderer/components/device-activity-label.ts
+++ b/desktop/src/renderer/components/device-activity-label.ts
@@ -1,0 +1,71 @@
+// desktop/src/renderer/components/device-activity-label.ts
+// Pure derivation of the "Your devices" row activity label from real sync
+// recency (2026-07-17 sync-menu-recency spec). Renderer-safe — no fs/os/window,
+// no Node APIs — because this same module ships to the Android WebView. Mirrors
+// the style of sync-dot-state.ts (its sibling): all logic lives here as pure
+// functions so the exact wording bands are unit-pinned and never drift.
+//
+// WHY this replaced the frozen "last seen {launch time}": lastSeen is a
+// launch-time heartbeat that only propagates over git, so a device that is on
+// and actively syncing still read "last seen a few hours ago" on every other
+// device. lastSyncByDevice (carried over the SyncHub Durable Object, keyed by
+// machineId) gives the real "last successful sync" time instead.
+
+// Relative time from a MILLISECOND epoch timestamp. `now` is injectable so the
+// helper stays pure/testable (no hidden Date.now() read). Full words on purpose
+// — the "Your devices" list is spec'd as plain text with no status glyphs, and
+// the recency band ("Last synced 12 minutes ago") reads better spelled out.
+// This is the SINGLE wording ladder for the sync menu — both the recency band
+// below and the launch-time fallback route through it (no duplicate ladder).
+export function relativeMs(ms: number, now: number = Date.now()): string {
+  if (!ms || !Number.isFinite(ms)) return 'unknown';
+  const seconds = Math.floor((now - ms) / 1000);
+  if (seconds < 45) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+export interface DeviceActivityInput {
+  /** Is this the current machine? Its row shows a live "Syncing…" while active. */
+  isSelf: boolean;
+  /** A sync is in flight right now (local signal, self only). */
+  syncInProgress: boolean;
+  /** Epoch-ms of this device's most recent successful sync, or null if unknown
+   *  (older main process with no lastSyncByDevice map, or a never-synced peer). */
+  lastSyncAt: number | null;
+  /** Launch-time heartbeat epoch-ms (device registry) — the graceful fallback. */
+  gitLastSeen: number;
+}
+
+// < 5 min ⇒ "Synced just now"; ≥ 5 min ⇒ "Last synced {relative} ago".
+const RECENT_WINDOW_MS = 5 * 60_000;
+
+/**
+ * The activity label for one device row. Bands:
+ *   self + syncing      → "Syncing…"        (live, local-only)
+ *   synced < 5 min ago  → "Synced just now"
+ *   synced ≥ 5 min ago  → "Last synced {relative} ago"
+ *   no sync record      → "last seen {relative}"  (launch-time fallback)
+ *
+ * Clock-skew safe: `at` is SERVER time compared against the viewer's local
+ * clock, so we clamp `max(0, now − at)` — a device whose clock runs ahead can
+ * never render a negative/future age (same guard as friends-data.ts).
+ */
+export function deviceActivityLabel(input: DeviceActivityInput, now: number = Date.now()): string {
+  // Self mid-sync trumps everything — it's the one live signal the row shows.
+  if (input.isSelf && input.syncInProgress) return 'Syncing…';
+
+  // No sync record → degrade to the old launch-time wording. This is the
+  // graceful path when the main process predates lastSyncByDevice, or a peer
+  // has never synced: nothing breaks, the row just reads the heartbeat.
+  if (input.lastSyncAt == null) return `last seen ${relativeMs(input.gitLastSeen, now)}`;
+
+  // Clamp so a skewed/future timestamp reads "just now", never a negative age.
+  const age = Math.max(0, now - input.lastSyncAt);
+  if (age < RECENT_WINDOW_MS) return 'Synced just now';
+  return `Last synced ${relativeMs(input.lastSyncAt, now)}`;
+}

--- a/desktop/tests/device-activity-label.test.ts
+++ b/desktop/tests/device-activity-label.test.ts
@@ -1,0 +1,66 @@
+// desktop/tests/device-activity-label.test.ts
+// Pins the exact wording bands of the pure device-row recency helper
+// (2026-07-17 sync-menu-recency spec/plan Task 4). Wording is a UI contract —
+// these strings render verbatim in the "Your devices" list.
+import { describe, it, expect } from 'vitest';
+import { deviceActivityLabel, relativeMs } from '../src/renderer/components/device-activity-label';
+
+const NOW = 1_700_000_000_000;
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+// Convenience: build the helper input with sane defaults, override per case.
+const input = (over: Partial<Parameters<typeof deviceActivityLabel>[0]> = {}) => ({
+  isSelf: false,
+  syncInProgress: false,
+  lastSyncAt: null as number | null,
+  gitLastSeen: NOW - 3 * HOUR,
+  ...over,
+});
+
+describe('deviceActivityLabel — self row', () => {
+  it('shows the live "Syncing…" while a sync is in flight', () => {
+    expect(deviceActivityLabel(input({ isSelf: true, syncInProgress: true, lastSyncAt: NOW - 2 * MIN }), NOW)).toBe('Syncing…');
+  });
+  it('self + not syncing + synced 2m ago → "Synced just now"', () => {
+    expect(deviceActivityLabel(input({ isSelf: true, syncInProgress: false, lastSyncAt: NOW - 2 * MIN }), NOW)).toBe('Synced just now');
+  });
+});
+
+describe('deviceActivityLabel — peer recency bands', () => {
+  it('synced 30s ago → "Synced just now"', () => {
+    expect(deviceActivityLabel(input({ lastSyncAt: NOW - 30_000 }), NOW)).toBe('Synced just now');
+  });
+
+  // BOUNDARY: the rule is < 5 min ⇒ "Synced just now"; ≥ 5 min ⇒ "Last synced {relative} ago".
+  it('exactly 5m ago → relative ("Last synced 5 minutes ago")', () => {
+    expect(deviceActivityLabel(input({ lastSyncAt: NOW - 5 * MIN }), NOW)).toBe('Last synced 5 minutes ago');
+  });
+  it('4m59s ago → still "Synced just now"', () => {
+    expect(deviceActivityLabel(input({ lastSyncAt: NOW - (5 * MIN - 1000) }), NOW)).toBe('Synced just now');
+  });
+
+  it('synced 12m ago → "Last synced 12 minutes ago"', () => {
+    expect(deviceActivityLabel(input({ lastSyncAt: NOW - 12 * MIN }), NOW)).toBe('Last synced 12 minutes ago');
+  });
+});
+
+describe('deviceActivityLabel — no sync record (fallback to launch time)', () => {
+  it('no lastSyncAt → falls back to today\'s launch-time wording via relativeMs', () => {
+    expect(deviceActivityLabel(input({ lastSyncAt: null, gitLastSeen: NOW - 3 * HOUR }), NOW)).toBe('last seen 3 hours ago');
+  });
+});
+
+describe('deviceActivityLabel — clock skew', () => {
+  it('a lastSyncAt in the FUTURE clamps to "Synced just now" (never negative/future)', () => {
+    expect(deviceActivityLabel(input({ lastSyncAt: NOW + 10 * MIN }), NOW)).toBe('Synced just now');
+  });
+});
+
+describe('relativeMs (co-located phrasing helper)', () => {
+  it('is injectable with now and reads in full words', () => {
+    expect(relativeMs(NOW - 5 * MIN, NOW)).toBe('5 minutes ago');
+    expect(relativeMs(NOW - 3 * HOUR, NOW)).toBe('3 hours ago');
+    expect(relativeMs(NOW - 30_000, NOW)).toBe('just now');
+  });
+});


### PR DESCRIPTION
## What

Each row in the sync menu's "Your devices" list showed `last seen {launch time}` — a frozen launch-time heartbeat (`upsertSelf` runs once on launch and only propagates over git), so a device that's on and actively syncing still read "last seen a few hours ago" on every other device. This replaces that with **real sync recency**.

| Condition | Label |
|---|---|
| Synced < 5 min ago | **"Synced just now"** |
| Synced ≥ 5 min ago | **"Last synced 12 minutes ago"** → hours → days |
| No sync record | Falls back to today's launch-time value |
| This device, mid-sync | Live **"Syncing…"** |

Implements **Tasks 4 + 5** of the [sync-menu-recency plan](https://github.com/itsdestin/youcoded-dev/blob/master/docs/active/plans/2026-07-17-sync-menu-recency-plan.md) (renderer half). The main-process half that populates `lastSyncByDevice` over the SyncHub Durable Object (Tasks 1–3) ships separately.

## How

- **New pure helper** `deviceActivityLabel()` in `device-activity-label.ts` (mirrors `sync-dot-state.ts`) — renderer-safe (no fs/os/window), so it also runs in the Android WebView. All wording bands are unit-pinned. Clock-skew-safe: clamps `max(0, now − at)` so a peer whose clock runs ahead never renders a negative/future age.
- **`relativeMs` co-located** into that pure module (single wording ladder, now injectable + full words) so the recency band and the launch-time fallback share one helper — no duplicated minutes/hours/days logic.
- **`SyncPanel.tsx`**: added `lastSyncByDevice?: Record<string, number>` to `SyncStatus`, patched it through both `status:data` merge effects, threaded it (plus `syncInProgress`) into `DevicesTab`, and wired the row to the helper (`lastSyncByDevice[d.id]`, keyed by machineId).

## Graceful degradation

The `lastSyncByDevice` field is **optional**. Until the main-process half ships (or for a never-synced peer), the field is absent and every row simply falls back to the old launch-time "last seen {time}" wording — no regression, no coordinated deploy required.

## Tests

- `device-activity-label.test.ts` — 9 cases pinning every band, the 5-min boundary (4m59s → "just now"; exactly 5m → relative), the null-record fallback, and the future/clock-skew clamp.
- Full suite: **2595 passed** locally; `tsc --noEmit` clean. (Two `sync-spaces-service` transition-timing tests flaked under parallel load and pass in isolation — an unrelated known flake; this PR touches renderer only.)

## Note

Minor cosmetic side effect of co-locating `relativeMs`: the conversation-list "last modified" caption now reads "5 minutes ago" instead of "5 min ago" (same single ladder, spelled out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)