### PR TITLE
fix(harness): widen + defer Git Bash detection on Windows

### DIFF
--- a/desktop/src/main/dev-tools.ts
+++ b/desktop/src/main/dev-tools.ts
@@ -12,6 +12,7 @@ import * as https from 'https';
 // submitIssue to embed the accurate YouCoded version in the issue body
 // instead of relying on navigator.userAgent from the renderer (Fix 2).
 import { app } from 'electron';
+import { getShell } from './harness/tools/bash';
 
 const GH_TOKEN_RE = /gh[opsu]_[A-Za-z0-9]{20,}/g;
 const ANTHROPIC_KEY_RE = /sk-ant-[A-Za-z0-9_-]{20,}/g;
@@ -331,6 +332,20 @@ export async function gatherDiagnostics(): Promise<string> {
     electronVersion: process.versions.electron || 'n/a',
     probes: {
       'git': git,
+      // Which shell the native harness resolved. A silent PowerShell fallback
+      // (no Git Bash found) degrades every local/OpenRouter session — no cwd
+      // persistence, bash-shaped commands fed to PowerShell — and was
+      // previously invisible in bug reports.
+      'harness shell': (() => {
+        try {
+          const s = getShell();
+          // ok:false for PowerShell — it IS a degraded state worth flagging in
+          // a report, not merely informational.
+          return { ok: s.label.startsWith('bash'), text: `${s.label} (${s.cmd})` };
+        } catch (err: any) {
+          return { ok: false, text: `detection failed: ${err?.message ?? String(err)}` };
+        }
+      })(),
       'claude': claude,
       'claude auth': claudeAuth,
       '~/.claude': claudeDir,

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -3,6 +3,11 @@
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+// `which` ships no type declarations and @types/which is not a dependency here.
+// Kept as a static import (not require) so the module-mocking layer can reach it
+// — that is what makes gitBashCandidates() unit-testable off-Windows.
+// @ts-ignore
+import * as which from 'which';
 import { z } from 'zod';
 import { defineTool } from './registry';
 
@@ -15,24 +20,99 @@ const MAX_TIMEOUT_MS = 600_000;
  *  evaporated, costing ~6 wasted tool calls in one observed session. */
 const CWD_SENTINEL = '__YC_CWD__';
 
+export interface ShellInfo { cmd: string; args: string[]; label: string }
+
+/** Every place Git Bash might live, best first. Two hardcoded Program Files
+ *  paths were the ENTIRE search before 2026-07-19, so a scoop/choco user-scope
+ *  install (%LOCALAPPDATA%\Programs\Git), a D:\Git install, or any non-default
+ *  location silently fell through to PowerShell — even though `git --version`
+ *  passed first-run's prerequisite check and git.exe was right there on PATH. */
+function gitBashCandidates(): string[] {
+  const out: string[] = [];
+  // Claude Code's own documented escape hatch for exactly this problem. Users
+  // who already set it for the CLI get correct detection here for free.
+  if (process.env.CLAUDE_CODE_GIT_BASH_PATH) out.push(process.env.CLAUDE_CODE_GIT_BASH_PATH);
+  // Derive from git.exe on PATH: <root>\cmd\git.exe -> <root>\bin\bash.exe.
+  // This is the branch that rescues every non-default install location.
+  const git = resolveOnPath('git');
+  if (git) {
+    // path.win32 explicitly, not `path`: this branch only runs on win32 (where
+    // they are the same), and naming it lets the test suite exercise Windows
+    // path shapes from a Linux/macOS runner — POSIX dirname() does not treat
+    // a backslash as a separator, so `path` here would be untestable off-Windows.
+    const root = path.win32.dirname(path.win32.dirname(git));
+    out.push(path.win32.join(root, 'bin', 'bash.exe'));
+    out.push(path.win32.join(root, 'usr', 'bin', 'bash.exe'));
+  }
+  out.push('C:/Program Files/Git/bin/bash.exe', 'C:/Program Files (x86)/Git/bin/bash.exe');
+  // Last resort: bash on PATH — but NEVER System32\bash.exe. That is the WSL
+  // launcher: it would run the command inside a Linux VM against a Windows cwd,
+  // so every path the model passed would be wrong. Worse than PowerShell.
+  const onPath = resolveOnPath('bash');
+  if (onPath && !/[\\/]system32[\\/]/i.test(onPath)) out.push(onPath);
+  return out;
+}
+
+/** `which`-based resolution, mirroring resolveCommand() in prerequisite-installer.
+ *  Returns null (not the bare name) so callers can tell "found" from "guessing". */
+function resolveOnPath(cmd: string): string | null {
+  try {
+    // Static import, not a runtime require(): require() escapes the module
+    // mocking layer, which made this branch impossible to unit-test.
+    return (which as any).sync(cmd, { nothrow: true }) || null;
+  } catch {
+    return null;
+  }
+}
+
 /** Windows shell preference (spec §2.3): Git Bash when present (models write
  *  bash), else PowerShell — and the tool DESCRIPTION states which is live. */
-export function detectShell(): { cmd: string; args: string[]; label: string } {
+export function detectShell(): ShellInfo {
   if (process.platform !== 'win32') return { cmd: '/bin/bash', args: ['-c'], label: 'bash' };
-  const gitBash = ['C:/Program Files/Git/bin/bash.exe', 'C:/Program Files (x86)/Git/bin/bash.exe'].find((p) =>
-    fs.existsSync(p),
-  );
+  const gitBash = gitBashCandidates().find((p) => {
+    try {
+      return fs.existsSync(p);
+    } catch {
+      return false;
+    }
+  });
   if (gitBash) return { cmd: gitBash, args: ['-c'], label: 'bash (Git Bash)' };
+  // Loud, because this degrades the tool: no cwd persistence, and the model is
+  // handed a shell its bash-shaped output does not fit. Silence here meant a
+  // PowerShell fallback never appeared in a bug report (dev-tools.ts surfaces
+  // it as the `harness shell` probe now).
+  console.warn(
+    '[harness/bash] Git Bash not found — falling back to PowerShell. ' +
+      '`cd` will NOT persist between calls. Install Git for Windows, or set ' +
+      'CLAUDE_CODE_GIT_BASH_PATH to your bash.exe.',
+  );
   return { cmd: 'powershell.exe', args: ['-NoProfile', '-Command'], label: 'PowerShell' };
 }
 
-const shell = detectShell();
+// LAZY + memoized, not module-load-time. First-run installs git via
+// `winget install Git.Git` AFTER the app has started (main.ts -> ipc-handlers ->
+// this module all import eagerly), so resolving at import pinned a brand-new
+// Windows user to PowerShell for their whole first session even though the
+// installer had just delivered bash.exe. Resolving on first USE — the earliest
+// of buildAiTools() reading .description or an actual execute() — lands after
+// first-run completes. Verified import chain: main.ts:8 -> ipc-handlers.ts:31.
+let cachedShell: ShellInfo | null = null;
+export function getShell(): ShellInfo {
+  if (!cachedShell) cachedShell = detectShell();
+  return cachedShell;
+}
+/** Test-only: drop the memo so a test can re-detect under a different platform. */
+export function resetShellCache(): void {
+  cachedShell = null;
+}
 
 /** Only the bash shells get cwd tracking. The PowerShell fallback would need a
  *  different sentinel AND an $LASTEXITCODE dance to preserve exit codes, and it
  *  only ever runs on Windows boxes without Git Bash — not worth the risk, so it
  *  stays stateless and the tool description says so. */
-const tracksCwd = shell.label.startsWith('bash');
+function tracksCwdFor(s: ShellInfo): boolean {
+  return s.label.startsWith('bash');
+}
 
 /** Wrap the command so the shell prints its final $PWD without clobbering the
  *  exit code. Newline-separated (not `;`) so trailing `&`, `# comments`, and
@@ -90,11 +170,14 @@ function isInside(root: string, candidate: string): boolean {
   return c === r || c.startsWith(r + path.sep);
 }
 
-export const BashTool = defineTool({
-  name: 'Bash',
-  description:
-    `Run a shell command (${shell.label} on this machine). ` +
-    (tracksCwd
+/** Built per-read so it reflects the LAZILY resolved shell (see getShell). A
+ *  module-level string would bake in whatever was detected at import — i.e.
+ *  "PowerShell" for a user whose git arrived during first-run. */
+export function bashDescription(): string {
+  const s = getShell();
+  return (
+    `Run a shell command (${s.label} on this machine). ` +
+    (tracksCwdFor(s)
       ? 'The working directory PERSISTS between calls: a `cd` carries to your next Bash call. ' +
         'Changing directory outside the workspace root is reverted (you get a reset notice). ' +
         'Environment variables, aliases, and shell functions do NOT persist — each call is a fresh shell. ' +
@@ -102,7 +185,15 @@ export const BashTool = defineTool({
         'workspace root, NOT from this shell directory — prefer absolute paths with them. '
       : 'Each call starts fresh in the workspace directory — `cd` does NOT carry to the next call, ' +
         'so use absolute paths or chain with `cd X && ...` in one command. ') +
-    'Output is capped; long-running commands time out (default 2 minutes, max 10 via timeout).',
+    'Output is capped; long-running commands time out (default 2 minutes, max 10 via timeout).'
+  );
+}
+
+export const BashTool = defineTool({
+  name: 'Bash',
+  // Placeholder: the real text comes from the getter installed below, which
+  // resolves the shell on first read (harness-session.ts buildAiTools()).
+  description: '',
   inputSchema: z.object({
     command: z.string(),
     timeout: z.number().int().optional().describe('Timeout in milliseconds'),
@@ -121,7 +212,8 @@ export const BashTool = defineTool({
     // line-continuation, or a dangling `&&`/`||`/`|` (which swallows the
     // `__yc_rc=$?` line, so a FAILED command would exit 0 — verified 2026-07-18).
     // Such commands are malformed anyway; skipping restores the plain behavior.
-    const probe = tracksCwd && !/(\\|&&|\|\||\|)\s*$/.test(args.command);
+    const shell = getShell();
+    const probe = tracksCwdFor(shell) && !/(\\|&&|\|\||\|)\s*$/.test(args.command);
     return new Promise((resolve) => {
       const child = spawn(shell.cmd, [...shell.args, probe ? withCwdProbe(args.command) : args.command], {
         cwd: startCwd,
@@ -186,4 +278,14 @@ export const BashTool = defineTool({
       child.on('close', (code) => finish(code === 0 ? '' : `(exit code ${code})\n`, code !== 0, code));
     });
   },
+});
+
+// Installed AFTER defineTool because that helper spreads its input ({...def}),
+// and a spread EVALUATES getters — declaring this inline would freeze the text
+// at import, defeating the lazy resolve. buildAiTools() reads .description once
+// per session (harness-session.ts), which is the moment we want detection.
+Object.defineProperty(BashTool, 'description', {
+  get: bashDescription,
+  enumerable: true,
+  configurable: true,
 });

--- a/desktop/tests/harness-bash-shell-detect.test.ts
+++ b/desktop/tests/harness-bash-shell-detect.test.ts
@@ -1,0 +1,109 @@
+// detectShell() had ZERO test coverage until 2026-07-19, which is how the
+// Windows branch shipped probing only two hardcoded Program Files paths.
+// These tests drive it as a pure function via mocked fs/which, so they run
+// identically on every CI platform (the win32 cases never touch a real disk).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const existsMock = vi.fn<(p: string) => boolean>();
+const whichMock = vi.fn<(c: string, o?: any) => string | null>();
+
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual<typeof import('fs')>();
+  return { ...actual, existsSync: (p: any) => existsMock(String(p)) };
+});
+vi.mock('which', () => ({ sync: (c: string, o?: any) => whichMock(c, o) }));
+
+import { detectShell, getShell, resetShellCache } from '../src/main/harness/tools/bash';
+
+const realPlatform = process.platform;
+function setPlatform(p: string) {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+
+beforeEach(() => {
+  existsMock.mockReset().mockReturnValue(false);
+  whichMock.mockReset().mockReturnValue(null);
+  resetShellCache();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  setPlatform(realPlatform);
+  resetShellCache();
+  vi.restoreAllMocks();
+  delete process.env.CLAUDE_CODE_GIT_BASH_PATH;
+});
+
+describe('detectShell', () => {
+  it('uses /bin/bash off win32 without probing the filesystem', () => {
+    setPlatform('linux');
+    expect(detectShell()).toEqual({ cmd: '/bin/bash', args: ['-c'], label: 'bash' });
+    expect(existsMock).not.toHaveBeenCalled();
+  });
+
+  it('finds Git Bash at the default Program Files path', () => {
+    setPlatform('win32');
+    existsMock.mockImplementation((p) => p === 'C:/Program Files/Git/bin/bash.exe');
+    const s = detectShell();
+    expect(s.cmd).toBe('C:/Program Files/Git/bin/bash.exe');
+    expect(s.label).toBe('bash (Git Bash)');
+  });
+
+  // The regression that motivated this file: git installed anywhere other than
+  // the two hardcoded paths (scoop/choco user-scope, a D: drive) resolved to
+  // PowerShell even though git.exe was plainly on PATH.
+  it('derives bash.exe from git.exe for a NON-default install location', () => {
+    setPlatform('win32');
+    whichMock.mockImplementation((c) => (c === 'git' ? 'D:\\Tools\\Git\\cmd\\git.exe' : null));
+    const derived = 'D:\\Tools\\Git\\bin\\bash.exe';
+    existsMock.mockImplementation((p) => p === derived);
+    expect(detectShell().cmd).toBe(derived);
+  });
+
+  it('honors CLAUDE_CODE_GIT_BASH_PATH above everything else', () => {
+    setPlatform('win32');
+    process.env.CLAUDE_CODE_GIT_BASH_PATH = 'E:\\custom\\bash.exe';
+    existsMock.mockReturnValue(true); // every candidate "exists" — override must still win
+    expect(detectShell().cmd).toBe('E:\\custom\\bash.exe');
+  });
+
+  // System32\bash.exe is the WSL launcher. Using it would run commands in a
+  // Linux VM against a Windows cwd, so every path would be wrong — strictly
+  // worse than the PowerShell fallback.
+  it('never selects the WSL launcher at System32\\bash.exe', () => {
+    setPlatform('win32');
+    whichMock.mockImplementation((c) => (c === 'bash' ? 'C:\\Windows\\System32\\bash.exe' : null));
+    existsMock.mockImplementation((p) => p === 'C:\\Windows\\System32\\bash.exe');
+    expect(detectShell().label).toBe('PowerShell');
+  });
+
+  it('falls back to PowerShell and WARNS when no bash exists', () => {
+    setPlatform('win32');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const s = detectShell();
+    expect(s).toEqual({ cmd: 'powershell.exe', args: ['-NoProfile', '-Command'], label: 'PowerShell' });
+    // Silence here is what kept this invisible in bug reports.
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toMatch(/CLAUDE_CODE_GIT_BASH_PATH/);
+  });
+});
+
+describe('getShell', () => {
+  it('memoizes so repeated tool calls do not re-probe the disk', () => {
+    setPlatform('win32');
+    getShell();
+    const callsAfterFirst = existsMock.mock.calls.length;
+    getShell();
+    getShell();
+    expect(existsMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  // The timing bug: main.ts -> ipc-handlers.ts -> bash.ts all import eagerly, so
+  // resolving at module load pinned a new Windows user to PowerShell for the
+  // whole session even after first-run's `winget install Git.Git` delivered bash.
+  it('resolves on FIRST USE, so a git install during first-run still counts', () => {
+    setPlatform('win32');
+    expect(existsMock).not.toHaveBeenCalled(); // nothing probed at import
+    existsMock.mockImplementation((p) => p === 'C:/Program Files/Git/bin/bash.exe');
+    expect(getShell().label).toBe('bash (Git Bash)');
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #178. `detectShell()` probed exactly two hardcoded `Program Files` paths, resolved at module import, and logged nothing when it fell back to PowerShell. Each of those silently degrades **every** local/OpenRouter session on Windows — `tracksCwd` is false so `cd` never persists, and the model's bash-shaped commands get handed to PowerShell.

This matters more than it looks: `CORE_TOOLS` is attached to every native session unconditionally (`native-session-host.ts:216`), native is on by default in production, and it's reachable from the remote-browser server too.

## The three defects

**1. Too narrow.** A scoop/choco user-scope install (`%LOCALAPPDATA%\Programs\Git`) or a `D:\Git` install fell through to PowerShell even though `git --version` satisfied first-run's prerequisite check and `git.exe` was on PATH. Now derives `bash.exe` from the resolved `git.exe`, honors Claude Code's documented `CLAUDE_CODE_GIT_BASH_PATH`, and consults `which`.

Notably it **refuses `System32\bash.exe`** — the WSL launcher. Selecting it would run commands inside a Linux VM against a Windows cwd, making every path the model passed wrong. Strictly worse than the PowerShell fallback; pinned by a test.

**2. Too early.** `main.ts:8` → `ipc-handlers.ts:31` → `bash.ts` all import eagerly, so `const shell = detectShell()` ran at app startup. A brand-new user whose git was installed *by first-run* (`winget install Git.Git`, `prerequisite-installer.ts:612`) stayed pinned to PowerShell for that entire session despite doing everything right. Detection is now lazy + memoized, resolving on first use — `buildAiTools()` reading `.description`, or an `execute()` — which lands after first-run completes.

**3. Silent.** Fallback now warns with the remedy, and `dev-tools.ts` reports a `harness shell` probe (`ok:false` on PowerShell) so it appears in bug reports. Previously a PowerShell fallback was undiagnosable from a user report.

## Tests

First coverage `detectShell()` has ever had — 8 cases driving the win32 branch from any platform via mocked `fs`/`which`.

Two production changes were needed to make it testable, rather than weakening the tests:
- `path.win32` for the `git.exe` derivation — POSIX `dirname` doesn't treat `\` as a separator, so plain `path` was untestable off-Windows. Semantically identical in production (that branch only runs on win32).
- A static `which` import — a runtime `require()` escapes the module-mocking layer.

## Context

Claude Code itself treats Git for Windows as **optional**, with a real PowerShell *tool* as the documented fallback. This PR deliberately does not add a hard requirement: it makes detection reliable enough that the PowerShell path should be near-empty, and now measurable via diagnostics. If it isn't, the hard-requirement decision can be made with data.

## Verification

Both legs green: https://github.com/itsdestin/youcoded/actions/runs/29701183551
Full suite: 2659 passing, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)