### PR TITLE
fix(permissions): make the destructive always-allow confirm accurate

### DIFF
--- a/desktop/src/renderer/components/ToolCard.tsx
+++ b/desktop/src/renderer/components/ToolCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { ToolCallState } from '../../shared/types';
 import { useChatDispatch } from '../state/chat-context';
+import { useArtifactOptional } from '../state/ArtifactContext';
 import { CheckIcon, FailIcon, QuestionIcon, ChevronIcon, NoteIcon } from './Icons';
 import BrailleSpinner from './BrailleSpinner';
 import { isAndroid } from '../platform';
@@ -224,11 +225,20 @@ export function friendlyToolDisplay(tool: ToolCallState): { label: string; detai
 // CC asks keep sending their real suggestion string. Task 13.
 const NATIVE_ALWAYS_ALLOW = 'native:always-allow';
 
-function PermissionButtons({ requestId, suggestions, denyListed, onResponded, onFailed }: {
+function PermissionButtons({ requestId, suggestions, denyListed, command, folderName, onResponded, onFailed }: {
   requestId: string;
   suggestions?: string[];
   /** Deny-listed native ask → gate "Always allow" behind a consequence confirm. */
   denyListed?: boolean;
+  /** The exact command the remembered rule will store, echoed in the confirm so
+   *  the user can see precisely what they're granting. Deny-listed asks are
+   *  Bash-only (DESTRUCTIVE_DENY_LIST has no non-Bash entries), so this is
+   *  `input.command` — the same string harness-session.ts:562 persists. */
+  command?: string;
+  /** Basename of the session cwd. The rule is scoped to that directory's slug
+   *  (permission-store.ts:35-43), so naming the folder is what makes the grant's
+   *  scope checkable — a worktree does NOT inherit its parent repo's rules. */
+  folderName?: string;
   onResponded?: () => void;
   onFailed?: () => void;
 }) {
@@ -320,21 +330,35 @@ function PermissionButtons({ requestId, suggestions, denyListed, onResponded, on
   if (confirmingAlways) {
     return (
       <div className="px-3 py-2 space-y-2 border-t border-edge bg-inset/30">
+        {/* The header carries the ask so the body only has to carry the risk.
+            Naming the folder keeps the promise checkable — the remembered rule is
+            cwd-scoped, so "in this folder" alone would be unverifiable. */}
+        <p className="text-xs font-medium text-fg-2">
+          Always allow this exact command{folderName ? ` in ${folderName}` : ''}?
+        </p>
+        {command && (
+          <p className="text-[11px] leading-relaxed text-fg-2 bg-inset/70 px-2 py-1.5 rounded-sm break-all">
+            {command}
+          </p>
+        )}
         <p className="text-[11px] text-fg-dim leading-relaxed">
-          This lets the assistant run commands like this without asking, including ones that can delete files or push code. You can undo this later in Settings.
+          It can delete files or change published code, and you won't be asked again.
         </p>
         <div className="flex items-center gap-2">
+          {/* "Allow once" IS the plain-allow decision, so it wears the same green
+              as Yes. Previously this slot was Cancel, which dead-ended back on the
+              button row and still left the user owing an answer. */}
           <button
             disabled={responding}
-            onClick={() => setConfirmingAlways(false)}
-            className={`px-3 ${pad} text-xs font-medium rounded-sm bg-inset/60 hover:bg-inset text-fg-muted transition-colors disabled:opacity-50`}
+            onClick={() => handleRespond({ decision: { behavior: 'allow' } })}
+            className={`px-3 ${pad} text-xs font-medium rounded-sm bg-green-600/60 hover:bg-green-600/80 text-green-100 transition-colors disabled:opacity-50`}
           >
-            Cancel
+            Nevermind, allow once
           </button>
           <button
             disabled={responding}
             onClick={() => handleRespond(alwaysAllowDecision())}
-            className={`px-3 ${pad} text-xs font-medium rounded-sm bg-amber-600/60 hover:bg-amber-600/80 text-amber-50 transition-colors disabled:opacity-50`}
+            className={`px-3 ${pad} text-xs font-medium rounded-sm bg-red-600/60 hover:bg-red-600/80 text-red-100 transition-colors disabled:opacity-50`}
           >
             Always allow
           </button>
@@ -648,6 +672,11 @@ export default React.memo(function ToolCard({ tool, sessionId, inGroup = false }
   const [expanded, setExpanded] = useState(() => getInitialExpanded());
   useExpandAllToggle(() => setExpanded(true), () => setExpanded(false));
   const dispatch = useChatDispatch();
+  // Optional: the tool sandbox (?mode=tool-sandbox) renders ToolCard outside the
+  // ArtifactProvider. Missing cwd just drops the folder name from the confirm
+  // header rather than crashing the card.
+  const artifacts = useArtifactOptional();
+  const sessionCwd = sessionId ? artifacts?.state.sessionCwd?.[sessionId] : undefined;
   const display = friendlyToolDisplay(tool);
   // Skill tool calls always return "Launching skill: X" with success — the body
   // is pure ceremony. Render header only, no chevron, non-interactive, with a
@@ -747,6 +776,8 @@ export default React.memo(function ToolCard({ tool, sessionId, inGroup = false }
             requestId={tool.requestId}
             suggestions={tool.permissionSuggestions}
             denyListed={tool.denyListed}
+            command={typeof (tool.input as any)?.command === 'string' ? (tool.input as any).command : undefined}
+            folderName={sessionCwd ? basename(sessionCwd) : undefined}
             onResponded={onRespondedCb}
             onFailed={onFailedCb}
           />

--- a/desktop/tests/permission-confirm-card.test.tsx
+++ b/desktop/tests/permission-confirm-card.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+/**
+ * Pins the deny-listed "Always allow" consequence confirm (ToolCard.tsx).
+ *
+ * Two things here are easy to regress silently and expensive when they do:
+ *  1. "Nevermind, allow once" must SEND a plain allow. It replaced a Cancel
+ *     button that merely closed the confirm, so a careless revert turns a
+ *     one-click answer back into a dead end.
+ *  2. The confirm must not promise a Settings undo. There is no UI to remove a
+ *     remembered rule (PermissionStore exposes only rulesFor/remember), so that
+ *     claim was inaccurate on the highest-stakes prompt in the app.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import ToolCard from '../src/renderer/components/ToolCard';
+import { ChatProvider } from '../src/renderer/state/chat-context';
+import type { ToolCallState } from '../src/shared/types';
+
+const respondToPermission = vi.fn().mockResolvedValue(true);
+
+beforeEach(() => {
+  respondToPermission.mockClear();
+  (window as any).claude = { session: { respondToPermission }, remote: { broadcastAction: vi.fn() } };
+});
+
+// This suite mounts the same card repeatedly; auto-cleanup isn't configured
+// globally, so unmount explicitly or queries match prior tests' leftover DOM.
+afterEach(cleanup);
+
+const denyListedTool = (): ToolCallState => ({
+  id: 'tool-1',
+  toolName: 'Bash',
+  input: { command: 'git worktree remove ../wt-grep && git branch -D fix/grep' },
+  status: 'awaiting-approval',
+  requestId: 'native-abc123',
+  denyListed: true,
+} as ToolCallState);
+
+// Open the confirm the way a user does — the confirm has no standalone entry.
+function renderConfirm() {
+  const utils = render(<ChatProvider><ToolCard tool={denyListedTool()} sessionId="s1" /></ChatProvider>);
+  fireEvent.click(screen.getByRole('button', { name: 'Always Allow' }));
+  return utils;
+}
+
+describe('deny-listed always-allow confirm', () => {
+  it('gates Always Allow behind the confirm instead of responding immediately', () => {
+    render(<ChatProvider><ToolCard tool={denyListedTool()} sessionId="s1" /></ChatProvider>);
+    fireEvent.click(screen.getByRole('button', { name: 'Always Allow' }));
+    expect(respondToPermission).not.toHaveBeenCalled();
+    expect(screen.getByText(/Always allow this exact command/)).toBeTruthy();
+  });
+
+  it('echoes the exact command the remembered rule will store', () => {
+    renderConfirm();
+    // harness-session.ts persists input.command verbatim as the rule pattern;
+    // showing anything else would misstate the grant.
+    expect(screen.getByText('git worktree remove ../wt-grep && git branch -D fix/grep')).toBeTruthy();
+  });
+
+  it('"Nevermind, allow once" sends a plain allow and remembers nothing', async () => {
+    renderConfirm();
+    fireEvent.click(screen.getByRole('button', { name: 'Nevermind, allow once' }));
+    await waitFor(() => expect(respondToPermission).toHaveBeenCalledTimes(1));
+    const [, decision] = respondToPermission.mock.calls[0];
+    expect(decision).toEqual({ decision: { behavior: 'allow' } });
+    // No updatedPermissions key at all — that array is what the broker reads as
+    // "always" (permission-broker.ts), so its absence is the whole point.
+    expect(decision).not.toHaveProperty('updatedPermissions');
+  });
+
+  it('"Always allow" sends the native always marker', async () => {
+    renderConfirm();
+    fireEvent.click(screen.getByRole('button', { name: 'Always allow' }));
+    await waitFor(() => expect(respondToPermission).toHaveBeenCalledTimes(1));
+    const [, decision] = respondToPermission.mock.calls[0];
+    expect(decision.decision).toEqual({ behavior: 'allow' });
+    expect(decision.updatedPermissions).toEqual(['native:always-allow']);
+  });
+
+  it('does not claim the grant can be undone in Settings', () => {
+    renderConfirm();
+    expect(screen.queryByText(/Settings/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Rewrites the consequence confirm shown before persisting an always-allow rule for a deny-listed (destructive) command.

**Before**
> This lets the assistant run commands like this without asking, including ones that can delete files or push code. You can undo this later in Settings.
>
> `[Cancel]` `[Always allow]`

**After**
> **Always allow this exact command in youcoded-dev?**
> `git worktree remove ../wt-grep && git branch -D fix/grep`
> It can delete files or change published code, and you won't be asked again.
>
> `[Nevermind, allow once]` (green) `[Always allow]` (red)

## Why

Both halves of the old copy were inaccurate, on the highest-stakes prompt in the app:

- **"commands like this"** implies a class. The stored rule is the *exact literal command string* — `harness-session.ts:562` emits `pattern: subject`, and Bash's `permissionSubject` is `(a) => a.command` (`bash.ts:35`), matched anchored `^...$` in `subject-glob.ts`. `git push origin main` grants nothing for `git push origin dev`.
- **"You can undo this later in Settings"** describes a surface that does not exist. `PermissionStore` exposes only `rulesFor`/`remember` — no delete, no IPC channel in `preload.ts`, no renderer caller. The only way to revoke a grant today is hand-editing `~/.youcoded/permissions.json`.

This matters more than usual because remembered rules are the **last** layer in `permission-engine.ts:26-41` and win over `DESTRUCTIVE_DENY_LIST` permanently.

## Notes

- The **folder name** is shown because the rule is scoped to the session cwd's slug (`permission-store.ts:35-43`). A worktree does not inherit its parent repo's rules, so "in this folder" alone would be an unverifiable promise. Sourced from `sessionCwd` via `useArtifactOptional()`, so the ToolCard sandbox (no ArtifactProvider) degrades to omitting the folder rather than crashing.
- **"Nevermind, allow once" is a behavior change, not just a relabel.** Cancel previously closed the confirm and returned to the Yes/Always/No row — a dead end that still left the user owing an answer. It now sends `{ behavior: 'allow' }` directly. It wears Yes's green because it is Yes.
- Deny-listed asks are Bash-only (`DESTRUCTIVE_DENY_LIST` has no non-Bash entries), which is why reading `input.command` for the echo is safe; a non-string falls back to omitting the block.

## Follow-ups this surfaced (not in scope here)

1. **No revocation UI.** Worth building: `PermissionStore.list`/`remove` + IPC + a Settings surface. The store's own header comment already flags unbounded rule growth with no eviction.
2. **Always-allow is near-useless for Bash** because the pattern is a literal string — every varying argument re-prompts. Fixing it *widens* the grant, so it wants its own design pass.

## Testing

- New `desktop/tests/permission-confirm-card.test.tsx` (5 tests) pins: the confirm gates rather than responding, the command is echoed verbatim, allow-once sends **no** `updatedPermissions` (the field the broker reads as "always"), always-allow sends the native marker, and the copy makes no Settings claim.
- Full suite: 2608 passed / 39 skipped. `tsc --noEmit` clean.
- Visual check left for you — it's a two-state card, quicker to eyeball than to rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)