### PR TITLE
test(sync): one named 60s ceiling for fs.watch integration waits + macOS CI

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -20,7 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # macOS added 2026-07-19 for the same reason Windows was: its only
+        # coverage was desktop-test-build.yml, so a macOS-only failure could
+        # not surface until a beta dispatch — which is exactly how the
+        # sync-spaces-engine 5s-ceiling timeouts were found (run 29701441150).
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/desktop/tests/sync-spaces-engine.test.ts
+++ b/desktop/tests/sync-spaces-engine.test.ts
@@ -23,6 +23,20 @@ let tmp: string;
 beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'yc-eng-')); });
 afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
 
+// These are fs.watch INTEGRATION tests — they wait on real filesystem events,
+// so their wall-clock scales with machine load and vitest's parallel pool
+// guarantees load. The 5000ms literal these replaced took the macOS leg of beta
+// run 29701441150 red TWICE on 2026-07-19, with a DIFFERENT victim test each
+// run ('debounces file changes…' then 'emits error events…') — the signature of
+// a too-tight budget, not a broken assertion. Windows and Linux passed both times.
+//
+// Note for whoever touches this next: PR #163 swapped this family's fixed
+// sleep()s for vi.waitFor bounded-retry polling, which was right — but
+// vi.waitFor carries its OWN fixed ceiling, so the budget moved rather than
+// disappeared. One named knob per file; do NOT reintroduce inline literals (an
+// inline third arg on it() silently overrides vi.setConfig — the #163 trap).
+const WAIT_MS = 60_000;
+
 describe('SpaceSyncEngine', () => {
   it('debounces file changes into one sync (pull then push)', async () => {
     const t = fakeTransport();
@@ -32,7 +46,7 @@ describe('SpaceSyncEngine', () => {
     await engine.addSpace(space);
     fs.writeFileSync(path.join(tmp, 'a.md'), '1');
     fs.writeFileSync(path.join(tmp, 'b.md'), '2');
-    await vi.waitFor(() => expect(t.pushes.length).toBe(1), { timeout: 5000 });
+    await vi.waitFor(() => expect(t.pushes.length).toBe(1), { timeout: WAIT_MS });
     expect(t.pulls.length).toBe(1);                 // pull-before-push ordering
     expect(events.some(e => e.type === 'synced')).toBe(true);
     await engine.stop();
@@ -72,7 +86,7 @@ describe('SpaceSyncEngine', () => {
     // The lock-dir ignore is scoped to `.json.lock` precisely so real lockfiles
     // (Cargo.lock, Gemfile.lock, poetry.lock) keep triggering an instant sync.
     fs.writeFileSync(path.join(tmp, 'Cargo.lock'), 'x');
-    await vi.waitFor(() => expect(t.pushes.length).toBe(1), { timeout: 5000 });
+    await vi.waitFor(() => expect(t.pushes.length).toBe(1), { timeout: WAIT_MS });
     await engine.stop();
   });
 
@@ -80,7 +94,7 @@ describe('SpaceSyncEngine', () => {
     const t = fakeTransport();
     const engine = new SpaceSyncEngine(t, { debounceMs: 5000, pollMs: 120, onEvent: () => {} });
     await engine.addSpace({ id: 'personal', kind: 'personal', root: tmp });
-    await vi.waitFor(() => expect(t.pulls.length).toBeGreaterThanOrEqual(1), { timeout: 5000 });
+    await vi.waitFor(() => expect(t.pulls.length).toBeGreaterThanOrEqual(1), { timeout: WAIT_MS });
     await engine.stop();
   });
 
@@ -102,13 +116,13 @@ describe('SpaceSyncEngine', () => {
     const space: SyncSpace = { id: 'project:x', kind: 'project', root: tmp };
     await engine.addSpace(space);
     const first = engine.syncSpace(space);                       // starts, blocks inside pull
-    await vi.waitFor(() => expect(t.pulls.length).toBe(1), { timeout: 5000 });
+    await vi.waitFor(() => expect(t.pulls.length).toBe(1), { timeout: WAIT_MS });
     void engine.syncSpace(space);                                // mid-sync: sets the rerun flag
     void engine.syncSpace(space);                                // mid-sync again: must NOT queue a second rerun
     releaseFirstPull();
     await first;
     // Exactly two syncs total: the original + one coalesced rerun.
-    await vi.waitFor(() => expect(t.pushes.length).toBe(2), { timeout: 5000 });
+    await vi.waitFor(() => expect(t.pushes.length).toBe(2), { timeout: WAIT_MS });
     await new Promise(r => setTimeout(r, 300));                  // settle: no third sync sneaks in
     expect(t.pushes.length).toBe(2);
     expect(t.pulls.length).toBe(2);
@@ -180,7 +194,7 @@ describe('SpaceSyncEngine', () => {
     const engine = new SpaceSyncEngine(t, { debounceMs: 100, pollMs: 0, onEvent: e => events.push(e) });
     await engine.addSpace({ id: 'project:x', kind: 'project', root: tmp });
     fs.writeFileSync(path.join(tmp, 'a.md'), '1');
-    await vi.waitFor(() => expect(events.some(e => e.type === 'error')).toBe(true), { timeout: 5000 });
+    await vi.waitFor(() => expect(events.some(e => e.type === 'error')).toBe(true), { timeout: WAIT_MS });
     await engine.stop();
   });
 });


### PR DESCRIPTION
## Why

The `5000ms` `vi.waitFor` literals in `sync-spaces-engine.test.ts` took the macOS leg of beta run 29701441150 red **twice**, with a **different victim test each run**:

- run 1 — `debounces file changes into one sync (pull then push)`
- run 2 — `emits error events instead of throwing (never-block, spec §13)`

Both `Test timed out in 5000ms`; Windows and Linux passed both times. A varying victim within one file is the signature of a too-tight budget, not a broken assertion.

## Verified, not assumed

Before raising anything I checked whether the assertions actually hold given more time — otherwise a raised timeout just buries a real macOS sync bug. With the new ceiling the **whole file (10 tests) runs in 3419ms on macOS** — nothing approaches 60s. The tests are fast when the runner has headroom; they only blow the 5s budget under parallel contention. A genuine engine bug would grind to the ceiling and fail regardless.

## What changed

- Six inline `{ timeout: 5000 }` literals → one named `WAIT_MS = 60_000`. Matches the precedent from #163, which raised the git-heavy sync tests 30s→120s.
- `macos-latest` added to Desktop CI.

## The lesson worth keeping

PR #163 replaced this family's fixed `sleep()`s with `vi.waitFor` bounded-retry polling — correct, but `vi.waitFor` carries its **own** fixed ceiling. The budget moved rather than disappeared. "Converted to waitFor" is not the same as "no fixed budget."

And macOS had the same coverage gap Windows did until this week: its only exposure was `desktop-test-build.yml`, so a macOS-only failure could not surface until a beta dispatch. That is now closed for both platforms.

## Verification

All three legs green: https://github.com/itsdestin/youcoded/actions/runs/29701852798

🤖 Generated with [Claude Code](https://claude.com/claude-code)