### PR TITLE
feat(sync): hub client + service carry per-device recency

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -50,7 +50,7 @@ import { getSyncStatus, getSyncConfig, setSyncConfig, forceSync, getSyncLog, dis
 // Cross-device sync spaces (spec 2026-07-03) — the folder-based sync engine.
 import {
   syncSpacesStatus, syncSpacesEnable, syncSpacesSyncNow, syncSpacesCreateProject, syncSpacesImportProject,
-  syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots, isSyncSpacesEnabled,
+  syncSpacesRenameProject, syncSpacesStopProject, getManagedRoots, isSyncSpacesEnabled, getLastSyncByDevice,
 } from './sync-spaces/service';
 import { readDevices, renameDevice, removeDevice } from './sync-spaces/device-registry';
 // Connect-GitHub modal (device-flow auth) — detectGh/installGh are step fns;
@@ -1706,6 +1706,11 @@ export function registerIpcHandlers(
     let syncInProgress = false;
     try { syncInProgress = fs.statSync(path.join(os.homedir(), '.claude', 'toolkit-state', '.sync-lock')).isDirectory(); } catch {}
     const backupMeta = readJsonFile(path.join(os.homedir(), '.claude', 'backup-meta.json'));
+    // Per-device sync recency (machineId → epoch-ms), carried over the SyncHub.
+    // Rides the live push so the "Your devices" rows update in real-time without
+    // waiting for a full getSyncStatus() refetch. Forwarded verbatim to remote
+    // browsers via broadcastStatusData (no reshape). Empty when the hub is down.
+    const lastSyncByDevice = getLastSyncByDevice();
 
     // Read per-session context remaining % (written by statusline.sh)
     const contextMap: Record<string, number> = {};
@@ -1758,7 +1763,7 @@ export function registerIpcHandlers(
     // (The background bulk-conversations pull + its restore-progress chip were
     // removed in sync-legacy-demolition — the pull path no longer exists.)
 
-    return { usage, announcement, updateStatus, syncStatus, syncWarnings, lastSyncEpoch, syncInProgress, backupMeta, contextMap, gitBranchMap, sessionStatsMap, attentionMap };
+    return { usage, announcement, updateStatus, syncStatus, syncWarnings, lastSyncEpoch, syncInProgress, lastSyncByDevice, backupMeta, contextMap, gitBranchMap, sessionStatsMap, attentionMap };
   }
 
   // Push status data every 10s — store handle so it can be cleared on shutdown

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1616,6 +1616,9 @@ app.whenReady().then(async () => {
         .filter((t) => t.base.length > 0);
     },
     (m) => log('INFO', 'SyncSpaces', m),
+    // Durable machineId → keys the hub's per-device sync-recency map (same id the
+    // device registry rows use). Null on machines without a built-app identity.
+    machineIdentity?.id ?? null,
   ).catch(e => log('ERROR', 'Main', 'SyncSpaces start failed', { error: String(e) }));
 
   // Device registry (spec §10a, Plan 2b): stamp this MACHINE's record (friendly

--- a/desktop/src/main/sync-hub-socket.ts
+++ b/desktop/src/main/sync-hub-socket.ts
@@ -42,19 +42,29 @@ export interface LeaseHolder { deviceId: string; device: string; expiresAt: numb
 export interface LeaseResult { ok: boolean; op: string; sessionId: string; holder: LeaseHolder | null }
 
 // The single event shape the consumer (Task 5 service wiring) sees. Replay and
-// live signals collapse to the same 'signal' event — device/at are dropped
-// because the engine only needs "some space changed, go sync it". `lease-event`
+// live signals collapse to the same 'signal' event. The engine only needs "some
+// space changed, go sync it" (kind/spaceKey); the OPTIONAL `at` (server
+// timestamp) + `deviceId` (durable machineId) ride along so the service can also
+// build a per-device recency map — they're additive and never disturb the
+// sync-trigger consumer. `sync-map` is the durable recency seed shipped in the
+// hello frame (older workers omit it — then no sync-map is emitted). `lease-event`
 // carries UNSOLICITED server pushes (another device released/took a lease, or is
 // asking us to hand one over) — these are not tied to a request() reqId.
 export type SyncHubEvent =
   | { type: 'connected' }
   | { type: 'disconnected' }
-  | { type: 'signal'; kind: string; spaceKey: string }
+  | { type: 'signal'; kind: string; spaceKey: string; at?: number; deviceId?: string }
+  | { type: 'sync-map'; map: Record<string, number> }
   | { type: 'lease-event'; kind: 'released' | 'taken' | 'takeover-request'; sessionId: string; device?: string; from?: { deviceId: string; device: string } };
 
 export interface SyncHubSocketOpts {
   getToken: () => string | null;
   deviceName: string;
+  // Durable per-MACHINE id (the registry's `<id>.json` key). Threaded so a
+  // relayed signal maps to a "Your devices" row reliably. Optional: a dev-only /
+  // no-built-app machine has no durable id — we then connect WITHOUT deviceId and
+  // simply contribute no recency entry (graceful, same as having no registry row).
+  deviceId?: string;
   onEvent: (e: SyncHubEvent) => void;
   WebSocketCtor?: WebSocketCtor; // injectable for tests
 }
@@ -74,7 +84,11 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
   const Ctor: WebSocketCtor = opts.WebSocketCtor ?? (WebSocket as unknown as WebSocketCtor);
   // device= identifies this client to the room so the server can fan a signal
   // out to the account's OTHER devices (never echo it back to the sender).
-  const url = `${SYNC_HUB_URL}?device=${encodeURIComponent(opts.deviceName)}`;
+  // deviceId= (when present) is the durable machineId the DO records into its
+  // lastSyncByDevice map — omitted for machines without a durable id so the
+  // server (and an old worker) sees exactly the pre-recency wire shape.
+  const url = `${SYNC_HUB_URL}?device=${encodeURIComponent(opts.deviceName)}`
+    + (opts.deviceId ? `&deviceId=${encodeURIComponent(opts.deviceId)}` : '');
 
   let desired = false;
   let ws: SyncHubWebSocketLike | null = null;
@@ -131,21 +145,33 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
     sock.on('message', (data) => {
       try {
         const msg = JSON.parse(String(data));
-        if (msg && msg.type === 'hello' && Array.isArray(msg.replay)) {
+        if (msg && msg.type === 'hello') {
+          // Seed the per-device recency map FIRST (Task 2): the DO ships the
+          // durable lastSyncByDevice snapshot in hello so a reconnecting device
+          // starts with every peer's last-sync, not just what arrives live after.
+          // Old workers omit it — then no sync-map is emitted (backward compat).
+          if (msg.lastSyncByDevice && typeof msg.lastSyncByDevice === 'object') {
+            opts.onEvent({ type: 'sync-map', map: msg.lastSyncByDevice as Record<string, number> });
+          }
           // Flatten the replay ring into ordinary signal events — the consumer
           // treats replay and live signals identically (see header note 3).
-          for (const entry of msg.replay) {
-            // Per-entry guard: a null/malformed entry must not throw out of the
-            // loop into the outer catch and silently strand the REST of the
-            // replay batch (same per-emit isolation principle as the transcript
-            // watcher's readNewLines), nor emit {kind: undefined} downstream.
-            if (entry && entry.kind && entry.spaceKey) {
-              opts.onEvent({ type: 'signal', kind: entry.kind, spaceKey: entry.spaceKey });
+          if (Array.isArray(msg.replay)) {
+            for (const entry of msg.replay) {
+              // Per-entry guard: a null/malformed entry must not throw out of the
+              // loop into the outer catch and silently strand the REST of the
+              // replay batch (same per-emit isolation principle as the transcript
+              // watcher's readNewLines), nor emit {kind: undefined} downstream.
+              // at/deviceId forwarded when present (undefined otherwise) for the
+              // recency map — additive, never disturbs the sync-trigger consumer.
+              if (entry && entry.kind && entry.spaceKey) {
+                opts.onEvent({ type: 'signal', kind: entry.kind, spaceKey: entry.spaceKey, at: entry.at, deviceId: entry.deviceId });
+              }
             }
           }
         } else if (msg && msg.type === 'signal' && msg.kind && msg.spaceKey) {
-          // Same guard on live frames — never hand the consumer undefined fields.
-          opts.onEvent({ type: 'signal', kind: msg.kind, spaceKey: msg.spaceKey });
+          // Same guard on live frames — never hand the consumer undefined kind/
+          // spaceKey. at/deviceId ride along when present (the DO's recency wire).
+          opts.onEvent({ type: 'signal', kind: msg.kind, spaceKey: msg.spaceKey, at: msg.at, deviceId: msg.deviceId });
         } else if (msg && msg.type === 'lease-result' && typeof msg.reqId === 'string' && pending.has(msg.reqId)) {
           // Correlate the reply to its request() promise by reqId. An unknown
           // reqId (stale/duplicate) matches nothing and is dropped harmlessly.

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -30,6 +30,21 @@ let logFn: (m: string) => void = console.log;
 let hubSocket: ReturnType<typeof createSyncHubSocket> | null = null;
 let hubStatus: 'off' | 'connecting' | 'connected' | 'disconnected' = 'off';
 
+// Durable per-MACHINE id (machineIdentity.id from main.ts), threaded into the hub
+// connection so the DO can key this device's sync recency. Null on machines with
+// no durable id (dev-only / no built app) — we then connect without a deviceId.
+let machineId: string | null = null;
+
+// Per-device sync recency (Task 3): machineId → epoch-ms of that device's most
+// recent successful sync. Seeded from the hub's hello snapshot (sync-map) and
+// advanced by each live signal that carries a deviceId + server timestamp. This
+// is the field surfaced on getSyncStatus()/status:data so the "Your devices" rows
+// can show real recency. Reset on teardown so a stale map never outlives the hub.
+let lastSyncByDevice: Record<string, number> = {};
+// Read by sync-state.ts's getSyncStatus() and ipc-handlers' buildStatusData()
+// (the status:data push) — the two paths SyncPanel reads recency from.
+export function getLastSyncByDevice(): Record<string, number> { return lastSyncByDevice; }
+
 // Auth store facade (marketplace token) wired from main.ts. Read lazily per
 // connect so a mid-session sign-in/out takes effect without an app restart.
 // Kept as a narrow facade so service.ts doesn't import the whole auth store.
@@ -135,8 +150,11 @@ function broadcast(e: SpaceSyncEvent): void {
  *  needs them); the engine only starts when the user enabled sync.
  *  getBackupTargets is async because the backend config read (getSyncConfig)
  *  is async — the daily backup timer awaits it fresh each cycle. */
-export async function startSyncSpaces(getBackupTargets: () => Promise<BackupTarget[]>, log: (m: string) => void): Promise<void> {
+export async function startSyncSpaces(getBackupTargets: () => Promise<BackupTarget[]>, log: (m: string) => void, machineIdArg: string | null = null): Promise<void> {
   logFn = log;
+  // Stash the durable machineId so startEngine (here AND on a later enable toggle)
+  // can hand it to the hub socket for per-device recency keying.
+  machineId = machineIdArg;
   roots = new ManagedRoots();
   roots.ensure();
   manager = new SpaceManager();
@@ -277,12 +295,29 @@ async function startEngine(log: (m: string) => void): Promise<void> {
   hubSocket = createSyncHubSocket({
     getToken: () => authStore?.getToken() ?? null,
     deviceName: os.hostname(),
+    // Durable machineId (undefined when this machine has none) — keys the DO's
+    // per-device recency map so a relayed signal maps to a "Your devices" row.
+    deviceId: machineId ?? undefined,
     onEvent: (ev) => {
-      if (ev.type === 'signal' && ev.kind === 'space-updated') {
-        // Another device pushed — pull that space now. syncSpace is single-flight
-        // + coalescing, so signal bursts and hello-replay dupes are free.
-        const space = spaceForKey(ev.spaceKey);
-        if (space && engine) void engine.syncSpace(space);
+      if (ev.type === 'signal') {
+        // Recency (Task 3): a signal carrying the durable deviceId + server
+        // timestamp records that peer's most recent sync. Independent of kind so
+        // any future signal type still advances recency. Math.max guards against
+        // out-of-order replay/live interleaving so recency never moves backwards.
+        if (ev.deviceId && ev.at) {
+          lastSyncByDevice[ev.deviceId] = Math.max(lastSyncByDevice[ev.deviceId] ?? 0, ev.at);
+        }
+        if (ev.kind === 'space-updated') {
+          // Another device pushed — pull that space now. syncSpace is single-flight
+          // + coalescing, so signal bursts and hello-replay dupes are free.
+          const space = spaceForKey(ev.spaceKey);
+          if (space && engine) void engine.syncSpace(space);
+        }
+      } else if (ev.type === 'sync-map') {
+        // Seed/replace from the hub's hello snapshot — the DO's durable map is
+        // authoritative (it already includes every recorded peer signal), so a
+        // reconnect starts fully populated rather than rebuilding from live only.
+        lastSyncByDevice = ev.map;
       } else if (ev.type === 'connected') {
         hubStatus = 'connected';
         broadcast({ type: 'hub-status', spaceId: 'hub', status: 'connected' });
@@ -310,6 +345,9 @@ function teardownHub(): void {
   hubSocket?.destroy();
   hubSocket = null;
   hubStatus = 'off';
+  // Drop the recency map with the socket — a stale map must not outlive the hub
+  // (sign-out / disable). The next connect's hello re-seeds it authoritatively.
+  lastSyncByDevice = {};
 }
 
 export async function stopSyncSpaces(): Promise<void> {

--- a/desktop/src/main/sync-state.ts
+++ b/desktop/src/main/sync-state.ts
@@ -17,6 +17,11 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import type { SyncService } from './sync-service';
+// Per-device sync recency lives in the sync-spaces service (it owns the SyncHub
+// socket that receives it). Surfaced here so getSyncStatus() — the SyncPanel's
+// full-snapshot source — carries it alongside the other sync fields. No cycle:
+// sync-spaces/service.ts does not import sync-state.
+import { getLastSyncByDevice } from './sync-spaces/service';
 
 // --- SyncService delegation ---
 // When the SyncService is running, forceSync() delegates to it instead
@@ -99,6 +104,11 @@ export interface SyncStatus {
   syncInProgress: boolean;
   syncingBackendId: string | null;     // Which backend is currently syncing
   syncedCategories: string[];
+  // Per-device sync recency (machineId → epoch-ms of that device's most recent
+  // successful sync), carried over the SyncHub. Keyed by the same machineId the
+  // "Your devices" rows use, so the UI reads `lastSyncByDevice[d.id]`. Empty when
+  // the hub is down / never connected — rows then fall back to their launch value.
+  lastSyncByDevice: Record<string, number>;
 }
 
 /** Config shape for the multi-instance model. */
@@ -426,6 +436,8 @@ export async function getSyncStatus(): Promise<SyncStatus> {
     syncInProgress: lockExists,
     syncingBackendId: null, // Set by SyncService at runtime via event
     syncedCategories: categoryChecks.filter(Boolean) as string[],
+    // Snapshot the SyncHub-carried per-device recency map (see interface note).
+    lastSyncByDevice: getLastSyncByDevice(),
   };
 }
 

--- a/desktop/tests/sync-hub-socket.test.ts
+++ b/desktop/tests/sync-hub-socket.test.ts
@@ -107,9 +107,10 @@ describe('sync-hub-socket state machine', () => {
     sock.destroy();
   });
 
-  // Behavior 4: Incoming signal frame → onEvent signal (stripped to the
-  // consumer shape — no device/at).
-  it('flattens an incoming live signal frame to a signal event', () => {
+  // Behavior 4: Incoming signal frame → onEvent signal. Task 2 recency: `at`
+  // (server timestamp) is now FORWARDED; the legacy `device` hostname label is
+  // still ignored (the consumer joins on the durable `deviceId`, not hostname).
+  it('flattens an incoming live signal frame to a signal event, forwarding at but ignoring the legacy device label', () => {
     const { sock, events } = makeSocket(() => 'tok');
     sock.setDesired(true);
     const inst = FakeSocket.instances[0];
@@ -117,7 +118,7 @@ describe('sync-hub-socket state machine', () => {
     inst.emit('message', JSON.stringify({
       type: 'signal', kind: 'space-updated', spaceKey: 'k', device: 'other', at: 123,
     }));
-    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'k' });
+    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'k', at: 123 });
     sock.destroy();
   });
 
@@ -136,8 +137,9 @@ describe('sync-hub-socket state machine', () => {
       ],
     }));
     expect(types(events)).toEqual(['connected', 'signal', 'signal']);
-    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'a' });
-    expect(events[2]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'b' });
+    // Task 2 recency: `at` is forwarded on replay entries too (device label ignored).
+    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'a', at: 1 });
+    expect(events[2]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'b', at: 2 });
     sock.destroy();
   });
 
@@ -158,12 +160,87 @@ describe('sync-hub-socket state machine', () => {
       ],
     }));
     expect(types(events)).toEqual(['connected', 'signal', 'signal']);
-    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'a' });
-    expect(events[2]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'b' });
+    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'a', at: 1 });
+    expect(events[2]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'b', at: 2 });
 
     // Live signal frames get the same guard — missing fields emit nothing.
     inst.emit('message', JSON.stringify({ type: 'signal', kind: 'space-updated' }));
     expect(types(events)).toEqual(['connected', 'signal', 'signal']);
+    sock.destroy();
+  });
+
+  // ---- Task 2: per-device recency (deviceId on connect, at+deviceId on
+  // signals, lastSyncByDevice hello map). Additive + backward-compatible. ----
+
+  it('appends &deviceId to the connect url when the deviceId opt is set, omits it when absent or empty', () => {
+    const mk = (deviceId?: string) => {
+      FakeSocket.instances = [];
+      const sock = createSyncHubSocket({
+        getToken: () => 'tok', deviceName: 'my-laptop', deviceId,
+        onEvent: () => {}, WebSocketCtor: FakeSocket as any,
+      });
+      sock.setDesired(true);
+      const url = FakeSocket.instances[0].url;
+      sock.destroy();
+      return url;
+    };
+    // Set → appended (and URL-encoded).
+    expect(mk('machine-123')).toContain('&deviceId=machine-123');
+    expect(mk('a b/c')).toContain(`&deviceId=${encodeURIComponent('a b/c')}`);
+    // Absent → omitted entirely (old app / no built-app machineId).
+    expect(mk(undefined)).not.toContain('deviceId=');
+    // Empty string → omitted (never send a blank id).
+    expect(mk('')).not.toContain('deviceId=');
+  });
+
+  it('forwards at + deviceId on a live signal frame', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+    inst.emit('message', JSON.stringify({
+      type: 'signal', kind: 'space-updated', spaceKey: 'k', deviceId: 'machine-9', at: 1_720_000_000_000,
+    }));
+    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'k', deviceId: 'machine-9', at: 1_720_000_000_000 });
+    sock.destroy();
+  });
+
+  it('emits a sync-map event from a hello frame carrying lastSyncByDevice (seed), alongside replay signals', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+    const map = { 'machine-1': 111, 'machine-2': 222 };
+    inst.emit('message', JSON.stringify({
+      type: 'hello',
+      replay: [{ kind: 'space-updated', spaceKey: 'a', at: 5 }],
+      lastSyncByDevice: map,
+    }));
+    // Both the seed map AND the replay signal come through.
+    expect(events).toContainEqual({ type: 'sync-map', map });
+    expect(events).toContainEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'a', at: 5 });
+    sock.destroy();
+  });
+
+  it('emits no sync-map when hello omits lastSyncByDevice (old worker, backward compat)', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+    inst.emit('message', JSON.stringify({ type: 'hello', replay: [] }));
+    expect(types(events)).toEqual(['connected']); // connected only — no sync-map, no signal
+    sock.destroy();
+  });
+
+  it('still emits {kind,spaceKey} for a signal frame with no at/deviceId (old worker, backward compat)', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+    inst.emit('message', JSON.stringify({ type: 'signal', kind: 'space-updated', spaceKey: 'k' }));
+    // Undefined at/deviceId are omitted — the sync-trigger consumer at
+    // service.ts is undisturbed (it reads only kind/spaceKey).
+    expect(events[1]).toEqual({ type: 'signal', kind: 'space-updated', spaceKey: 'k' });
     sock.destroy();
   });
 


### PR DESCRIPTION
## What

Carries **per-device sync recency** from the SyncHub Durable Object to the renderer so the "Your devices" rows can show real recency ("Synced just now" / "Last synced 12 minutes ago") instead of the frozen launch-time value. Implements **Task 2 + Task 3** of the sync-menu-recency plan (`docs/active/plans/2026-07-17-sync-menu-recency-plan.md`).

The DO already relays a signal carrying a server timestamp `at` on every successful push; the client was dropping it. This change threads a stable `deviceId` (the machineId) into the hub connection, stops dropping `at`, captures the DO's `lastSyncByDevice` hello snapshot, and exposes the map on the sync-status surface.

## Changes

**Task 2 — `sync-hub-socket.ts` (+ tests)**
- Optional `deviceId` on `SyncHubSocketOpts`; `&deviceId=` appended to the connect URL only when non-empty.
- `signal` event extended with optional `at` / `deviceId`, forwarded at both the hello-replay and live-frame sites.
- New `sync-map` event emitted from the hello frame's `lastSyncByDevice` snapshot.

**Task 3 — `service.ts`, `main.ts`, `sync-state.ts`, `ipc-handlers.ts`**
- `main.ts` passes `machineIdentity?.id ?? null` into `startSyncSpaces`.
- `service.ts` threads it into the socket as `deviceId`, holds a module-level `lastSyncByDevice` map (seeded from `sync-map`, advanced by each signal's `deviceId`+`at` via `Math.max`), resets it in `teardownHub()`, and exposes it via `getLastSyncByDevice()`.
- `getSyncStatus()` (sync-state.ts) and the `status:data` push (ipc-handlers `buildStatusData`) both surface the field. Remote browsers receive it verbatim through `broadcastStatusData` (no reshape needed — verified).

## Cross-stream contract (consumed by the renderer stream)

Exposed on **both** the `getSyncStatus()` return **and** the `status:data` push:

    lastSyncByDevice: Record<string, number>   // key = device machineId, value = epoch-ms of that device's most recent successful sync

Keyed by machineId — the consumer reads `status.lastSyncByDevice?.[d.id]`. No renderer files touched.

## Backward compatibility

- Machines with no durable id connect **without** `deviceId` and contribute no entry (graceful, same as having no registry row).
- Old worker: no `lastSyncByDevice` in hello, no `at`/`deviceId` on frames → no `sync-map`, rows fall back to launch value. No coordinated deploy required.
- The existing sync-trigger consumer reads only `kind`/`spaceKey`; the new optional fields are omitted when absent, leaving it functionally untouched (pinned by the backward-compat tests).
- The DO stays an accelerant, not a source of truth — an empty map degrades a row to its launch-time fallback, nothing breaks.

## Testing

- `sync-hub-socket.test.ts` extended (deviceId URL, at/deviceId forwarding, sync-map seed, old-worker/old-frame backward compat). 25/25 pass.
- Full suite: **2593 passed, 39 skipped, 0 failed** (bounded workers; an earlier concurrent run's failures were vitest worker-startup timeouts under CPU contention, not logic — clean re-run is green).
- `tsc --noEmit`: clean.

Depends on Task 1 (worker `deviceId` + `lastSyncByDevice` map) to actually light up; until both ship, rows show today's launch-time fallback (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)