### PR TITLE
fix(harness): spawn ripgrep with explicit cwd — Grep no longer fails with spawn ENOTDIR

### DIFF
--- a/desktop/src/main/harness/tools/grep.ts
+++ b/desktop/src/main/harness/tools/grep.ts
@@ -26,7 +26,13 @@ export const GrepTool = defineTool({
     if (args.glob) rgArgs.push('--glob', args.glob);
     rgArgs.push('--', args.pattern, resolveP(args.path ?? '.', ctx.cwd));
     return new Promise((resolve) => {
-      const child = spawn(rgPath, rgArgs, { windowsHide: true });
+      // Fix: pass `cwd: ctx.cwd` explicitly. Grep was the only tool spawning a
+      // child with no `cwd`, so rg inherited the Electron main process's ambient
+      // cwd — which in the packaged app is not a usable directory for posix_spawn
+      // and failed every search with `spawn ENOTDIR`. ctx.cwd is the validated
+      // session cwd already used to resolve the search path above; the Bash tool
+      // passes it the same way (bash.ts) and works. Never inherit ambient cwd.
+      const child = spawn(rgPath, rgArgs, { cwd: ctx.cwd, windowsHide: true });
       let out = '';
       let err = '';
       child.stdout.on('data', (d) => {
@@ -37,6 +43,13 @@ export const GrepTool = defineTool({
       });
       const onAbort = () => child.kill('SIGKILL');
       ctx.signal.addEventListener('abort', onAbort, { once: true });
+      // Surface a spawn-level failure (rg missing, bad cwd) with the cwd actually
+      // used, instead of letting it escape to defineTool's catch as a bare
+      // `spawn <CODE>` — which hid this bug's cause for a whole session.
+      child.on('error', (e) => {
+        ctx.signal.removeEventListener('abort', onAbort);
+        resolve({ text: `Grep failed: could not start ripgrep (${e.message}; cwd=${ctx.cwd}).`, isError: true });
+      });
       child.on('close', (code) => {
         ctx.signal.removeEventListener('abort', onAbort);
         // An interrupt SIGKILLs rg → exit code null (not 2). Surface it as a

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -1,7 +1,25 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as childProcess from 'child_process';
+
+// Spy on child_process.spawn so the Grep cwd regression test can assert the
+// exact options the tool passes. `importActual` keeps the REAL implementation —
+// the search genuinely runs; we only observe the call. (Mocking process.cwd()
+// does NOT work as a pin: Node's spawn reads the inherited cwd via the native
+// binding, not the JS process.cwd() we could stub — verified 2026-07-17.)
+const spawnSpy = vi.fn();
+vi.mock('child_process', async (importActual) => {
+  const actual = await importActual<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: any[]) => {
+      spawnSpy(...args);
+      return (actual.spawn as any)(...args);
+    },
+  };
+});
 import { ReadTool, readSizeError, MAX_READ_BYTES } from '../src/main/harness/tools/read';
 import { WriteTool } from '../src/main/harness/tools/write';
 import { EditTool } from '../src/main/harness/tools/edit';
@@ -308,6 +326,26 @@ describe('Grep', () => {
     const r = await promise;
     expect(r.isError).toBe(true);
     expect(r.text).toMatch(/Canceled: the user interrupted this search/);
+  });
+
+  it('spawns rg with an explicit cwd of ctx.cwd (never inherits ambient cwd)', async () => {
+    // Regression pin for the `spawn ENOTDIR` bug: Grep used to omit `cwd` from
+    // spawn(), so rg inherited the Electron main process's ambient cwd — which in
+    // the packaged app was not a usable directory and failed EVERY search. The
+    // fix passes `cwd: ctx.cwd` explicitly (same pattern as BashTool). Assert the
+    // contract directly: the spawn call for THIS search must carry ctx.cwd.
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'findme here\n');
+    spawnSpy.mockClear();
+    const r = await GrepTool.execute({ pattern: 'findme', output_mode: 'content' }, ctx);
+    expect(r.isError).toBeFalsy();
+    expect(r.text).toMatch(/findme/);
+    // Find the spawn invocation that ran ripgrep and inspect its options arg.
+    const rgCall = spawnSpy.mock.calls.find(
+      (c) => Array.isArray(c[1]) && c[1].includes('findme'),
+    );
+    expect(rgCall, 'expected a spawn call running ripgrep for the search').toBeTruthy();
+    const opts = rgCall![2] as { cwd?: string };
+    expect(opts?.cwd, 'rg must be spawned with an explicit cwd (ctx.cwd), not inherit ambient cwd').toBe(ctx.cwd);
   });
 });
 


### PR DESCRIPTION
## Root cause

`Grep` was the **only** tool that spawned a child process **without an explicit `cwd`** (`grep.ts:29`), so `rg` inherited the Electron main process's ambient cwd. In the packaged app that inherited cwd is not a usable directory for `posix_spawn`, so **every** `Grep` call failed with `spawn ENOTDIR` (surfaced by `defineTool`'s catch as `Grep failed: spawn ENOTDIR`).

The sibling **Bash** tool passes `cwd: ctx.cwd` (`bash.ts:40`) and works — same runtime, the *only* difference is the `cwd` option. That asymmetry is the smoking gun.

## Fix (two changes to `grep.ts`)

1. **Pass `cwd: ctx.cwd` to `spawn()`** — `ctx.cwd` is the validated session cwd already used to resolve the search path on the line above; mirrors the proven Bash pattern. Principle: *never inherit ambient cwd, always pass it explicitly.*
2. **Add `child.on('error')`** that resolves with the cwd actually used, so a future spawn-level failure is diagnosable instead of a bare `spawn <CODE>` — which hid this bug's cause for a whole session.

## Verification

- **Pin test** spies on `child_process.spawn` (delegating to the real impl so the search genuinely runs) and asserts the rg spawn carries `cwd === ctx.cwd`. **Mutation-verified**: reverting the fix fails the test with `expected undefined to be ctx.cwd`. (An earlier `process.cwd()`-mock attempt was a no-op — Node's spawn reads inherited cwd via the native binding, not the JS stub.)
- Full `harness-tools-core` suite **31/31 green** (the `child_process` mock delegates, so Bash/other tools are undisturbed).
- `tsc --noEmit` identical to master (no new errors).

Full investigation with the ruled-in/out hypothesis table: `docs/active/investigations/2026-07-17-agent-shell-cwd-and-grep-enotdir.md` (workspace repo).