### PR TITLE
fix(native): three safety fixes for native sessions in the sync system

### DIFF
--- a/desktop/src/main/conversations/conversation-store.ts
+++ b/desktop/src/main/conversations/conversation-store.ts
@@ -27,6 +27,7 @@ export interface ConversationStore {
   setFlag(provider: string, id: string, flag: string, value: boolean): Promise<void>;
   setTitle(provider: string, id: string, title: string): Promise<void>;
   setNote(provider: string, id: string, note: string): Promise<void>;
+  remove(provider: string, id: string): Promise<boolean>;
   root(): string;
 }
 
@@ -370,6 +371,45 @@ export function createConversationStore(conversationsRoot: string): Conversation
         const base = existing ?? toRecord({ id, provider });
         return { ...base, title };
       });
+    },
+
+    /**
+     * Delete a record outright. Returns true if anything was removed.
+     *
+     * The ONLY destructive operation on this store, added 2026-07-18 for the
+     * native phantom-record cleanup — nothing else deletes records, and nothing
+     * else should without a comparably narrow justification. The deletion syncs
+     * (the transport stages the whole tree), which is the point: the junk must
+     * clear on every device, not just the one that noticed.
+     *
+     * WHY it also sweeps conflict copies and quarantine files: heal() seeds a
+     * canonical FROM a conflict copy when none exists ("Without one (only
+     * conflict copies exist): seed from the first copy"). Deleting the canonical
+     * alone would let the very next get()/list() resurrect the record from a
+     * surviving copy — the delete would look successful and silently undo itself.
+     */
+    async remove(provider, id) {
+      if (!isSafeSegment(provider) || !isSafeSegment(id)) return false;
+      let dir: string;
+      try { dir = providerDir(provider); } catch { return false; }
+      let names: string[];
+      try { names = fs.readdirSync(dir); } catch { return false; }
+      const baseName = `${id}.json`;
+      // Canonical + every conflict copy + every quarantine file for this id.
+      // Same name-matching rules heal() uses, so the two agree on what "belongs
+      // to this id" means.
+      const targets = names.filter((n) => {
+        if (n === baseName) return true;
+        const h = n.indexOf(HEALING_MARKER);
+        const original = h >= 0 ? n.slice(0, h) : n;
+        return isConflictCopyName(original) && extractConflictBase(original) === baseName;
+      });
+      let removed = false;
+      for (const n of targets) {
+        try { fs.unlinkSync(path.join(dir, n)); removed = true; }
+        catch { /* already gone / raced another remover — treat as removed by someone */ }
+      }
+      return removed;
     },
 
     async setNote(provider, id, note) {

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -8,6 +8,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { createConversationStore, ConversationStore } from './conversation-store';
+import { log } from '../logger';
+import { NativeHome } from '../native-home';
+import type { ConversationRecord } from './store-core';
 import { mirrorIn, materializeOut } from './transcript-mirror';
 import { reconcile } from './reconciler';
 import { ccProjectSlug } from '../project-conversations';
@@ -24,7 +27,7 @@ const RECONCILE_INTERVAL_MS = 30 * 60_000; // slow tick; the startup scan is the
 // targeted materialize copies a peer's version over the local file, wait for the
 // local file to stop growing — two equal-size stats this far apart = CC done.
 const QUIESCE_PROBE_MS = 750;   // gap between size probes
-const QUIESCE_MAX_MS = 6_000;   // give up waiting; skip this round (reconciler/startup sweep catch up)
+export const QUIESCE_MAX_MS = 6_000;   // give up waiting; skip this round (reconciler/startup sweep catch up)
 // Handoff sync budget: how long flushSessionToSpace waits for the final turn's push
 // to actually land before giving up (and letting the push continue in the background).
 // COUPLED to the requester's takeover poll budget (MAX_MS in takeover.ts): that budget
@@ -51,6 +54,7 @@ export function getConversationStore(): ConversationStore | null { return store;
 
 export async function startConversationStore(opts?: {
   conversationsRoot?: string; projectsDir?: string; topicsDir?: string; device?: string;
+  nativeHomeRoot?: string;  // tests only — production reads ~/.youcoded
 }): Promise<void> {
   // Idempotent start (review fix 4): a second start without a stop would leak
   // the first onSyncSpacesEvent subscription (duplicate materialize sweeps
@@ -99,6 +103,13 @@ export async function startConversationStore(opts?: {
   // transcript is dangerous without single-writer guarantees).
   void materializeSweep();
 
+  // One-shot cleanup of the PR #176 phantom records (see the function's comment).
+  // Detached + never-throws, same as the two sweeps above — it must not delay
+  // startup, and finding nothing (the steady state after the first run) is cheap.
+  void pruneNativePhantomRecords({ nativeHomeRoot: opts?.nativeHomeRoot })
+    .then((n) => { if (n > 0) log('INFO', 'ConversationStore', 'phantom native record cleanup complete', { pruned: n }); })
+    .catch(() => { /* best-effort — never block startup */ });
+
   reconcileTimer = setInterval(() => { runReconcile(); }, RECONCILE_INTERVAL_MS);
   reconcileTimer.unref?.();
 }
@@ -114,6 +125,62 @@ export function stopConversationStore(): void {
 
 export function noteSessionStarted(claudeSessionId: string, cwd: string): void {
   sessions.set(claudeSessionId, { cwd });
+}
+
+/**
+ * One-shot cleanup for the phantom records PR #176 caused (2026-07-18).
+ *
+ * Flagging or noting a NATIVE session seeded a record under `claude/` with a
+ * hardcoded provider — blank projectName / originalPath / transcriptRef, EPOCH
+ * lastActive — which synced everywhere and was never pruned (flagged records are
+ * deliberately kept). The write path is gated at its source now (ipc-handlers'
+ * canWriteStoreRecord), but records already on disk need clearing, or they stay
+ * forever AND collide with the real `native/` record once the parity work lands:
+ * two Resume Browser rows for one conversation, one of them unopenable.
+ *
+ * DELIBERATELY CONSERVATIVE. Every condition must hold before anything is
+ * deleted — this is the store's only destructive caller, and a false positive
+ * would delete a real conversation record on every synced device:
+ *   1. transcriptRef is blank — a real CC record always points at a transcript, AND
+ *   2. projectName AND originalPath are blank, AND
+ *   3. lastActive is EPOCH — the record never saw a single turn, AND
+ *   4. a persisted ~/.youcoded/sessions file exists for the id, so the id is
+ *      confirmed native rather than merely shaped like a phantom.
+ * A phantom whose native session file was since deleted therefore survives. That
+ * is the intended trade: leaving one stale row beats deleting a real one.
+ *
+ * Idempotent (a second run finds nothing) and best-effort — a failure here must
+ * never block store startup.
+ */
+export async function pruneNativePhantomRecords(opts?: { nativeHomeRoot?: string }): Promise<number> {
+  const s = store;
+  if (!s) return 0;
+  let records: ConversationRecord[];
+  try { records = await s.list('claude'); } catch { return 0; }
+  // Cheap shape filter FIRST, so the sessions-dir listing below is only paid for
+  // when a candidate actually exists (the common case is zero candidates).
+  const candidates = records.filter(
+    (r) => !r.transcriptRef && !r.projectName && !r.originalPath && Date.parse(r.lastActive) === 0,
+  );
+  if (candidates.length === 0) return 0;
+  // Read-only listing (readdir + stat, no file contents) of every persisted
+  // native session id on this device.
+  let nativeIds: Set<string>;
+  try {
+    const home = new NativeHome(opts?.nativeHomeRoot);
+    nativeIds = new Set(home.listSessionFiles().map((f) => f.sessionId));
+  } catch { return 0; } // can't confirm nativeness → delete nothing
+  let pruned = 0;
+  for (const rec of candidates) {
+    if (!nativeIds.has(rec.id)) continue;
+    try {
+      if (await s.remove('claude', rec.id)) {
+        pruned++;
+        log('INFO', 'ConversationStore', 'pruned a phantom native record mislabeled as claude', { id: rec.id });
+      }
+    } catch { /* per-record isolation — one failure must not abort the pass */ }
+  }
+  return pruned;
 }
 
 // <root>/claude/transcripts/<projectKey>/<id>.jsonl — the durable space copy.

--- a/desktop/src/main/conversations/takeover.ts
+++ b/desktop/src/main/conversations/takeover.ts
@@ -7,7 +7,8 @@
 //   4-5. wait for CC to flush the interrupted turn, then push local->space
 //   6. release the lease so the requester can acquire
 //   7. tell the renderer + remote the conversation moved (BEFORE destroy)
-//   8. end the local session (fires session-exit -> Task 7 cleanup)
+//   8. tear down the native harness (no-op for CC), then end the local session
+//      (fires session-exit -> Task 7 cleanup)
 //
 // Extracted into an injected-deps factory (not inlined in ipc-handlers) so it's
 // unit-testable — the real handler needs sessionIdMap, which is local to
@@ -26,6 +27,14 @@ export interface HolderTakeoverDeps {
   leaseClient: { release(sessionId: string): Promise<void> };
   flushSessionToSpace: (claudeSessionId: string) => Promise<void>;
   pushMoved: (desktopId: string, device?: string) => void;  // dual-path push (renderer + remote)
+  // Native teardown, injected rather than imported so this module keeps its
+  // fake-collaborator test style. Idempotent + a no-op for non-native ids, so
+  // step 8 can call it unconditionally (same contract as nativeHost.destroy).
+  // WHY it must be here: destroySession alone only tears down the PTY half. For
+  // a native session the in-process HarnessSession survives with its
+  // transcript-event listener attached and keeps appending — a leaked model
+  // ref-count, an un-aborted stream, and a second writer on the transcript.
+  destroyNative: (desktopId: string) => Promise<void>;
 }
 
 // Returns the async handler wired to the lease client's onTakeoverRequest.
@@ -79,6 +88,12 @@ export function createHolderTakeover(deps: HolderTakeoverDeps):
       //    one bad push can't leave a sibling session alive (half-done handoff).
       for (const desktopId of liveDesktopIds) {
         try { deps.pushMoved(desktopId, from?.device); } catch { /* best-effort */ }
+        // Native teardown BEFORE destroySession, matching the sanctioned
+        // SESSION_DESTROY order (ipc-handlers): stop the appending source first,
+        // then drop the SessionManager record. Awaited so the append chain drains
+        // and the open streaming part flushes before we move on — an un-awaited
+        // destroy would race the release below and could still lose the tail.
+        try { await deps.destroyNative(desktopId); } catch { /* best-effort */ }
         try { deps.sessionManager.destroySession(desktopId); } catch { /* best-effort */ }
       }
     } catch { /* never surface out of a fire-and-forget hub-event handler */ }
@@ -117,6 +132,11 @@ export interface RequesterOutcome { outcome: 'acquired' | 'timeout' | 'error' }
 // main.ts can build the flow and pass it through without a circular import.
 export type RequesterTakeoverType = ReturnType<typeof createRequesterTakeover>;
 
+// Exported so the coupling to the holder's costs is PINNABLE, not just
+// documented in prose at three separate sites (2026-07-18). See
+// tests/handoff-timing-contract.test.ts.
+export const REQUESTER_MAX_MS = 25_000;
+
 export function createRequesterTakeover(deps: RequesterTakeoverDeps) {
   const POLL_MS = 1_000;
   // Poll budget for a clean handoff. COUPLED to the holder's costs (see
@@ -126,7 +146,7 @@ export function createRequesterTakeover(deps: RequesterTakeoverDeps) {
   // sync that never actually waited — once the flush awaits its push, 10s trips
   // the force dialog on a HEALTHY holder. 25s = 6s quiesce + 15s push + slack, so
   // the force offer is reserved for a genuinely unresponsive holder.
-  const MAX_MS = 25_000;
+  const MAX_MS = REQUESTER_MAX_MS;
   return {
     async takeover(sessionId: string): Promise<RequesterOutcome> {
       try {

--- a/desktop/src/main/harness/native-session-host.ts
+++ b/desktop/src/main/harness/native-session-host.ts
@@ -276,6 +276,14 @@ export class NativeSessionHost extends EventEmitter {
 
   /** Fresh session: write the header, build + wire a live HarnessSession. */
   async create(opts: CreateNativeSessionOpts): Promise<void> {
+    // Same single-writer guard as resume() — create() also ends in wire(), so an
+    // id that is somehow still live would gain a second appending listener here
+    // too. Cheap and idempotent; closes the class at BOTH wire() entry points
+    // rather than only the one we know a caller reached.
+    if (this.live.has(opts.sessionId)) {
+      log('WARN', 'NativeSessionHost', 'create found a live session under the same id — destroying the orphan first', { sessionId: opts.sessionId });
+      await this.destroy(opts.sessionId);
+    }
     const preset = resolvePreset(opts.presetId);
     const contextLength = await this.contextLengthFor(opts.binding);
     await this.store.create({
@@ -301,6 +309,20 @@ export class NativeSessionHost extends EventEmitter {
   /** Rebuild a live session from its stored header + events. Returns false when
    *  no native session file exists for this id (caller should fall through). */
   async resume(sessionId: string, cwd: string): Promise<boolean> {
+    // SINGLE-WRITER GUARD (2026-07-18): tear down any session already live under
+    // this id BEFORE wiring a new one. Without this, resuming an id that is still
+    // live leaves the old HarnessSession's transcript-event listener attached —
+    // it closes over the OLD `entry`, so wire()'s `this.live.set` overwriting the
+    // map entry does NOT stop it appending (see destroy()'s comment below). The
+    // result was two writers on one JSONL, unordered against each other, breaking
+    // the single-writer invariant at native-home.ts:5-7 that justifies the absence
+    // of a file lock. Callers could orphan a session from several paths (takeover,
+    // session-exit), so the guard lives HERE, at the one place a second writer can
+    // actually be created, rather than in each caller.
+    if (this.live.has(sessionId)) {
+      log('WARN', 'NativeSessionHost', 'resume found a live session under the same id — destroying the orphan first', { sessionId });
+      await this.destroy(sessionId);
+    }
     const header = this.store.readHeader(sessionId, cwd);
     if (!header) return false;
     // Read-side legacy mapping: a stored 'chat' header (or any unknown id)
@@ -329,6 +351,14 @@ export class NativeSessionHost extends EventEmitter {
 
   isNative(sessionId: string): boolean {
     return this.live.has(sessionId);
+  }
+
+  /** Is this id a native session AT ALL — live now, or persisted from any
+   *  earlier run? isNative() only answers for LIVE sessions, which is the wrong
+   *  question for the phantom-record gate: a past native session picked from the
+   *  Resume Browser is not live, but must still never seed a CC store record. */
+  isNativeSessionId(sessionId: string): boolean {
+    return this.live.has(sessionId) || this.store.has(sessionId);
   }
 
   /** Send a user turn. false when the session isn't live OR when the turn

--- a/desktop/src/main/harness/session-store.ts
+++ b/desktop/src/main/harness/session-store.ts
@@ -151,6 +151,17 @@ export class SessionStore {
     }
   }
 
+  /**
+   * Does a persisted native session file exist for this id, in any project?
+   * Deliberately a readdir-only check (listSessionFiles stats names; it does NOT
+   * read file contents like list() does) so callers on user-initiated paths —
+   * flagging/noting a session — can ask "is this id native?" without paying a
+   * 256KB head-read per session. Used by the phantom-record gate in ipc-handlers.
+   */
+  has(sessionId: string): boolean {
+    return this.home.listSessionFiles().some((f) => f.sessionId === sessionId);
+  }
+
   /** Line 1 of the session file, validated as a v1 header for this session. */
   readHeader(sessionId: string, cwd: string): NativeSessionHeader | null {
     const lines = this.home.readSessionLines(cwdToProjectSlug(cwd), sessionId);

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -540,15 +540,31 @@ export function registerIpcHandlers(
         // dead session.
         sessionIdMap.set(info.id, info.id);
         noteSessionStarted(info.id, info.cwd);
-        if (isSyncSpacesEnabled()) {
-          void leaseWiring?.client.acquire(info.id)
-            .then((res) => {
-              if (res && res.ok === false) {
-                log('WARN', 'Lease', 'native session running without its lease (held by another device)', { sessionId: info.id, holder: res.holder });
-              }
-            })
-            .catch(() => { /* never-block */ });
-        }
+        // NO LEASE FOR NATIVE SESSIONS (2026-07-18 — reverts the acquire added by
+        // PR #176; the sessionIdMap + noteSessionStarted lines above deliberately
+        // STAY, see below).
+        //
+        // #176 correctly noticed native sessions had no takeover protection and
+        // enrolled them in the lease system. But native conversations do not
+        // participate in the conversation store or space sync at all, so every
+        // step the lease implies is a no-op for them: the holder's flush mirrors a
+        // file that isn't there, and the requester materializes a record that does
+        // not exist. The net effect was WORSE than the gap it closed — a takeover
+        // destroyed the holder's live session and transferred nothing, while the
+        // requester resumed its own unchanged local copy.
+        //
+        // A lease is a way to serialize access to a SHARED resource. Until native
+        // transcripts sync there is no shared resource: two devices "resuming the
+        // same native session" are resuming two unrelated local files. So not
+        // taking the lease is the honest state, not a stopgap — leaseQuery answers
+        // held:false, the resume gate never offers a handoff, and the holder keeps
+        // running. This is exactly pre-#176 behavior.
+        //
+        // Re-enable this together with the parity work, NOT before — the lease only
+        // becomes meaningful at the same moment the transcript becomes shared.
+        // Spec: docs/active/specs/2026-07-18-native-sync-parity-design.md (§3.3 for
+        // why the two lines above stay: the store writes they enable are gated at
+        // the write sites instead, which is the enforceable version of the rule).
       } catch (e) {
         log('ERROR', 'IPC', 'native session start failed', { sessionId: info.id, error: String(e) });
       }
@@ -1892,6 +1908,9 @@ export function registerIpcHandlers(
     const holderTakeover = createHolderTakeover({
       sessionManager, sessionIdMap, leaseClient: leaseWiring.client,
       flushSessionToSpace, pushMoved,
+      // Idempotent + no-op for non-native ids, so the holder flow calls it
+      // unconditionally without needing to know the provider.
+      destroyNative: (id) => nativeHost.destroy(id),
     });
     // Fire-and-forget from a hub event — the handler never throws (each step is
     // try/caught inside createHolderTakeover), so void is safe.
@@ -2321,6 +2340,17 @@ export function registerIpcHandlers(
   // Stop watching when a session is destroyed
   sessionManager.on('session-exit', (sessionId: string) => {
     teardownSessionWatchers(sessionId);
+    // Native teardown backstop (2026-07-18). SESSION_DESTROY already awaits
+    // nativeHost.destroy before destroySession, but session-exit ALSO fires for
+    // paths that go straight to SessionManager (a crashed worker, a takeover, an
+    // internal destroy) — and for a native session those left the HarnessSession
+    // running with its transcript-event listener still appending. Idempotent and
+    // a no-op for non-native ids, so calling it here is free on the CC path.
+    // Fire-and-forget: this listener is sync, and destroy() never rejects for an
+    // unknown id — the .catch guards a future change.
+    void nativeHost.destroy(sessionId).catch((e) => {
+      log('ERROR', 'IPC', 'native teardown on session-exit failed', { sessionId, error: String(e) });
+    });
     // Clean up context + session stats cache files
     const claudeId = sessionIdMap.get(sessionId);
     if (claudeId) {
@@ -2350,6 +2380,27 @@ export function registerIpcHandlers(
   // store) or a desktop session ID — the desktop ID is resolved via
   // sessionIdMap. Unknown flag names are rejected server-side so a typo
   // surfaces as an error rather than silently writing dead data.
+  //
+  // Phantom-record gate, PART 2 (2026-07-18). The original gate below keys off
+  // `sessionIdMap.has(sessionId)`, which was a reliable "this is a CC id" proxy
+  // only while native sessions stayed out of that map. PR #176 started mapping
+  // native sessions (identity, for the lease), which silently opened the exact
+  // hole the gate was written to close — for NATIVE ids this time. setFlag /
+  // setTitle / setNote all SEED a record when none exists (conversation-store.ts),
+  // each with a hardcoded provider:'claude', so flagging or noting a native
+  // session wrote a mislabeled record with blank projectName / originalPath /
+  // transcriptRef and an EPOCH lastActive — synced to every device and never
+  // pruned (flagged records are deliberately kept). Confirmed on disk 2026-07-18.
+  //
+  // Native conversations do not participate in the store at all until the parity
+  // work lands (v1.3.1 — docs/active/specs/2026-07-18-native-sync-parity-design.md),
+  // so the correct answer today is to write nothing. Checked against BOTH live and
+  // persisted native ids: a past native session opened from the Resume Browser is
+  // not live, but must not seed a record either.
+  const canWriteStoreRecord = (sessionId: string, resolved: string): boolean => {
+    if (nativeHost.isNativeSessionId(resolved)) return false;
+    return sessionIdMap.has(sessionId) || !sessionManager.getSession(sessionId);
+  };
   ipcMain.handle(IPC.SESSION_SET_FLAG, async (_event, sessionId: string, flag: string, value: boolean) => {
     if (!SESSION_FLAG_NAMES.includes(flag as SessionFlagName)) {
       return { ok: false, error: `unknown flag: ${flag}` };
@@ -2373,7 +2424,7 @@ export function registerIpcHandlers(
       // flag re-applies once the SessionStart hook establishes the mapping and
       // the user (or a re-flag) drives it again — flags are store-only now,
       // so there's no legacy index still catching it in the meantime.
-      if (sessionIdMap.has(sessionId) || !sessionManager.getSession(sessionId)) {
+      if (canWriteStoreRecord(sessionId, resolved)) {
         noteFlagChanged(resolved, flag, !!value);
       }
       const payload = { flag, value: !!value };
@@ -2443,8 +2494,10 @@ export function registerIpcHandlers(
     const key = tagFlagKey(tagId);
     try {
       // Same phantom-record gate as SESSION_SET_FLAG: only write the store when
-      // `resolved` is a known CLAUDE id or a non-live session.
-      if (sessionIdMap.has(sessionId) || !sessionManager.getSession(sessionId)) {
+      // `resolved` is a known CLAUDE id or a non-live session, and never for a
+      // native session. (Tags are stored as `tag:<id>` flags, so this is the path
+      // that made "tag a native session" seed a phantom CC record.)
+      if (canWriteStoreRecord(sessionId, resolved)) {
         noteFlagChanged(resolved, key, !!value);
       }
       const payload = { flag: key, value: !!value };
@@ -2460,7 +2513,7 @@ export function registerIpcHandlers(
     const text = String(note ?? '');
     if (text.length > 8000) return { ok: false, error: 'note exceeds 8000 characters' };
     try {
-      if (sessionIdMap.has(sessionId) || !sessionManager.getSession(sessionId)) {
+      if (canWriteStoreRecord(sessionId, resolved)) {
         noteSessionNote(resolved, text);
       }
       const payload = { note: text };

--- a/desktop/tests/conversation-store.test.ts
+++ b/desktop/tests/conversation-store.test.ts
@@ -231,6 +231,46 @@ describe('createConversationStore', () => {
     expect(noHealingLeftovers(path.join(tmp, 'claude'))).toBe(true);
   });
 
+  // Contract 5b: remove() — the store's ONLY destructive operation (added
+  // 2026-07-18 for the native phantom-record cleanup).
+  //
+  // The load-bearing part is that it sweeps CONFLICT COPIES too, not just the
+  // canonical. heal() seeds a canonical FROM a copy when none exists, so a
+  // remove that deleted only `<id>.json` would be silently undone by the very
+  // next get()/list() — the delete would report success and the record would
+  // reappear (and re-sync) moments later.
+  it('remove deletes the canonical AND its conflict copies, so heal cannot resurrect it', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1' }));
+    stage(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json', recJson({ id: 'sess-1' }));
+    stage(tmp, 'claude', 'sess-1 (from Desktop, 2026-07-04).json', recJson({ id: 'sess-1' }));
+    // A DIFFERENT record and its copy must survive untouched.
+    stage(tmp, 'claude', 'sess-2.json', recJson({ id: 'sess-2' }));
+    stage(tmp, 'claude', 'sess-2 (from Laptop, 2026-07-03).json', recJson({ id: 'sess-2' }));
+
+    expect(await store.remove('claude', 'sess-1')).toBe(true);
+
+    // Gone from disk — canonical and both copies.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1.json'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from Laptop, 2026-07-03).json'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1 (from Desktop, 2026-07-04).json'))).toBe(false);
+    // THE POINT: a read runs heal first — it must not rebuild the record.
+    expect(await store.get('claude', 'sess-1')).toBeNull();
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1.json'))).toBe(false);
+
+    // The neighbour is intact and still heals normally.
+    expect(await store.get('claude', 'sess-2')).not.toBeNull();
+  });
+
+  it('remove reports false for an unknown id and refuses unsafe segments', async () => {
+    stage(tmp, 'claude', 'sess-1.json', recJson({ id: 'sess-1' }));
+    expect(await store.remove('claude', 'nope')).toBe(false);
+    // Path-escape attempts are refused, not resolved — same guard as get/list.
+    expect(await store.remove('claude', '../../etc/passwd')).toBe(false);
+    expect(await store.remove('..', 'sess-1')).toBe(false);
+    // The real record is untouched by any of the above.
+    expect(fs.existsSync(path.join(tmp, 'claude', 'sess-1.json'))).toBe(true);
+  });
+
   // Contract 6: the healer only touches RECORD conflict copies (.json), never a
   // non-record conflict copy, and never reaches into another provider's dir.
   it('heal ignores non-record conflict copies and never crosses providers', async () => {

--- a/desktop/tests/conversations-service.test.ts
+++ b/desktop/tests/conversations-service.test.ts
@@ -25,6 +25,10 @@ const h = vi.hoisted(() => {
       list: vi.fn(async (_provider: string): Promise<any[]> => []),
       setFlag: vi.fn(async () => {}),
       setTitle: vi.fn(async () => {}),
+      setNote: vi.fn(async () => {}),
+      // The store's only destructive op — used solely by the native
+      // phantom-record cleanup (2026-07-18).
+      remove: vi.fn(async (_provider: string, _id: string) => true),
       root: vi.fn(() => ''),
     },
     // Default reconciler NEVER resolves — that's how the non-blocking-start test
@@ -80,6 +84,7 @@ function fireSync(e: any): void {
 
 async function freshService(opts?: {
   conversationsRoot?: string; projectsDir?: string; topicsDir?: string; device?: string;
+  nativeHomeRoot?: string;
 }) {
   vi.resetModules();
   const svc = await import('../src/main/conversations/service');
@@ -102,6 +107,8 @@ describe('conversations service composition root', () => {
     h.store.list.mockReset().mockResolvedValue([]);
     h.store.setFlag.mockReset().mockResolvedValue(undefined as any);
     h.store.setTitle.mockReset().mockResolvedValue(undefined as any);
+    h.store.setNote.mockReset().mockResolvedValue(undefined as any);
+    h.store.remove.mockReset().mockResolvedValue(true as any);
     h.reconcile.mockReset().mockImplementation(() => new Promise<number>(() => {}));
     h.mirrorIn.mockReset().mockReturnValue({ copied: true } as any);
     h.materializeOut.mockReset().mockReturnValue({ copied: true } as any);
@@ -596,6 +603,75 @@ describe('conversations service composition root', () => {
     await new Promise((r) => setTimeout(r, 10));
     // World keeps turning: the prompt push still fired despite the upsert reject.
     expect(h.syncSpacesSyncNow).toHaveBeenCalledWith('personal');
+  });
+
+  // --- Native phantom-record cleanup (2026-07-18) -------------------------
+  //
+  // PR #176 started mapping native sessions in sessionIdMap, which defeated the
+  // phantom-record gate in ipc-handlers: flagging or noting a NATIVE session
+  // seeded a record under claude/ with a hardcoded provider and blank metadata,
+  // which synced everywhere and was never pruned. These pin the cleanup that
+  // clears the ones already written — and, just as importantly, that it does
+  // NOT touch anything else (it is the store's only destructive caller).
+  describe('pruneNativePhantomRecords', () => {
+    // A record with the phantom signature: blank refs/metadata, EPOCH lastActive.
+    const phantom = (id: string) => ({
+      schema: 1, id, provider: 'claude', projectName: '', originalPath: '', title: '',
+      lastActive: '1970-01-01T00:00:00.000Z', device: '', flags: { complete: { value: true, updatedAt: 'x' } },
+      transcriptRef: '', createdAt: 'x', note: '', noteUpdatedAt: 'x',
+    });
+    // Lay down ~/.youcoded/sessions/<slug>/<id>.jsonl so the id reads as native.
+    function seedNativeSession(homeRoot: string, id: string) {
+      const dir = path.join(homeRoot, '.youcoded', 'sessions', 'proj-slug');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, `${id}.jsonl`), '{"v":1}\n');
+    }
+
+    it('removes a phantom whose id is a real native session', async () => {
+      const homeRoot = path.join(tmpRoot, 'nh-hit');
+      seedNativeSession(homeRoot, 'native-1');
+      h.store.list.mockResolvedValue([phantom('native-1')]);
+      const svc = await freshService({ ...startOpts(), nativeHomeRoot: homeRoot });
+      const pruned = await svc.pruneNativePhantomRecords({ nativeHomeRoot: homeRoot });
+      expect(pruned).toBe(1);
+      expect(h.store.remove).toHaveBeenCalledWith('claude', 'native-1');
+    });
+
+    it('leaves a phantom-shaped record alone when no native session file exists', async () => {
+      const homeRoot = path.join(tmpRoot, 'nh-miss');
+      fs.mkdirSync(homeRoot, { recursive: true });   // exists, but no sessions
+      h.store.list.mockResolvedValue([phantom('not-native')]);
+      const svc = await freshService({ ...startOpts(), nativeHomeRoot: homeRoot });
+      // The shape alone must never be enough — confirmation that the id IS
+      // native is what separates junk from a record we simply can't explain.
+      expect(await svc.pruneNativePhantomRecords({ nativeHomeRoot: homeRoot })).toBe(0);
+      expect(h.store.remove).not.toHaveBeenCalled();
+    });
+
+    it('never removes a record carrying real data, even for a native id', async () => {
+      const homeRoot = path.join(tmpRoot, 'nh-real');
+      seedNativeSession(homeRoot, 'native-2');
+      h.store.list.mockResolvedValue([
+        // Each of these differs from the phantom signature by ONE field. All must survive.
+        { ...phantom('native-2'), transcriptRef: 'claude/transcripts/p/native-2.jsonl' },
+        { ...phantom('native-2'), projectName: 'youcoded-dev' },
+        { ...phantom('native-2'), originalPath: '/home/d/p' },
+        { ...phantom('native-2'), lastActive: '2026-07-18T00:00:00.000Z' },
+      ]);
+      const svc = await freshService({ ...startOpts(), nativeHomeRoot: homeRoot });
+      expect(await svc.pruneNativePhantomRecords({ nativeHomeRoot: homeRoot })).toBe(0);
+      expect(h.store.remove).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — a second pass finds nothing', async () => {
+      const homeRoot = path.join(tmpRoot, 'nh-idem');
+      seedNativeSession(homeRoot, 'native-3');
+      h.store.list.mockResolvedValue([phantom('native-3')]);
+      const svc = await freshService({ ...startOpts(), nativeHomeRoot: homeRoot });
+      expect(await svc.pruneNativePhantomRecords({ nativeHomeRoot: homeRoot })).toBe(1);
+      h.store.list.mockResolvedValue([]);   // the record is gone now
+      expect(await svc.pruneNativePhantomRecords({ nativeHomeRoot: homeRoot })).toBe(0);
+    });
   });
 
   // Guard: no managed roots + no explicit root → store stays off (no reconcile).

--- a/desktop/tests/handoff-timing-contract.test.ts
+++ b/desktop/tests/handoff-timing-contract.test.ts
@@ -1,0 +1,45 @@
+// Pins the arithmetic relationship between the three coupled handoff constants.
+//
+// A takeover has the holder do two slow things in sequence before it releases
+// the lease: wait for the interrupted turn to stop growing the transcript
+// (QUIESCE_MAX_MS), then genuinely await the personal-space git push
+// (HANDOFF_SYNC_TIMEOUT_MS). Meanwhile the requester polls for the release and
+// gives up after REQUESTER_MAX_MS, at which point it offers the user a FORCE.
+//
+// So the requester's budget must exceed the holder's worst-case cost, or a
+// perfectly healthy handoff trips the force dialog — which is exactly the bug
+// PR #176 fixed by raising the budget 10s -> 25s once the push became awaited.
+//
+// Until now this coupling lived only in prose comments at all three definition
+// sites (2026-07-18 review: "documented in comments at all three sites, pinned
+// by no test"). Prose does not fail CI. Lowering any one of these — or raising
+// either holder cost — now breaks this test instead of silently re-introducing
+// a force dialog on healthy holders.
+import { describe, it, expect } from 'vitest';
+import { QUIESCE_MAX_MS, HANDOFF_SYNC_TIMEOUT_MS } from '../src/main/conversations/service';
+import { REQUESTER_MAX_MS } from '../src/main/conversations/takeover';
+
+describe('handoff timing contract', () => {
+  it('the requester budget exceeds the holder worst case (quiesce + awaited push)', () => {
+    const holderWorstCase = QUIESCE_MAX_MS + HANDOFF_SYNC_TIMEOUT_MS;
+    expect(REQUESTER_MAX_MS).toBeGreaterThan(holderWorstCase);
+  });
+
+  it('keeps a real slack margin, not a hairline pass', () => {
+    // A budget that only just clears the sum leaves nothing for poll granularity
+    // (1s), hub round-trips, or a slow disk — the force dialog would fire on
+    // healthy-but-unlucky handoffs. 2s is the minimum margin the current values
+    // were chosen to preserve (25_000 - 21_000 = 4_000).
+    const slack = REQUESTER_MAX_MS - (QUIESCE_MAX_MS + HANDOFF_SYNC_TIMEOUT_MS);
+    expect(slack).toBeGreaterThanOrEqual(2_000);
+  });
+
+  it('documents the values these fixes were sized against', () => {
+    // Not a style assertion — a tripwire. If someone retunes a constant, this
+    // failure points them at the comment blocks explaining WHY it was that value
+    // (PR #176: the old 10s budget predated the push actually being awaited).
+    expect(QUIESCE_MAX_MS).toBe(6_000);
+    expect(HANDOFF_SYNC_TIMEOUT_MS).toBe(15_000);
+    expect(REQUESTER_MAX_MS).toBe(25_000);
+  });
+});

--- a/desktop/tests/holder-takeover.test.ts
+++ b/desktop/tests/holder-takeover.test.ts
@@ -31,6 +31,13 @@ function makeDeps(opts?: { liveDesktopIds?: string[]; flushRejects?: boolean }) 
       if (opts?.flushRejects) throw new Error('flush blew up');
     }),
     pushMoved: vi.fn((did: string, device?: string) => { order.push(`push:${did}:${device ?? ''}`); }),
+    // Native teardown. In production this is nativeHost.destroy — idempotent and a
+    // no-op for non-native ids. It MUST be in the fake bundle: every step in the
+    // handler is individually try/caught, so an absent dep throws into a
+    // best-effort catch and the suite goes green on a teardown that never ran
+    // (the same "the suite certifies the bug" trap that hid the missing native
+    // interrupt — 2026-07-18 review).
+    destroyNative: vi.fn(async (did: string) => { order.push(`destroyNative:${did}`); }),
   };
   return deps;
 }
@@ -50,7 +57,8 @@ describe('createHolderTakeover', () => {
       'flush:claude-abc',
       'release:claude-abc',
       'push:desktop-1:Laptop-B',       // desktopId reverse-mapped, from.device forwarded
-      'destroy:desktop-1',
+      'destroyNative:desktop-1',       // native teardown BEFORE destroySession...
+      'destroy:desktop-1',             // ...matching the sanctioned SESSION_DESTROY order
     ]);
     // The reverse-map picked the correct desktop id, not desktop-2.
     expect(deps.sessionManager.sendInput).toHaveBeenCalledWith('desktop-1', '\x1b');
@@ -103,6 +111,7 @@ describe('createHolderTakeover', () => {
       'flush:c1',
       'release:c1',
       'push:d1:X',     // from.device still forwarded despite the flush reject
+      'destroyNative:d1',
       'destroy:d1',
     ]);
   });
@@ -117,7 +126,46 @@ describe('createHolderTakeover', () => {
     await expect(handler('c1', { deviceId: 'x', device: 'X' })).resolves.toBeUndefined();
     // Step 8 still runs after the guarded push throw — no half-done handoff.
     expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d1');
-    expect(deps.order).toEqual(['interrupt:d1:"\\u001b"', 'flush:c1', 'release:c1', 'push:d1', 'destroy:d1']);
+    expect(deps.order).toEqual(['interrupt:d1:"\\u001b"', 'flush:c1', 'release:c1', 'push:d1', 'destroyNative:d1', 'destroy:d1']);
+  });
+
+  // 2026-07-18 (investigation Break 4). destroySession alone tears down the PTY
+  // half only. For a NATIVE session that left the in-process HarnessSession alive
+  // with its transcript-event listener still attached — an un-aborted stream, a
+  // leaked model ref-count, and a second writer on the transcript JSONL.
+  it('awaits the native teardown before destroySession, for every live holder', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['d1', 'd2'] });
+    // A create+resume pair maps TWO desktop ids to one claude id — both must be
+    // torn down natively, not just the first.
+    deps.sessionIdMap.set('d1', 'c1');
+    deps.sessionIdMap.set('d2', 'c1');
+    // Make the native teardown genuinely async so an un-awaited call would let
+    // destroySession land first and reorder the log.
+    (deps.destroyNative as any) = vi.fn(async (did: string) => {
+      await new Promise((r) => setTimeout(r, 5));
+      deps.order.push(`destroyNative:${did}`);
+    });
+    const handler = createHolderTakeover(deps as any);
+    await handler('c1', { deviceId: 'x', device: 'X' });
+
+    expect(deps.destroyNative).toHaveBeenCalledWith('d1');
+    expect(deps.destroyNative).toHaveBeenCalledWith('d2');
+    for (const id of ['d1', 'd2']) {
+      const iNative = deps.order.indexOf(`destroyNative:${id}`);
+      const iDestroy = deps.order.indexOf(`destroy:${id}`);
+      expect(iNative).toBeGreaterThanOrEqual(0);
+      expect(iDestroy).toBeGreaterThan(iNative); // stop the appending source FIRST
+    }
+  });
+
+  it('still destroys the session when the native teardown rejects', async () => {
+    const deps = makeDeps({ liveDesktopIds: ['d1'] });
+    deps.sessionIdMap.set('d1', 'c1');
+    (deps.destroyNative as any) = vi.fn(async () => { throw new Error('harness teardown blew up'); });
+    const handler = createHolderTakeover(deps as any);
+    await expect(handler('c1', { deviceId: 'x', device: 'X' })).resolves.toBeUndefined();
+    // A failed native teardown must not strand a live SessionManager entry.
+    expect(deps.sessionManager.destroySession).toHaveBeenCalledWith('d1');
   });
 
   it('never throws even when the lease release rejects', async () => {

--- a/desktop/tests/native-session-host.test.ts
+++ b/desktop/tests/native-session-host.test.ts
@@ -139,6 +139,53 @@ describe('NativeSessionHost', () => {
     await midHost.destroyAll();
   });
 
+  // SINGLE-WRITER GUARD (2026-07-18, investigation Break 4). resume() used to
+  // wire a fresh HarnessSession without touching an existing live one. wire()
+  // overwrites this.live's entry, but the ORPHAN's transcript-event listener
+  // closes over the OLD entry — so it kept appending to the same JSONL, giving
+  // two writers unordered against each other (native-home.ts:5-7 says session
+  // files are single-writer by design, which is why they carry no file lock).
+  //
+  // Asserts on APPEND CALLS, not on map state: the map entry is not what keeps
+  // the orphan alive, so a map-shaped assertion would pass on the broken code.
+  it('resume() on an id that is still live destroys the orphan — no second writer', async () => {
+    const store = new SessionStore(new NativeHome(root));
+    const appends: string[] = [];
+    const realAppend = store.append.bind(store);
+    vi.spyOn(store, 'append').mockImplementation(async (cwd, event) => {
+      appends.push(event.type);
+      return realAppend(cwd, event);
+    });
+    // delayedFactory trickles chunks, so the first turn is genuinely mid-stream
+    // when resume lands — the exact window where an orphan does its damage.
+    const orphanHost = new NativeSessionHost(store, delayedFactory, async () => null);
+    const gotDelta = new Promise<void>((res) => {
+      orphanHost.on('transcript-event', (e) => { if (e.type === 'assistant-text') res(); });
+    });
+    await orphanHost.create({ sessionId: 's-orphan', cwd: root, binding: { providerId: 'openrouter', modelId: 'm' } });
+    const p = orphanHost.send('s-orphan', 'hi'); // don't await — resume mid-stream
+    await gotDelta;
+
+    // Resume the SAME id while it is live. This is what a takeover-orphaned
+    // session did on the next open.
+    const resumed = await orphanHost.resume('s-orphan', root);
+    expect(resumed).toBe(true);
+    await expect(p).resolves.toBe(true); // the interrupted send still settles cleanly
+
+    // Everything the old session could still have written must already be done:
+    // resume() awaits destroy(), which aborts the stream, drains the append chain
+    // and flushes the open part. Give the old stream's remaining chunk delays
+    // (15ms each) generous room to fire if the abort did NOT take.
+    const afterResume = appends.length;
+    await new Promise((r) => setTimeout(r, 120));
+    expect(appends.length).toBe(afterResume); // the orphan wrote nothing more
+
+    // And the file is a coherent single-writer transcript, not an interleave.
+    const events = store.readEvents('s-orphan', root);
+    expect(events.map((e) => e.type)).toEqual(['user-message', 'assistant-text']);
+    await orphanHost.destroyAll();
+  });
+
   it('a failed append does not wedge the chain — later events still persist', async () => {
     const store = new SessionStore(new NativeHome(root));
     const realAppend = store.append.bind(store);

--- a/desktop/tests/session-store.test.ts
+++ b/desktop/tests/session-store.test.ts
@@ -215,4 +215,27 @@ describe('SessionStore', () => {
     const events = store.readEvents('s-1', HEADER.cwd);
     expect((events[0] as any).data).toMatchObject({ text: 'Hello!', partId: 'p1' });
   });
+
+  // has() backs the phantom-record gate (2026-07-18): ipc-handlers asks "is this
+  // id native?" before letting a flag/note seed a conversation-store record.
+  // It must answer for PERSISTED sessions, not just live ones — a past native
+  // session opened from the Resume Browser is not live but must still be
+  // recognized, which is the case isNative()/this.live cannot answer.
+  describe('has', () => {
+    it('finds a persisted session regardless of which project it lives under', async () => {
+      await store.create(HEADER);
+      expect(store.has('s-1')).toBe(true);
+    });
+
+    it('is false for an unknown id, and does not require the session to be live', async () => {
+      await store.create(HEADER);
+      expect(store.has('never-existed')).toBe(false);
+      // Nothing here is "live" — the store has no concept of liveness — so a
+      // true answer above proves the check is disk-backed, not registry-backed.
+    });
+
+    it('is false when no sessions directory exists at all', () => {
+      expect(store.has('s-1')).toBe(false); // no create() call in this test
+    });
+  });
 });


### PR DESCRIPTION
The v1.3 gate from the native-sync design review — correctness only. Full parity (making native conversations real store citizens) is deferred to v1.3.1, blocked on a design decision about model-binding portability.

## What broke

PR #176 enrolled native-provider sessions in the lease system. The observation was right — native sessions genuinely had no takeover protection — but native conversations don't participate in the conversation store or space sync at all, so every step the lease implies is a no-op for them. A takeover destroyed the holder's live session and transferred nothing.

## The three fixes

**1. Orphaned harness — data corruption.** `resume()` wired a fresh `HarnessSession` without touching one already live under the same id. `wire()` overwrites the `this.live` entry, but the orphan's `transcript-event` listener closes over the *old* entry, so it kept appending — two writers on one JSONL, unordered against each other, against the single-writer invariant at `native-home.ts:5-7` that justifies the absence of a file lock.

The load-bearing fix is in `resume()` (and `create()`, the other `wire()` entry point), not the callers — `resume` was unguarded against an orphan from *any* source. `takeover.ts` also gains an injected `destroyNative` awaited before `destroySession`, and `session-exit` gets the same teardown as a backstop.

**2. Phantom `claude/` records — found in review, not in the investigation.** `SESSION_SET_FLAG`'s phantom-record gate keys off `sessionIdMap.has()`, a valid "this is a CC id" proxy only while native sessions stayed out of that map. #176 started mapping them, silently opening the exact hole the gate was written to close. `setFlag`/`setTitle`/`setNote` all *seed* a record when none exists with a hardcoded `provider:'claude'` — so flagging, tagging or noting a native session wrote a mislabeled record with blank metadata that syncs everywhere and is never pruned. **Confirmed on disk.**

Gates all three write sites, plus a conservative one-shot startup cleanup for records already written (blank refs AND blank metadata AND EPOCH `lastActive` AND a confirmed native session file — it drives the store's only destructive op, and a false positive would delete a real record on every synced device). `store.remove()` sweeps conflict copies too, because `heal()` reseeds a canonical from a copy — deleting only the canonical would silently undo itself on the next read.

**3. Gate the native lease acquire.** A lease serializes access to a *shared* resource; until native transcripts sync there isn't one. Not taking it is the honest state. Restores pre-#176 behavior.

## Tests

- The orphan pin asserts on **append calls, not map state** — the map entry isn't what keeps the orphan alive, so a map-shaped assertion passes on the broken code. Verified it fails without the fix.
- `holder-takeover`'s fake bundle gains `destroyNative`. It had to: every step is individually try/caught, so an absent dep throws into a best-effort catch and the suite goes green on a teardown that never ran — the same "suite certifies the bug" trap that hid the missing native interrupt.
- New `handoff-timing-contract.test.ts` pins the arithmetic between the three coupled handoff constants (6s quiesce + 15s push < 25s requester budget), which lived only in prose comments at three separate sites.

Full suite green (2651 passed), `tsc` clean. `npm run build` compiles and bundles; only the RPM packaging step fails locally for a missing `rpmbuild`.

Spec: `docs/active/specs/2026-07-18-native-sync-parity-design.md` §3

🤖 Generated with [Claude Code](https://claude.com/claude-code)