### PR TITLE
fix(sync): conversation takeover — lost turns on force + blind timeout

### DIFF
--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -11,7 +11,7 @@ import { createConversationStore, ConversationStore } from './conversation-store
 import { mirrorIn, materializeOut } from './transcript-mirror';
 import { reconcile } from './reconciler';
 import { ccProjectSlug } from '../project-conversations';
-import { onSyncSpacesEvent, syncSpacesSyncNow, getManagedRoots } from '../sync-spaces/service';
+import { onSyncSpacesEvent, syncSpacesSyncNow, syncSpacesSyncNowAwaited, getManagedRoots } from '../sync-spaces/service';
 import { readFolders } from '../saved-folders';
 import { resolveLocalProject } from './resolve-local-project';
 import type { TranscriptEvent } from '../../shared/types';
@@ -25,6 +25,12 @@ const RECONCILE_INTERVAL_MS = 30 * 60_000; // slow tick; the startup scan is the
 // local file to stop growing — two equal-size stats this far apart = CC done.
 const QUIESCE_PROBE_MS = 750;   // gap between size probes
 const QUIESCE_MAX_MS = 6_000;   // give up waiting; skip this round (reconciler/startup sweep catch up)
+// Handoff sync budget: how long flushSessionToSpace waits for the final turn's push
+// to actually land before giving up (and letting the push continue in the background).
+// COUPLED to the requester's takeover poll budget (MAX_MS in takeover.ts): that budget
+// must exceed QUIESCE_MAX_MS + HANDOFF_SYNC_TIMEOUT_MS or a healthy handoff trips the
+// force dialog. Keep all three constants in sync if you change one.
+export const HANDOFF_SYNC_TIMEOUT_MS = 15_000;
 
 interface SessionCtx { cwd: string }
 
@@ -348,7 +354,12 @@ export async function flushSessionToSpace(claudeSessionId: string): Promise<void
   await waitForQuiescence(localPath); // best-effort wait; push regardless of the result
   try { mirrorIn({ localJsonlPath: localPath, spaceTranscriptPath: spaceTranscriptPath(key, claudeSessionId) }); }
   catch { /* best-effort; the reconciler re-mirrors */ }
-  try { await Promise.resolve(syncSpacesSyncNow('personal')); } catch { /* the poll covers a miss */ }
+  // MIRROR-BEFORE-RELEASE is load-bearing: genuinely AWAIT the push so the final
+  // turn is in the space before the requester pulls. syncSpacesSyncNow would be
+  // fire-and-forget here (resolves before git runs) — the awaitable variant is what
+  // makes the barrier real. Bounded by HANDOFF_SYNC_TIMEOUT_MS so a slow network
+  // can't wedge the handoff.
+  try { await syncSpacesSyncNowAwaited('personal', HANDOFF_SYNC_TIMEOUT_MS); } catch { /* the poll covers a miss */ }
 }
 
 function runReconcile(): void {

--- a/desktop/src/main/conversations/takeover.ts
+++ b/desktop/src/main/conversations/takeover.ts
@@ -51,35 +51,36 @@ export function createHolderTakeover(deps: HolderTakeoverDeps):
         try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
         return;
       }
-      // Pick-first is deliberate: the rare same-claudeId-in-two-live-windows case
-      // hands off only the first holder (the others' leases drop on their own exit).
-      const desktopId = liveDesktopIds[0];
+      // 3. Interrupt EVERY live holder, not just the first. A create+resume pair can
+      //    leave two desktop ids mapped to one claude id; the old pick-first behavior
+      //    interrupted only one and left the OTHER running as a silent second writer
+      //    on the same transcript (never interrupted, flushed, or told it moved). The
+      //    single ESC byte is safe to write directly per PITFALLS "Keyboard Routing"
+      //    (single-byte writes reach Ink as a fresh keystroke regardless of timing).
+      for (const desktopId of liveDesktopIds) {
+        try { deps.sessionManager.sendInput(desktopId, '\x1b'); } catch { /* best-effort */ }
+      }
 
-      // 3. Interrupt the in-flight turn. Single ESC byte — safe to write directly
-      //    per PITFALLS "Keyboard Routing" (single-byte writes reach Ink as a fresh
-      //    keystroke regardless of timing; no paste-classification applies).
-      try { deps.sessionManager.sendInput(desktopId, '\x1b'); } catch { /* best-effort */ }
-
-      // 4-5. Wait for CC to finish flushing the interrupted turn, mirror local->space,
-      //      and nudge a personal-space sync. MIRROR-BEFORE-RELEASE is load-bearing:
-      //      the requester pulls the moment it sees the release, so the final turn
-      //      must already be in the space (flushSessionToSpace does both steps).
+      // 4-5. Wait for CC to finish flushing the interrupted turn(s), mirror
+      //      local->space, and AWAIT the personal-space push. Keyed on the claude id,
+      //      so one flush covers every live holder. MIRROR-BEFORE-RELEASE is
+      //      load-bearing: the requester pulls the moment it sees the release, so the
+      //      final turn must already be in the space.
       try { await deps.flushSessionToSpace(claudeId); } catch { /* best-effort */ }
 
       // 6. Release the lease so the requester can acquire. Idempotent + best-effort.
       try { await deps.leaseClient.release(claudeId); } catch { /* best-effort */ }
 
-      // 7. Tell the renderer + remote this conversation moved. BEFORE destroy, while
-      //    the session still exists so the "moved to <device>" banner can attach.
-      //    Guarded: pushMoved fans out to remoteServer.broadcast -> ws.send in a
-      //    loop, which can THROW synchronously if a remote socket is mid-teardown
-      //    (readyState checked, then transitions to CLOSING). An escape here would
-      //    skip step 8 (leaving the local CC session alive → half-done handoff).
-      try { deps.pushMoved(desktopId, from?.device); } catch { /* best-effort */ }
-
-      // 8. End the holder's session — fires session-exit -> Task 7 cleanup +
-      //    idempotent lease release.
-      try { deps.sessionManager.destroySession(desktopId); } catch { /* best-effort */ }
+      // 7-8. Tell the renderer + remote each moved session, then destroy it. pushMoved
+      //    runs BEFORE destroy, while the session still exists so the "moved to
+      //    <device>" banner can attach. Guarded: pushMoved fans out to
+      //    remoteServer.broadcast -> ws.send in a loop, which can THROW synchronously
+      //    if a remote socket is mid-teardown. Each id is independently try/caught so
+      //    one bad push can't leave a sibling session alive (half-done handoff).
+      for (const desktopId of liveDesktopIds) {
+        try { deps.pushMoved(desktopId, from?.device); } catch { /* best-effort */ }
+        try { deps.sessionManager.destroySession(desktopId); } catch { /* best-effort */ }
+      }
     } catch { /* never surface out of a fire-and-forget hub-event handler */ }
   };
 }
@@ -117,7 +118,15 @@ export interface RequesterOutcome { outcome: 'acquired' | 'timeout' | 'error' }
 export type RequesterTakeoverType = ReturnType<typeof createRequesterTakeover>;
 
 export function createRequesterTakeover(deps: RequesterTakeoverDeps) {
-  const POLL_MS = 1_000, MAX_MS = 10_000;
+  const POLL_MS = 1_000;
+  // Poll budget for a clean handoff. COUPLED to the holder's costs (see
+  // HANDOFF_SYNC_TIMEOUT_MS in conversations/service.ts): a healthy handoff now
+  // takes up to QUIESCE_MAX_MS (6s, waiting for the interrupted turn to flush)
+  // + a genuinely-awaited git push (≤15s). 10s was sized for the fire-and-forget
+  // sync that never actually waited — once the flush awaits its push, 10s trips
+  // the force dialog on a HEALTHY holder. 25s = 6s quiesce + 15s push + slack, so
+  // the force offer is reserved for a genuinely unresponsive holder.
+  const MAX_MS = 25_000;
   return {
     async takeover(sessionId: string): Promise<RequesterOutcome> {
       try {

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -184,6 +184,30 @@ export function registerIpcHandlers(
     if (!mainWindow.isDestroyed()) mainWindow.webContents.send(channel, ...args);
   };
 
+  // Broadcast a session-scoped channel to EVERY registered main window. Use this
+  // (not sendForSession) when the payload is self-scoping — i.e. the renderer only
+  // acts on it if it's actually displaying that session — AND the session may have
+  // no registered owner. sendForSession's ownerless fallback targets only the
+  // PRIMARY mainWindow (window 1), which is the wrong window when the session is
+  // shown in a secondary window: the 2026-07-18 "moved pill never appears, session
+  // looks like it vanished" bug. A no-op in non-displaying windows makes the
+  // fan-out safe. (SESSION_MOVED is such a payload: recordMoved is keyed by
+  // sessionId and ignores sessions the window isn't showing.)
+  const sendToAllMainWindows = (channel: string, ...args: any[]) => {
+    const ids = windowRegistry ? windowRegistry.getWindowIds() : [];
+    if (ids.length === 0) {
+      // No registry / nothing registered — preserve the pre-buddy single-window
+      // behavior so the event still reaches a renderer.
+      if (!mainWindow.isDestroyed()) mainWindow.webContents.send(channel, ...args);
+      return;
+    }
+    for (const wid of ids) {
+      if (windowRegistry && windowRegistry.getKind(wid) !== 'main') continue; // skip buddy floaters
+      const wc = webContents.fromId(wid);
+      if (wc && !wc.isDestroyed()) wc.send(channel, ...args);
+    }
+  };
+
   // Registry-wide push (not session-scoped): notify every window. Mirrors the
   // getAllWindows loop already used for 'appearance:sync' / 'update:progress'.
   const broadcastToAllWindows = (channel: string, payload: any) => {
@@ -501,6 +525,30 @@ export function registerIpcHandlers(
         // preset badge + resume rows can read it. getHarnessId is authoritative
         // after create/resume awaited above.
         info.harnessId = nativeHost.getHarnessId(info.id) ?? undefined;
+
+        // Native sessions emit NO CC SessionStart hook, so the CC lease path
+        // (sessionIdMap + acquire at the SessionStart listener) never fires for
+        // them — without this they run with NO takeover protection at all: a
+        // leaseQuery always answers held:false and the resume gate never offers a
+        // handoff, so two devices could both resume the same native conversation
+        // (2026-07-18 investigation §3.5). For native, info.id IS the claude
+        // session id (createSession uses resumeSessionId as the id; fresh native
+        // sessions mint one), so the mapping is identity. The existing session-exit
+        // release + holder teardown both key off sessionIdMap, so they pick native
+        // sessions up unchanged once the entry exists. Registered here (after the
+        // host create/resume succeeded) so a FAILED start doesn't take a lease on a
+        // dead session.
+        sessionIdMap.set(info.id, info.id);
+        noteSessionStarted(info.id, info.cwd);
+        if (isSyncSpacesEnabled()) {
+          void leaseWiring?.client.acquire(info.id)
+            .then((res) => {
+              if (res && res.ok === false) {
+                log('WARN', 'Lease', 'native session running without its lease (held by another device)', { sessionId: info.id, holder: res.holder });
+              }
+            })
+            .catch(() => { /* never-block */ });
+        }
       } catch (e) {
         log('ERROR', 'IPC', 'native session start failed', { sessionId: info.id, error: String(e) });
       }
@@ -1832,7 +1880,13 @@ export function registerIpcHandlers(
       const projectPath = info?.cwd;
       const projectSlug = projectPath ? ccProjectSlug(projectPath) : undefined;
       const payload = { sessionId: desktopId, device, claudeSessionId, projectSlug, projectPath };
-      sendForSession(desktopId, IPC.SESSION_MOVED, payload);          // owning renderer window
+      // Broadcast to ALL main windows, not sendForSession: at push time the holder
+      // session still exists but may have no registered owner (e.g. it's shown in a
+      // secondary window), and sendForSession's ownerless fallback hits only the
+      // PRIMARY window — the Moved pill would never render and the conversation would
+      // look like it vanished. recordMoved is keyed by sessionId and no-ops in windows
+      // not showing this session, so the fan-out is safe.
+      sendToAllMainWindows(IPC.SESSION_MOVED, payload);               // every main renderer window
       remoteServer?.broadcast({ type: IPC.SESSION_MOVED, payload }); // remote clients
     };
     const holderTakeover = createHolderTakeover({
@@ -2246,7 +2300,20 @@ export function registerIpcHandlers(
         // Leases/ dir for no reason. Release on session-exit stays UNCONDITIONAL
         // (idempotent — harmless if never acquired) so a session that acquired while
         // sync was on still releases if sync later flips off.
-        if (isSyncSpacesEnabled()) void leaseWiring?.client.acquire(claudeId).catch(() => { /* never-block */ });
+        // Log a denied acquire: today a session can run its whole life NOT owning
+        // its lease with zero trace, which is exactly how the 2026-07-18 handoff
+        // timeout went undiagnosed (the holder never held, so it never responded).
+        // Still never-block — the resume must not wait on the lease — but leave a
+        // breadcrumb so the next "takeover didn't respond" is diagnosable.
+        if (isSyncSpacesEnabled()) {
+          void leaseWiring?.client.acquire(claudeId)
+            .then((res) => {
+              if (res && res.ok === false) {
+                log('WARN', 'Lease', 'session running without its lease (held by another device)', { claudeId, holder: res.holder });
+              }
+            })
+            .catch(() => { /* never-block */ });
+        }
       }
     });
   }

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -18,7 +18,7 @@ import { FirstRunManager } from './first-run';
 import { SyncService } from './sync-service';
 import { setSyncService, getSyncConfig } from './sync-state';
 // Cross-device sync spaces (spec 2026-07-03) — folder-based sync engine.
-import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore, hubLeaseRequest, setSyncSpacesLeaseEventListener, getManagedRoots, syncSpacesSyncNow } from './sync-spaces/service';
+import { startSyncSpaces, stopSyncSpaces, setSyncSpacesRemoteBroadcaster, setSyncSpacesAuthStore, hubLeaseRequest, setSyncSpacesLeaseEventListener, getManagedRoots, syncSpacesSyncNowAwaited } from './sync-spaces/service';
 // Plan 2b Task 8: conversation-lease lifecycle. The lease client coordinates
 // which device "holds" a conversation so two devices don't append to the same
 // transcript. Constructed in the main process (needs userData-scoped device id).
@@ -32,7 +32,7 @@ import { upsertSelf } from './sync-spaces/device-registry';
 // Conversation Store (Phase 2a): records + transcript sync ride the personal
 // space. Imported statically like the sync-spaces stop so the non-async quit
 // handler can call stopConversationStore() directly.
-import { startConversationStore, stopConversationStore, materializeOne } from './conversations/service';
+import { startConversationStore, stopConversationStore, materializeOne, HANDOFF_SYNC_TIMEOUT_MS } from './conversations/service';
 // One-time cleanup of the legacy sync-service's slug-symlink aggregation (Plan 2c).
 import { sweepProjectSymlinks } from './conversations/symlink-sweep';
 import { startTagRegistry } from './conversations/tag-registry-service';
@@ -712,7 +712,11 @@ function createWindow(firstRunManager?: FirstRunManager) {
   // installs share a hostname (the dev instance + built app dogfood gate).
   const requester = createRequesterTakeover({
     leaseClient,
-    syncNow: () => syncSpacesSyncNow('personal'),
+    // AWAITABLE sync (not the fire-and-forget syncSpacesSyncNow): the requester
+    // pulls the holder's final turn right after this, so the pull must not run
+    // until the push it depends on has actually landed. Bounded so a slow network
+    // can't wedge the resume.
+    syncNow: () => syncSpacesSyncNowAwaited('personal', HANDOFF_SYNC_TIMEOUT_MS),
     materializeOne: (id) => materializeOne(id),
     forceAcquire: (id) => hubLeaseRequest('force-acquire', id, deviceIdentity!.id),
     delay: (ms) => new Promise((r) => setTimeout(r, ms)),
@@ -1595,10 +1599,28 @@ app.whenReady().then(async () => {
   // lazily per-connect so sign-in/out mid-session is picked up without a restart.
   // Must be set before startSyncSpaces so a sync enabled at boot can connect.
   setSyncSpacesAuthStore(marketplaceAuthStore);
-  // Plan 2b Task 8: route hub takeover-requests to the lease client, which
-  // filters to sessions THIS device actually holds before driving the handoff.
+  // Plan 2b Task 8: route hub lease events to the lease client, which filters to
+  // sessions THIS device actually holds before driving the handoff.
+  //
+  // BOTH 'takeover-request' AND 'taken' drive the holder teardown:
+  //   - 'takeover-request': a peer asked politely — interrupt, flush, release so it
+  //     can acquire. The requester is waiting on our release.
+  //   - 'taken': a peer FORCE-acquired the lease (its user confirmed the steal after
+  //     we didn't respond in time). The lease is already gone; if we don't interrupt
+  //     + flush NOW, our in-flight turn never reaches the space and the requester
+  //     resumes a stale copy (the 2026-07-18 lost-turns bug). handleTakeoverRequest's
+  //     held.has() guard no-ops the ATTACKER (who doesn't hold the session) so only
+  //     the VICTIM tears down — the 'taken' frame carries no deviceId to compare.
+  //
+  // KNOWN RESIDUAL WINDOW: on 'taken' the requester has already force-acquired and is
+  // pulling immediately, so it may grab the pre-flush copy. The holder's awaited flush
+  // (HANDOFF_SYNC_TIMEOUT_MS) shrinks this from "never flushes" to a ~1s race, but
+  // fully closing it needs the requester to wait on a holder ack — the deferred
+  // holder-ack protocol (investigation Fix 4). Do not assume 'taken' => turn saved.
   setSyncSpacesLeaseEventListener((ev) => {
-    if (ev.kind === 'takeover-request') leaseClient?.handleTakeoverRequest(ev.sessionId, ev.from);
+    if (ev.kind === 'takeover-request' || ev.kind === 'taken') {
+      leaseClient?.handleTakeoverRequest(ev.sessionId, ev.from);
+    }
   });
   startSyncSpaces(
     async () => {

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -455,6 +455,34 @@ export async function syncSpacesSyncNow(spaceId?: string) {
   return { ok: true };
 }
 
+// Awaitable counterpart to syncSpacesSyncNow, for the takeover handoff barrier.
+// syncSpacesSyncNow is fire-and-forget (void engine.syncSpace) so a UI "Sync now"
+// click never blocks on the network — but that means its Promise resolves BEFORE
+// any git pull/push runs, which is exactly why the takeover "mirror-before-release"
+// barrier didn't exist (2026-07-18 investigation §3.2): the holder's flush and the
+// requester's pre-materialize pull both returned before the final turn reached the
+// space. This variant resolves only AFTER each targeted space's pull+push settles,
+// so the caller can genuinely sequence "push landed" before "peer pulls".
+//
+// Bounded by timeoutMs: on timeout we resolve anyway (the push keeps running in the
+// background) because a handoff must never hard-block on a slow network — the cost
+// of a timed-out wait is the pre-fix behavior (the turn may arrive a beat late),
+// never a wedged handoff. engine.syncSpace never throws (fully try/caught inside),
+// so allSettled is belt-and-suspenders.
+export async function syncSpacesSyncNowAwaited(spaceId: string, timeoutMs: number): Promise<void> {
+  // Capture engine/roots into locals: both are module-level `let` nulled on teardown,
+  // and a sync-disable could null them between the guard and the async resolution.
+  const eng = engine;
+  const r = roots;
+  if (!eng || !r) return;
+  const targets = r.spaces().filter((s) => s.id === spaceId);
+  if (targets.length === 0) return;
+  await Promise.race([
+    Promise.allSettled(targets.map((s) => eng.syncSpace(s))),
+    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+  ]);
+}
+
 // Register a project so peers can discover it. repoName is derived purely from
 // the id, so ensureProjectEntry writes the same file on every device (§8).
 function registerProject(name: string, root: string): void {

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2138,9 +2138,22 @@ function AppInner() {
         if (r?.outcome === 'timeout') {
           const forced = await askTakeover(device, 'force');
           if (!forced) return; // "Never mind" — abort
-          await window.claude.syncSpaces?.leaseForce?.(claudeSessionId);
+          const fr = await window.claude.syncSpaces?.leaseForce?.(claudeSessionId);
+          // A failed force means the lease was never overwritten — the other device
+          // may STILL be live and holding it. Never-block (proceed with the resume),
+          // but say so: the user is about to have two writers on one transcript and
+          // recent turns may be missing. Silent here was the 2026-07-18 bug's mask.
+          if (fr && fr.ok === false) {
+            setToast(`Couldn't confirm the handoff from ${device} — it may still be editing this conversation, and recent turns may be missing.`);
+            setTimeout(() => setToast(null), 8000);
+          }
+        } else if (r?.outcome === 'error') {
+          // The takeover request itself failed (hub error / exception). Same deal:
+          // proceed (never-block) but warn that the other device may still be live.
+          setToast(`Couldn't reach ${device} to hand off this conversation — it may still be editing, and recent turns may be missing.`);
+          setTimeout(() => setToast(null), 8000);
         }
-        // 'acquired' or 'error' -> fall through and resume (never-block).
+        // 'acquired' -> clean handoff, fall through and resume.
       }
     } catch { /* never-block: a lease query/takeover failure must not stop the resume */ }
 

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -34,6 +34,9 @@ const h = vi.hoisted(() => {
     mirrorIn: vi.fn((_o: any) => ({ copied: true })),
     materializeOut: vi.fn((_o: any) => ({ copied: true })),
     syncSpacesSyncNow: vi.fn(async (_spaceId?: string) => ({ ok: true })),
+    // Awaitable variant (2026-07-18): flushSessionToSpace now pushes via this, not
+    // the fire-and-forget syncSpacesSyncNow, so the handoff barrier is real.
+    syncSpacesSyncNowAwaited: vi.fn(async (_spaceId?: string, _timeoutMs?: number) => {}),
     // onSyncSpacesEvent subscribers — fireSync() drives them like the real
     // broadcast() fan-out would.
     syncListeners: new Set<(e: any) => void>(),
@@ -63,6 +66,7 @@ vi.mock('../src/main/sync-spaces/service', () => ({
     return () => h.syncListeners.delete(fn);
   },
   syncSpacesSyncNow: (spaceId?: string) => h.syncSpacesSyncNow(spaceId),
+  syncSpacesSyncNowAwaited: (spaceId?: string, timeoutMs?: number) => h.syncSpacesSyncNowAwaited(spaceId, timeoutMs),
   getManagedRoots: () => h.managedRoots,
 }));
 vi.mock('../src/main/saved-folders', () => ({
@@ -102,6 +106,7 @@ describe('conversations service composition root', () => {
     h.mirrorIn.mockReset().mockReturnValue({ copied: true } as any);
     h.materializeOut.mockReset().mockReturnValue({ copied: true } as any);
     h.syncSpacesSyncNow.mockReset().mockResolvedValue({ ok: true } as any);
+    h.syncSpacesSyncNowAwaited.mockReset().mockResolvedValue(undefined as any);
     h.savedFolders = [];
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'conv-svc-'));
     h.managedRoots = { personalRoot: path.join(tmpRoot, 'Personal'), listProjects: () => [] };
@@ -445,7 +450,9 @@ describe('conversations service composition root', () => {
     expect(h.mirrorIn.mock.calls[0][0].localJsonlPath).toBe(localPath);
     // Space transcript path is <root>/claude/transcripts/<projectKey>/<id>.jsonl.
     expect(h.mirrorIn.mock.calls[0][0].spaceTranscriptPath).toContain(`${id}.jsonl`);
-    expect(h.syncSpacesSyncNow).toHaveBeenCalledWith('personal');
+    // flush pushes via the AWAITABLE variant (mirror-before-release barrier), not
+    // the fire-and-forget syncSpacesSyncNow.
+    expect(h.syncSpacesSyncNowAwaited).toHaveBeenCalledWith('personal', expect.any(Number));
     svc.stopConversationStore();
     vi.useRealTimers();
   });
@@ -455,7 +462,7 @@ describe('conversations service composition root', () => {
     const svc = await freshService(startOpts());
     await svc.flushSessionToSpace('never-announced');
     expect(h.mirrorIn).not.toHaveBeenCalled();
-    expect(h.syncSpacesSyncNow).not.toHaveBeenCalled();
+    expect(h.syncSpacesSyncNowAwaited).not.toHaveBeenCalled();
   });
 
   // Store not started (or stopped) → noteSessionEnded must be a silent no-op,

--- a/desktop/tests/holder-takeover.test.ts
+++ b/desktop/tests/holder-takeover.test.ts
@@ -130,4 +130,31 @@ describe('createHolderTakeover', () => {
     expect(deps.pushMoved).toHaveBeenCalledWith('d1', 'X');
     expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d1');
   });
+
+  it('interrupts + destroys EVERY live holder when two desktop ids map to one claude id', async () => {
+    // A create+resume pair can leave TWO live desktop ids on one claude id. The old
+    // pick-first behavior interrupted only the first and left the other running as a
+    // silent second writer. Now both must be interrupted, moved, and destroyed; the
+    // claude-id-keyed flush + release run once.
+    const deps = makeDeps({ liveDesktopIds: ['d1', 'd2'] });
+    deps.sessionIdMap.set('d1', 'c1');
+    deps.sessionIdMap.set('d2', 'c1');
+    const handler = createHolderTakeover(deps as any);
+    await handler('c1', { deviceId: 'dev-b', device: 'Laptop-B' });
+
+    // Both holders interrupted, both moved, both destroyed.
+    expect(deps.sessionManager.sendInput).toHaveBeenCalledWith('d1', '\x1b');
+    expect(deps.sessionManager.sendInput).toHaveBeenCalledWith('d2', '\x1b');
+    expect(deps.pushMoved).toHaveBeenCalledWith('d1', 'Laptop-B');
+    expect(deps.pushMoved).toHaveBeenCalledWith('d2', 'Laptop-B');
+    expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d1');
+    expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d2');
+    // Flush + release are claude-id-keyed: exactly once each, not per-holder.
+    expect(deps.flushSessionToSpace).toHaveBeenCalledTimes(1);
+    expect(deps.leaseClient.release).toHaveBeenCalledTimes(1);
+    // Every interrupt happens before the single flush (both turns quiesce before push).
+    const iFlush = deps.order.indexOf('flush:c1');
+    expect(deps.order.indexOf('interrupt:d1:"\\u001b"')).toBeLessThan(iFlush);
+    expect(deps.order.indexOf('interrupt:d2:"\\u001b"')).toBeLessThan(iFlush);
+  });
 });

--- a/desktop/tests/lease-client.test.ts
+++ b/desktop/tests/lease-client.test.ts
@@ -163,6 +163,27 @@ describe('lease-client', () => {
     expect(takeoverSpy).not.toHaveBeenCalled();
   });
 
+  it('handleTakeoverRequest is the victim-only guard for BOTH takeover-request AND taken', async () => {
+    // main.ts routes BOTH 'takeover-request' and 'taken' (force-acquire) lease events
+    // into handleTakeoverRequest. The 'taken' frame carries NO deviceId to compare, so
+    // the held.has() guard is what separates VICTIM from ATTACKER: the device that
+    // forced the steal does NOT hold the session (no-op), the device that holds it is
+    // the victim (tears down). Pin that contract here — if the guard ever keyed on a
+    // payload field instead of held.has(), a force would tear down the wrong device.
+    hubRequest.mockResolvedValue(okResult('acquire', 's-held', Date.now() + 300_000));
+    await client.acquire('s-held'); // WE hold it -> we are the victim
+
+    // A 'taken' event arrives with NO `from` (the DO's taken frame has no deviceId).
+    client.handleTakeoverRequest('s-held', undefined);
+    expect(takeoverSpy).toHaveBeenCalledWith('s-held', undefined);
+
+    // The attacker's perspective: it does NOT hold the session, so the same event
+    // no-ops (it must NOT tear down the session it just stole).
+    takeoverSpy.mockClear();
+    client.handleTakeoverRequest('s-not-ours', undefined);
+    expect(takeoverSpy).not.toHaveBeenCalled();
+  });
+
   it('renew failure (force-acquired) stops the timer, deletes the file, and attributes the takeover', async () => {
     hubRequest.mockResolvedValue(okResult('acquire', 's1', Date.now() + 300_000));
     await client.acquire('s1');

--- a/desktop/tests/requester-takeover.test.ts
+++ b/desktop/tests/requester-takeover.test.ts
@@ -1,6 +1,6 @@
 // Plan 2b Task 9 — pins the requester-side takeover flow (createRequesterTakeover).
 // When the user resumes a conversation another device holds, THIS device asks the
-// holder to hand off, polls the lease until it frees (or times out at 10s), then
+// holder to hand off, polls the lease until it frees (or times out at MAX_MS), then
 // pulls the peer's final turn and acquires the lease. All collaborators are
 // injected fakes; the poll loop is driven with fake timers. The flow must NEVER
 // throw (spec §3 never-block) — errors surface as {outcome:'error'}/{ok:false}.
@@ -101,7 +101,9 @@ describe('createRequesterTakeover', () => {
     const deps = makeDeps({ queryResults: [{ held: true, device: 'This-Device', self: false }] });
     const flow = createRequesterTakeover(deps as any);
     const p = flow.takeover('c1');
-    await vi.advanceTimersByTimeAsync(11_000);
+    // Advance past the 25s MAX_MS (raised from 10s once the holder's flush genuinely
+    // awaits its push — see takeover.ts) so the poll loop exhausts its budget.
+    await vi.advanceTimersByTimeAsync(26_000);
     const res = await p;
     expect(res).toEqual({ outcome: 'timeout' });
     // Did NOT short-circuit on a same-label lease: no free-path work ran.
@@ -110,12 +112,13 @@ describe('createRequesterTakeover', () => {
     expect(deps.materializeOne).not.toHaveBeenCalled();
   });
 
-  it('takeover: holder never releases -> timeout after 10s (no acquire)', async () => {
+  it('takeover: holder never releases -> timeout after MAX_MS (no acquire)', async () => {
     const deps = makeDeps({ queryResults: [{ held: true, device: 'Laptop-B' }] });
     const flow = createRequesterTakeover(deps as any);
     const p = flow.takeover('c1');
-    // Advance well past MAX_MS so every poll interval elapses and the loop exits.
-    await vi.advanceTimersByTimeAsync(11_000);
+    // Advance well past MAX_MS (now 25s — see takeover.ts) so every poll interval
+    // elapses and the loop exits.
+    await vi.advanceTimersByTimeAsync(26_000);
     const res = await p;
     expect(res).toEqual({ outcome: 'timeout' });
     expect(deps.leaseClient.acquire).not.toHaveBeenCalled();
@@ -150,5 +153,33 @@ describe('createRequesterTakeover', () => {
     const flow = createRequesterTakeover(deps as any);
     const res = await flow.force('c1');
     expect(res).toEqual({ ok: false });
+  });
+
+  it('takeover: materializeOne is NOT called until the syncNow promise RESOLVES (mirror-before-pull)', async () => {
+    // §3.2 regression guard. The requester pulls the peer's final turn via
+    // materializeOne right after syncNow. If syncNow is fire-and-forget (resolves
+    // before the git push/pull actually runs), materialize grabs the STALE copy —
+    // the lost-turns bug. The flow must AWAIT the injected syncNow before calling
+    // materializeOne. Today's real syncNow is syncSpacesSyncNowAwaited (resolves only
+    // after the push lands); this test pins that the flow honors the promise.
+    const deps = makeDeps({ queryResults: [{ held: false }] });
+    let releaseSync!: () => void;
+    const syncGate = new Promise<void>((r) => { releaseSync = r; });
+    (deps.syncNow as any) = vi.fn(() => { deps.order.push('syncNow'); return syncGate; });
+    const flow = createRequesterTakeover(deps as any);
+    const p = flow.takeover('c1');
+
+    // Let the microtask queue drain: takeover + query + syncNow have run, but the
+    // flow is now parked awaiting syncGate. materializeOne must NOT have run yet.
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+    expect(deps.syncNow).toHaveBeenCalled();
+    expect(deps.materializeOne).not.toHaveBeenCalled();
+    expect(deps.leaseClient.acquire).not.toHaveBeenCalled();
+
+    // Release the sync (push landed) -> NOW materialize + acquire run.
+    releaseSync();
+    const res = await p;
+    expect(res).toEqual({ outcome: 'acquired' });
+    expect(deps.order).toEqual(['takeover:c1', 'syncNow', 'materialize:c1', 'acquire:c1']);
   });
 });

--- a/desktop/tests/sync-spaces-service.test.ts
+++ b/desktop/tests/sync-spaces-service.test.ts
@@ -269,6 +269,50 @@ describe('sync-spaces service transition serialization', () => {
     expect(engine.syncSpace.mock.calls.length).toBeGreaterThan(1);
   });
 
+  // ---- Awaitable sync variant (2026-07-18 takeover mirror-before-release fix) ----
+  // syncSpacesSyncNowAwaited backs the takeover handoff barrier: it must NOT resolve
+  // until the targeted space's push settles (unlike fire-and-forget syncSpacesSyncNow).
+
+  it('syncSpacesSyncNowAwaited does NOT resolve until the targeted space sync settles', async () => {
+    const svc = await enabledMultiSpaceService();
+    const engine = h.engines[0];
+    // Gate the matching space's sync so we control when it "lands".
+    let releaseSync!: () => void;
+    engine.syncSpace = vi.fn((space: { id: string }) =>
+      space.id === 'project:beta'
+        ? new Promise<void>((r) => { releaseSync = r; })
+        : Promise.resolve()) as any;
+
+    let resolved = false;
+    const p = svc.syncSpacesSyncNowAwaited('project:beta', 10_000).then(() => { resolved = true; });
+    await new Promise((r) => setTimeout(r, 20)); // let the call reach the engine
+    expect(engine.syncSpace).toHaveBeenCalled();
+    expect(resolved).toBe(false); // parked awaiting the push — must not have resolved
+
+    releaseSync();
+    await p;
+    expect(resolved).toBe(true);
+  });
+
+  it('syncSpacesSyncNowAwaited resolves after the timeout even if the sync never settles', async () => {
+    const svc = await enabledMultiSpaceService();
+    const engine = h.engines[0];
+    engine.syncSpace = vi.fn(() => new Promise<void>(() => { /* never settles */ })) as any;
+    const start = Date.now();
+    // 50ms timeout: the handoff must never hard-block on a stuck push.
+    await svc.syncSpacesSyncNowAwaited('project:beta', 50);
+    expect(Date.now() - start).toBeLessThan(5_000); // resolved via the timeout, not the sync
+  });
+
+  it('syncSpacesSyncNowAwaited targets ONLY the matching space', async () => {
+    const svc = await enabledMultiSpaceService();
+    const engine = h.engines[0];
+    engine.syncSpace.mockClear();
+    await svc.syncSpacesSyncNowAwaited('project:alpha', 10_000);
+    expect(engine.syncSpace).toHaveBeenCalledTimes(1);
+    expect(engine.syncSpace.mock.calls[0][0].id).toBe('project:alpha');
+  });
+
   it('broadcast stamps events with an `at` timestamp', async () => {
     const svc = await enabledMultiSpaceService();
     // Fire the engine's onEvent hook (= service.broadcast) the way the real


### PR DESCRIPTION
## Summary

Fixes the conversation-takeover failures Destin hit testing a beta build: a force-takeover from device B resumed the conversation **missing the last couple of turns**, and the requester's poll was blind (couldn't tell a live handoff from a dead holder).

Root causes confirmed in `docs/active/investigations/2026-07-18-conversation-takeover-failures.md` (workspace repo). Plan: `docs/active/plans/2026-07-18-conversation-takeover-fixes.md`.

### What was broken

1. **The "mirror-before-release" barrier didn't exist.** `syncSpacesSyncNow` was fire-and-forget (`void engine.syncSpace(s)`), so the holder's flush and the requester's pre-materialize pull both resolved *before any git ran*. The requester pulled a stale space copy.
2. **A force never notified the holder.** The DO broadcasts `{kind:"taken"}` on force-acquire, but the client dropped every lease-event kind except `takeover-request` — so the holder kept running, never flushed, and the requester materialized stale state.

### The fixes

- **Awaitable sync** (`syncSpacesSyncNowAwaited`): resolves only after the targeted space's pull+push settles, bounded by a timeout so a handoff never hard-blocks. Used at **both** barrier sites (holder flush + requester pre-materialize pull).
- **Requester budget** `MAX_MS` 10s → 25s, coupled to 6s quiescence + 15s awaited push, so a *healthy* handoff no longer trips the force dialog.
- **`taken` routes through the holder teardown.** The `held.has()` guard no-ops the attacker (who doesn't hold the session) so only the victim tears down — the `taken` frame carries no `deviceId` to compare.

### Secondary issues fixed en route

- Interrupt **all** live desktop ids on one claude id, not just the first.
- `pushMoved` broadcasts to **all main windows** (the ownerless fallback hit only the primary window, so the moved pill never rendered — the session looked like it vanished).
- **Native-provider sessions** now register `sessionIdMap` + acquire a lease (they emit no CC SessionStart hook, so they ran with zero takeover protection).
- Failed force / `error` outcome surfaces a **non-blocking toast** instead of silently resuming into a possible two-writer state.
- **Denied lease acquires are logged** — the observability that would have settled the investigation's open question immediately.

### Guard tests

Awaitable-sync settle/timeout/targeting · requester awaits `syncNow` before `materializeOne` (the §3.2 regression guard — today's stub hid it) · `taken` drives victim-only teardown · all-holders interrupt · flush uses the awaited variant.

**Full desktop suite green (2614 passed), `tsc --noEmit` clean, `vite build` clean.**

### Deferred (not this PR)

- **Holder-ack protocol** — closes the residual force-window where the requester pulls before the holder's flush lands. Needs a new DO op/event kind + a product call on what "never-block" means. Specced separately.
- **TTL/sweeper tuning** — the 300s TTL is a deliberate sleep-tolerance choice, not an accident.

### Interactive verification (for Destin)

The two-instance dev repro (resume a mid-turn conversation from a second dev profile; watch the holder flush + the requester resume with all turns) is multi-window and interactive — left for you to eyeball per the workspace convention. Not run against the live built app.