### PR TITLE
fix(artifacts): stop scroll-anchoring from closing the list panel on open

### DIFF
--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -573,7 +573,7 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
               onClose={() => setFindOpen(false)}
             />
           )}
-          <div ref={contentRef} className="h-full overflow-hidden">
+          <div ref={contentRef} className="h-full overflow-hidden artifact-content-pane">
             <ActiveArtifactView
               ref={editRef}
               artifact={active}

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -1805,3 +1805,17 @@ html[data-platform="electron"][data-view-mode="terminal"] body:not([data-chrome-
 .doc-html th { background: var(--inset); font-weight: 600; color: var(--fg); }
 .doc-html img { max-width: 100%; height: auto; }
 .doc-html blockquote { border-left: 2px solid var(--edge); padding-left: 0.75rem; margin: 0.75rem 0; color: var(--fg-dim); font-style: italic; }
+
+/* Fix: opening the artifact list panel (SessionDrawer) animates the content
+   pane narrower over 200ms, reflowing whatever's scrolled inside it. Chromium's
+   default scroll anchoring then "corrects" scrollTop to compensate — firing a
+   real scroll event with zero user input, which SessionDrawer's
+   engage-to-collapse listener reads as "user scrolled" and closes the list it
+   just opened. Only happens when scrolled away from the top (nothing to
+   anchor to at position 0), matching the reported repro exactly. Disabling
+   anchoring on the pane and everything inside it removes the spurious event
+   at the source instead of trying to filter it out after the fact. */
+.artifact-content-pane,
+.artifact-content-pane * {
+  overflow-anchor: none;
+}


### PR DESCRIPTION
## Summary
- Opening the artifact list panel (☰) narrows the content pane over a 200ms width transition.
- If the artifact was scrolled away from the top, Chromium's scroll anchoring auto-corrects `scrollTop` to compensate for the reflow — firing a genuine `scroll` event with zero user input.
- `SessionDrawer.tsx`'s engage-to-collapse listener reads that as the user scrolling and immediately closes the list it just opened, matching the reported repro exactly (opens fine at the top of a document, instantly closes when scrolled down).
- Fix: `overflow-anchor: none` on the artifact content pane and its descendants (`globals.css`) removes the spurious correction at the source, rather than trying to filter it out in the listener.

## Test plan
- [x] Verified live in an isolated dev instance (`bash scripts/run-dev.sh`): scrolled down in a markdown artifact, clicked ☰ — list now opens and stays open.
- [x] `tsc --noEmit` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)