### PR TITLE
fix(harness): scoped cwd persistence was broken on Windows + run CI there

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -11,7 +11,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Windows runs the TESTS only (not the packaging build) because a whole
+    # class of bug is invisible on Linux: Git Bash path semantics, MSYS mounts,
+    # drive-relative resolution, CRLF. This job was ubuntu-only, so PR #174's
+    # scoped-cwd-persistence tests never ran on Windows and merged green while
+    # broken there — first seen 2026-07-19, at BETA-BUILD time, because
+    # desktop-test-build.yml was the only workflow with a Windows runner.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: desktop
@@ -38,7 +48,11 @@ jobs:
       # bsdtar-missing failure. Mirror desktop-release.yml's setup step:
       #   libarchive-tools -> provides bsdtar, required by the pacman target
       #   rpm              -> required by the rpm target
+      # Packaging is Linux-only here: the deb/rpm/pacman targets are what CI
+      # regressed on before, and the Windows NSIS build is already covered by
+      # desktop-test-build.yml / desktop-release.yml. Windows stops after tests.
       - name: Install Linux build deps
+        if: runner.os == 'Linux'
         # apt-get update prefix: the cached package index on ubuntu-latest
         # frequently points to .deb versions that have already rolled off
         # the mirror, so a bare `install` fails with HTTP 404 / exit 100.
@@ -47,4 +61,5 @@ jobs:
         working-directory: .
 
       - name: Build
+        if: runner.os == 'Linux'
         run: npm run build

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -67,6 +67,18 @@ export function extractCwd(out: string): { text: string; cwd: string | null } {
  *  workspace root doesn't read as "outside itself". */
 function isInside(root: string, candidate: string): boolean {
   const real = (p: string) => {
+    // .native FIRST: plain realpathSync does NOT expand Windows 8.3 short names.
+    // ctx.cwd arrives short (C:\Users\RUNNER~1\...) while `pwd -W` may report the
+    // SAME directory long (C:\Users\runneradmin\...), so startsWith() judged a
+    // plain `cd sub` "outside the workspace" and the scope guard reverted EVERY
+    // cd on Windows — persistence looked broken and each call emitted a bogus
+    // reset notice. .native canonicalizes both sides via GetFinalPathNameByHandle.
+    // Confirmed on windows-latest 2026-07-19 (short/long forms observed side by side).
+    try {
+      return fs.realpathSync.native(p);
+    } catch {
+      /* not on disk (yet) — fall back */
+    }
     try {
       return fs.realpathSync(p);
     } catch {

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -272,13 +272,23 @@ describe('Bash', () => {
       return c;
     }
 
+    // Must mirror withCwdProbe()'s `pwd -W 2>/dev/null || pwd` — a bare `pwd`
+    // makes these assertions fail on WINDOWS ONLY. Git Bash mounts %TEMP% at
+    // /tmp, so inside a mkdtemp sandbox bare `pwd` prints /tmp/native-tools-xxx;
+    // fs.realpathSync() then resolves that leading slash against the runner's
+    // CURRENT DRIVE (D: on GitHub's windows-latest) -> ENOENT 'D:\tmp'. `pwd -W`
+    // is the MSYS builtin that emits a real Win32 path instead. Broke the
+    // 2026-07-19 beta build; the tool itself was never wrong. (POSIX: -W is
+    // invalid, the `|| pwd` fallback takes over, stderr suppressed.)
+    const PWD = 'pwd -W 2>/dev/null || pwd';
+
     it('a cd carries to the next call and the sentinel never reaches the model', async () => {
       fs.mkdirSync(path.join(dir, 'sub'));
       const c = trackingCtx(dir);
       const first = await BashTool.execute({ command: 'cd sub && echo moved' }, c);
       expect(first.text).toContain('moved');
       expect(first.text).not.toContain('__YC_CWD__');
-      const second = await BashTool.execute({ command: 'pwd' }, c);
+      const second = await BashTool.execute({ command: PWD }, c);
       expect(fs.realpathSync(second.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
     });
 
@@ -286,7 +296,7 @@ describe('Bash', () => {
       const c = trackingCtx(dir);
       const r = await BashTool.execute({ command: `cd ${JSON.stringify(os.tmpdir())}` }, c);
       expect(r.text).toMatch(/Shell cwd was reset to/);
-      const after = await BashTool.execute({ command: 'pwd' }, c);
+      const after = await BashTool.execute({ command: PWD }, c);
       expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(dir));
     });
 
@@ -302,7 +312,7 @@ describe('Bash', () => {
       const c = trackingCtx(dir);
       await BashTool.execute({ command: 'cd gone' }, c);
       fs.rmSync(gone, { recursive: true });
-      const r = await BashTool.execute({ command: 'pwd' }, c);
+      const r = await BashTool.execute({ command: PWD }, c);
       expect(r.isError).toBeFalsy();
       expect(fs.realpathSync(r.text.trim())).toBe(fs.realpathSync(dir));
     });
@@ -331,7 +341,7 @@ describe('Bash', () => {
         { command: `cd sub && node -e "for(let i=0;i<3000;i++)console.log('X'.repeat(100))"` },
         c,
       );
-      const after = await BashTool.execute({ command: 'pwd' }, c);
+      const after = await BashTool.execute({ command: PWD }, c);
       expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
     });
 

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -282,6 +282,19 @@ describe('Bash', () => {
     // invalid, the `|| pwd` fallback takes over, stderr suppressed.)
     const PWD = 'pwd -W 2>/dev/null || pwd';
 
+    // Same 8.3 trap the tool itself hit: plain fs.realpathSync leaves a SHORT
+    // root (C:\Users\RUNNER~1\...) short while `pwd -W` reports the LONG form
+    // (C:\Users\runneradmin\...) for the very same directory, so comparing the
+    // two never matches on Windows. .native canonicalizes both. Compare paths
+    // through this, never through raw realpathSync.
+    const canon = (p: string) => {
+      try {
+        return fs.realpathSync.native(p);
+      } catch {
+        return fs.realpathSync(p);
+      }
+    };
+
     it('a cd carries to the next call and the sentinel never reaches the model', async () => {
       fs.mkdirSync(path.join(dir, 'sub'));
       const c = trackingCtx(dir);
@@ -295,7 +308,7 @@ describe('Bash', () => {
       // assertions below can't catch that alone — they expect the ROOT, which is
       // also what a fully broken persistence returns, so they passed vacuously.
       expect(first.text).not.toMatch(/Shell cwd was reset/);
-      expect(fs.realpathSync(second.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
+      expect(canon(second.text.trim())).toBe(canon(path.join(dir, 'sub')));
     });
 
     it('a cd outside the workspace is reverted WITH a notice (never silent)', async () => {
@@ -303,7 +316,7 @@ describe('Bash', () => {
       const r = await BashTool.execute({ command: `cd ${JSON.stringify(os.tmpdir())}` }, c);
       expect(r.text).toMatch(/Shell cwd was reset to/);
       const after = await BashTool.execute({ command: PWD }, c);
-      expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(dir));
+      expect(canon(after.text.trim())).toBe(canon(dir));
     });
 
     it('the probe preserves the command exit code', async () => {
@@ -320,7 +333,7 @@ describe('Bash', () => {
       fs.rmSync(gone, { recursive: true });
       const r = await BashTool.execute({ command: PWD }, c);
       expect(r.isError).toBeFalsy();
-      expect(fs.realpathSync(r.text.trim())).toBe(fs.realpathSync(dir));
+      expect(canon(r.text.trim())).toBe(canon(dir));
     });
 
     // Regression (2026-07-18): without a trailing newline after the sentinel, a
@@ -348,7 +361,7 @@ describe('Bash', () => {
         c,
       );
       const after = await BashTool.execute({ command: PWD }, c);
-      expect(fs.realpathSync(after.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
+      expect(canon(after.text.trim())).toBe(canon(path.join(dir, 'sub')));
     });
 
     // Regression (2026-07-18): a dangling `&&` absorbs the probe's `__yc_rc=$?`

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -289,6 +289,18 @@ describe('Bash', () => {
       expect(first.text).toContain('moved');
       expect(first.text).not.toContain('__YC_CWD__');
       const second = await BashTool.execute({ command: PWD }, c);
+      // TEMP DIAGNOSTIC (2026-07-19) — remove before merge. vitest swallows
+      // console.log here, so the payload rides on expect()'s message arg.
+      const diag = `DIAG ${JSON.stringify({
+        firstText: first.text,
+        shellCwd: c.shellCwd ?? null,
+        root: dir,
+        rootReal: fs.realpathSync(dir),
+        second: second.text.trim(),
+      })}`;
+      // A cd INTO a workspace subdir must never trip the scope guard. If this
+      // fires, `reported` is being judged outside ctx.cwd -> isInside() is the bug.
+      expect(first.text, diag).not.toMatch(/Shell cwd was reset/);
       expect(fs.realpathSync(second.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
     });
 

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -289,18 +289,12 @@ describe('Bash', () => {
       expect(first.text).toContain('moved');
       expect(first.text).not.toContain('__YC_CWD__');
       const second = await BashTool.execute({ command: PWD }, c);
-      // TEMP DIAGNOSTIC (2026-07-19) — remove before merge. vitest swallows
-      // console.log here, so the payload rides on expect()'s message arg.
-      const diag = `DIAG ${JSON.stringify({
-        firstText: first.text,
-        shellCwd: c.shellCwd ?? null,
-        root: dir,
-        rootReal: fs.realpathSync(dir),
-        second: second.text.trim(),
-      })}`;
-      // A cd INTO a workspace subdir must never trip the scope guard. If this
-      // fires, `reported` is being judged outside ctx.cwd -> isInside() is the bug.
-      expect(first.text, diag).not.toMatch(/Shell cwd was reset/);
+      // A cd INTO a workspace subdir must never trip the scope guard. Windows-only
+      // regression (2026-07-19): isInside() compared an 8.3 SHORT root against a
+      // LONG candidate, so this fired on every cd and reverted it. The two
+      // assertions below can't catch that alone — they expect the ROOT, which is
+      // also what a fully broken persistence returns, so they passed vacuously.
+      expect(first.text).not.toMatch(/Shell cwd was reset/);
       expect(fs.realpathSync(second.text.trim())).toBe(fs.realpathSync(path.join(dir, 'sub')));
     });
 


### PR DESCRIPTION
## What

Scoped cwd persistence (#174) never worked on Windows. Found while building the 2026-07-19 beta, which failed its Windows job.

## Root cause

`fs.realpathSync` does **not** expand Windows 8.3 short names. `ctx.cwd` arrives short (`C:\Users\RUNNER~1\...`) while `pwd -W` reports the same directory long (`C:\Users\runneradmin\...`), so `isInside()`'s `startsWith` check said a plain `cd sub` was *outside the workspace*. The scope guard reverted every `cd` and emitted a spurious "Shell cwd was reset" notice on each call.

Captured live on a windows-latest runner:

```
reported: C:/Users/runneradmin/AppData/Local/Temp/native-tools-k3wYU7/sub
ctx.cwd:  C:\Users\RUNNER~1\AppData\Local\Temp\native-tools-k3wYU7
-> "Shell cwd was reset to ... (.../sub is outside the workspace)"
```

## Fix

- `isInside()` resolves via `fs.realpathSync.native` (GetFinalPathNameByHandle), which canonicalizes both sides to the long form.
- Tests hit the identical trap one layer up — the `Expected` side resolved short while `Received` came back long. Added a `canon()` helper and routed the four cwd assertions through it.
- Test assertions used a bare `pwd`; Git Bash mounts `%TEMP%` at `/tmp`, so `fs.realpathSync` resolved the leading slash against the runner's current drive (`ENOENT 'D:\tmp'`). They now mirror the tool's own `pwd -W 2>/dev/null || pwd`.

## Why it hid

Two of the four tests passed **vacuously** — they assert the cwd equals the *root*, which is also what totally broken persistence returns. Added an explicit "no reset notice on an in-workspace cd" assertion that fails on the real bug.

And `desktop-ci.yml` was `runs-on: ubuntu-latest` only, so these tests never ran on Windows at all; #174 merged green. This PR adds a `windows-latest` matrix leg (tests only — packaging stays Linux, already covered by the test-build/release workflows).

## Verification

Both legs green: https://github.com/itsdestin/youcoded/actions/runs/29700800179

## Follow-up (separate PR)

`detectShell()` only probes two hardcoded `Program Files` paths, resolves at module import (so a first-run `winget install Git.Git` doesn't take effect until restart), and logs nothing when it falls back to PowerShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)