### PR TITLE
feat(harness): scoped cwd persistence for the Bash tool

### DIFF
--- a/desktop/src/main/harness/harness-session.ts
+++ b/desktop/src/main/harness/harness-session.ts
@@ -160,6 +160,10 @@ export class HarnessSession extends EventEmitter {
   private toolByName: Map<string, NativeTool>;
   private readRegistry = new Map<string, number>();  // canonical path → mtimeMs at last Read
   private todos: ToolContext['todos'] = [];
+  /** Scoped-persistence shell cwd (ROADMAP 2026-07-17): where the next Bash call
+   *  starts. null → the session root. Session runtime like readRegistry/todos —
+   *  never persisted to the transcript, so it resets on resume. */
+  private shellCwd: string | null = null;
   private retryDelays: number[];
 
   constructor(private opts: HarnessSessionOpts, private modelFactory: ModelFactory) {
@@ -179,6 +183,7 @@ export class HarnessSession extends EventEmitter {
     // satisfying the read-before-edit gate on the first edit after resume.
     this.readRegistry.clear();
     this.todos.length = 0;
+    this.shellCwd = null; // a resumed session starts back at the workspace root
   }
 
   /** Mid-session model swap (next turn uses the new binding). */
@@ -679,6 +684,10 @@ export class HarnessSession extends EventEmitter {
       cwd: this.opts.cwd,
       signal: this.abort!.signal,
       readRegistry: this.readRegistry,
+      shellCwd: this.shellCwd ?? this.opts.cwd,
+      setShellCwd: (next: string) => {
+        this.shellCwd = next;
+      },
       todos: this.todos,
       ...(this.opts.toolServices ? { services: this.opts.toolServices } : {}),
     });

--- a/desktop/src/main/harness/history-rebuild.ts
+++ b/desktop/src/main/harness/history-rebuild.ts
@@ -16,9 +16,10 @@
 // step 2's text from merging into step 1's assistant message); an assistant-text
 // or tool-use arriving flushes any open tool-results.
 //
-// Deliberately NOT reconstructed: readRegistry (read-before-edit mtimes) and the
-// todo list — those are per-session RUNTIME state, never persisted, and
-// seedHistory() clears them on resume (the reset-on-resume ruling, spec §2.5).
+// Deliberately NOT reconstructed: readRegistry (read-before-edit mtimes), the
+// todo list, and the tracked shell cwd — those are per-session RUNTIME state,
+// never persisted, and seedHistory() clears them on resume (the reset-on-resume
+// ruling, spec §2.5). A resumed session's Bash therefore starts at the root again.
 // assistant-thinking / compact-summary / session-error never entered model
 // history live either, so they're skipped here too.
 import type { TranscriptEvent } from '../../shared/types';

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -38,7 +38,11 @@ const tracksCwd = shell.label.startsWith('bash');
  *  exit code. Newline-separated (not `;`) so trailing `&`, `# comments`, and
  *  heredocs in the user's command don't turn into syntax errors. */
 function withCwdProbe(command: string): string {
-  return `${command}\n__yc_rc=$?\nprintf '\\n${CWD_SENTINEL}%s' "$PWD"\nexit $__yc_rc`;
+  // TRAILING newline is load-bearing: a background writer ('cmd &') can flush to
+  // the pipe AFTER the sentinel, and without a terminator that text concatenates
+  // onto the path — yielding a garbage cwd, a spurious reset notice, and output
+  // silently dropped from the result. Verified 2026-07-18.
+  return `${command}\n__yc_rc=$?\nprintf '\\n${CWD_SENTINEL}%s\\n' "$PWD"\nexit $__yc_rc`;
 }
 
 /** Split the sentinel back off the combined stdout+stderr. Returns the text the
@@ -76,7 +80,9 @@ export const BashTool = defineTool({
     (tracksCwd
       ? 'The working directory PERSISTS between calls: a `cd` carries to your next Bash call. ' +
         'Changing directory outside the workspace root is reverted (you get a reset notice). ' +
-        'Environment variables, aliases, and shell functions do NOT persist — each call is a fresh shell. '
+        'Environment variables, aliases, and shell functions do NOT persist — each call is a fresh shell. ' +
+        'Note that the other tools (Read/Edit/Write/Glob/Grep) resolve relative paths from the ' +
+        'workspace root, NOT from this shell directory — prefer absolute paths with them. '
       : 'Each call starts fresh in the workspace directory — `cd` does NOT carry to the next call, ' +
         'so use absolute paths or chain with `cd X && ...` in one command. ') +
     'Output is capped; long-running commands time out (default 2 minutes, max 10 via timeout).',
@@ -103,8 +109,13 @@ export const BashTool = defineTool({
         env: process.env,
       });
       let out = '';
+      // The 200KB cap below would drop the trailing sentinel on a chatty command
+      // ("cd sub && <huge output>"), silently losing the cd. Keep a small rolling
+      // tail that is never capped so the probe survives regardless of volume.
+      let tail = '';
       const cap = (s: string) => {
         if (out.length < 200_000) out += s;
+        if (probe) tail = (tail + s).slice(-4096);
       };
       child.stdout.on('data', (d) => cap(String(d)));
       child.stderr.on('data', (d) => cap(String(d)));
@@ -119,15 +130,17 @@ export const BashTool = defineTool({
         if (probe) {
           const parsed = extractCwd(out);
           body = parsed.text;
-          if (parsed.cwd && path.resolve(parsed.cwd) !== path.resolve(startCwd)) {
-            if (isInside(ctx.cwd, parsed.cwd)) {
-              ctx.setShellCwd?.(path.resolve(parsed.cwd));
+          // Sentinel past the 200KB cap → recover it from the uncapped tail.
+          const reported = parsed.cwd ?? extractCwd(tail).cwd;
+          if (reported && path.resolve(reported) !== path.resolve(startCwd)) {
+            if (isInside(ctx.cwd, reported)) {
+              ctx.setShellCwd?.(path.resolve(reported));
             } else {
               // Scope guard: don't let the session wander out of the workspace,
               // and TELL the model — a silent revert is the exact failure mode
               // the Claude Code issues (#35058 et al.) complain about.
               ctx.setShellCwd?.(ctx.cwd);
-              notice = `\nShell cwd was reset to ${ctx.cwd} (${parsed.cwd} is outside the workspace).`;
+              notice = `\nShell cwd was reset to ${ctx.cwd} (${reported} is outside the workspace).`;
             }
           }
         }

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -42,7 +42,12 @@ function withCwdProbe(command: string): string {
   // the pipe AFTER the sentinel, and without a terminator that text concatenates
   // onto the path — yielding a garbage cwd, a spurious reset notice, and output
   // silently dropped from the result. Verified 2026-07-18.
-  return `${command}\n__yc_rc=$?\nprintf '\\n${CWD_SENTINEL}%s\\n' "$PWD"\nexit $__yc_rc`;
+  // `pwd -W` is the MSYS/Git Bash builtin that prints a WINDOWS-style path
+  // (C:/Users/...). Without it $PWD is /c/Users/... which path.resolve() on
+  // Windows turns into C:\\c\\Users\\... — never inside ctx.cwd, so EVERY call
+  // would emit a bogus reset notice. Invalid on Linux/macOS bash, where the
+  // `|| pwd` fallback takes over (stderr suppressed so it can't reach output).
+  return `${command}\n__yc_rc=$?\nprintf '\\n${CWD_SENTINEL}%s\\n' "$(pwd -W 2>/dev/null || pwd)"\nexit $__yc_rc`;
 }
 
 /** Split the sentinel back off the combined stdout+stderr. Returns the text the
@@ -100,8 +105,11 @@ export const BashTool = defineTool({
     const tracked = ctx.shellCwd;
     const startCwd =
       tracked && tracked !== ctx.cwd && fs.existsSync(tracked) && fs.statSync(tracked).isDirectory() ? tracked : ctx.cwd;
-    // A command ending in a line-continuation would swallow our probe lines.
-    const probe = tracksCwd && !/\\\s*$/.test(args.command);
+    // Skip the probe when the command's last line would ABSORB ours: a trailing
+    // line-continuation, or a dangling `&&`/`||`/`|` (which swallows the
+    // `__yc_rc=$?` line, so a FAILED command would exit 0 — verified 2026-07-18).
+    // Such commands are malformed anyway; skipping restores the plain behavior.
+    const probe = tracksCwd && !/(\\|&&|\|\||\|)\s*$/.test(args.command);
     return new Promise((resolve) => {
       const child = spawn(shell.cmd, [...shell.args, probe ? withCwdProbe(args.command) : args.command], {
         cwd: startCwd,

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -2,11 +2,18 @@
 // that is a CC-TUI constraint, not an exec constraint.
 import { spawn } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import { z } from 'zod';
 import { defineTool } from './registry';
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 600_000;
+
+/** Marker the shell prints after the user's command so we can read the final
+ *  $PWD back out of stdout. Scoped-persistence (ROADMAP 2026-07-17): before
+ *  this, every Bash call spawned fresh at the session root and `cd` silently
+ *  evaporated, costing ~6 wasted tool calls in one observed session. */
+const CWD_SENTINEL = '__YC_CWD__';
 
 /** Windows shell preference (spec §2.3): Git Bash when present (models write
  *  bash), else PowerShell — and the tool DESCRIPTION states which is live. */
@@ -21,10 +28,57 @@ export function detectShell(): { cmd: string; args: string[]; label: string } {
 
 const shell = detectShell();
 
+/** Only the bash shells get cwd tracking. The PowerShell fallback would need a
+ *  different sentinel AND an $LASTEXITCODE dance to preserve exit codes, and it
+ *  only ever runs on Windows boxes without Git Bash — not worth the risk, so it
+ *  stays stateless and the tool description says so. */
+const tracksCwd = shell.label.startsWith('bash');
+
+/** Wrap the command so the shell prints its final $PWD without clobbering the
+ *  exit code. Newline-separated (not `;`) so trailing `&`, `# comments`, and
+ *  heredocs in the user's command don't turn into syntax errors. */
+function withCwdProbe(command: string): string {
+  return `${command}\n__yc_rc=$?\nprintf '\\n${CWD_SENTINEL}%s' "$PWD"\nexit $__yc_rc`;
+}
+
+/** Split the sentinel back off the combined stdout+stderr. Returns the text the
+ *  model should see and the reported cwd (null when the command exited early,
+ *  timed out, or was killed — all cases where cwd simply doesn't change). */
+export function extractCwd(out: string): { text: string; cwd: string | null } {
+  const at = out.lastIndexOf(`\n${CWD_SENTINEL}`);
+  if (at === -1) return { text: out, cwd: null };
+  const after = out.slice(at + 1 + CWD_SENTINEL.length);
+  const nl = after.indexOf('\n');
+  const reported = (nl === -1 ? after : after.slice(0, nl)).trim();
+  const rest = nl === -1 ? '' : after.slice(nl + 1);
+  return { text: out.slice(0, at) + rest, cwd: reported || null };
+}
+
+/** Containment check for the scope guard. realpath both sides so a symlinked
+ *  workspace root doesn't read as "outside itself". */
+function isInside(root: string, candidate: string): boolean {
+  const real = (p: string) => {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return path.resolve(p);
+    }
+  };
+  const r = real(root);
+  const c = real(candidate);
+  return c === r || c.startsWith(r + path.sep);
+}
+
 export const BashTool = defineTool({
   name: 'Bash',
   description:
-    `Run a shell command (${shell.label} on this machine) in the workspace directory. ` +
+    `Run a shell command (${shell.label} on this machine). ` +
+    (tracksCwd
+      ? 'The working directory PERSISTS between calls: a `cd` carries to your next Bash call. ' +
+        'Changing directory outside the workspace root is reverted (you get a reset notice). ' +
+        'Environment variables, aliases, and shell functions do NOT persist — each call is a fresh shell. '
+      : 'Each call starts fresh in the workspace directory — `cd` does NOT carry to the next call, ' +
+        'so use absolute paths or chain with `cd X && ...` in one command. ') +
     'Output is capped; long-running commands time out (default 2 minutes, max 10 via timeout).',
   inputSchema: z.object({
     command: z.string(),
@@ -35,9 +89,16 @@ export const BashTool = defineTool({
   permissionSubject: (a) => a.command,
   async execute(args, ctx) {
     const timeout = Math.min(args.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+    // A tracked dir can be deleted out from under us (rm -rf, worktree remove);
+    // falling back to the root beats spawning into ENOENT.
+    const tracked = ctx.shellCwd;
+    const startCwd =
+      tracked && tracked !== ctx.cwd && fs.existsSync(tracked) && fs.statSync(tracked).isDirectory() ? tracked : ctx.cwd;
+    // A command ending in a line-continuation would swallow our probe lines.
+    const probe = tracksCwd && !/\\\s*$/.test(args.command);
     return new Promise((resolve) => {
-      const child = spawn(shell.cmd, [...shell.args, args.command], {
-        cwd: ctx.cwd,
+      const child = spawn(shell.cmd, [...shell.args, probe ? withCwdProbe(args.command) : args.command], {
+        cwd: startCwd,
         windowsHide: true,
         env: process.env,
       });
@@ -53,7 +114,25 @@ export const BashTool = defineTool({
         done = true;
         clearTimeout(timer);
         ctx.signal.removeEventListener('abort', onAbort);
-        resolve({ text: `${prefix}${out}`.trim() || `(no output, exit ${code ?? '?'})`, isError });
+        let body = out;
+        let notice = '';
+        if (probe) {
+          const parsed = extractCwd(out);
+          body = parsed.text;
+          if (parsed.cwd && path.resolve(parsed.cwd) !== path.resolve(startCwd)) {
+            if (isInside(ctx.cwd, parsed.cwd)) {
+              ctx.setShellCwd?.(path.resolve(parsed.cwd));
+            } else {
+              // Scope guard: don't let the session wander out of the workspace,
+              // and TELL the model — a silent revert is the exact failure mode
+              // the Claude Code issues (#35058 et al.) complain about.
+              ctx.setShellCwd?.(ctx.cwd);
+              notice = `\nShell cwd was reset to ${ctx.cwd} (${parsed.cwd} is outside the workspace).`;
+            }
+          }
+        }
+        const text = (`${prefix}${body}`.trim() + notice).trim();
+        resolve({ text: text || `(no output, exit ${code ?? '?'})`, isError });
       };
       const timer = setTimeout(() => {
         child.kill('SIGKILL');

--- a/desktop/src/main/harness/tools/types.ts
+++ b/desktop/src/main/harness/tools/types.ts
@@ -18,6 +18,13 @@ export interface ToolContext {
   signal: AbortSignal;
   /** read-before-edit registry: canonical path → mtimeMs at last Read. RESETS on resume (spec §2.5). */
   readRegistry: Map<string, number>;
+  /** Scoped-persistence shell cwd: the directory the NEXT Bash call starts in.
+   *  Absent → Bash falls back to `cwd` (stateless, the pre-2026-07-18 behavior),
+   *  which is what test/one-off contexts get for free. */
+  shellCwd?: string;
+  /** Bash reports the post-command directory here when it resolved INSIDE `cwd`.
+   *  The session owns the state; the tool never mutates ctx directly. */
+  setShellCwd?(next: string): void;
   /** per-session todo list (TodoWrite state) */
   todos: Array<{ content: string; status: 'pending' | 'in_progress' | 'completed'; activeForm: string }>;
   /** Injected runtime services (e.g. WebSearch's SearchService). Absent for tools

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -335,6 +335,14 @@ describe('Bash', () => {
       expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
     });
 
+    // Regression (2026-07-18): a dangling `&&` absorbs the probe's `__yc_rc=$?`
+    // line, so `exit $__yc_rc` fell through to printf's status — a FAILED
+    // command reported success. Malformed commands must skip the probe.
+    it('a dangling && does not mask a failing command as success', async () => {
+      const r = await BashTool.execute({ command: 'false &&' }, trackingCtx(dir));
+      expect(r.isError).toBe(true);
+    });
+
     it('a context without setShellCwd still works (stateless fallback)', async () => {
       const r = await BashTool.execute({ command: 'echo plain' }, makeCtx(dir));
       expect(r.text).toBe('plain');

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -260,6 +260,59 @@ describe('Bash', () => {
     expect(r.text).toMatch(/timed out/i);
   });
 
+  // Scoped persistence (ROADMAP 2026-07-17). Before this, every call spawned
+  // fresh at the session root and `cd` silently evaporated — the failure mode
+  // that burned ~6 tool calls in the 2026-07-17 session.
+  describe('scoped cwd persistence', () => {
+    function trackingCtx(root: string): ToolContext {
+      const c = makeCtx(root);
+      c.setShellCwd = (next) => {
+        c.shellCwd = next;
+      };
+      return c;
+    }
+
+    it('a cd carries to the next call and the sentinel never reaches the model', async () => {
+      fs.mkdirSync(path.join(dir, 'sub'));
+      const c = trackingCtx(dir);
+      const first = await BashTool.execute({ command: 'cd sub && echo moved' }, c);
+      expect(first.text).toContain('moved');
+      expect(first.text).not.toContain('__YC_CWD__');
+      const second = await BashTool.execute({ command: 'pwd' }, c);
+      expect(fs.realpathSync(second.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
+    });
+
+    it('a cd outside the workspace is reverted WITH a notice (never silent)', async () => {
+      const c = trackingCtx(dir);
+      const r = await BashTool.execute({ command: `cd ${JSON.stringify(os.tmpdir())}` }, c);
+      expect(r.text).toMatch(/Shell cwd was reset to/);
+      const after = await BashTool.execute({ command: 'pwd' }, c);
+      expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(dir));
+    });
+
+    it('the probe preserves the command exit code', async () => {
+      const r = await BashTool.execute({ command: 'exit 3' }, trackingCtx(dir));
+      expect(r.isError).toBe(true);
+      expect(r.text).toContain('(exit code 3)');
+    });
+
+    it('falls back to the root when the tracked dir was deleted', async () => {
+      const gone = path.join(dir, 'gone');
+      fs.mkdirSync(gone);
+      const c = trackingCtx(dir);
+      await BashTool.execute({ command: 'cd gone' }, c);
+      fs.rmSync(gone, { recursive: true });
+      const r = await BashTool.execute({ command: 'pwd' }, c);
+      expect(r.isError).toBeFalsy();
+      expect(fs.realpathSync(r.text.trim())).toBe(fs.realpathSync(dir));
+    });
+
+    it('a context without setShellCwd still works (stateless fallback)', async () => {
+      const r = await BashTool.execute({ command: 'echo plain' }, makeCtx(dir));
+      expect(r.text).toBe('plain');
+    });
+  });
+
   it('an aborted signal kills the child', async () => {
     const ac = new AbortController();
     const actx = makeCtx(dir, ac.signal);

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -307,6 +307,34 @@ describe('Bash', () => {
       expect(fs.realpathSync(r.text.trim())).toBe(fs.realpathSync(dir));
     });
 
+    // Regression (2026-07-18): without a trailing newline after the sentinel, a
+    // background writer's output concatenated onto the path — garbage cwd, a
+    // spurious reset notice, and the late text silently dropped from the result.
+    it('output arriving AFTER the sentinel is preserved and does not corrupt the cwd', async () => {
+      fs.mkdirSync(path.join(dir, 'sub'));
+      const c = trackingCtx(dir);
+      const r = await BashTool.execute(
+        { command: 'cd sub && { sleep 0.2; echo LATE-OUTPUT >&2; } &' },
+        c,
+      );
+      expect(r.text).toContain('LATE-OUTPUT'); // not swallowed
+      expect(r.text).not.toMatch(/Shell cwd was reset/); // no spurious notice
+      expect(String(c.shellCwd ?? dir)).not.toContain('LATE-OUTPUT'); // path never corrupted
+    });
+
+    // Regression (2026-07-18): the 200KB accumulator cap dropped the trailing
+    // sentinel on chatty commands, silently losing the cd.
+    it('a cd survives a command that blows past the output cap', async () => {
+      fs.mkdirSync(path.join(dir, 'sub'));
+      const c = trackingCtx(dir);
+      await BashTool.execute(
+        { command: `cd sub && node -e "for(let i=0;i<3000;i++)console.log('X'.repeat(100))"` },
+        c,
+      );
+      const after = await BashTool.execute({ command: 'pwd' }, c);
+      expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
+    });
+
     it('a context without setShellCwd still works (stateless fallback)', async () => {
       const r = await BashTool.execute({ command: 'echo plain' }, makeCtx(dir));
       expect(r.text).toBe('plain');


### PR DESCRIPTION
## Problem

Every Bash tool call spawned a **fresh shell at the session root**, so `cd` in one call silently evaporated before the next. Verified 2026-07-17: PID changed `1042732 → 1042910` across two calls. Nothing told the model this — YouCoded was an undocumented fourth CWD model (fresh process, never persists, *no notice*). Observed cost in one session: ~6 failed tool calls (`node_modules/.bin/vitest` "not found", `git add` "pathspec did not match") before the model worked out that CWD just doesn't persist.

## Fix — Claude Code's scoped-persistence model

Destin's call (2026-07-17, ROADMAP). Concretely:

- The harness tracks cwd per session (`HarnessSession.shellCwd`, reset on resume alongside `readRegistry`/`todos`) and passes it as `cwd:` to each spawn.
- The post-command `$PWD` comes back via a `__YC_CWD__` sentinel appended on its **own line** — newline-separated rather than `;`-joined, so a trailing `&`, `# comment`, or heredoc in the user's command stays valid — with `exit $__yc_rc` preserving the real exit code.
- A `cd` resolving **outside the workspace root** is reverted *and announced* (`Shell cwd was reset to …`). Silent reverts are the #1 complaint across the upstream issues (CC #35058, #42837, #28228, #22023, #37659).
- **Only cwd persists, not env** — aliases/exports stay per-call, matching Claude Code.
- The tool **description** now states the rules plainly instead of leaving the model to guess.
- PowerShell (Windows without Git Bash) stays stateless — its sentinel would need an `$LASTEXITCODE` dance for no real benefit — and its description says so rather than claiming persistence it doesn't have.

## Verification

5 new tests in `harness-tools-core` drive a **real shell** end-to-end: a `cd` carries to the next call, the sentinel never reaches the model, an out-of-root `cd` reverts *with* the notice, exit codes survive the probe, a deleted tracked dir falls back to the root, and a context without `setShellCwd` keeps the old stateless behavior.

`npx tsc --noEmit` clean; full suite **2627 passed / 39 skipped**.

Desktop-only — the native harness has no Android counterpart (Android runs Claude Code under Termux).

Full investigation: `youcoded-dev docs/active/investigations/2026-07-17-agent-shell-cwd-and-grep-enotdir.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)