### PR TITLE
refactor(ui): tranche 2 — migrate every hand-rolled button to the Button primitive

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -20,6 +20,7 @@ const WELCOME_MODEL_LABELS: Record<string, string> = {
 };
 import ErrorBoundary from './components/ErrorBoundary';
 import { Scrim, OverlayPanel } from './components/overlays/Overlay';
+import { Button } from './components/ui';
 import GamePanel from './components/game/GamePanel';
 import TerminalRightSlot from './components/TerminalRightSlot';
 import { ChatProvider, useChatDispatch, useChatStore } from './state/chat-context';
@@ -2838,13 +2839,22 @@ function AppInner() {
                     <p className="text-[10px] text-[#DD4444]">Claude will execute tools without asking for approval.</p>
                   )}
                   <div className="flex gap-2">
-                    <button
+                    {/* secondary, not ghost: this was the filled-grey family
+                        (bg-inset text-fg-dim hover:bg-edge) that decision 60 collapses
+                        into the outline, and it sits beside Create as a peer choice —
+                        the exact case decision 60 gives for rejecting ghost. */}
+                    <Button
+                      variant="secondary"
+                      size="lg"
                       onClick={() => setWelcomeFormOpen(false)}
-                      className="px-3 py-1.5 text-sm rounded-md bg-inset text-fg-dim hover:bg-edge transition-colors"
                     >
                       Cancel
-                    </button>
-                    <button
+                    </Button>
+                    {/* Third skip-permissions Create button — spec decision 62 cited only
+                        SessionStrip and ResumeBrowser plus App.tsx's toggle, and missed this
+                        one on the welcome form. Same call: FILLED danger, deliberately
+                        identical to "Remove project". See the note in SessionStrip. */}
+                    <Button
                       onClick={() => {
                         // Native runtime carries a provider/model binding; persist
                         // the choice so it sticks. The disabled guard already blocks
@@ -2866,20 +2876,27 @@ function AppInner() {
                         setWelcomeRuntime('claude');
                       }}
                       disabled={welcomeNb.nativeCreateBlocked}
-                      className={`flex-1 text-sm font-medium rounded-md py-1.5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-                        welcomeDangerous
-                          ? 'bg-[#DD4444] hover:bg-[#E55555] text-white'
-                          : 'bg-accent hover:bg-accent text-on-accent'
-                      }`}
+                      variant={welcomeDangerous ? 'danger' : 'primary'}
+                      size="lg"
+                      className="flex-1 py-1.5"
                     >
                       {welcomeDangerous ? 'Create (Dangerous)' : 'Create Session'}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               ) : (
                 /* Collapsed state: two side-by-side buttons */
                 <>
-                  <button
+                  {/* `panel-glass` and `text-base` are deliberate className
+                      overrides, NOT leftovers (spec §11.3 decision 69):
+                      panel-glass re-tiers translucency from bubble→panel on
+                      wallpaper themes (globals.css:843-856), and text-base is
+                      larger than any Button size. buttonClasses() merges both
+                      correctly — it drops the conflicting base tokens. */}
+                  <Button
+                    variant="primary"
+                    size="lg"
+                    className="panel-glass w-full px-8 text-base"
                     onClick={() => {
                       setWelcomeCwd(sessionDefaults.projectFolder || '');
                       setWelcomeDangerous(sessionDefaults.skipPermissions || false);
@@ -2888,19 +2905,22 @@ function AppInner() {
                       // false→true edge — no manual touched reset needed here.
                       setWelcomeFormOpen(true);
                     }}
-                    className="panel-glass w-full px-8 py-2 text-base font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors"
                   >
                     New Session
-                  </button>
-                  <button
+                  </Button>
+                  {/* Same decision-69 rationale as above: panel-glass is preserved
+                      as a className override so wallpaper themes still re-tier it. */}
+                  <Button
+                    variant="secondary"
+                    size="lg"
+                    className="panel-glass w-full px-6"
                     onClick={() => setResumeRequested(true)}
-                    className="panel-glass w-full px-6 py-2 rounded-lg bg-inset hover:bg-edge text-fg-dim hover:text-fg transition-colors flex items-center justify-center gap-1.5"
                   >
                     <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     <span className="text-sm font-medium">Resume Session</span>
-                  </button>
+                  </Button>
                 </>
               )}
             </div>
@@ -3061,13 +3081,14 @@ function AppInner() {
         <div className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg bg-panel border border-edge text-sm text-fg shadow-lg flex items-center gap-3">
           <span>{typeof toast === 'string' ? toast : toast.message}</span>
           {typeof toast !== 'string' && (
-            <button
-              type="button"
-              className="shrink-0 rounded-md border border-edge px-2 py-0.5 text-xs font-medium text-fg hover:bg-inset"
+            <Button
+              variant="secondary"
+              size="sm"
+              className="shrink-0"
               onClick={toast.action.onClick}
             >
               {toast.action.label}
-            </button>
+            </Button>
           )}
         </div>
       )}
@@ -3091,20 +3112,21 @@ function AppInner() {
                 : `${takeoverPrompt.device} isn't responding — take over anyway?`}
             </p>
             <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                className="px-3 py-1.5 rounded-lg border border-edge text-sm text-fg-2 hover:bg-inset"
+              <Button
+                variant="secondary"
+                size="lg"
                 onClick={() => resolveTakeover(false)}
               >
                 Never mind
-              </button>
-              <button
-                type="button"
-                className="px-3 py-1.5 rounded-lg bg-accent text-on-accent text-sm hover:opacity-90"
+              </Button>
+              <Button
+                variant="primary"
+                size="lg"
+                className="px-3 py-1.5"
                 onClick={() => resolveTakeover(true)}
               >
                 Take over
-              </button>
+              </Button>
             </div>
           </OverlayPanel>
         </>

--- a/desktop/src/renderer/components/AboutPopup.tsx
+++ b/desktop/src/renderer/components/AboutPopup.tsx
@@ -4,6 +4,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import { Toggle } from './SettingsPanel';
+import { CloseButton } from './ui';
 import { formatVersionLine } from '../../shared/version-line';
 
 // Shared About popup for Desktop and Android settings. Previously this was an
@@ -108,15 +109,7 @@ export default function AboutPopup({ open, onClose, platform, version, build, ch
             <h3 id="about-popup-title" className="text-sm font-semibold text-fg">About</h3>
             <p className="text-[10px] text-fg-muted mt-0.5">{versionLine}</p>
           </div>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-fg-muted hover:text-fg transition-colors w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         {/* Padding lives on an inner wrapper so scroll-fade has no padding;

--- a/desktop/src/renderer/components/AccountSection.tsx
+++ b/desktop/src/renderer/components/AccountSection.tsx
@@ -318,13 +318,14 @@ function SignedInBody({
                 </div>
                 {/* No confirm — unblocking is the recovery action, not the
                     destructive one (blocking is what's consequence-gated). */}
-                <button
+                <Button
+                  variant="secondary"
                   onClick={() => void onUnblock(b.id)}
                   disabled={unblockingId === b.id}
-                  className="shrink-0 text-xs font-medium px-3 py-1.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                  className="shrink-0"
                 >
                   {unblockingId === b.id ? 'Unblocking…' : 'Unblock'}
-                </button>
+                </Button>
               </div>
               {unblockErrors[b.id] && <p className="text-[10px] text-red-500">{unblockErrors[b.id]}</p>}
             </div>
@@ -334,16 +335,19 @@ function SignedInBody({
 
       <hr className="border-edge-dim" />
 
-      {/* The single edit affordance — pencil icon + label, per the rework spec. */}
-      <button
-        onClick={() => setMode('edit')}
-        className="w-full flex items-center justify-center gap-2 text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-      >
+      {/* The single edit affordance — pencil icon + label, per the rework spec.
+          The primitive already centers its children and owns the icon gap, so
+          only the full-bleed width survives as a layout extra (the py-2.5 row
+          shortens to md's py-1.5, same as the danger-zone Cancel — change 3). */}
+      <Button variant="secondary" onClick={() => setMode('edit')} className="w-full">
         <PencilIcon />
         Edit account
-      </button>
+      </Button>
 
-      <button
+      {/* Sign out is reversible (you can sign back in), so it stays secondary
+          rather than joining the danger family. */}
+      <Button
+        variant="secondary"
         onClick={async () => {
           setSigningOut(true);
           try {
@@ -353,22 +357,23 @@ function SignedInBody({
           }
         }}
         disabled={signingOut}
-        className="w-full text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        className="w-full"
       >
         {signingOut ? 'Signing out…' : 'Sign out'}
-      </button>
+      </Button>
 
       {/* Download my data — GDPR-style export of everything the server stores.
           Desktop shows a save dialog (resolves to {path}); Android writes to
           Downloads. Single-fire guarded while the request is in flight. */}
       <section className="space-y-1.5">
-        <button
+        <Button
+          variant="secondary"
           onClick={() => void onExport()}
           disabled={exporting}
-          className="w-full text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          className="w-full"
         >
           {exporting ? 'Preparing export…' : 'Download my data'}
-        </button>
+        </Button>
         <p className="text-[10px] text-fg-muted leading-relaxed">
           Downloads a file containing everything YouCoded's server stores about your account.
         </p>
@@ -493,12 +498,9 @@ function EditAccountBody({
       {/* Edit-mode header: label + the way back to view mode. */}
       <div className="flex items-center justify-between">
         <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Edit account</h4>
-        <button
-          onClick={onDone}
-          className="text-xs font-medium px-3 py-1.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-        >
+        <Button variant="secondary" onClick={onDone}>
           Done
-        </button>
+        </Button>
       </div>
 
       {/* Display name */}
@@ -514,14 +516,13 @@ function EditAccountBody({
             onChange={(e) => { setNameDraft(e.target.value); setNameSaved(false); }}
             className="flex-1 text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
           />
-          <button
+          <Button
             onClick={() => void saveName()}
             aria-label="Save display name"
             disabled={nameSaving || nameDraft.trim().length === 0}
-            className="text-xs font-medium px-3 py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
           >
             {nameSaving ? 'Saving…' : 'Save'}
-          </button>
+          </Button>
         </div>
         {nameError && <p className="text-[10px] text-red-500">{nameError}</p>}
         {nameSaved && !nameError && <p className="text-[10px] text-fg-muted">Saved</p>}
@@ -550,14 +551,13 @@ function EditAccountBody({
             />
           </div>
           {!handleConfirming && (
-            <button
+            <Button
               onClick={onSaveHandleClick}
               aria-label="Save handle"
               disabled={handleSaving || trimmedHandle.length === 0 || handleUnchanged}
-              className="text-xs font-medium px-3 py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
             >
               {handleSaving ? 'Saving…' : 'Save'}
-            </button>
+            </Button>
           )}
         </div>
 
@@ -570,20 +570,25 @@ function EditAccountBody({
               need your new handle.
             </p>
             <div className="flex gap-2">
-              <button
+              {/* This Cancel unarms the confirm step rather than closing the
+                  popup, so it survives the "no redundant text cancel" rule. */}
+              <Button
+                variant="secondary"
                 onClick={() => setHandleConfirming(false)}
                 aria-label="Cancel handle change"
-                className="flex-1 text-xs font-medium py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
+                className="flex-1"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              {/* Stays primary, not danger: a handle change is consequential but
+                  not destructive — nothing attached to the account is deleted. */}
+              <Button
                 onClick={() => void commitHandle()}
                 disabled={handleSaving}
-                className="flex-1 text-xs font-medium py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+                className="flex-1"
               >
                 {handleSaving ? 'Saving…' : 'Confirm change'}
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/desktop/src/renderer/components/AttentionBanner.tsx
+++ b/desktop/src/renderer/components/AttentionBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { AttentionState } from '../state/chat-types';
 import BrailleSpinner from './BrailleSpinner';
+import { Button } from './ui';
 
 // Banner shown in place of ThinkingIndicator when the classifier (or a
 // process-exit event) concludes chat view is out of sync with what the user
@@ -95,13 +96,13 @@ export default function AttentionBanner({ state, anthropicRequestId, errorMessag
         {showOpenSettings && (
           // ml-auto pushes the CTA to the right edge of the bubble, past the
           // message text. Plain-words label (no glyph) per standing preference.
-          <button
-            type="button"
+          <Button
+            size="sm"
             onClick={onOpenProviderSettings}
-            className="ml-auto shrink-0 text-xs font-medium rounded-md px-2.5 py-1 bg-accent text-on-accent hover:opacity-90 transition-opacity"
+            className="ml-auto shrink-0"
           >
             Open Settings
-          </button>
+          </Button>
         )}
       </div>
       {showRequestId && (

--- a/desktop/src/renderer/components/CloseSessionPrompt.tsx
+++ b/desktop/src/renderer/components/CloseSessionPrompt.tsx
@@ -4,6 +4,7 @@ import { useEscClose } from '../hooks/use-esc-close';
 import { useTagRegistry } from '../hooks/useTagRegistry';
 import { TagPicker } from './tags/TagPicker';
 import { NoteEditor } from './tags/NoteEditor';
+import { Button } from './ui';
 
 // Flag order must match ResumeBrowser's pill order so the UI is consistent.
 type FlagName = 'priority' | 'complete';
@@ -168,13 +169,10 @@ export default function CloseSessionPrompt({ open, sessionName, sessionId, onCan
               Don't show again
             </button>
             <div className="flex gap-2">
-              <button
-                onClick={onCancel}
-                className="text-[11px] text-fg-dim hover:text-fg px-3 py-1.5 rounded-md hover:bg-inset transition-colors"
-              >
+              <Button variant="ghost" onClick={onCancel}>
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={() => {
                   // Persist suppress preference before confirming so the caller
                   // can immediately skip the prompt on the next close.
@@ -183,10 +181,9 @@ export default function CloseSessionPrompt({ open, sessionName, sessionId, onCan
                   }
                   onConfirm(buildResult());
                 }}
-                className="text-[11px] font-medium bg-accent text-on-accent px-3 py-1.5 rounded-md hover:opacity-90 transition-opacity"
               >
                 Close session
-              </button>
+              </Button>
             </div>
           </div>
         </OverlayPanel>

--- a/desktop/src/renderer/components/ConnectGithubModal.tsx
+++ b/desktop/src/renderer/components/ConnectGithubModal.tsx
@@ -277,22 +277,17 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
                   <div className="flex-1 font-mono text-2xl tracking-[0.25em] text-fg text-center bg-inset rounded-md py-3 select-all">
                     {code.userCode}
                   </div>
-                  <button
-                    onClick={copyCode}
-                    className="text-xs px-3 py-2 rounded bg-inset hover:bg-edge text-fg-2 shrink-0"
-                  >
+                  <Button variant="secondary" onClick={copyCode} className="shrink-0">
                     {copied ? 'Copied' : 'Copy'}
-                  </button>
+                  </Button>
                 </div>
 
                 {isElectron ? (
-                  // Desktop — open the OS browser directly.
-                  <button
-                    onClick={openVerificationUrl}
-                    className="w-full text-sm px-3 py-2 rounded bg-accent text-on-accent"
-                  >
+                  // Desktop — open the OS browser directly. lg: this is the one
+                  // thing to do on this screen, and it had no hover state at all.
+                  <Button size="lg" onClick={openVerificationUrl} className="w-full">
                     Open github.com/login/device
-                  </button>
+                  </Button>
                 ) : (
                   // Remote / touch — no shell access; render a copyable link the
                   // user opens themselves. <a target=_blank> works in a browser.
@@ -307,12 +302,14 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
                       >
                         {code.verificationUri}
                       </a>
-                      <button
+                      <Button
+                        variant="secondary"
+                        size="sm"
                         onClick={() => navigator.clipboard?.writeText(code.verificationUri).catch(() => {})}
-                        className="text-xs px-2 py-1 rounded bg-inset hover:bg-edge text-fg-dim shrink-0"
+                        className="shrink-0"
                       >
                         Copy
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 )}
@@ -324,12 +321,11 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
             )}
 
             <div className="flex justify-end pt-1">
-              <button
-                onClick={handleClose}
-                className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors"
-              >
+              {/* Not redundant with the header ✕: this one aborts a live device
+                  flow, so it stays even though §11.4's rule kills text cancels. */}
+              <Button variant="ghost" onClick={handleClose}>
                 Never mind
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -351,18 +347,13 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
               {errorReason ? ERROR_COPY[errorReason] : ERROR_COPY.network}
             </p>
             <div className="flex justify-end gap-2">
-              <button
-                onClick={handleClose}
-                className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors"
-              >
+              <Button variant="ghost" onClick={handleClose}>
                 Never mind
-              </button>
-              <button
-                onClick={() => void startCode()}
-                className="text-sm px-3 py-1 rounded bg-accent text-on-accent"
-              >
+              </Button>
+              {/* Had no hover state at all before. */}
+              <Button onClick={() => void startCode()}>
                 Try again
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/desktop/src/renderer/components/ContextPopup.tsx
+++ b/desktop/src/renderer/components/ContextPopup.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { Button } from './ui';
 import { useEscClose } from '../hooks/use-esc-close';
 import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './SettingsExplainer';
 
@@ -168,17 +169,20 @@ export default function ContextPopup({
                     autoFocus
                   />
                   <div className="flex gap-2">
-                    <button
+                    <Button
+                      variant="secondary"
+                      size="lg"
                       onClick={() => {
                         // Back resets draft so it doesn't leak if the user cancels then reopens.
                         setCustomizing(false);
                         setInstructions('');
                       }}
-                      className="flex-1 py-2 px-3 text-sm rounded-sm border border-edge bg-panel text-fg-2 hover:bg-inset transition-colors"
+                      className="flex-1"
                     >
                       Back
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      size="lg"
                       onClick={() => {
                         const trimmed = instructions.trim();
                         if (!trimmed || !sessionId) return;
@@ -186,10 +190,10 @@ export default function ContextPopup({
                         onClose();
                       }}
                       disabled={!sessionId || instructions.trim().length === 0}
-                      className="flex-1 py-2 px-3 text-sm font-medium rounded-sm bg-accent text-on-accent hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="flex-1"
                     >
                       Compact with instructions
-                    </button>
+                    </Button>
                   </div>
                 </div>
               ) : (
@@ -220,18 +224,25 @@ export default function ContextPopup({
                     </div>
                   </div>
 
-                  {/* Clear secondary action. */}
+                  {/* Clear secondary action.
+                      danger-outline per spec change 73: /clear throws the whole
+                      conversation away with no summary kept, but it used to look
+                      like a plain neutral button sitting right under the harmless
+                      Compact. The red outline is a deliberate escalation so the
+                      consequence is visible before the click, not after. */}
                   <div>
-                    <button
+                    <Button
+                      variant="danger-outline"
+                      size="lg"
                       onClick={() => {
                         onDispatch('/clear');
                         onClose();
                       }}
                       disabled={!sessionId}
-                      className="w-full py-2 px-3 text-sm rounded-sm border border-edge bg-panel text-fg-2 hover:bg-inset transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full"
                     >
                       Clear and start over
-                    </button>
+                    </Button>
                     <p className="text-[11px] text-fg-muted mt-1 leading-snug">
                       Erases the visible timeline and resets Claude's memory for this session. No summary is kept.
                     </p>

--- a/desktop/src/renderer/components/ContextPopup.tsx
+++ b/desktop/src/renderer/components/ContextPopup.tsx
@@ -194,14 +194,23 @@ export default function ContextPopup({
                 <>
                   {/* Split-button: main = /compact, chevron = open inline editor. */}
                   <div>
-                    <div className="flex w-full rounded-sm overflow-hidden border border-accent">
+                    {/* SPLIT BUTTON — a documented exception to "every button is a
+                        <Button>" (spec §11.8 C, Destin's call). The two halves share
+                        one clipped wrapper so the chevron reads as "options for THAT
+                        action"; giving either half its own rounded-lg corner would put
+                        a rounded edge inside the clip and break the seam. Kept
+                        hand-rolled, but adopting the app's radius and the real
+                        background-fade hover (was hover:opacity-90, which fades the
+                        label too — spec change 53). Don't "finish" this by splitting
+                        it into two Buttons; that was considered and rejected. */}
+                    <div className="flex w-full rounded-lg overflow-hidden border border-accent">
                       <button
                         onClick={() => {
                           onDispatch('/compact');
                           onClose();
                         }}
                         disabled={!sessionId}
-                        className="flex-1 py-2 px-3 text-sm font-medium bg-accent text-on-accent hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="flex-1 py-2 px-3 text-sm font-medium bg-accent text-on-accent hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         Compact conversation
                       </button>
@@ -209,7 +218,7 @@ export default function ContextPopup({
                         onClick={() => setCustomizing(true)}
                         disabled={!sessionId}
                         aria-label="Customize compact instructions"
-                        className="px-2 bg-accent text-on-accent border-l border-on-accent/30 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+                        className="px-2 bg-accent text-on-accent border-l border-on-accent/30 hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
                       >
                         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden>
                           <path strokeLinecap="round" strokeLinejoin="round" d="M6 9l6 6 6-6" />

--- a/desktop/src/renderer/components/ContextPopup.tsx
+++ b/desktop/src/renderer/components/ContextPopup.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 import { useEscClose } from '../hooks/use-esc-close';
 import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './SettingsExplainer';
 
@@ -125,13 +125,7 @@ export default function ContextPopup({
               <div className="flex items-center gap-1">
                 {/* (i) button — opens the explainer view explaining what context percentage means */}
                 <InfoIconButton onClick={() => setShowInfo(true)} />
-                <button
-                  onClick={onClose}
-                  aria-label="Close"
-                  className="text-fg-muted hover:text-fg leading-none w-6 h-6 flex items-center justify-center rounded-sm hover:bg-inset"
-                >
-                  ✕
-                </button>
+                <CloseButton onClick={onClose} label="Close context panel" />
               </div>
             </div>
 

--- a/desktop/src/renderer/components/EngineCard.tsx
+++ b/desktop/src/renderer/components/EngineCard.tsx
@@ -4,6 +4,7 @@
 // Class idioms (text sizes, bg-well surface, accent buttons, border-edge-dim)
 // mirror ProvidersSection's own rows so the card reads as part of the section.
 import React, { useEffect, useState } from 'react';
+import { Button } from './ui';
 
 interface EngineStatusView {
   installed: boolean;
@@ -90,23 +91,27 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
           <p className="text-xs text-fg font-medium">Local engine (llama.cpp)</p>
           <p className="text-[10px] text-fg-muted">{stateLabel}</p>
         </div>
+        {/* Primary row action via the shared primitive — drops the hand-rolled
+            accent fill + hover:brightness-110 (invisible on near-black accents). */}
         {status.state === 'not-installed' && (
-          <button
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed shrink-0"
+          <Button
+            size="sm"
+            className="shrink-0"
             disabled={busy}
             onClick={() => run(() => window.claude.engine.install())}
           >
             {busy ? 'Installing…' : 'Install'}
-          </button>
+          </Button>
         )}
         {status.state === 'error' && (
-          <button
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed shrink-0"
+          <Button
+            size="sm"
+            className="shrink-0"
             disabled={busy}
             onClick={() => run(() => window.claude.engine.restart())}
           >
             Restart engine
-          </button>
+          </Button>
         )}
       </div>
       {busy && progress?.kind === 'download' && (
@@ -127,13 +132,15 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
           <div className="flex items-center justify-between gap-2">
             <p className="text-[11px] text-fg-dim">Using: {status.backend ?? 'default'}</p>
             {isWindows && status.backend !== 'cuda' && (
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => run(() => window.claude.models.setBackend('cuda'))}
                 disabled={busy}
-                className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60 shrink-0"
+                className="shrink-0"
               >
                 Switch to CUDA (faster on NVIDIA)
-              </button>
+              </Button>
             )}
           </div>
 

--- a/desktop/src/renderer/components/ErrorBoundary.tsx
+++ b/desktop/src/renderer/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from './ui';
 
 interface Props {
   /** Label shown in the fallback UI so users know which panel failed */
@@ -29,12 +30,15 @@ export default class ErrorBoundary extends React.Component<Props, State> {
           <span className="text-fg-faint max-w-md text-center break-words">
             {this.state.error.message}
           </span>
-          <button
+          {/* Filled-grey (bg-inset/hover:bg-edge) becomes the outline `secondary`
+              per spec decision 60. py-1 keeps the original compact height. */}
+          <Button
+            variant="secondary"
             onClick={() => this.setState({ error: null })}
-            className="mt-2 px-3 py-1 rounded-sm bg-inset hover:bg-edge text-fg-2 transition-colors"
+            className="mt-2 py-1"
           >
             Retry
-          </button>
+          </Button>
         </div>
       );
     }

--- a/desktop/src/renderer/components/HandlePrompt.tsx
+++ b/desktop/src/renderer/components/HandlePrompt.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 import { useAccount } from '../state/account-context';
+import { Button } from './ui';
 
 // Persisted "don't nag me again" flag. Set on skip (and on ESC, which is the
 // same as skip), never set when the user actually claims a handle.
@@ -124,23 +125,20 @@ function HandlePromptPopup({
                 className="flex-1 text-xs bg-transparent text-fg focus:outline-none ml-0.5"
               />
             </div>
-            <button
+            <Button
               onClick={() => void save()}
               disabled={saving || draft.trim().length === 0}
-              className="text-xs font-medium px-3 py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+              className="py-2"
             >
               {saving ? 'Saving…' : 'Save'}
-            </button>
+            </Button>
           </div>
           {/* Plain words for status, never glyphs. */}
           {error && <p className="text-[10px] text-red-500">{error}</p>}
 
-          <button
-            onClick={skip}
-            className="w-full text-xs font-medium py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-          >
+          <Button variant="secondary" onClick={skip} className="w-full py-2">
             Skip for now
-          </button>
+          </Button>
         </div>
       </OverlayPanel>
     </>,

--- a/desktop/src/renderer/components/ImportProjectModal.tsx
+++ b/desktop/src/renderer/components/ImportProjectModal.tsx
@@ -5,6 +5,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
+import { Button } from './ui';
 
 interface Props {
   sourcePath: string;
@@ -113,7 +114,7 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
               {doneWarnings.map((w, i) => <li key={i}>{w}</li>)}
             </ul>
             <div className="mt-4 flex justify-end">
-              <button onClick={() => onDone(donePath!)} className="text-sm px-3 py-1 rounded bg-accent text-on-accent">Done</button>
+              <Button size="lg" className="py-1" onClick={() => onDone(donePath!)}>Done</Button>
             </div>
           </>
         ) : (
@@ -137,10 +138,10 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
             {error && <div role="alert" className="mt-2 text-xs text-red-500">{error}</div>}
             {syncOffNote}
             <div className="mt-4 flex justify-end gap-2">
-              <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
-              <button onClick={() => void confirm()} disabled={busy || !name.trim()} className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50">
+              <Button variant="ghost" size="lg" className="py-1" onClick={onClose} disabled={busy}>Cancel</Button>
+              <Button size="lg" className="py-1" onClick={() => void confirm()} disabled={busy || !name.trim()}>
                 {busy ? 'Moving…' : 'Move and sync'}
-              </button>
+              </Button>
             </div>
           </>
         )}

--- a/desktop/src/renderer/components/InputBar.tsx
+++ b/desktop/src/renderer/components/InputBar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback, useEffect, useLayoutEffect, useIm
 import { useChatDispatch } from '../state/chat-context';
 import QuickChips, { QuickChip } from './QuickChips';
 import TerminalToolbar from './TerminalToolbar';
+import { Button } from './ui';
 import { AttachIcon, CompassIcon } from './Icons';
 import BrailleBurst from './BrailleBurst';
 import FlowingKeywordsText from './FlowingKeywords';
@@ -526,12 +527,20 @@ const InputBar = forwardRef<InputBarHandle, Props>(function InputBar({ sessionId
                   </span>
                 </div>
               )}
-              <button
+              {/* In-chip remover, NOT a panel closer — CloseButton's 28px would be
+                  nearly as tall as the chip it sits on. Destin's call (spec §11.8 F):
+                  keep the 16px geometry, take the accessible name and focus ring.
+                  Still owed a `.coarse-hit` pass: 16px is well under the ~44dp touch
+                  guideline and this renderer is the Android UI too. */}
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove ${att.name ?? 'attachment'}`}
                 onClick={() => removeAttachment(att.path)}
-                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-inset text-fg-2 hover:bg-edge flex items-center justify-center text-[10px] leading-none opacity-0 group-hover:opacity-100 transition-opacity"
+                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-inset text-fg-2 hover:bg-edge text-[10px] leading-none opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
               >
                 ×
-              </button>
+              </Button>
             </div>
           ))}
         </div>
@@ -652,15 +661,26 @@ const InputBar = forwardRef<InputBarHandle, Props>(function InputBar({ sessionId
             className="input-bar-textarea scroll-fade relative block w-full bg-transparent text-sm text-transparent placeholder-fg-muted outline-none disabled:opacity-50 resize-none leading-snug p-0 m-0 align-middle break-words"
           />
           </div>
-          <button
+          {/* The app's most-used control. Geometry is unchanged — 28x28 is exactly
+              what size="icon" emits — and it keeps `bg-accent`, which matters:
+              community packs style the send button through `.bg-accent` (Halftone's
+              custom_css glow), so a variant without that class would silently drop
+              their glow. What changes: a real hover (hover:brightness-110 is
+              imperceptible on Light/Creme's near-black accent) and a focus ring.
+              disabled:opacity-30 is kept deliberately — it is dimmer than the
+              primitive's 50%, because an un-sendable composer should read as clearly
+              inert rather than merely faded. */}
+          <Button
             type="submit"
+            size="icon"
+            aria-label="Send message"
             disabled={disabled || (!minimal && !text.trim() && attachments.length === 0)}
-            className="shrink-0 w-7 h-7 flex items-center justify-center rounded-lg bg-accent hover:brightness-110 disabled:opacity-30 transition-colors"
+            className="shrink-0 disabled:opacity-30"
           >
             <svg className="w-4 h-4 text-on-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M12 5l7 7-7 7" />
             </svg>
-          </button>
+          </Button>
         </form>
       </div>
     </div>

--- a/desktop/src/renderer/components/LocalModelsSection.tsx
+++ b/desktop/src/renderer/components/LocalModelsSection.tsx
@@ -384,13 +384,11 @@ function RepoCard({
             )}
           </div>
         </button>
+        {/* Inline row action -> sm, matching EngineCard's Install/Restart. */}
         {chosen && !dl && (
-          <button
-            onClick={() => void startDefault()}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all shrink-0"
-          >
+          <Button size="sm" onClick={() => void startDefault()} className="shrink-0">
             Download
-          </button>
+          </Button>
         )}
       </div>
       {dl && <DownloadProgressRow dl={dl} />}
@@ -572,20 +570,15 @@ function PartialRow({
           </p>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
-          <button
-            onClick={() => void resume()}
-            disabled={busy}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60"
-          >
+          <Button variant="secondary" size="sm" onClick={() => void resume()} disabled={busy}>
             Resume
-          </button>
-          <button
-            onClick={() => void discard()}
-            disabled={busy}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-red-500/40 text-red-500 hover:bg-red-500/10 transition-colors disabled:opacity-60"
-          >
+          </Button>
+          {/* Discard deletes the partial file on disk -> danger-outline. The
+              hand-rolled red-500/40 border becomes the --destructive token, so
+              community packs can restyle it (identical #DD4444 today). */}
+          <Button variant="danger-outline" size="sm" onClick={() => void discard()} disabled={busy}>
             Discard
-          </button>
+          </Button>
         </div>
       </div>
     </div>
@@ -620,12 +613,9 @@ function QuantDownloadRow({ repo, q, downloads }: { repo: string; q: QuantWithFi
           </p>
         </div>
         {!dl && (
-          <button
-            onClick={() => void startDownload()}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all shrink-0"
-          >
+          <Button size="sm" onClick={() => void startDownload()} className="shrink-0">
             Download
-          </button>
+          </Button>
         )}
       </div>
       {dl && <DownloadProgressRow dl={dl} />}
@@ -676,13 +666,15 @@ function OtherLocalApps() {
     <div className="rounded-lg border border-edge-dim bg-well px-3 py-2.5">
       <div className="flex items-center justify-between gap-2">
         <p className="text-xs text-fg font-medium">Other local apps</p>
-        <button
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={() => void detect()}
           disabled={detecting}
-          className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60 shrink-0"
+          className="shrink-0"
         >
           {detecting ? 'Detecting…' : 'Detect'}
-        </button>
+        </Button>
       </div>
 
       {hits !== null && (
@@ -708,12 +700,9 @@ function OtherLocalApps() {
                       )}
                     </div>
                     {!isAdded && (
-                      <button
-                        onClick={() => void addEndpoint(hit)}
-                        className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all shrink-0"
-                      >
+                      <Button size="sm" onClick={() => void addEndpoint(hit)} className="shrink-0">
                         Add as endpoint
-                      </button>
+                      </Button>
                     )}
                   </div>
                 </div>

--- a/desktop/src/renderer/components/MarkdownContent.tsx
+++ b/desktop/src/renderer/components/MarkdownContent.tsx
@@ -6,6 +6,7 @@ import type { Plugin } from 'unified';
 import type { Root, Element, Text, RootContent } from 'hast';
 import { visitParents } from 'unist-util-visit-parents';
 import { detectFilepaths } from '../hooks/useInlineFilepathDetector';
+import { Button } from './ui';
 import { FilepathToken } from './FilepathToken';
 
 // Stable plugin arrays — avoids re-creating on every render when sessionId
@@ -81,12 +82,19 @@ function CopyButton({ text }: { text: string }) {
   };
 
   return (
-    <button
+    <Button
+      // ghost, not secondary (spec §11 decision 74): this floats over a code
+      // block, and a bordered button would draw a visible box on top of the code.
+      variant="ghost"
+      size="sm"
       onClick={handleCopy}
-      className="absolute top-2 right-2 px-2 py-1 text-xs rounded-sm bg-inset text-fg-2 hover:bg-edge transition-colors opacity-0 group-hover:opacity-100"
+      // Floating overlay control in the code block's corner, so opacity-0 at rest
+      // is correct and stays (spec decision 74). focus-visible:opacity-100 is new:
+      // at opacity-0 the button was invisible to keyboard users who tabbed to it.
+      className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
     >
       {copied ? 'Copied!' : 'Copy'}
-    </button>
+    </Button>
   );
 }
 

--- a/desktop/src/renderer/components/ModelLoadingBar.tsx
+++ b/desktop/src/renderer/components/ModelLoadingBar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { EngineModelState } from '../../shared/engine-types';
+import { Button } from './ui';
 
 // Centered status strip that floats just ABOVE the input area for a NATIVE
 // (local-model) session. States (2026-07-14 memory-lifecycle UX):
@@ -152,13 +153,13 @@ export default function ModelLoadingBar({ modelState, modelInfo, loadedBytes, ev
         ) : (
           <div className="flex items-center justify-center gap-3">
             <span className="text-sm text-fg-muted">Model unloaded to save memory.</span>
-            <button
-              type="button"
-              onClick={() => onReload(modelInfo.modelId)}
-              className="text-xs font-medium px-3 py-1 rounded-full bg-accent text-on-accent hover:opacity-90 shrink-0"
-            >
+            {/* Spec change 65: this one NORMALIZES — rounded-full drops to the
+                one control radius. The pill exception is reserved for floating
+                overlay affordances (e.g. ChatView's "Jump to bottom"); this sits
+                inside a panel, so it's an ordinary primary action. */}
+            <Button size="sm" onClick={() => onReload(modelInfo.modelId)} className="shrink-0">
               Reload model
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/desktop/src/renderer/components/ModelPickerPopup.tsx
+++ b/desktop/src/renderer/components/ModelPickerPopup.tsx
@@ -4,7 +4,7 @@ import type { ModelAlias } from './StatusBar';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { FastIcon } from './Icons';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button, FOCUS_RING } from './ui';
+import { Button, CloseButton, FOCUS_RING } from './ui';
 
 // Model + effort + fast picker. Replaces the cycle-only status bar chip with
 // a full picker. Invoked by:
@@ -314,11 +314,7 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
         >
           <div className="flex items-center justify-between px-5 py-3 border-b border-edge">
             <h3 className="text-sm font-semibold text-fg">Model</h3>
-            <button onClick={onClose} className="text-fg-muted hover:text-fg transition-colors w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset">
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+            <CloseButton onClick={onClose} label="Close model picker" />
           </div>
           <div className="px-5 pt-3">
             <input
@@ -386,11 +382,7 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
       >
         <div className="flex items-center justify-between px-5 py-3 border-b border-edge">
           <h3 className="text-sm font-semibold text-fg">Model &amp; Effort</h3>
-          <button onClick={onClose} className="text-fg-muted hover:text-fg transition-colors w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} label="Close model picker" />
         </div>
 
         {!loaded ? (

--- a/desktop/src/renderer/components/ModelPickerPopup.tsx
+++ b/desktop/src/renderer/components/ModelPickerPopup.tsx
@@ -4,6 +4,7 @@ import type { ModelAlias } from './StatusBar';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { FastIcon } from './Icons';
 import { useEscClose } from '../hooks/use-esc-close';
+import { Button, FOCUS_RING } from './ui';
 
 // Model + effort + fast picker. Replaces the cycle-only status bar chip with
 // a full picker. Invoked by:
@@ -515,18 +516,26 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
               </div>
 
               <div className="flex justify-end gap-2 pt-1">
-                <button
-                  onClick={() => setFastConfirmOpen(false)}
-                  className="px-3 py-1.5 text-xs rounded bg-inset text-fg-2 hover:bg-well transition-colors"
-                >
+                {/* Spec change 60: the filled-grey family (bg-inset/hover:bg-well)
+                    collapses into the outline `secondary` — it's a genuine peer of
+                    the confirm beside it, which ghost would under-weight. */}
+                <Button variant="secondary" onClick={() => setFastConfirmOpen(false)}>
                   Cancel
-                </button>
+                </Button>
+                {/* Spec change 66: KEEPS #FF9800 + text-black. This is a billing-
+                    consent warning colour (same family as the permission triad), not
+                    a theme surface, so it must NOT become `primary` — the accent
+                    would erase the "you are agreeing to charges" signal. Left
+                    hand-rolled because the primitive's variants would fight the
+                    custom fill; only radius (rounded → rounded-lg, the one control
+                    radius) and the shared focus ring are normalized. */}
                 <button
+                  type="button"
                   onClick={() => {
                     applyFast(true);
                     setFastConfirmOpen(false);
                   }}
-                  className="px-3 py-1.5 text-xs rounded bg-[#FF9800] text-black font-medium hover:brightness-110 transition-all"
+                  className={`px-3 py-1.5 text-xs rounded-lg bg-[#FF9800] text-black font-medium hover:bg-[#FF9800]/90 transition-colors ${FOCUS_RING}`}
                 >
                   Enable & Accept Charges
                 </button>

--- a/desktop/src/renderer/components/ModelProvidersPopup.tsx
+++ b/desktop/src/renderer/components/ModelProvidersPopup.tsx
@@ -9,7 +9,7 @@ import LocalModelsSection from './LocalModelsSection';
 import type { FirstRunState } from '../../shared/first-run-types';
 import type { ProviderStatus } from '../../shared/provider-types';
 import SettingsRow from './SettingsRow';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 
 // Settings → Model Providers. One settings row that opens an L2 popup gathering
 // every engine/provider surface in one place: Claude Code (the default engine),
@@ -106,15 +106,7 @@ function ModelProvidersPopupInner({
       >
         <div className="shrink-0 border-b border-edge flex items-center justify-between px-5 py-3">
           <h3 id="model-providers-title" className="text-sm font-semibold text-fg">Model Providers</h3>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-fg-muted hover:text-fg transition-colors w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <div ref={scrollRef} className="scroll-fade">
@@ -405,15 +397,7 @@ function ConnectOpenRouterModal({
           <h3 id="connect-openrouter-title" className="text-sm font-semibold text-fg">
             {hasKey ? 'Replace OpenRouter key' : 'Connect OpenRouter'}
           </h3>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-fg-muted hover:text-fg transition-colors w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <div className="p-4 space-y-3">

--- a/desktop/src/renderer/components/ModelProvidersPopup.tsx
+++ b/desktop/src/renderer/components/ModelProvidersPopup.tsx
@@ -9,6 +9,7 @@ import LocalModelsSection from './LocalModelsSection';
 import type { FirstRunState } from '../../shared/first-run-types';
 import type { ProviderStatus } from '../../shared/provider-types';
 import SettingsRow from './SettingsRow';
+import { Button } from './ui';
 
 // Settings → Model Providers. One settings row that opens an L2 popup gathering
 // every engine/provider surface in one place: Claude Code (the default engine),
@@ -235,13 +236,17 @@ function ClaudeCodeBlock({
           Every session runs through Claude Code unless you pick another provider below.
         </p>
 
+        {/* Outline peer action — the shared secondary recipe replaces the
+            hand-rolled border-edge-dim/text-fg-2 copy of it. */}
         {onOpenClaudePreferences && (
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => { onCloseParent(); onOpenClaudePreferences(); }}
-            className="mt-2.5 text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
+            className="mt-2.5"
           >
             Claude Code preferences
-          </button>
+          </Button>
         )}
       </div>
     </section>
@@ -312,21 +317,18 @@ function OpenRouterBlock() {
               {openrouter === undefined ? 'Checking…' : connected ? 'Connected' : 'Not connected'}
             </p>
           </div>
-          <button
-            onClick={() => { setTestNote(null); setConnectOpen(true); }}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all shrink-0"
-          >
+          {/* Primary row action. hover:brightness-110 dropped — the primitive's
+              bg fade is the one hover idiom (it stays visible on near-black
+              accents, where brightness-110 does nothing). */}
+          <Button size="sm" onClick={() => { setTestNote(null); setConnectOpen(true); }} className="shrink-0">
             {connected ? 'Replace key' : 'Connect to OpenRouter'}
-          </button>
+          </Button>
         </div>
         {connected && (
           <div className="flex items-center gap-1.5 mt-2">
-            <button
-              onClick={() => void runTest()}
-              className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-            >
+            <Button variant="secondary" size="sm" onClick={() => void runTest()}>
               Test
-            </button>
+            </Button>
           </div>
         )}
         {testNote && (
@@ -446,19 +448,18 @@ function ConnectOpenRouterModal({
           )}
 
           <div className="flex gap-2 pt-1">
-            <button
-              onClick={onClose}
-              className="flex-1 text-xs font-medium py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-            >
+            {/* Popup footer pair — md is the footer size; only the flex-1 stretch
+                and the taller py-2 are genuine layout extras. */}
+            <Button variant="secondary" onClick={onClose} className="flex-1 py-2">
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={() => void save()}
               disabled={busy || keyDraft.trim().length === 0}
-              className="flex-1 text-xs font-medium py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+              className="flex-1 py-2"
             >
               {busy ? 'Connecting…' : 'Connect'}
-            </button>
+            </Button>
           </div>
         </div>
       </OverlayPanel>
@@ -619,25 +620,21 @@ function SearchProvidersBlock() {
                 {row.hasKey ? (
                   <div className="flex items-center gap-1.5 shrink-0">
                     <span className="text-[10px] font-medium text-green-600">Key saved</span>
-                    <button
-                      onClick={() => void remove(row.id)}
-                      disabled={busy}
-                      className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-                    >
+                    {/* danger-outline per spec change 68: "Remove" reads the same
+                        everywhere. This one was the neutral half of the
+                        ProvidersSection(red)-vs-here(neutral) contradiction; it
+                        deletes a stored API key, so it takes the red outline. */}
+                    <Button variant="danger-outline" size="sm" onClick={() => void remove(row.id)} disabled={busy}>
                       Remove
-                    </button>
+                    </Button>
                   </div>
                 ) : !isEditing ? (
                   // Disabled while ANY row's save/remove is in flight — otherwise
                   // opening this editor mid-save gets clobbered when the in-flight
                   // save resolves and clears editing/draft.
-                  <button
-                    onClick={() => openEditor(row.id)}
-                    disabled={busy}
-                    className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all shrink-0 disabled:opacity-60 disabled:cursor-not-allowed"
-                  >
+                  <Button size="sm" onClick={() => openEditor(row.id)} disabled={busy} className="shrink-0">
                     Add key
-                  </button>
+                  </Button>
                 ) : null}
               </div>
 
@@ -661,19 +658,12 @@ function SearchProvidersBlock() {
                       Get a free key
                     </button>
                     <div className="flex gap-2">
-                      <button
-                        onClick={() => { setEditing(null); setDraft(''); }}
-                        className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-                      >
+                      <Button variant="secondary" size="sm" onClick={() => { setEditing(null); setDraft(''); }}>
                         Cancel
-                      </button>
-                      <button
-                        onClick={() => void save(row.id)}
-                        disabled={busy || draft.trim().length === 0}
-                        className="text-[11px] font-medium px-2.5 py-1 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
-                      >
+                      </Button>
+                      <Button size="sm" onClick={() => void save(row.id)} disabled={busy || draft.trim().length === 0}>
                         {busy ? 'Checking…' : 'Save'}
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 </div>

--- a/desktop/src/renderer/components/MovedGate.tsx
+++ b/desktop/src/renderer/components/MovedGate.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppIcon, ThemeMascot } from './Icons';
+import { Button } from './ui';
 
 // Plan 2b "Moved Gate" (2026-07-14). When another device takes over a session's
 // lease, the holder side cleanly interrupts → flushes → releases → destroys the
@@ -43,19 +44,19 @@ export default function MovedGate({ device, onExit, onResume, canResume = true }
         device, or close it out.
       </p>
       <div className="flex gap-3">
-        <button
-          onClick={onExit}
-          className="px-4 py-1.5 text-sm font-medium rounded-md transition-colors bg-inset hover:bg-edge text-fg"
-        >
+        {/* The filled-grey "bg-inset hover:bg-edge" treatment collapses into the
+            primitive's `secondary` outline (spec decision 60) — the two buttons
+            are genuine peers here, so ghost would under-weight Exit. */}
+        <Button variant="secondary" size="lg" onClick={onExit} className="py-1.5">
           Exit Session
-        </button>
+        </Button>
         {canResume && (
-          <button
-            onClick={onResume}
-            className="px-4 py-1.5 text-sm font-medium rounded-md transition-colors bg-accent hover:bg-accent text-on-accent"
-          >
+          // Behavior change (spec change 75): this button's old `hover:bg-accent`
+          // sat on top of a `bg-accent` base, so hovering it did nothing visible.
+          // `primary` gives it a real hover fade for the first time.
+          <Button size="lg" onClick={onResume} className="py-1.5">
             Resume on this device
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/desktop/src/renderer/components/OpenTasksPopup.tsx
+++ b/desktop/src/renderer/components/OpenTasksPopup.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 import type { TaskState } from '../state/task-state';
+import { Button } from './ui';
 
 // L2 popup opened by OpenTasksChip in the StatusBar. Groups tasks by status:
 // In Progress → Pending → Completed (collapsible). A separate "Marked Inactive"
@@ -65,21 +66,29 @@ function Row({ t, group, onMarkInactive, onUnhide }: {
         {showDesc && <div className="text-[11px] text-fg-muted mt-0.5 leading-tight">{t.description}</div>}
       </div>
       {group === 'inactive' ? (
-        <button
-          className="text-[10px] text-fg-muted hover:text-fg bg-inset hover:bg-well px-2 py-0.5 rounded border border-edge-dim"
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={() => onUnhide(t.id)}
           aria-label={`Unhide task #${t.id}`}
         >
           Unhide
-        </button>
+        </Button>
       ) : (
-        <button
-          className="text-[10px] text-fg-muted hover:text-fg bg-inset hover:bg-well px-2 py-0.5 rounded border border-edge-dim opacity-40 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+        // The 40% resting opacity is deliberate (spec decision 74): it's the
+        // standing hint that rows are dismissible, so it is NOT dropped to 0.
+        // Careful: 40% sits BELOW BUTTON_BASE's `disabled:opacity-50`, so if a
+        // `disabled` prop is ever added here a disabled button would render
+        // BRIGHTER than an enabled one — revisit this resting value first.
+        <Button
+          variant="ghost"
+          size="sm"
+          className="opacity-40 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
           onClick={() => onMarkInactive(t.id)}
           aria-label={`Mark task #${t.id} inactive`}
         >
           Mark Inactive
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/desktop/src/renderer/components/PerformancePopup.tsx
+++ b/desktop/src/renderer/components/PerformancePopup.tsx
@@ -3,6 +3,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import type { ExplainerSection } from './SettingsExplainer';
+import { Button } from './ui';
 
 // Explainer copy lives here as a const because it pairs tightly with the
 // controls above it — both are about GPU choice. Sections render inline in
@@ -141,14 +142,13 @@ export default function PerformancePopup({
             {needsRestart && (
               <div className="px-3 py-2 rounded-lg bg-inset flex items-center justify-between gap-3">
                 <span className="text-xs text-fg-2">⟳ Restart YouCoded to apply.</span>
-                <button
+                <Button
                   type="button"
                   onClick={handleRestart}
                   disabled={restarting}
-                  className="text-xs px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-60"
                 >
                   {restarting ? 'Restarting…' : 'Restart now'}
-                </button>
+                </Button>
               </div>
             )}
 

--- a/desktop/src/renderer/components/PerformancePopup.tsx
+++ b/desktop/src/renderer/components/PerformancePopup.tsx
@@ -3,7 +3,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import type { ExplainerSection } from './SettingsExplainer';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 
 // Explainer copy lives here as a const because it pairs tightly with the
 // controls above it — both are about GPU choice. Sections render inline in
@@ -104,13 +104,7 @@ export default function PerformancePopup({
             visually fits with the rest of the settings UI. */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-edge shrink-0">
           <h2 className="text-sm font-bold text-fg">Performance</h2>
-          <button
-            onClick={onClose}
-            className="text-fg-muted hover:text-fg-2 text-lg leading-none w-6 h-6 flex items-center justify-center"
-            aria-label="Close"
-          >
-            ✕
-          </button>
+          <CloseButton onClick={onClose} label="Close performance settings" />
         </div>
 
         {/* Scrollable body. Controls at top, explainer below. */}

--- a/desktop/src/renderer/components/PreferencesPopup.tsx
+++ b/desktop/src/renderer/components/PreferencesPopup.tsx
@@ -4,6 +4,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useTheme } from '../state/theme-context';
 import { useEscClose } from '../hooks/use-esc-close';
+import { Button } from './ui';
 
 // Native replacement for Claude Code's /config TUI. Reads/writes fields in
 // ~/.claude/settings.json via the settings:* IPC bridge.
@@ -242,15 +243,17 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced }: Prop
 
             {/* Advanced escape hatch — opens Claude Code's native TUI for any option not covered here */}
             <section className="pt-3 border-t border-edge-dim">
-              <button
+              <Button
+                variant="secondary"
+                size="lg"
                 onClick={() => {
                   onClose();
                   onOpenAdvanced();
                 }}
-                className="w-full py-2 px-3 text-sm bg-inset text-fg-2 hover:bg-well border border-edge-dim rounded transition-colors"
+                className="w-full"
               >
                 Advanced (terminal) →
-              </button>
+              </Button>
               <p className="text-[11px] text-fg-muted mt-1.5 text-center">
                 Switches to terminal view and runs Claude Code's full <code>/config</code>
               </p>

--- a/desktop/src/renderer/components/PreferencesPopup.tsx
+++ b/desktop/src/renderer/components/PreferencesPopup.tsx
@@ -4,7 +4,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useTheme } from '../state/theme-context';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 
 // Native replacement for Claude Code's /config TUI. Reads/writes fields in
 // ~/.claude/settings.json via the settings:* IPC bridge.
@@ -130,11 +130,7 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced }: Prop
       >
         <div className="shrink-0 bg-panel border-b border-edge flex items-center justify-between px-5 py-3">
           <h3 className="text-sm font-semibold text-fg">Claude Code Preferences</h3>
-          <button onClick={onClose} className="text-fg-muted hover:text-fg transition-colors w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} label="Close preferences" />
         </div>
 
         {!loaded ? (

--- a/desktop/src/renderer/components/ProvidersSection.tsx
+++ b/desktop/src/renderer/components/ProvidersSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { Button } from './ui';
 import type { ProviderStatus, ProviderConfig, ProviderType } from '../../shared/provider-types';
 
 // Settings → Providers section (Phase 1 Plan A, Task 13). Lets the user add,
@@ -164,12 +165,9 @@ export default function ProvidersSection({ embedded = false }: { embedded?: bool
                   ? `Couldn't load providers — ${listError}`
                   : `Couldn't refresh — ${listError}`}
               </p>
-              <button
-                onClick={() => void refresh()}
-                className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors shrink-0"
-              >
+              <Button variant="secondary" size="sm" onClick={() => void refresh()} className="shrink-0">
                 Retry
-              </button>
+              </Button>
             </div>
           )}
 
@@ -180,12 +178,9 @@ export default function ProvidersSection({ embedded = false }: { embedded?: bool
           {adding ? (
             <AddProviderForm onDone={async () => { setAdding(false); await refresh(); }} onCancel={() => setAdding(false)} />
           ) : (
-            <button
-              onClick={() => setAdding(true)}
-              className="w-full text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-            >
+            <Button variant="secondary" onClick={() => setAdding(true)} className="w-full py-2.5">
               Add provider
-            </button>
+            </Button>
           )}
         </div>
       )}
@@ -296,29 +291,22 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
       {!isLocal && (
         <div className="flex items-center gap-1.5 mt-2 flex-wrap">
           {!keyOpen && (
-            <button
-              onClick={() => { setKeyOpen(true); setNote(null); }}
-              className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-            >
+            <Button variant="secondary" size="sm" onClick={() => { setKeyOpen(true); setNote(null); }}>
               {provider.hasKey ? 'Replace key' : 'Add key'}
-            </button>
+            </Button>
           )}
-          <button
-            onClick={() => void runTest()}
-            disabled={busy}
-            className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors disabled:opacity-60"
-          >
+          <Button variant="secondary" size="sm" onClick={() => void runTest()} disabled={busy}>
             {busy ? 'Testing…' : 'Test'}
-          </button>
+          </Button>
           {/* Remove — non-builtIn rows only (local/openrouter are builtIn and
-              cannot be removed). Consequence-gated inline confirm. */}
+              cannot be removed). Consequence-gated inline confirm.
+              danger-outline per spec change 68: "Remove" reads the same everywhere,
+              because removing a provider deletes a key the user pasted in. Was a
+              hand-rolled border-red-500/40 + text-red-500. */}
           {!provider.builtIn && !confirmingRemove && (
-            <button
-              onClick={() => { setConfirmingRemove(true); setNote(null); }}
-              className="text-[11px] font-medium px-2.5 py-1 rounded-lg border border-red-500/40 text-red-500 hover:bg-red-500/10 transition-colors"
-            >
+            <Button variant="danger-outline" size="sm" onClick={() => { setConfirmingRemove(true); setNote(null); }}>
               Remove
-            </button>
+            </Button>
           )}
         </div>
       )}
@@ -336,19 +324,12 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
             aria-label={`${provider.label} API key`}
             className="flex-1 text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
           />
-          <button
-            onClick={() => void saveKey()}
-            disabled={busy || keyDraft.trim().length === 0}
-            className="text-xs font-medium px-3 py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
-          >
+          <Button onClick={() => void saveKey()} disabled={busy || keyDraft.trim().length === 0} className="py-2">
             {busy ? 'Saving…' : 'Save'}
-          </button>
-          <button
-            onClick={() => { setKeyOpen(false); setKeyDraft(''); }}
-            className="text-xs font-medium px-3 py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-          >
+          </Button>
+          <Button variant="secondary" onClick={() => { setKeyOpen(false); setKeyDraft(''); }} className="py-2">
             Cancel
-          </button>
+          </Button>
         </div>
       )}
 
@@ -359,19 +340,15 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
             Remove {provider.label}? Its API key is deleted from this computer.
           </p>
           <div className="flex gap-2">
-            <button
-              onClick={() => setConfirmingRemove(false)}
-              className="flex-1 text-xs font-medium py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-            >
+            <Button variant="secondary" onClick={() => setConfirmingRemove(false)} className="flex-1 py-2">
               Cancel
-            </button>
-            <button
-              onClick={() => void confirmRemove()}
-              disabled={busy}
-              className="flex-1 text-xs font-medium py-2 rounded-lg bg-red-500 text-white hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            </Button>
+            {/* Filled danger for the committing action (the confirm), outline for the
+                one that opens it — spec change 59. Was bg-red-500 + text-white; the
+                token pair carries an engine-derived label color instead. */}
+            <Button variant="danger" onClick={() => void confirmRemove()} disabled={busy} className="flex-1 py-2">
               {busy ? 'Removing…' : 'Remove'}
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -495,19 +472,12 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
       {error && <p className="text-[10px] text-red-500">{error}</p>}
 
       <div className="flex gap-2 pt-1">
-        <button
-          onClick={onCancel}
-          className="flex-1 text-xs font-medium py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-        >
+        <Button variant="secondary" onClick={onCancel} className="flex-1 py-2">
           Cancel
-        </button>
-        <button
-          onClick={() => void submit()}
-          disabled={busy}
-          className="flex-1 text-xs font-medium py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
-        >
+        </Button>
+        <Button onClick={() => void submit()} disabled={busy} className="flex-1 py-2">
           {busy ? 'Adding…' : 'Add provider'}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/desktop/src/renderer/components/QuickChips.tsx
+++ b/desktop/src/renderer/components/QuickChips.tsx
@@ -4,7 +4,7 @@ import { isAndroid } from '../platform';
 import { useSkills } from '../state/skill-context';
 import type { ChipConfig } from '../../shared/types';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 
@@ -275,14 +275,7 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
             never clips it. Matches PreferencesPopup/StatusBar pattern. */}
         <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-edge">
           <h2 className="text-sm font-bold text-fg">Edit Quick Chips</h2>
-          <button
-            onClick={onClose}
-            className="text-fg-muted hover:text-fg-2 text-lg leading-none w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <CloseButton onClick={onClose} label="Close quick chips editor" />
         </div>
 
         <div ref={bodyRef} className="scroll-fade">

--- a/desktop/src/renderer/components/QuickChips.tsx
+++ b/desktop/src/renderer/components/QuickChips.tsx
@@ -4,6 +4,7 @@ import { isAndroid } from '../platform';
 import { useSkills } from '../state/skill-context';
 import type { ChipConfig } from '../../shared/types';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { Button } from './ui';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 
@@ -356,13 +357,13 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
                     className="w-full px-2 py-1 text-[11px] bg-well border border-edge-dim rounded-md text-fg placeholder:text-fg-faint focus:outline-none focus:border-accent resize-none"
                   />
                   <div className="flex gap-2">
-                    <button
+                    <Button
+                      size="sm"
                       onClick={addCustom}
                       disabled={!customLabel.trim() || !customPrompt.trim()}
-                      className="px-2 py-1 text-[10px] bg-accent text-on-accent rounded-md disabled:opacity-40"
                     >
                       Add Custom
-                    </button>
+                    </Button>
                     <button onClick={() => setShowAddForm(false)} className="px-2 py-1 text-[10px] text-fg-muted hover:text-fg">Cancel</button>
                   </div>
                 </div>

--- a/desktop/src/renderer/components/QuickChips.tsx
+++ b/desktop/src/renderer/components/QuickChips.tsx
@@ -311,6 +311,12 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
                       <button
                         onPointerDown={(e) => e.stopPropagation()}
                         onClick={() => { if (!suppressClick.current) remove(i); }}
+                        // Deliberately NOT a ui/Button. Unlike InputBar's attachment ✕
+                        // (which is a 16px badge and did migrate), this is a bare glyph
+                        // with no background, radius or padding — routing it through the
+                        // primitive would ADD chrome it has never had. It sits below
+                        // spec §11.1's "real button chrome" bar. `title` already gives it
+                        // an accessible name.
                         className="shrink-0 px-1 text-fg-muted hover:text-red-400"
                         title="Remove chip"
                       >

--- a/desktop/src/renderer/components/ResumeBrowser.tsx
+++ b/desktop/src/renderer/components/ResumeBrowser.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom';
 import { MODELS, type ModelAlias } from './StatusBar';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { Button } from './ui';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import { SkipPermissionsInfoTooltip } from './SkipPermissionsInfoTooltip';
@@ -554,16 +555,16 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
         {(() => {
           const dangerous = s.provider !== 'native' && resumeDangerous;
           return (
-            <button
+            /* Filled danger for skip-permissions — same call as SessionStrip's
+               Create button (spec §11, change 62). See the longer note there. */
+            <Button
+              variant={dangerous ? 'danger' : 'primary'}
+              size="lg"
               onClick={() => handleConfirmResume(s)}
-              className={`w-full text-sm font-medium rounded-md py-1.5 transition-colors ${
-                dangerous
-                  ? 'bg-[#DD4444] hover:bg-[#E55555] text-white'
-                  : 'bg-accent hover:bg-accent text-on-accent'
-              }`}
+              className="w-full py-1.5"
             >
               {dangerous ? 'Resume (Dangerous)' : 'Resume Session'}
-            </button>
+            </Button>
           );
         })()}
       </div>

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -17,6 +17,7 @@ import type { ArtifactRecord } from '../../shared/artifacts/types';
 import { categorizeArtifact } from '../../shared/artifacts/categorization';
 import { getPlatform } from '../platform';
 import { formatRelativeTime } from '../utils/format-time';
+import { CloseButton } from './ui';
 
 type SortKey = 'recent' | 'name' | 'type';
 
@@ -340,11 +341,11 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
             only what Claude made + pinned files. */}
         <span className="font-semibold text-sm">Files ({listedArtifacts.length})</span>
         {!active && (
-          <button
-            className="text-fg-muted hover:text-fg px-1 text-base leading-none"
+          <CloseButton
             onClick={() => dispatch({ type: 'DRAWER_CLOSED', sessionId })}
             title="Close drawer"
-          >×</button>
+            label="Close drawer"
+          />
         )}
       </div>
       {/* Search + sort */}
@@ -683,15 +684,14 @@ function ArtifactListItem({ artifact, isActive, isDeleted, onSelect, onRemove }:
         <div className="text-[10px] text-fg-muted ml-0.5">{statusWord} · {relTime}</div>
       </button>
       {onRemove && (
-        <button
-          type="button"
-          className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-6 h-6 rounded-md inline-flex items-center justify-center text-fg-muted hover:text-fg hover:bg-well"
+        <CloseButton
+          // w-6 h-6 survives as a className override: hover-revealed row affordance,
+          // sized to the row rather than the standard 28px panel-header closer.
+          className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-6 h-6 rounded-md"
           title={`Remove ${fileName} from this list (the file itself is not deleted)`}
-          aria-label={`Remove ${fileName} from this list`}
+          label={`Remove ${fileName} from this list`}
           onClick={(e) => { e.stopPropagation(); onRemove(); }}
-        >
-          <Ic name="close" size={12} />
-        </button>
+        />
       )}
     </div>
   );

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { SessionStatusColor } from './StatusDot';
+import { Button } from './ui';
 import { isAndroid, isRemoteMode } from '../platform';
 import { MODELS, type ModelAlias } from './StatusBar';
 import FolderSwitcher from './FolderSwitcher';
@@ -1063,17 +1064,25 @@ export default function SessionStrip({
                   </button>
                 </div>
               )}
-              <button
+              {/* Skip-permissions sessions get the FILLED danger variant (spec §11,
+                  change 62 — Destin's call). Known and accepted consequence: this now
+                  looks identical to "Remove project". Filled red in this app means
+                  "stop and read this", not strictly "this destroys something"; the
+                  outline variant is the confirm-y tier. Don't downgrade this to
+                  danger-outline for consistency — that was considered and rejected.
+                  Was raw bg-[#DD4444]/[#E55555] + text-white; the token pair carries
+                  an engine-derived label color so a pale community red can't go
+                  white-on-pink. The non-dangerous branch also gains a real hover
+                  (it was hover:bg-accent over bg-accent — inert; change 75). */}
+              <Button
+                variant={dangerous ? 'danger' : 'primary'}
+                size="lg"
                 onClick={handleCreate}
                 disabled={nb.nativeCreateBlocked}
-                className={`w-full text-sm font-medium rounded-md py-1.5 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-                  dangerous
-                    ? 'bg-[#DD4444] hover:bg-[#E55555] text-white'
-                    : 'bg-accent hover:bg-accent text-on-accent'
-                }`}
+                className="w-full py-1.5"
               >
                 {dangerous ? 'Create (Dangerous)' : 'Create Session'}
-              </button>
+              </Button>
             </div>
           ) : (
             <div className="flex rounded-b-lg overflow-hidden">

--- a/desktop/src/renderer/components/SettingsExplainer.tsx
+++ b/desktop/src/renderer/components/SettingsExplainer.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { useScrollFade } from '../hooks/useScrollFade';
+import { CloseButton } from './ui';
 import { useEscClose } from '../hooks/use-esc-close';
 
 export interface ExplainerBullet {
@@ -61,13 +62,7 @@ export default function SettingsExplainer({ title, intro, sections, onBack, onCl
           </svg>
         </button>
         <h2 className="text-sm font-bold text-fg">About {title}</h2>
-        <button
-          onClick={onClose}
-          className="text-fg-muted hover:text-fg-2 text-lg leading-none w-6 h-6 flex items-center justify-center"
-          aria-label="Close"
-        >
-          ✕
-        </button>
+        <CloseButton onClick={onClose} />
       </div>
 
       {/* Body — intro paragraph, then each section with its own heading.

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1059,17 +1059,22 @@ function RemoteButton({
                       </div>
                     </section>
 
-                    {/* Add Device — requires Tailscale running, otherwise tailscale.url is null */}
+                    {/* Add Device — requires Tailscale running, otherwise tailscale.url is null.
+                        Was a soft-blue tinted outline (bg-blue-500/10 + text-blue-400) that matched
+                        no variant. Destin's call (spec §11.8 A): plain `secondary`. Unlike the
+                        orange billing button, nothing here is a warning — the blue was decorative,
+                        not signal. */}
                     {tailscale?.installed && tailscale?.connected && tailscale?.url && config?.hasPassword && (
-                      <button
+                      <Button
                         onClick={() => onSetShowAddDevice(!showAddDevice)}
-                        className="w-full px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-500/25 text-xs text-blue-400 font-medium hover:bg-blue-500/20 transition-colors flex items-center justify-center gap-1.5"
+                        variant="secondary"
+                        className="w-full py-2"
                       >
                         <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                           <path strokeLinecap="round" strokeLinejoin="round" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
                         </svg>
                         Add Device
-                      </button>
+                      </Button>
                     )}
 
                     {/* Remote Clients section */}

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -424,25 +424,24 @@ function SoundCategorySection({ category, label, description, dotColor }: {
           />
           {/* Custom sound controls */}
           <div className="flex items-center gap-2 mt-2">
-            <button
-              onClick={handlePickCustom}
-              className="px-2 py-1 rounded text-[10px] bg-inset text-fg-dim hover:bg-edge transition-colors flex items-center gap-1"
-            >
+            <Button variant="secondary" size="sm" onClick={handlePickCustom}>
               <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                 <polyline points="17 8 12 3 7 8" />
                 <line x1="12" y1="3" x2="12" y2="15" />
               </svg>
               {customName ? 'Change file' : 'Custom sound'}
-            </button>
+            </Button>
+            {/* ghost, not danger-outline: this only clears a sound preference. */}
             {customName && (
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={handleClearCustom}
-                className="px-2 py-1 rounded text-[10px] text-fg-muted hover:text-fg hover:bg-edge transition-colors"
                 title="Remove custom sound"
               >
                 Remove
-              </button>
+              </Button>
             )}
           </div>
         </>
@@ -1026,13 +1025,15 @@ function RemoteButton({
                             onKeyDown={(e) => e.key === 'Enter' && onSetPassword()}
                             className="flex-1 px-2 py-1 rounded-sm bg-well border border-edge-dim text-xs text-fg focus:outline-none focus:border-fg-muted"
                           />
-                          <button
+                          {/* sm keeps this level with the text input it sits beside. */}
+                          <Button
+                            variant="secondary"
+                            size="sm"
                             onClick={onSetPassword}
                             disabled={!newPassword.trim() || passwordStatus === 'saving'}
-                            className="px-2 py-1 rounded-sm bg-inset hover:bg-edge text-xs disabled:opacity-50"
                           >
                             {passwordStatus === 'saved' ? '✓' : passwordStatus === 'saving' ? '...' : 'Set'}
-                          </button>
+                          </Button>
                         </div>
                       </div>
 
@@ -1118,12 +1119,9 @@ function RemoteButton({
                           <QRCodeSVG value={tailscale.url} size={140} />
                         </div>
                         <p className="text-[10px] text-fg-muted mt-2 text-center font-mono">{tailscale.url}</p>
-                        <button
-                          onClick={onCopyLink}
-                          className="w-full mt-2 px-3 py-1.5 rounded-sm bg-inset hover:bg-edge text-xs"
-                        >
+                        <Button variant="secondary" onClick={onCopyLink} className="w-full mt-2">
                           {copied ? 'Copied!' : 'Copy Link'}
-                        </button>
+                        </Button>
                       </section>
                     )}
 
@@ -1161,13 +1159,13 @@ function RemoteButton({
                           <p className="text-xs text-fg-muted mb-2">
                             Tailscale is not installed. It creates a secure private network so you can access YouCoded from anywhere.
                           </p>
-                          <button
+                          <Button
+                            variant="secondary"
                             onClick={onRunSetup}
                             disabled={setupStatus === 'installing' || setupStatus === 'authenticating'}
-                            className="px-3 py-1.5 rounded-sm bg-inset hover:bg-edge text-xs disabled:opacity-50"
                           >
                             {setupStatus === 'installing' ? 'Installing...' : setupStatus === 'authenticating' ? 'Authenticating...' : 'Install Tailscale'}
-                          </button>
+                          </Button>
                         </div>
                       )}
                     </section>
@@ -1337,18 +1335,19 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
                     These protections exist for a reason. Disabling them means a single bad model output could corrupt your repository, hijack your shell environment, or escalate access beyond this project. There is no undo.
                   </p>
                   <div className="flex gap-2 pt-2">
-                    <button
-                      onClick={() => setConfirmOpen(false)}
-                      className="flex-1 px-3 py-1.5 text-[11px] font-medium rounded-md bg-inset hover:bg-edge text-fg-muted transition-colors"
-                    >
+                    <Button variant="secondary" onClick={() => setConfirmOpen(false)} className="flex-1">
                       Cancel
-                    </button>
-                    <button
+                    </Button>
+                    {/* Change 59: was stock bg-red-600/70 + text-white — a second
+                        red beside the app's #DD4444, and white-on-pale on packs
+                        that soften --destructive. Filled danger commits. */}
+                    <Button
+                      variant="danger"
                       onClick={() => { updateOverride('approveAll', true); setConfirmOpen(false); }}
-                      className="flex-1 px-3 py-1.5 text-[11px] font-medium rounded-md bg-red-600/70 hover:bg-red-600/90 text-white transition-colors"
+                      className="flex-1"
                     >
                       I understand, enable anyway
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </OverlayPanel>
@@ -1808,13 +1807,14 @@ function ConnectToDesktopButton() {
                       Connected to {connectedDeviceName || 'Desktop'}
                     </span>
                   </div>
-                  <button
+                  <Button
+                    variant="secondary"
                     onClick={handleDisconnect}
                     disabled={connecting}
-                    className="w-full px-3 py-1.5 rounded-sm bg-inset hover:bg-edge text-xs text-fg-2 disabled:opacity-50"
+                    className="w-full"
                   >
                     {connecting ? 'Disconnecting...' : 'Disconnect — Return to Local'}
-                  </button>
+                  </Button>
                 </div>
               )}
 
@@ -2095,21 +2095,22 @@ function AndroidSettings({ open, onClose, onSendInput, onOpenThemeMarketplace, o
               </div>
               <p className="text-[11px] text-fg-dim mb-5">Okay to open donation link?</p>
               <div className="flex gap-2">
-                <button
-                  onClick={() => setShowDonateConfirm(false)}
-                  className="flex-1 text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-                >
+                {/* py-2.5 kept as a deliberate override: this two-button footer is
+                    the whole modal, so md's py-1.5 reads too slight here. */}
+                <Button variant="secondary" onClick={() => setShowDonateConfirm(false)} className="flex-1 py-2.5">
                   Cancel
-                </button>
-                <button
+                </Button>
+                {/* Change 52: hover:brightness-110 was invisible on Light/Creme's
+                    near-black accent and blew out the glow packs. */}
+                <Button
                   onClick={() => {
                     window.open('https://buymeacoffee.com/itsdestin', '_blank');
                     setShowDonateConfirm(false);
                   }}
-                  className="flex-1 text-xs font-medium py-2.5 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all"
+                  className="flex-1 py-2.5"
                 >
                   Open
-                </button>
+                </Button>
               </div>
             </div>
           </div>,
@@ -2426,21 +2427,22 @@ function DesktopSettings({ open, onClose, onSendInput, hasActiveSession, onOpenT
               </div>
               <p className="text-[11px] text-fg-dim mb-5">Okay to open donation link?</p>
               <div className="flex gap-2">
-                <button
-                  onClick={() => setShowDonateConfirm(false)}
-                  className="flex-1 text-xs font-medium py-2.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
-                >
+                {/* py-2.5 kept as a deliberate override: this two-button footer is
+                    the whole modal, so md's py-1.5 reads too slight here. */}
+                <Button variant="secondary" onClick={() => setShowDonateConfirm(false)} className="flex-1 py-2.5">
                   Cancel
-                </button>
-                <button
+                </Button>
+                {/* Change 52: hover:brightness-110 was invisible on Light/Creme's
+                    near-black accent and blew out the glow packs. */}
+                <Button
                   onClick={() => {
                     window.open('https://buymeacoffee.com/itsdestin', '_blank');
                     setShowDonateConfirm(false);
                   }}
-                  className="flex-1 text-xs font-medium py-2.5 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all"
+                  className="flex-1 py-2.5"
                 >
                   Open
-                </button>
+                </Button>
               </div>
             </div>
           </div>,

--- a/desktop/src/renderer/components/ShareSheet.tsx
+++ b/desktop/src/renderer/components/ShareSheet.tsx
@@ -3,6 +3,7 @@ import { QRCodeSVG } from 'qrcode.react';
 import { useSkills } from '../state/skill-context';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
+import { Button } from './ui';
 
 interface ShareSheetProps {
   skillId: string;
@@ -114,12 +115,9 @@ export default function ShareSheet({ skillId, onClose }: ShareSheetProps) {
           <div className="mb-4">
             <div className="flex items-center gap-2 bg-well border border-edge-dim rounded-lg px-3 py-2">
               <span className="flex-1 text-[11px] text-fg-muted truncate select-all">{shareLink}</span>
-              <button
-                onClick={handleCopy}
-                className="shrink-0 text-[11px] font-medium px-2 py-1 rounded-sm bg-accent text-on-accent hover:brightness-110 transition-colors"
-              >
+              <Button size="sm" onClick={handleCopy} className="shrink-0">
                 {copied ? 'Copied!' : 'Copy'}
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -140,13 +138,13 @@ export default function ShareSheet({ skillId, onClose }: ShareSheetProps) {
             </div>
           ) : (
             <>
-              <button
+              <Button
                 onClick={handlePublish}
                 disabled={publishing}
-                className="w-full text-xs font-medium py-2.5 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
+                className="w-full py-2.5"
               >
                 {publishing ? 'Publishing...' : 'Publish to Marketplace'}
-              </button>
+              </Button>
               {publishError && (
                 <p className="text-xs text-red-400 text-center mt-2">{publishError}</p>
               )}

--- a/desktop/src/renderer/components/SkillCard.tsx
+++ b/desktop/src/renderer/components/SkillCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { SkillEntry } from '../../shared/types';
 import { useMarketplaceStats } from '../state/marketplace-stats-context';
+import { Button } from './ui';
 import StarRating from './marketplace/StarRating';
 import FavoriteStar from './marketplace/FavoriteStar';
 
@@ -172,12 +173,13 @@ function SkillCardImpl({
             Installing...
           </div>
         ) : onInstall ? (
-          <button
+          <Button
+            size="sm"
             onClick={(e) => { e.stopPropagation(); onInstall(skill); }}
-            className="w-full bg-accent text-on-accent text-[11px] font-medium py-1 mt-2 rounded-sm hover:brightness-110 transition-colors"
+            className="w-full mt-2"
           >
             Get
-          </button>
+          </Button>
         ) : null}
       </div>
     );

--- a/desktop/src/renderer/components/SkillEditor.tsx
+++ b/desktop/src/renderer/components/SkillEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import type { SkillEntry } from '../../shared/types';
 import { useSkills } from '../state/skill-context';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
+import { Button } from './ui';
 import { useEscClose } from '../hooks/use-esc-close';
 
 interface SkillEditorProps {
@@ -137,27 +138,31 @@ export default function SkillEditor({ skillId, onClose }: SkillEditorProps) {
 
         {/* Buttons */}
         <div className="flex gap-2">
-          <button
+          {/* Reset was the odd one out with text-fg-muted; secondary makes it a
+              visual peer of Cancel, which is what it is (spec decision 60). */}
+          <Button
+            variant="secondary"
             onClick={handleReset}
             disabled={saving}
-            className="text-xs font-medium px-3 py-2 rounded-lg border border-edge-dim text-fg-muted hover:text-fg hover:bg-inset transition-colors disabled:opacity-50"
+            className="py-2"
           >
             Reset to Default
-          </button>
+          </Button>
           <div className="flex-1" />
-          <button
+          <Button
+            variant="secondary"
             onClick={onClose}
-            className="text-xs font-medium px-3 py-2 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
+            className="py-2"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            size="lg"
             onClick={handleSave}
             disabled={saving}
-            className="text-xs font-medium px-4 py-2 rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Save'}
-          </button>
+          </Button>
         </div>
       </OverlayPanel>
     </>

--- a/desktop/src/renderer/components/StatusBar.tsx
+++ b/desktop/src/renderer/components/StatusBar.tsx
@@ -15,6 +15,7 @@ import ContextPopup from './ContextPopup';
 import OpenTasksChip from './OpenTasksChip';
 import { isAndroid } from '../platform';
 import { SessionTagsChip } from './tags/SessionTagsChip';
+import { CloseButton } from './ui';
 
 // --- Session stats shape (written by statusline.sh to .session-stats-{id}.json) ---
 
@@ -500,14 +501,7 @@ function WidgetConfigPopup({ open, onClose, visible, toggle }: {
           {/* Header */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-edge">
             <h2 className="text-sm font-bold text-fg">Status Bar Widgets</h2>
-            <button
-              onClick={onClose}
-              className="text-fg-muted hover:text-fg-2 text-lg leading-none w-7 h-7 flex items-center justify-center rounded-sm hover:bg-inset"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
+            <CloseButton onClick={onClose} label="Close status bar widgets" />
           </div>
 
           {/* Widget list grouped by category — scrolls within the panel.

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Button } from './ui';
 import type { SyncWarning } from '../../main/sync-state';
 import { deriveSyncState, type SyncDisplayState } from '../state/sync-display-state';
 import { createPortal } from 'react-dom';
@@ -962,19 +963,21 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
               // CTA row — tucked directly under the sub (aligned past the dot, no divider).
               const cta =
                 hk === 'waiting-github' ? (
-                  <button onClick={() => setShowConnectGithub(true)} className="px-2.5 py-1 rounded-md text-[11px] font-medium bg-accent text-on-accent hover:brightness-110">
+                  <Button size="sm" onClick={() => setShowConnectGithub(true)}>
                     Connect GitHub…
-                  </button>
+                  </Button>
                 ) : hk === 'error' ? (
                   <>
                     {/* Try again reuses syncNow() with the existing .catch error routing. */}
-                    <button onClick={runSpacesSyncNow} className="px-2.5 py-1 rounded-md text-[11px] font-medium bg-accent text-on-accent hover:brightness-110">
+                    <Button size="sm" onClick={runSpacesSyncNow}>
                       Try again
-                    </button>
+                    </Button>
+                    {/* secondary (outline) so it reads as a peer of the primary "Try again"
+                        rather than competing with it for the same weight. */}
                     {githubUnauthed && (
-                      <button onClick={() => setShowConnectGithub(true)} className="px-2.5 py-1 rounded-md text-[11px] font-medium border border-edge-dim text-fg-2 hover:bg-inset">
+                      <Button variant="secondary" size="sm" onClick={() => setShowConnectGithub(true)}>
                         Connect GitHub…
-                      </button>
+                      </Button>
                     )}
                   </>
                 ) : null;
@@ -1266,12 +1269,17 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                       up now row; keeps handleForceSync's syncing state + label behavior). */}
                   {list.length > 0 && (
                     <div className="mt-2 space-y-2">
-                      <button
+                      {/* Dashed border is a documented exception (spec decision 64): the dash
+                          is what marks this as an "add" affordance rather than a real action,
+                          so it rides on top of `secondary` as a className override. The label
+                          also lifts from fg-muted to the variant's fg-2. */}
+                      <Button
+                        variant="secondary"
                         onClick={() => setView('add-type')}
-                        className="w-full border border-dashed border-edge-dim rounded-lg py-2.5 text-center text-[11px] text-fg-muted hover:text-fg-2 hover:border-edge hover:bg-inset/30 transition-colors"
+                        className="w-full border-dashed py-2.5"
                       >
                         ＋ Add a backup
-                      </button>
+                      </Button>
                       {anyActive && (
                         <button
                           onClick={handleForceSync}
@@ -1316,20 +1324,14 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                       )}
                       <div className="flex gap-2 mt-2">
                         {w.fixAction && (
-                          <button
-                            onClick={() => handleFixAction(w)}
-                            className="text-[11px] px-2 py-0.5 rounded bg-accent text-on-accent hover:brightness-110"
-                          >
+                          <Button size="sm" onClick={() => handleFixAction(w)}>
                             {w.fixAction.label}
-                          </button>
+                          </Button>
                         )}
                         {w.dismissible && (
-                          <button
-                            onClick={() => handleDismiss(w.code)}
-                            className="text-[11px] px-2 py-0.5 rounded border border-edge-dim text-fg-muted hover:bg-inset"
-                          >
+                          <Button variant="secondary" size="sm" onClick={() => handleDismiss(w.code)}>
                             Dismiss
-                          </button>
+                          </Button>
                         )}
                       </div>
                     </div>
@@ -1493,12 +1495,12 @@ function ConfirmDialog({
         <div className="px-4 py-3 space-y-3">
           <p className="text-[11px] text-fg-dim leading-relaxed">{message}</p>
           <div className="flex gap-2 pt-1">
-            <button
-              onClick={onCancel}
-              className="flex-1 px-3 py-1.5 text-[11px] font-medium rounded-md bg-inset hover:bg-edge text-fg-muted transition-colors"
-            >
+            {/* Was a filled-grey button (bg-inset/hover:bg-edge). Spec decision 60 folds
+                that whole family into `secondary` (outline) — it sits beside a real
+                confirm button as a peer, which the lighter `ghost` would under-weight. */}
+            <Button variant="secondary" onClick={onCancel} className="flex-1">
               Cancel
-            </button>
+            </Button>
             <button
               onClick={onConfirm}
               className={`flex-1 px-3 py-1.5 text-[11px] font-medium rounded-md transition-colors ${btnBg}`}
@@ -1649,25 +1651,30 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
                   Remove {d.name}? It stops being listed here. If this device syncs again, it comes back.
                 </p>
                 <div className="flex gap-2">
-                  <button
+                  <Button
+                    variant="secondary"
                     type="button"
                     onClick={() => setConfirmingId(null)}
                     aria-label={`Keep ${d.name}`}
-                    className="flex-1 text-xs font-medium py-1.5 rounded-lg border border-edge-dim text-fg-2 hover:bg-inset transition-colors"
+                    className="flex-1"
                   >
                     Cancel
-                  </button>
+                  </Button>
                   {/* autoFocus: the trigger just unmounted, so without this the focus
-                      falls to <body> and a keyboard user re-tabs from the top. */}
-                  <button
+                      falls to <body> and a keyboard user re-tabs from the top.
+                      danger-outline replaces the hand-rolled border-red-500/50 pair, so the
+                      red comes from the theme's --destructive token rather than stock red
+                      (spec decision 68 — "Remove" reads the same everywhere). */}
+                  <Button
+                    variant="danger-outline"
                     type="button"
                     autoFocus
                     onClick={() => void confirmRemove(d.id)}
                     aria-label={`Confirm removing ${d.name}`}
-                    className="flex-1 text-xs font-medium py-1.5 rounded-lg border border-red-500/50 text-red-500 hover:bg-red-500/10 transition-colors"
+                    className="flex-1"
                   >
                     Remove
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}
@@ -1773,15 +1780,16 @@ function EditBackendForm({
           To change these settings, remove this backup and add a new one.
         </div>
 
-        <button
+        {/* The old faded "cursor-wait" saving fill is gone — the primitive's plain
+            disabled state covers it for now, and a dedicated `busy` state lands later
+            with the spinner work (spec decision 72). The label still says "Saving...". */}
+        <Button
           onClick={handleSave}
           disabled={!label.trim() || saving}
-          className={`px-4 py-1.5 rounded-md text-[11px] font-medium transition-colors ${
-            saving ? 'bg-accent/20 text-accent/60 cursor-wait' : 'bg-accent hover:bg-accent/80 text-on-accent cursor-pointer'
-          }`}
+          className="px-6"
         >
           {saving ? 'Saving...' : 'Save'}
-        </button>
+        </Button>
         </div>
       </div>
     </div>

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 import type { SyncWarning } from '../../main/sync-state';
 import { deriveSyncState, type SyncDisplayState } from '../state/sync-display-state';
 import { createPortal } from 'react-dom';
@@ -854,9 +854,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
             <h2 className="text-sm font-bold text-fg">Backup &amp; Sync</h2>
             <div className="flex items-center gap-1">
               <InfoIconButton onClick={() => setShowInfo(true)} />
-              <button onClick={onClose} className="text-fg-muted hover:text-fg-2 text-lg leading-none w-8 h-8 flex items-center justify-center rounded-sm hover:bg-inset">
-                {'\u2715'}
-              </button>
+              <CloseButton onClick={onClose} label="Close backup and sync" />
             </div>
           </div>
 
@@ -1446,7 +1444,6 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
             title="Remove backup?"
             message={<>Remove <strong>{target.label}</strong>? This disconnects this backup destination. Your backed-up data in {BACKEND_LABELS[target.type]} won't be deleted &mdash; you can reconnect later.</>}
             confirmLabel="Remove"
-            confirmColor="red"
             onConfirm={() => { handleRemoveBackend(confirmRemoveId); setConfirmRemoveId(null); }}
             onCancel={() => setConfirmRemoveId(null)}
           />
@@ -1463,34 +1460,32 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
 // L3 destructive confirmation — uses OverlayPanel destructive variant for theme-driven danger border.
 
 function ConfirmDialog({
-  title, message, confirmLabel, confirmColor, onConfirm, onCancel,
+  title, message, confirmLabel, onConfirm, onCancel,
 }: {
   title: string;
   message: React.ReactNode;
   confirmLabel: string;
-  confirmColor: 'red' | 'blue';
   onConfirm: () => void;
   onCancel: () => void;
 }) {
-  const borderColor = confirmColor === 'red' ? 'border-red-600/30' : 'border-blue-600/30';
-  const headerBg = confirmColor === 'red' ? 'bg-red-600/10' : 'bg-blue-600/10';
-  const headerText = confirmColor === 'red' ? 'text-[#DD4444]' : 'text-blue-400';
-  const btnBg = confirmColor === 'red'
-    ? 'bg-red-600/70 hover:bg-red-600/90 text-white'
-    : 'bg-blue-600 hover:bg-blue-500 text-white';
-
   return createPortal(
     // Overlay layer L3 — destructive confirmations use OverlayPanel destructive variant.
     <>
       <Scrim layer={3} onClick={onCancel} />
+      {/* The `confirmColor: 'red' | 'blue'` prop is gone. There was exactly one call
+          site and it passed "red", so the whole blue branch — border, header tint,
+          header text, and a `bg-blue-600 hover:bg-blue-500 text-white` confirm button
+          — was unreachable. It was also one of the last hardcoded-blue survivors spec
+          change 55 exists to kill, so it's deleted rather than migrated. This dialog
+          is now unconditionally destructive, which is what it always rendered as. */}
       <OverlayPanel
         layer={3}
-        destructive={confirmColor === 'red'}
+        destructive
         className="fixed overflow-hidden"
         style={{ top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: 'min(360px, 85vw)' }}
       >
-        <div className={`px-4 py-3 border-b ${borderColor} ${headerBg}`}>
-          <h3 className={`text-xs font-bold ${headerText}`}>{title}</h3>
+        <div className="px-4 py-3 border-b border-destructive/30 bg-destructive/10">
+          <h3 className="text-xs font-bold text-destructive">{title}</h3>
         </div>
         <div className="px-4 py-3 space-y-3">
           <p className="text-[11px] text-fg-dim leading-relaxed">{message}</p>
@@ -1501,12 +1496,9 @@ function ConfirmDialog({
             <Button variant="secondary" onClick={onCancel} className="flex-1">
               Cancel
             </Button>
-            <button
-              onClick={onConfirm}
-              className={`flex-1 px-3 py-1.5 text-[11px] font-medium rounded-md transition-colors ${btnBg}`}
-            >
+            <Button variant="danger" onClick={onConfirm} className="flex-1">
               {confirmLabel}
-            </button>
+            </Button>
           </div>
         </div>
       </OverlayPanel>
@@ -1718,9 +1710,7 @@ function SubViewHeader({ title, onBack, onClose }: { title: string; onBack: () =
         </button>
         <h2 className="text-sm font-bold text-fg">{title}</h2>
       </div>
-      <button onClick={onClose} className="text-fg-muted hover:text-fg-2 text-lg leading-none w-8 h-8 flex items-center justify-center rounded-sm hover:bg-inset">
-        {'\u2715'}
-      </button>
+      <CloseButton onClick={onClose} label="Close backup and sync" />
     </div>
   );
 }

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 import { isAndroid as checkIsAndroid } from '../platform';
 import { useEscClose } from '../hooks/use-esc-close';
 import { useScrollFade } from '../hooks/useScrollFade';
@@ -86,9 +86,7 @@ function WizardHeader({ title, onBack, onClose }: { title: string; onBack?: () =
         )}
         <h2 className="text-sm font-bold text-fg">{title}</h2>
       </div>
-      <button onClick={onClose} className="text-fg-muted hover:text-fg-2 text-lg leading-none w-8 h-8 flex items-center justify-center rounded-sm hover:bg-inset">
-        {'\u2715'}
-      </button>
+      <CloseButton onClick={onClose} label="Close setup wizard" />
     </div>
   );
 }

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { Button } from './ui';
 import { isAndroid as checkIsAndroid } from '../platform';
 import { useEscClose } from '../hooks/use-esc-close';
 import { useScrollFade } from '../hooks/useScrollFade';
@@ -508,24 +509,26 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
           })()}
 
           {/* Start Backup button */}
-          <button
+          {/* Was a hardcoded bg-blue-600 family (spec change 55 — the last survivors of a
+              blue that ignored the user's theme). `primary` paints it in the theme accent.
+              The three-way saving/empty/ready className is gone: both the saving and the
+              empty-label states are just `disabled` now (spec decision 72), and the spinner
+              goes with the shared busy state later rather than being re-hardcoded here. */}
+          <Button
+            size="lg"
             onClick={handleStartBackup}
             disabled={!label.trim() || saving || (backendType === 'github' && repoMode === 'existing' && !repoUrl.trim())}
-            className={`w-full px-4 py-2.5 rounded-md text-[12px] font-medium transition-colors ${
-              saving
-                ? 'bg-blue-500/20 text-blue-300 cursor-wait'
-                : !label.trim()
-                  ? 'bg-accent/20 text-accent/40 cursor-not-allowed'
-                  : 'bg-blue-600 hover:bg-blue-500 text-white cursor-pointer'
-            }`}
+            className="w-full"
           >
-            {saving ? (
-              <span className="flex items-center justify-center gap-1.5">
-                <span className="w-3 h-3 border-2 border-blue-300/30 border-t-blue-300 rounded-full animate-spin" />
-                Setting up...
-              </span>
-            ) : 'Start Backup'}
-          </button>
+            {/* Spinner uses currentColor so it tracks the variant's label color on
+                every theme — the old one hardcoded blue-300, which change 55 kills.
+                It stays because setting up a backup takes several seconds: a
+                disabled button with changed text and no motion reads as hung. */}
+            {saving && (
+              <span className="w-3 h-3 border-2 border-current/30 border-t-current rounded-full animate-spin" />
+            )}
+            {saving ? 'Setting up...' : 'Start Backup'}
+          </Button>
           </div>
         </div>
       </div>
@@ -547,12 +550,9 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
             Your first backup is syncing now. Backups happen automatically every 15 minutes.
             You can manage them anytime from the Sync panel.
           </div>
-          <button
-            onClick={onClose}
-            className="px-6 py-2 rounded-md text-[11px] font-medium bg-accent hover:bg-accent/80 text-on-accent cursor-pointer transition-colors"
-          >
+          <Button onClick={onClose} className="px-6 py-2">
             Done
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -661,22 +661,17 @@ function PrereqCheckStep({
             <div className="text-[11px] text-fg-dim">
               YouCoded needs a small helper tool to connect to Google Drive.
             </div>
-            <button
-              onClick={handleInstall}
-              disabled={installing}
-              className={`px-4 py-2 rounded-md text-[11px] font-medium transition-colors ${
-                installing
-                  ? 'bg-blue-500/20 text-blue-300 cursor-wait'
-                  : 'bg-blue-600 hover:bg-blue-500 text-white cursor-pointer'
-              }`}
-            >
-              {installing ? (
-                <span className="flex items-center gap-1.5">
-                  <span className="w-3 h-3 border-2 border-blue-300/30 border-t-blue-300 rounded-full animate-spin" />
-                  Installing...
-                </span>
-              ) : 'Install Now'}
-            </button>
+            {/* Another hardcoded blue survivor (spec change 55) — now the theme accent.
+                The faded busy FILL collapses to plain `disabled` (spec decision 72),
+                but the spinner stays: this install advertises "about a minute" right
+                below it, and a minute of a motionless disabled button reads as hung.
+                currentColor so it tracks the label on every theme. */}
+            <Button size="lg" onClick={handleInstall} disabled={installing}>
+              {installing && (
+                <span className="w-3 h-3 border-2 border-current/30 border-t-current rounded-full animate-spin" />
+              )}
+              {installing ? 'Installing...' : 'Install Now'}
+            </Button>
             <div className="text-[10px] text-fg-faint">This usually takes about a minute.</div>
           </div>
         )}
@@ -753,12 +748,10 @@ function IcloudMissingHelp({ onRecheck }: { onRecheck: () => void }) {
         </div>
       )}
       {os !== 'linux' && (
-        <button
-          onClick={onRecheck}
-          className="px-4 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-inset/80 text-fg cursor-pointer transition-colors"
-        >
+        /* Filled-grey (bg-inset) becomes the outline `secondary` — spec decision 60. */
+        <Button variant="secondary" onClick={onRecheck}>
           Check Again
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -800,12 +793,10 @@ function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
         </div>
       )}
       <div className="text-[10px] text-fg-faint">After installing, come back and tap "Check Again".</div>
-      <button
-        onClick={onRecheck}
-        className="px-4 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-inset/80 text-fg cursor-pointer transition-colors"
-      >
+      {/* Filled-grey (bg-inset) becomes the outline `secondary` — spec decision 60. */}
+      <Button variant="secondary" onClick={onRecheck}>
         Check Again
-      </button>
+      </Button>
     </div>
   );
 }
@@ -908,12 +899,11 @@ function AuthStep({
                 </div>
               )}
             </div>
-            <button
-              onClick={handleAuth}
-              className="px-6 py-2.5 rounded-md text-[12px] font-medium bg-blue-600 hover:bg-blue-500 text-white cursor-pointer transition-colors"
-            >
+            {/* Last of the hardcoded bg-blue-600 buttons (spec change 55) — the sign-in
+                CTA now uses the theme accent like every other primary action. */}
+            <Button size="lg" onClick={handleAuth}>
               {buttonLabel}
-            </button>
+            </Button>
           </>
         ) : (
           <>
@@ -933,12 +923,10 @@ function AuthStep({
             <div className="text-[11px] text-fg-dim">
               Looks like the sign-in didn't complete. No worries — try again when you're ready.
             </div>
-            <button
-              onClick={handleAuth}
-              className="px-4 py-1.5 rounded-md text-[11px] font-medium bg-inset hover:bg-inset/80 text-fg cursor-pointer transition-colors"
-            >
+            {/* Filled-grey (bg-inset) becomes the outline `secondary` — spec decision 60. */}
+            <Button variant="secondary" onClick={handleAuth}>
               Try Again
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/desktop/src/renderer/components/ThemeScreen.tsx
+++ b/desktop/src/renderer/components/ThemeScreen.tsx
@@ -7,6 +7,7 @@ import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './Sett
 import type { LoadedTheme } from '../themes/theme-types';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
+import { Button } from './ui';
 
 // Plain-language explainer for the Appearance popup. Shown when the user taps
 // the (i) icon in the popup header — see ThemeScreen's `showInfo` state.
@@ -209,28 +210,35 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
         {/* Build with Claude — surfaced directly below the grid so users see
             the "make a new one" affordance before the ancillary toggles.
             Follow-up will relocate to the popup header and launch in a new
-            session instead of piping into the current one. */}
-        <button
+            session instead of piping into the current one.
+
+            Now a filled `primary` (spec change 63). It used to be an accent-tinted
+            OUTLINE (border-accent/30 + bg-accent/10 + text-accent) — a 5th button
+            style that the shared Button doesn't have and that we don't want to add.
+            Filling it keeps Build visually stronger than Browse (secondary) below,
+            which is the hierarchy the tinted outline was there to create. */}
+        <Button
           onClick={() => {
             onSendInput?.('/theme-builder ');
             onClose();
           }}
-          className="w-full py-2 rounded-lg border border-accent/30 bg-accent/10 text-accent text-xs font-medium hover:bg-accent/20 transition-colors"
+          className="w-full py-2"
         >
           ✦ Build New Theme with Claude
-        </button>
+        </Button>
 
         {/* Browse marketplace — paired with Build as the two acquisition paths */}
         {onOpenMarketplace && (
-          <button
+          <Button
+            variant="secondary"
             onClick={() => {
               onOpenMarketplace();
               onClose();
             }}
-            className="w-full py-2 rounded-lg border border-edge-dim bg-panel text-fg-2 text-xs font-medium hover:bg-inset transition-colors"
+            className="w-full py-2"
           >
             Browse Theme Marketplace
-          </button>
+          </Button>
         )}
 
         {/* Reduce Visual Effects — always on the main screen (accessibility/perf toggle).
@@ -508,15 +516,17 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
 
         {/* Publish — user themes only */}
         {isUserTheme && onPublishTheme && (
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => {
               onPublishTheme(theme.slug);
               onClose();
             }}
-            className="w-full py-1.5 rounded-lg border border-edge-dim text-fg-2 text-[10px] font-medium hover:bg-inset transition-colors"
+            className="w-full"
           >
             Publish to Marketplace
-          </button>
+          </Button>
         )}
         </div>
       </div>

--- a/desktop/src/renderer/components/ThemeScreen.tsx
+++ b/desktop/src/renderer/components/ThemeScreen.tsx
@@ -7,7 +7,7 @@ import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './Sett
 import type { LoadedTheme } from '../themes/theme-types';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 
 // Plain-language explainer for the Appearance popup. Shown when the user taps
 // the (i) icon in the popup header — see ThemeScreen's `showInfo` state.
@@ -139,7 +139,9 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
         <h2 className="text-sm font-bold text-fg">Themes</h2>
         <div className="flex items-center gap-1">
           <InfoIconButton onClick={() => setShowInfo(true)} />
-          <button onClick={onClose} className="text-fg-muted hover:text-fg-2 text-lg leading-none w-6 h-6 flex items-center justify-center">✕</button>
+          {/* w-6 h-6 kept: this sits in a tight header row beside InfoIconButton,
+              and CloseButton's default 28px would break their alignment. */}
+          <CloseButton onClick={onClose} label="Close themes" className="w-6 h-6" />
         </div>
       </div>
 
@@ -363,7 +365,9 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
           </button>
           <h2 className="text-sm font-bold text-fg truncate">Edit: {theme.name}</h2>
         </div>
-        <button onClick={onClose} className="text-fg-muted hover:text-fg-2 text-lg leading-none w-6 h-6 flex items-center justify-center shrink-0">✕</button>
+        {/* Same w-6 h-6 as the list header above, so the two views' close buttons
+            don't jump size when you switch between them. */}
+        <CloseButton onClick={onClose} label="Close theme editor" className="w-6 h-6 shrink-0" />
       </div>
 
       <div ref={editScrollRef} className="scroll-fade flex-1">

--- a/desktop/src/renderer/components/ThemeShareSheet.tsx
+++ b/desktop/src/renderer/components/ThemeShareSheet.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '../state/theme-context';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 import type { PublishState } from '../../shared/theme-marketplace-types';
+import { Button } from './ui';
 
 interface ThemeShareSheetProps {
   themeSlug: string;
@@ -220,13 +221,13 @@ function renderPublishButton(args: {
   if (state.kind === 'published-drift') {
     return (
       <>
-        <button
+        <Button
           onClick={onPublish}
           disabled={publishing || previewLoading}
-          className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
+          className="w-full py-2.5"
         >
           {publishing ? 'Publishing update…' : 'Publish update'}
-        </button>
+        </Button>
         <p className="text-[10px] text-fg-faint text-center mt-1.5">
           Local changes not yet published
         </p>
@@ -237,14 +238,14 @@ function renderPublishButton(args: {
   if (state.kind === 'unknown') {
     return (
       <>
-        <button
+        <Button
           onClick={onPublish}
           disabled={publishing || previewLoading}
-          className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
+          className="w-full py-2.5"
           title={`Couldn't verify publish status — proceed at your own risk (${state.reason})`}
         >
           {publishing ? 'Publishing…' : previewLoading ? 'Generating preview…' : '⚠ Publish to Marketplace'}
-        </button>
+        </Button>
         <p className="text-[10px] text-fg-faint text-center mt-1.5">
           Could not verify status: {state.reason}
         </p>
@@ -254,12 +255,12 @@ function renderPublishButton(args: {
 
   // draft — the default happy path.
   return (
-    <button
+    <Button
       onClick={onPublish}
       disabled={publishing || previewLoading}
-      className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
+      className="w-full py-2.5"
     >
       {publishing ? 'Publishing…' : previewLoading ? 'Generating preview…' : 'Publish to Marketplace'}
-    </button>
+    </Button>
   );
 }

--- a/desktop/src/renderer/components/ToolCard.tsx
+++ b/desktop/src/renderer/components/ToolCard.tsx
@@ -371,18 +371,26 @@ function PermissionButtons({ requestId, suggestions, denyListed, command, folder
         <div className="flex items-center gap-2">
           {/* "Allow once" IS the plain-allow decision, so it wears the same green
               as Yes. Previously this slot was Cancel, which dead-ended back on the
-              button row and still left the user owing an answer. */}
+              button row and still left the user owing an answer.
+
+              These permission buttons deliberately do NOT go through ui/Button
+              (spec §11, change 61). Their green/red/blue are STATUS colors, not
+              theme surfaces — desktop/CLAUDE.md keeps those hardcoded — and
+              Destin explicitly kept the red on "Always allow" even though red
+              means "No" one row down: muscle memory on the app's most-clicked
+              control beats colour-semantics tidiness. Only the radius normalizes
+              to the app's one control radius (was rounded-sm). */}
           <button
             disabled={responding}
             onClick={() => handleRespond({ decision: { behavior: 'allow' } })}
-            className={`px-3 ${pad} text-xs font-medium rounded-sm bg-green-600/60 hover:bg-green-600/80 text-green-100 transition-colors disabled:opacity-50`}
+            className={`px-3 ${pad} text-xs font-medium rounded-lg bg-green-600/60 hover:bg-green-600/80 text-green-100 transition-colors disabled:opacity-50`}
           >
             Nevermind, allow once
           </button>
           <button
             disabled={responding}
             onClick={() => handleRespond(alwaysAllowDecision())}
-            className={`px-3 ${pad} text-xs font-medium rounded-sm bg-red-600/60 hover:bg-red-600/80 text-red-100 transition-colors disabled:opacity-50`}
+            className={`px-3 ${pad} text-xs font-medium rounded-lg bg-red-600/60 hover:bg-red-600/80 text-red-100 transition-colors disabled:opacity-50`}
           >
             Always allow
           </button>
@@ -392,12 +400,18 @@ function PermissionButtons({ requestId, suggestions, denyListed, command, folder
   }
 
   return (
+    // Same §11/change-61 carve-out as the confirm row above: status colors stay,
+    // radius normalizes. The `ring` here is NOT a focus ring — it tracks focusIdx,
+    // the Arrow Left/Right roving selection. Arrow keys also move real DOM focus
+    // (buttonsRef[next].focus()), so adding ui/Button's focus-visible ring would
+    // paint an accent ring on top of this one on the selected button. Left alone
+    // on purpose; don't "finish the migration" by adding FOCUS_RING here.
     <div className="flex items-center gap-2 px-3 py-2 border-t border-edge bg-inset/30">
       <button
         ref={el => { buttonsRef.current[0] = el; }}
         disabled={responding}
         onClick={() => handleRespond({ decision: { behavior: 'allow' } })}
-        className={`px-3 ${pad} text-xs font-medium rounded-sm bg-green-600/60 hover:bg-green-600/80 text-green-100 transition-colors disabled:opacity-50 ${focusIdx === 0 ? ring : ''}`}
+        className={`px-3 ${pad} text-xs font-medium rounded-lg bg-green-600/60 hover:bg-green-600/80 text-green-100 transition-colors disabled:opacity-50 ${focusIdx === 0 ? ring : ''}`}
       >
         Yes
       </button>
@@ -406,7 +420,7 @@ function PermissionButtons({ requestId, suggestions, denyListed, command, folder
           ref={el => { buttonsRef.current[1] = el; }}
           disabled={responding}
           onClick={onAlwaysAllow}
-          className={`px-3 ${pad} text-xs font-medium rounded-sm bg-blue-600/60 hover:bg-blue-600/80 text-blue-100 transition-colors disabled:opacity-50 ${focusIdx === 1 ? ring : ''}`}
+          className={`px-3 ${pad} text-xs font-medium rounded-lg bg-blue-600/60 hover:bg-blue-600/80 text-blue-100 transition-colors disabled:opacity-50 ${focusIdx === 1 ? ring : ''}`}
         >
           Always Allow
         </button>
@@ -415,7 +429,7 @@ function PermissionButtons({ requestId, suggestions, denyListed, command, folder
         ref={el => { buttonsRef.current[canAlwaysAllow ? 2 : 1] = el; }}
         disabled={responding}
         onClick={() => handleRespond({ decision: { behavior: 'deny' } })}
-        className={`px-3 ${pad} text-xs font-medium rounded-sm bg-red-600/60 hover:bg-red-600/80 text-red-100 transition-colors disabled:opacity-50 ${focusIdx === (canAlwaysAllow ? 2 : 1) ? ring : ''}`}
+        className={`px-3 ${pad} text-xs font-medium rounded-lg bg-red-600/60 hover:bg-red-600/80 text-red-100 transition-colors disabled:opacity-50 ${focusIdx === (canAlwaysAllow ? 2 : 1) ? ring : ''}`}
       >
         No
       </button>
@@ -659,12 +673,24 @@ function AskUserQuestionCard({ tool, requestId, onResponded, onFailed }: {
           </div>
         </div>
       ))}
-      {/* Submit + Deny buttons */}
+      {/* Submit + Deny buttons.
+
+          NOT YET MIGRATED — spec §11's change 61 enumerated only the five
+          permission-prompt buttons (:375 :382 :396 :405 :414) and never covered
+          this AskUserQuestion pair, so there is no approved variant for them.
+          Radius normalized here so the row doesn't sit at a different corner
+          from the permission row directly above it; the variant call is still
+          open. Two things to decide before migrating:
+            - Submit hand-rolls its own disabled look (bg-inset/50 when
+              !allAnswered) on top of a real `disabled` prop — ui/Button's
+              disabled:opacity-50 would replace that branch entirely.
+            - Dismiss uses a grey→red hover as a bespoke "this rejects" signal,
+              which is neither ghost nor danger-outline. */}
       <div className="flex items-center gap-2 pt-1">
         <button
           disabled={!allAnswered || responding}
           onClick={handleSubmit}
-          className={`px-3 ${pad} text-xs font-medium rounded-sm transition-colors disabled:opacity-40
+          className={`px-3 ${pad} text-xs font-medium rounded-lg transition-colors disabled:opacity-40
             ${allAnswered ? 'bg-accent/70 hover:bg-accent/90 text-on-accent' : 'bg-inset/50 text-fg-muted'}`}
         >
           Submit
@@ -672,7 +698,7 @@ function AskUserQuestionCard({ tool, requestId, onResponded, onFailed }: {
         <button
           disabled={responding}
           onClick={handleDeny}
-          className={`px-3 ${pad} text-xs font-medium rounded-sm bg-inset/40 hover:bg-red-600/40 text-fg-muted hover:text-red-200 transition-colors disabled:opacity-50`}
+          className={`px-3 ${pad} text-xs font-medium rounded-lg bg-inset/40 hover:bg-red-600/40 text-fg-muted hover:text-red-200 transition-colors disabled:opacity-50`}
         >
           Dismiss
         </button>

--- a/desktop/src/renderer/components/ToolCard.tsx
+++ b/desktop/src/renderer/components/ToolCard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { ToolCallState } from '../../shared/types';
 import { useChatDispatch } from '../state/chat-context';
 import { useArtifactOptional } from '../state/ArtifactContext';
+import { Button } from './ui';
 import { CheckIcon, FailIcon, QuestionIcon, ChevronIcon, NoteIcon } from './Icons';
 import BrailleSpinner from './BrailleSpinner';
 import { isAndroid } from '../platform';
@@ -675,33 +676,27 @@ function AskUserQuestionCard({ tool, requestId, onResponded, onFailed }: {
       ))}
       {/* Submit + Deny buttons.
 
-          NOT YET MIGRATED — spec §11's change 61 enumerated only the five
-          permission-prompt buttons (:375 :382 :396 :405 :414) and never covered
-          this AskUserQuestion pair, so there is no approved variant for them.
-          Radius normalized here so the row doesn't sit at a different corner
-          from the permission row directly above it; the variant call is still
-          open. Two things to decide before migrating:
-            - Submit hand-rolls its own disabled look (bg-inset/50 when
-              !allAnswered) on top of a real `disabled` prop — ui/Button's
-              disabled:opacity-50 would replace that branch entirely.
-            - Dismiss uses a grey→red hover as a bespoke "this rejects" signal,
-              which is neither ghost nor danger-outline. */}
+          Unlike the permission triad above (which keeps its status colors), this
+          pair DOES go through ui/Button — Destin's call, spec §11.8 B. Two things
+          the migration deliberately drops:
+            - Submit hand-rolled its own disabled look (bg-inset/50 + bg-accent/70)
+              on top of a real `disabled` prop. The primitive's disabled:opacity-50
+              replaces that branch, and the enabled state goes to full accent.
+            - Dismiss had a grey→red hover as a bespoke "this rejects" signal.
+              Dismissing a question isn't destructive — nothing is lost, Claude
+              just doesn't get an answer — so it reads as `ghost`, and position
+              plus label already carry "this is the negative option". */}
       <div className="flex items-center gap-2 pt-1">
-        <button
+        <Button
           disabled={!allAnswered || responding}
           onClick={handleSubmit}
-          className={`px-3 ${pad} text-xs font-medium rounded-lg transition-colors disabled:opacity-40
-            ${allAnswered ? 'bg-accent/70 hover:bg-accent/90 text-on-accent' : 'bg-inset/50 text-fg-muted'}`}
+          className={pad}
         >
           Submit
-        </button>
-        <button
-          disabled={responding}
-          onClick={handleDeny}
-          className={`px-3 ${pad} text-xs font-medium rounded-lg bg-inset/40 hover:bg-red-600/40 text-fg-muted hover:text-red-200 transition-colors disabled:opacity-50`}
-        >
+        </Button>
+        <Button variant="ghost" disabled={responding} onClick={handleDeny} className={pad}>
           Dismiss
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/desktop/src/renderer/components/UpdatePanel.tsx
+++ b/desktop/src/renderer/components/UpdatePanel.tsx
@@ -9,7 +9,7 @@ import type { UpdateLaunchResult } from '../../shared/update-install-types';
 import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import MarkdownContent from './MarkdownContent';
-import { Button } from './ui';
+import { Button, CloseButton } from './ui';
 
 // Error codes where a fresh download might succeed (transient or file-level).
 // The complement (dmg-corrupt, appimage-not-writable, unsupported-platform,
@@ -260,7 +260,7 @@ export default function UpdatePanel({ open, onClose, updateStatus }: Props) {
           <h1 id="update-panel-title" className="text-base font-medium">
             {updateStatus.update_available ? 'Update available' : "What's new"}
           </h1>
-          <button onClick={onClose} aria-label="Close" className="text-fg-dim hover:text-fg">✕</button>
+          <CloseButton onClick={onClose} />
         </header>
         <div className="flex-1 overflow-y-auto px-5 py-4">{body}</div>
         {updateStatus.update_available && (

--- a/desktop/src/renderer/components/UpdatePanel.tsx
+++ b/desktop/src/renderer/components/UpdatePanel.tsx
@@ -9,6 +9,7 @@ import type { UpdateLaunchResult } from '../../shared/update-install-types';
 import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import MarkdownContent from './MarkdownContent';
+import { Button } from './ui';
 
 // Error codes where a fresh download might succeed (transient or file-level).
 // The complement (dmg-corrupt, appimage-not-writable, unsupported-platform,
@@ -264,7 +265,8 @@ export default function UpdatePanel({ open, onClose, updateStatus }: Props) {
         <div className="flex-1 overflow-y-auto px-5 py-4">{body}</div>
         {updateStatus.update_available && (
           <footer className="px-5 py-3 border-t border-edge-dim flex flex-col items-end">
-            <button
+            <Button
+              size="lg"
               onClick={handleUpdate}
               disabled={
                 installState.kind === 'downloading' ||
@@ -272,7 +274,6 @@ export default function UpdatePanel({ open, onClose, updateStatus }: Props) {
                 // Disable "retry" for errors where a fresh download won't help.
                 (installState.kind === 'error' && !isRetriableErrorCode(installState.code))
               }
-              className="px-4 py-2 rounded-sm bg-accent text-on-accent font-medium hover:opacity-90 disabled:opacity-60"
             >
               {installState.kind === 'idle' && `Update Now: v${updateStatus.current} → v${updateStatus.latest}`}
               {installState.kind === 'downloading' && (
@@ -289,7 +290,7 @@ export default function UpdatePanel({ open, onClose, updateStatus }: Props) {
                   ? 'Download failed — Retry'
                   : 'Launch failed'
               )}
-            </button>
+            </Button>
             {installState.kind === 'error' && (
               <div className="text-xs text-fg-dim mt-2">
                 <button

--- a/desktop/src/renderer/components/artifact-views/BinaryFallback.tsx
+++ b/desktop/src/renderer/components/artifact-views/BinaryFallback.tsx
@@ -1,5 +1,6 @@
 import type { ArtifactViewProps } from './types';
 import { getPlatform } from '../../platform';
+import { Button } from '../ui';
 
 export function BinaryFallback({ path, absolutePath }: ArtifactViewProps) {
   // shell.openPath is desktop-only — the remote shim stubs it as a no-op and
@@ -15,16 +16,15 @@ export function BinaryFallback({ path, absolutePath }: ArtifactViewProps) {
       <p className="mb-4">Cannot preview this file type.</p>
       <p className="mb-4 font-mono text-sm">{path}</p>
       {isElectron && (
-        <button
-          type="button"
-          // rounded-md + the same accent-primary language as the detail-overlay
-          // tool buttons, and the same title wording as the other "Open" actions.
-          className="px-4 py-2 rounded-md bg-accent text-on-accent text-[13px] hover:opacity-90 transition-opacity"
+        <Button
+          // `primary` (the default) + lg reproduces the old accent fill and
+          // px-4 py-2 sizing; the primitive owns radius, hover and focus ring.
+          size="lg"
           onClick={openExternally}
           title="Open with the default app"
         >
           Open in default app
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/desktop/src/renderer/components/artifact-views/ViewerErrorBoundary.tsx
+++ b/desktop/src/renderer/components/artifact-views/ViewerErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from '../ui';
 
 // Error boundary around the artifact viewer render. Two failure modes land
 // here that <Suspense> can NOT catch:
@@ -31,12 +32,9 @@ export class ViewerErrorBoundary extends React.Component<Props, { error: Error |
         <div className="flex flex-col items-center justify-center h-full p-8 text-fg-muted text-sm text-center">
           <p className="mb-2">Couldn’t display this file.</p>
           <p className="mb-4 font-mono text-xs break-all">{this.props.path}</p>
-          <button
-            className="px-3 py-1.5 rounded bg-well border border-edge text-fg text-xs"
-            onClick={() => this.setState({ error: null })}
-          >
+          <Button variant="secondary" onClick={() => this.setState({ error: null })}>
             Try again
-          </button>
+          </Button>
         </div>
       );
     }

--- a/desktop/src/renderer/components/development/BugReportPopup.tsx
+++ b/desktop/src/renderer/components/development/BugReportPopup.tsx
@@ -9,6 +9,7 @@ import { createPortal } from 'react-dom';
 import { useEffect, useState } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
+import { Button } from '../ui';
 
 interface Props {
   open: boolean;
@@ -197,13 +198,13 @@ function DescribeScreen({ kind, setKind, description, setDescription, onContinue
         placeholder="What's happening? (Or what would you like to see?)"
         className="w-full h-32 p-2 text-xs bg-inset/50 border border-edge-dim rounded-lg resize-none focus:outline-none focus:border-accent"
       />
-      <button
+      <Button
         disabled={description.trim().length < 10 || busy}
         onClick={onContinue}
-        className="w-full mt-3 py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+        className="w-full mt-3 py-2.5"
       >
         {busy ? 'Summarizing…' : 'Continue'}
-      </button>
+      </Button>
     </>
   );
 }
@@ -231,20 +232,23 @@ function ReviewScreen({ kind, summary, logTail, setLogTail, onEdit, onSubmit, on
         </details>
       )}
       <div className="flex flex-col gap-2">
-        <button
+        <Button
           disabled={busy}
           onClick={onSubmit}
-          className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 disabled:opacity-40"
+          className="w-full py-2.5"
         >
           Submit as GitHub Issue
-        </button>
-        <button
+        </Button>
+        {/* secondary, not primary: "Let Claude try to fix it" burns a lot of Claude
+            usage (see the warning below it), so it stays the quieter of the two. */}
+        <Button
+          variant="secondary"
           disabled={busy}
           onClick={onLetClaudeTry}
-          className="w-full py-2.5 text-xs font-medium rounded-lg border border-edge-dim text-fg-2 hover:bg-inset disabled:opacity-40"
+          className="w-full py-2.5"
         >
           {ctaLabel}
-        </button>
+        </Button>
         <p className="text-[10px] text-amber-400/80 text-center">⚠ High Claude usage — not recommended for Pro plans</p>
         <button onClick={onEdit} className="text-[10px] text-fg-muted hover:text-fg underline">Edit description</button>
       </div>
@@ -270,12 +274,9 @@ function ResultScreen({ resultMessage, installLines, onDone }: any) {
           {installLines.map((l: string, i: number) => <div key={i}>{l}</div>)}
         </div>
       )}
-      <button
-        onClick={onDone}
-        className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110"
-      >
+      <Button onClick={onDone} className="w-full py-2.5">
         Done
-      </button>
+      </Button>
     </>
   );
 }

--- a/desktop/src/renderer/components/development/ContributePopup.tsx
+++ b/desktop/src/renderer/components/development/ContributePopup.tsx
@@ -8,6 +8,7 @@ import { createPortal } from 'react-dom';
 import { useEffect, useState } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
+import { Button } from '../ui';
 
 interface Props {
   open: boolean;
@@ -83,12 +84,9 @@ export function ContributePopup({ open, onClose }: Props) {
               Open it as a project folder, ask Claude to make changes, and push PRs to the relevant
               <strong> sub-repo</strong> — never to <code>youcoded-dev</code> itself.
             </p>
-            <button
-              onClick={onInstall}
-              className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110"
-            >
+            <Button onClick={onInstall} className="w-full py-2.5">
               Install Workspace
-            </button>
+            </Button>
           </>
         )}
         {installing && (
@@ -99,7 +97,10 @@ export function ContributePopup({ open, onClose }: Props) {
         {error && (
           <>
             <div className="text-xs text-fg mb-3">{error}</div>
-            <button onClick={onClose} className="w-full py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent">Done</button>
+            {/* Spec change 75: this button had no hover state at all (bg-accent with
+                no hover rule), so it looked inert. The primitive gives it the standard
+                hover fade — a real behavior change, not just a restyle. */}
+            <Button onClick={onClose} className="w-full py-2.5">Done</Button>
           </>
         )}
         {done && (
@@ -108,8 +109,8 @@ export function ContributePopup({ open, onClose }: Props) {
               Workspace installed at <code className="text-[11px]">{done.path}</code>. Added to your project folders.
             </div>
             <div className="flex gap-2">
-              <button onClick={onClose} className="flex-1 py-2.5 text-xs font-medium rounded-lg border border-edge-dim text-fg-2 hover:bg-inset">Done</button>
-              <button onClick={onOpenInNewSession} className="flex-1 py-2.5 text-xs font-medium rounded-lg bg-accent text-on-accent">Open in New Session</button>
+              <Button variant="secondary" onClick={onClose} className="flex-1 py-2.5">Done</Button>
+              <Button onClick={onOpenInNewSession} className="flex-1 py-2.5">Open in New Session</Button>
             </div>
           </>
         )}

--- a/desktop/src/renderer/components/game/ConnectFourBoard.tsx
+++ b/desktop/src/renderer/components/game/ConnectFourBoard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useGameState, useGameDispatch } from '../../state/game-context';
 import { GameConnection } from '../../state/game-types';
+import { Button } from '../ui';
 
 const COLS = 7;
 const ROWS = 6;
@@ -52,12 +53,16 @@ export default function ConnectFourBoard({ connection }: Props) {
             <span className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
             <span className="text-xs text-red-300 flex-1">Opponent disconnected — waiting for reconnection...</span>
           </div>
-          <button
+          {/* Low-emphasis escape hatch inside a warning banner — `ghost` keeps it
+              quiet. Radius, hover and focus ring now come from the shared button. */}
+          <Button
+            variant="ghost"
+            size="md"
             onClick={() => { connection.leaveGame(); dispatch({ type: 'RETURN_TO_LOBBY' }); }}
-            className="mt-2 w-full text-xs text-fg-dim hover:text-fg bg-inset rounded-lg py-1.5 transition-colors"
+            className="w-full mt-2"
           >
             Leave Game
-          </button>
+          </Button>
         </div>
       )}
 

--- a/desktop/src/renderer/components/game/GameLobby.tsx
+++ b/desktop/src/renderer/components/game/GameLobby.tsx
@@ -4,6 +4,7 @@ import { useAccount } from '../../state/account-context';
 import BrailleSpinner from '../BrailleSpinner';
 import { GameConnection } from '../../state/game-types';
 import { mergeFriends, statusLabel } from './friends-data';
+import { Button } from '../ui';
 import type { FriendRow, RequestsPayload } from '../../state/marketplace-api-client';
 
 // Local mirror of the renderer/main ApiResult shape (useIpc.ts declares it but
@@ -149,22 +150,31 @@ function FriendRowMenu({ onUnfriend, onBlock, pending }: { onUnfriend: () => voi
                 from each other. You can unblock later in Settings → Account.
               </p>
               <div className="flex gap-2">
-                {/* py-1.5 keeps these ≥32px tall for touch (see the ⋯ trigger note). */}
-                <button
+                {/* The raw `bg-red-600`/`text-white` was a stock Tailwind red that didn't
+                    match the app's own destructive colour and ignored themes. The shared
+                    `danger` variant uses the theme's destructive token and derives a
+                    readable label colour per theme.
+                    The `md` size already supplies py-1.5, which keeps these ≥32px tall
+                    for touch (see the ⋯ trigger note). */}
+                <Button
                   type="button"
+                  variant="danger"
+                  size="md"
                   onClick={() => { onBlock(); close(); }}
                   disabled={pending}
-                  className="flex-1 bg-red-600 hover:bg-red-500 disabled:opacity-40 text-white font-medium rounded py-1.5 transition-colors"
+                  className="flex-1"
                 >
                   Block
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="secondary"
+                  size="md"
                   onClick={() => setConfirmingBlock(false)}
-                  className="flex-1 bg-inset hover:bg-edge text-fg-2 rounded py-1.5 transition-colors"
+                  className="flex-1"
                 >
                   Cancel
-                </button>
+                </Button>
               </div>
             </div>
           ) : (
@@ -364,22 +374,31 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
             <span> wants to play!</span>
           </p>
           <div className="flex gap-2">
-            <button
+            {/* WHY green → `primary`: accepting a game invite is not a safety decision.
+                The green was borrowed from the permission prompt, where green/red really
+                does mean allow/deny. Here it just meant "the main action", which is what
+                `primary` is for — and it also removes the last hardcoded `text-white`
+                from the games screens, so this button now follows the user's theme. */}
+            <Button
+              variant="primary"
+              size="md"
               onClick={() => {
                 connection.respondToChallenge(state.challengeFrom!.id, true);
                 connection.joinGame(state.challengeCode!);
                 dispatch({ type: 'CLEAR_CHALLENGE' });
               }}
-              className="flex-1 bg-green-600 hover:bg-green-500 text-white text-xs font-medium rounded-lg py-1.5 transition-colors"
+              className="flex-1"
             >
               Accept
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="secondary"
+              size="md"
               onClick={() => { connection.respondToChallenge(state.challengeFrom!.id, false); dispatch({ type: 'CLEAR_CHALLENGE' }); }}
-              className="flex-1 bg-inset hover:bg-edge text-fg-2 text-xs font-medium rounded-lg py-1.5 transition-colors"
+              className="flex-1"
             >
               Decline
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -445,13 +464,17 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
             placeholder="friend's handle"
             className="flex-1 bg-well border border-edge rounded-lg px-3 py-2 text-sm text-fg placeholder-fg-muted outline-none focus:border-fg-dim transition-colors"
           />
-          <button
+          {/* Filled-grey (`bg-inset`) was an unofficial second secondary style; it
+              collapses into the primitive's outlined `secondary`. `lg` matches the
+              height of the handle input next to it. */}
+          <Button
+            variant="secondary"
+            size="lg"
             onClick={() => void submitAddFriend()}
             disabled={!addHandle.trim() || addPending}
-            className="bg-inset hover:bg-edge disabled:opacity-40 disabled:cursor-not-allowed text-fg text-sm font-medium rounded-lg px-3 py-2 transition-colors"
           >
             Send request
-          </button>
+          </Button>
         </div>
         {addFeedback && (
           <p className={`text-xs ${addFeedback.ok ? 'text-green-400' : 'text-red-400'}`}>{addFeedback.text}</p>
@@ -612,13 +635,17 @@ function SignInScreen() {
       <p className="text-xs text-fg-muted text-center max-w-xs">
         Games use your GitHub name as your player tag.
       </p>
-      <button
+      {/* The old classes had `hover:bg-accent` on top of a `bg-accent` base, so
+          hovering changed nothing. The shared `primary` fades the fill on hover,
+          so this button now visibly responds to the cursor. */}
+      <Button
+        variant="primary"
+        size="lg"
         onClick={() => { void startSignIn(); }}
         disabled={signInPending}
-        className="bg-accent hover:bg-accent text-on-accent text-sm font-medium rounded-lg px-4 py-2 transition-colors disabled:opacity-50"
       >
         {signInPending ? 'Signing in…' : 'Sign in with GitHub'}
-      </button>
+      </Button>
       {/* knowledge-debt #6: surface a failed sign-in instead of silently swallowing it. */}
       {signInError && !signInPending && (
         <p className="text-xs text-red-400 text-center max-w-xs">Sign-in failed: {signInError}. Try again.</p>

--- a/desktop/src/renderer/components/game/GameOverlay.tsx
+++ b/desktop/src/renderer/components/game/GameOverlay.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useGameState, useGameDispatch } from '../../state/game-context';
 import { GameConnection } from '../../state/game-types';
 import { OverlayPanel } from '../overlays/Overlay';
+import { Button } from '../ui';
 
 interface Props {
   connection: GameConnection;
@@ -47,19 +48,29 @@ export default function GameOverlay({ connection }: Props) {
         </div>
 
         <div className="flex flex-col gap-2 w-40">
-          <button
+          {/* Rematch is the main action here, so it's the shared `primary` button.
+              The old hand-rolled classes had `hover:bg-accent` on top of a
+              `bg-accent` base — i.e. the hover did nothing. The primitive fades
+              the fill on hover, so this button now actually responds to the cursor. */}
+          <Button
+            variant="primary"
+            size="lg"
             onClick={() => { if (!state.rematchRequested) connection.requestRematch(); }}
             disabled={state.rematchRequested}
-            className="w-full bg-accent hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed text-on-accent text-sm font-medium rounded-lg py-2 transition-colors"
+            className="w-full"
           >
             {state.rematchRequested ? 'Rematch Requested' : 'Rematch'}
-          </button>
-          <button
+          </Button>
+          {/* Filled-grey (`bg-inset`) was a second, unofficial secondary style —
+              it collapses into the primitive's outlined `secondary`. */}
+          <Button
+            variant="secondary"
+            size="lg"
             onClick={() => { connection.leaveGame(); dispatch({ type: 'RETURN_TO_LOBBY' }); }}
-            className="w-full bg-inset hover:bg-edge text-fg-2 text-sm font-medium rounded-lg py-2 transition-colors"
+            className="w-full"
           >
             Back to Lobby
-          </button>
+          </Button>
         </div>
       </OverlayPanel>
     </div>

--- a/desktop/src/renderer/components/library/LibraryScreen.tsx
+++ b/desktop/src/renderer/components/library/LibraryScreen.tsx
@@ -5,6 +5,7 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { useMarketplace } from "../../state/marketplace-context";
 import { useEscClose } from "../../hooks/use-esc-close";
+import { Button } from "../ui";
 import MarketplaceCard from "../marketplace/MarketplaceCard";
 import WallpaperBackdrop from "../WallpaperBackdrop";
 import MarketplaceGrid from "../marketplace/MarketplaceGrid";
@@ -130,11 +131,16 @@ export default function LibraryScreen({
       <div className="flex items-center justify-between gap-2 p-3">
         <h1 className="text-xl font-semibold text-fg pl-2 truncate min-w-0">Your Library</h1>
         <div className="flex items-center gap-2 shrink-0">
+          {/* panel-glass and the tighter py-1 stay as className overrides (spec
+              decision 69) — glass re-tiers translucency on wallpaper themes, so a
+              naive migration would leave this chip opaque over the wallpaper. */}
           {onOpenMarketplace && (
-            <button
+            <Button
+              variant="secondary"
+              size="lg"
               type="button"
               onClick={onOpenMarketplace}
-              className="panel-glass bg-inset text-fg-2 hover:text-fg text-sm rounded-md border border-edge-dim hover:border-edge px-3 py-1 inline-flex items-center justify-center"
+              className="panel-glass py-1"
               aria-label="Open marketplace"
               title="Marketplace"
             >
@@ -147,7 +153,7 @@ export default function LibraryScreen({
                   <path d="M9 13h6" />
                 </svg>
               </span>
-            </button>
+            </Button>
           )}
           {/* Wide: Esc text. Narrow: bordered close-X — matches the marketplace top bar. */}
           <button

--- a/desktop/src/renderer/components/marketplace/FileViewerOverlay.tsx
+++ b/desktop/src/renderer/components/marketplace/FileViewerOverlay.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from "react";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
 import MarkdownContent from "../MarkdownContent";
 import { useEscClose } from "../../hooks/use-esc-close";
+import { CloseButton } from "../ui";
 
 export type FileViewerTarget = {
   pluginId: string;
@@ -86,17 +87,13 @@ export default function FileViewerOverlay({ target, onClose }: Props) {
           >
             Esc · Close
           </button>
-          <button
-            type="button"
+          {/* The border survives as a className override: this narrow-only closer is
+              deliberately a bordered container matching the marketplace top bar. */}
+          <CloseButton
             onClick={onClose}
-            className="sm:hidden shrink-0 p-1.5 rounded-md border border-edge-dim hover:border-edge text-fg-dim hover:text-fg"
-            aria-label="Close file viewer"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+            label="Close file viewer"
+            className="sm:hidden shrink-0 rounded-md border border-edge-dim hover:border-edge"
+          />
         </header>
         <div className="flex-1 overflow-y-auto p-3 sm:p-6">
           {state.status === "loading" && (

--- a/desktop/src/renderer/components/marketplace/MarketplaceDetailOverlay.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceDetailOverlay.tsx
@@ -18,7 +18,7 @@ import RatingSubmitModal from "./RatingSubmitModal";
 import ReviewList from "./ReviewList";
 import LikeButton from "./LikeButton";
 import FileViewerOverlay, { type FileViewerTarget } from "./FileViewerOverlay";
-import { Button } from "../ui";
+import { Button, CloseButton } from "../ui";
 
 export type DetailTarget =
   | { kind: "skill"; id: string }
@@ -124,17 +124,12 @@ export default function MarketplaceDetailOverlay({
           >
             Esc · Close
           </button>
-          <button
-            type="button"
+          {/* panel-glass + the border survive as className overrides: this narrow-only
+              closer is deliberately a bordered container matching the marketplace top bar. */}
+          <CloseButton
             onClick={onClose}
-            className="sm:hidden panel-glass bg-inset p-1.5 rounded-md border border-edge-dim hover:border-edge text-fg-dim hover:text-fg"
-            aria-label="Close"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+            className="sm:hidden panel-glass bg-inset rounded-md border border-edge-dim hover:border-edge"
+          />
         </header>
         <div className="flex-1 overflow-y-auto p-3 sm:p-6">{content}</div>
       </OverlayPanel>

--- a/desktop/src/renderer/components/marketplace/MarketplaceFilterBar.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceFilterBar.tsx
@@ -11,6 +11,7 @@
 
 import React, { useState } from "react";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
+import { Button } from "../ui";
 import { useEscClose } from "../../hooks/use-esc-close";
 import { useNarrowViewport } from "../../hooks/use-narrow-viewport";
 
@@ -211,13 +212,14 @@ function FilterSheet({
           </SheetGroup>
         </div>
         <footer className="sticky bottom-0 z-10 px-4 py-3 border-t border-edge-dim bg-panel">
-          <button
+          <Button
+            size="lg"
             type="button"
             onClick={onClose}
-            className="w-full px-4 py-2 rounded-md bg-accent text-on-accent font-medium hover:opacity-90"
+            className="w-full"
           >
             Apply
-          </button>
+          </Button>
         </footer>
       </OverlayPanel>
     </>

--- a/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
@@ -19,7 +19,7 @@ import WallpaperBackdrop from "../WallpaperBackdrop";
 import InstallingFooterStrip from "./InstallingFooterStrip";
 import MarketplaceAuthChip from "./MarketplaceAuthChip";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
-import { Button } from "../ui";
+import { Button, CloseButton } from "../ui";
 import { useEscClose } from "../../hooks/use-esc-close";
 import { useCurrentPlatform } from "../../state/platform";
 import { platformDisplayName, platformListDisplay } from "../../../shared/platform-display";
@@ -327,17 +327,13 @@ export default function MarketplaceScreen({
           {/* Narrow: bordered close-X button — touch users have no Esc key, so we
               give them an obvious close affordance with a button-shaped container
               matching the Library button next to it. */}
-          <button
-            type="button"
+          {/* panel-glass + the border survive as className overrides — the bordered
+              container is what makes this match the Library button next to it. */}
+          <CloseButton
             onClick={onExit}
-            className="sm:hidden panel-glass bg-inset p-1.5 rounded-md border border-edge-dim hover:border-edge text-fg-dim hover:text-fg"
-            aria-label="Exit marketplace"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+            label="Exit marketplace"
+            className="sm:hidden panel-glass bg-inset rounded-md border border-edge-dim hover:border-edge"
+          />
         </div>
       </div>
 
@@ -641,17 +637,12 @@ function IntegrationDetailOverlay({
           >
             Esc · Close
           </button>
-          <button
-            type="button"
+          {/* panel-glass + the border survive as className overrides — deliberately a
+              bordered container matching the marketplace top bar. */}
+          <CloseButton
             onClick={onClose}
-            className="sm:hidden panel-glass bg-inset p-1.5 rounded-md border border-edge-dim hover:border-edge text-fg-dim hover:text-fg"
-            aria-label="Close"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+            className="sm:hidden panel-glass bg-inset rounded-md border border-edge-dim hover:border-edge"
+          />
         </header>
         <div className="flex-1 overflow-y-auto p-3 sm:p-6">
           <article className="flex flex-col gap-4 max-w-3xl mx-auto">

--- a/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
@@ -19,6 +19,7 @@ import WallpaperBackdrop from "../WallpaperBackdrop";
 import InstallingFooterStrip from "./InstallingFooterStrip";
 import MarketplaceAuthChip from "./MarketplaceAuthChip";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
+import { Button } from "../ui";
 import { useEscClose } from "../../hooks/use-esc-close";
 import { useCurrentPlatform } from "../../state/platform";
 import { platformDisplayName, platformListDisplay } from "../../../shared/platform-display";
@@ -291,11 +292,16 @@ export default function MarketplaceScreen({
           <h1 className="text-xl font-semibold text-fg truncate">Marketplace</h1>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {/* panel-glass and the tighter py-1 stay as className overrides (spec
+              decision 69): glass re-tiers translucency on wallpaper themes, and
+              dropping it in a naive migration would make this chip opaque. */}
           {onOpenLibrary && (
-            <button
+            <Button
+              variant="secondary"
+              size="lg"
               type="button"
               onClick={onOpenLibrary}
-              className="panel-glass bg-inset text-fg-2 hover:text-fg text-sm rounded-md border border-edge-dim hover:border-edge px-3 py-1 sm:px-3 sm:py-1 inline-flex items-center justify-center"
+              className="panel-glass py-1"
               aria-label="Open Your Library"
               title="Your Library"
             >
@@ -307,7 +313,7 @@ export default function MarketplaceScreen({
                   <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
                 </svg>
               </span>
-            </button>
+            </Button>
           )}
           {/* Wide: text "Esc · Back to chat" hint, no border (Esc key does the work). */}
           <button
@@ -852,20 +858,23 @@ function SetupHintBanner({
         <code className="flex-1 min-w-0 truncate px-2 py-1.5 rounded bg-inset text-fg text-sm font-mono border border-edge-dim">
           {command}
         </code>
-        <button
+        <Button
+          variant="secondary"
+          size="lg"
           type="button"
           onClick={copy}
-          className="shrink-0 text-sm px-3 py-1.5 rounded-md border border-edge-dim hover:border-edge text-fg-2 hover:text-fg"
+          className="shrink-0"
         >
           {copied ? 'Copied' : 'Copy'}
-        </button>
-        <button
+        </Button>
+        <Button
+          size="lg"
           type="button"
           onClick={onOpenSetupSession}
-          className="shrink-0 text-sm px-3 py-1.5 rounded-md bg-accent text-on-accent hover:opacity-90"
+          className="shrink-0"
         >
           Open new setup session
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onDismiss}

--- a/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
+++ b/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
@@ -24,6 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
+import { Button } from '../ui';
 import { useEscClose } from '../../hooks/use-esc-close';
 import { useAccount } from '../../state/account-context';
 import { useMarketplaceStats } from '../../state/marketplace-stats-context';
@@ -259,12 +260,13 @@ export default function RatingSubmitModal({
             <p className="text-sm text-fg-muted text-center">
               Sign in with GitHub to rate this plugin.
             </p>
-            <button
+            <Button
+              size="lg"
               onClick={() => void startSignIn()}
-              className="px-4 py-1.5 text-sm font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors"
+              className="py-1.5"
             >
               Sign in with GitHub
-            </button>
+            </Button>
             {/* knowledge-debt #6: surface a failed sign-in instead of silently swallowing it. */}
             {signInError && (
               <p className="text-xs text-red-400 text-center">Sign-in failed: {signInError}. Try again.</p>
@@ -331,13 +333,13 @@ export default function RatingSubmitModal({
                 <p className="text-xs text-fg-muted">
                   You need to install this plugin before you can rate it.
                 </p>
-                <button
+                <Button
                   onClick={() => void handleInstallAndRate()}
                   disabled={installing}
-                  className="self-start px-3 py-1.5 text-xs font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
+                  className="self-start"
                 >
                   {installing ? 'Installing…' : 'Install and rate'}
-                </button>
+                </Button>
               </div>
             )}
 
@@ -350,14 +352,15 @@ export default function RatingSubmitModal({
                 >
                   Cancel
                 </button>
-                <button
+                <Button
+                  size="lg"
                   onClick={() => void handleSubmit()}
                   disabled={submitDisabled}
                   aria-disabled={submitDisabled}
-                  className="px-4 py-1.5 text-sm font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-50"
+                  className="py-1.5"
                 >
                   {inFlight ? 'Submitting…' : 'Submit rating'}
-                </button>
+                </Button>
               </div>
             )}
           </div>

--- a/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
+++ b/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
@@ -24,7 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
-import { Button } from '../ui';
+import { Button, CloseButton } from '../ui';
 import { useEscClose } from '../../hooks/use-esc-close';
 import { useAccount } from '../../state/account-context';
 import { useMarketplaceStats } from '../../state/marketplace-stats-context';
@@ -244,13 +244,7 @@ export default function RatingSubmitModal({
           <h2 id="rate-modal-title" className="text-sm font-semibold text-fg">
             Rate this plugin
           </h2>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-fg-muted hover:text-fg transition-colors leading-none text-lg"
-          >
-            &times;
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         {/* Body */}

--- a/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
+++ b/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
@@ -24,6 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
+import { Button } from '../ui';
 import { useEscClose } from '../../hooks/use-esc-close';
 import { useAccount } from '../../state/account-context';
 import { REPORT_REASON_MAX } from '../../state/marketplace-constants';
@@ -220,16 +221,19 @@ function ReportDialog({ reviewerLogin, onClose, onSubmit }: ReportDialogProps) {
               >
                 Cancel
               </button>
-              <button
+              {/* danger-outline replaces the hand-rolled var(--destructive) border/text/hover
+                  trio — same intent (signal severity from the theme token, no hex), now
+                  spelled once in the primitive. */}
+              <Button
+                variant="danger-outline"
+                size="lg"
                 onClick={() => void handleSubmit()}
                 disabled={inFlight}
                 aria-disabled={inFlight}
-                // Use --destructive token via Tailwind's text-[var(...)] pattern so the
-                // submit button signals severity without hard-coding a hex color.
-                className="px-4 py-1.5 text-sm font-medium rounded-lg border border-[color:var(--destructive,theme(colors.red.500))] text-[color:var(--destructive,theme(colors.red.500))] hover:bg-[color:var(--destructive,theme(colors.red.500))]/10 transition-colors disabled:opacity-50"
+                className="py-1.5"
               >
                 {inFlight ? 'Submitting…' : 'Report review'}
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
+++ b/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
@@ -24,7 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
-import { Button } from '../ui';
+import { Button, CloseButton } from '../ui';
 import { useEscClose } from '../../hooks/use-esc-close';
 import { useAccount } from '../../state/account-context';
 import { REPORT_REASON_MAX } from '../../state/marketplace-constants';
@@ -155,14 +155,7 @@ function ReportDialog({ reviewerLogin, onClose, onSubmit }: ReportDialogProps) {
             Report this review?
           </h2>
           {/* Fix: disabled during submitting phase to prevent closing a mid-flight request */}
-          <button
-            onClick={onClose}
-            disabled={inFlight}
-            aria-label="Close"
-            className="text-fg-muted hover:text-fg transition-colors leading-none text-lg disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            &times;
-          </button>
+          <CloseButton onClick={onClose} disabled={inFlight} />
         </div>
 
         {/* Success state */}

--- a/desktop/src/renderer/components/marketplace/SignInPromptModal.tsx
+++ b/desktop/src/renderer/components/marketplace/SignInPromptModal.tsx
@@ -8,7 +8,7 @@
 
 import React from "react";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
-import { Button } from "../ui";
+import { Button, CloseButton } from "../ui";
 import { useAccount } from "../../state/account-context";
 import { useEscClose } from "../../hooks/use-esc-close";
 
@@ -47,13 +47,7 @@ export default function SignInPromptModal({ open, onClose, title, message }: Pro
           <h2 id="signin-prompt-title" className="text-sm font-semibold text-fg">
             {title}
           </h2>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-fg-muted hover:text-fg transition-colors leading-none text-lg"
-          >
-            &times;
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <div className="flex flex-col items-center gap-3 py-2">

--- a/desktop/src/renderer/components/marketplace/SignInPromptModal.tsx
+++ b/desktop/src/renderer/components/marketplace/SignInPromptModal.tsx
@@ -8,6 +8,7 @@
 
 import React from "react";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
+import { Button } from "../ui";
 import { useAccount } from "../../state/account-context";
 import { useEscClose } from "../../hooks/use-esc-close";
 
@@ -57,17 +58,18 @@ export default function SignInPromptModal({ open, onClose, title, message }: Pro
 
         <div className="flex flex-col items-center gap-3 py-2">
           <p className="text-sm text-fg-muted text-center">{message}</p>
-          <button
+          <Button
+            size="lg"
             onClick={() => void startSignIn()}
             disabled={signInPending}
-            className="flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded-lg bg-accent text-on-accent hover:brightness-110 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            className="py-1.5"
           >
             {/* GitHub octocat — same path used in MarketplaceAuthChip for consistency */}
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
             </svg>
             {signInPending ? "Waiting for browser…" : "Sign in with GitHub"}
-          </button>
+          </Button>
           {signInPending && (
             <p className="text-xs text-fg-faint text-center">
               Complete sign-in in your browser. This window will close automatically.

--- a/desktop/src/renderer/components/project-view/AddProjectModal.tsx
+++ b/desktop/src/renderer/components/project-view/AddProjectModal.tsx
@@ -10,6 +10,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
 import ImportProjectModal from '../ImportProjectModal';
+import { Button } from '../ui';
 
 interface Props {
   onClose: () => void;
@@ -143,13 +144,15 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
                   placeholder="Project name…"
                   className="flex-1 bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
                 />
-                <button
+                {/* py-1 keeps the button the same height as the name input beside it. */}
+                <Button
+                  size="lg"
+                  className="py-1"
                   onClick={() => void createNew()}
                   disabled={busy || !name.trim()}
-                  className="text-sm px-3 py-1 rounded bg-accent text-on-accent disabled:opacity-50"
                 >
                   {busy ? 'Creating…' : 'Create'}
-                </button>
+                </Button>
               </div>
             </div>
 
@@ -166,7 +169,7 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
             {error && <div className="mt-2 text-xs text-red-500" role="alert">{error}</div>}
             {syncOffNote}
             <div className="mt-4 flex justify-end">
-              <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
+              <Button variant="ghost" size="lg" className="py-1" onClick={onClose} disabled={busy}>Cancel</Button>
             </div>
           </>
         ) : (
@@ -196,8 +199,8 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
             {error && <div className="mt-2 text-xs text-red-500" role="alert">{error}</div>}
             {syncOffNote}
             <div className="mt-4 flex justify-between">
-              <button onClick={() => { setError(null); setStep({ kind: 'choose' }); }} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Back</button>
-              <button onClick={onClose} disabled={busy} className="text-sm px-3 py-1 rounded text-fg-dim hover:text-fg hover:bg-inset transition-colors">Cancel</button>
+              <Button variant="ghost" size="lg" className="py-1" onClick={() => { setError(null); setStep({ kind: 'choose' }); }} disabled={busy}>Back</Button>
+              <Button variant="ghost" size="lg" className="py-1" onClick={onClose} disabled={busy}>Cancel</Button>
             </div>
           </>
         )}

--- a/desktop/src/renderer/components/project-view/ContextIntroBanner.tsx
+++ b/desktop/src/renderer/components/project-view/ContextIntroBanner.tsx
@@ -32,7 +32,8 @@ function persistDismissed(): void {
 }
 
 // Info-circle + close glyphs — shared module (./icons.tsx).
-import { InfoIcon, CloseIcon } from './icons';
+import { InfoIcon } from './icons';
+import { CloseButton } from '../ui';
 
 export function ContextIntroBanner() {
   // Initialize from localStorage so a previously-dismissed banner never flashes
@@ -63,18 +64,17 @@ export function ContextIntroBanner() {
         </p>
       </div>
       {/* × dismiss — persists the flag AND hides immediately via local state. */}
-      <button
-        type="button"
-        className="absolute top-2 right-2 w-6 h-6 rounded-md inline-flex items-center justify-center text-fg-muted hover:text-fg hover:bg-well transition-colors"
+      {/* w-6 h-6 survives as a className override: this sits inside a compact banner
+          corner, where the standard 28px icon button would crowd the text. */}
+      <CloseButton
+        className="absolute top-2 right-2 w-6 h-6 rounded-md"
         title="Dismiss — won't show again"
-        aria-label="Dismiss context intro"
+        label="Dismiss context intro"
         onClick={() => {
           persistDismissed();
           setDismissed(true);
         }}
-      >
-        <CloseIcon size={14} />
-      </button>
+      />
     </div>
   );
 }

--- a/desktop/src/renderer/components/project-view/HowContextWorksPopup.tsx
+++ b/desktop/src/renderer/components/project-view/HowContextWorksPopup.tsx
@@ -19,6 +19,7 @@
 import React, { useState } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
+import { CloseButton } from '../ui';
 import type { ContextScope } from '../../../shared/project-context-types';
 
 // The five teaching topics. `overview` is the broad→specific stack; the other
@@ -102,15 +103,7 @@ function InfoIcon({ size = 16 }: IconProps) {
   );
 }
 
-function CloseIcon({ size = 17 }: IconProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M18 6 6 18" />
-      <path d="M6 6l12 12" />
-    </svg>
-  );
-}
+// (local CloseIcon removed — the header ✕ is now the shared <CloseButton /> primitive.)
 
 // Per-tab nav metadata. The `icon` is a component (not a string), so the nav can
 // never reference an undefined icon.
@@ -401,15 +394,7 @@ export function HowContextWorksPopup({ initialTab, onClose }: HowContextWorksPop
         {/* Header */}
         <header className="flex items-center justify-between px-4 py-3 border-b border-edge shrink-0">
           <span className="text-[15px] font-semibold text-fg">How context works</span>
-          <button
-            type="button"
-            className="text-fg-dim hover:text-fg w-7 h-7 inline-flex items-center justify-center"
-            onClick={onClose}
-            title="Close"
-            aria-label="Close"
-          >
-            <CloseIcon size={17} />
-          </button>
+          <CloseButton onClick={onClose} title="Close" />
         </header>
 
         {/* Body: left nav + scrollable content */}

--- a/desktop/src/renderer/components/project-view/ProjectDetailOverlay.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectDetailOverlay.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
-import { CloseIcon } from './icons';
+import { CloseButton } from '../ui';
 
 interface ProjectDetailOverlayProps {
   title: React.ReactNode;
@@ -45,15 +45,7 @@ export function ProjectDetailOverlay({ title, onClose, tools, meta, children }: 
           <span className="text-[15px] font-semibold text-fg truncate min-w-0">{title}</span>
           <div className="flex items-center gap-1.5 shrink-0">
             {tools}
-            <button
-              type="button"
-              className="ml-1 text-fg-dim hover:text-fg w-7 h-7 inline-flex items-center justify-center shrink-0"
-              onClick={onClose}
-              title="Close"
-              aria-label="Close"
-            >
-              <CloseIcon size={17} />
-            </button>
+            <CloseButton className="ml-1 shrink-0" onClick={onClose} title="Close" />
           </div>
         </header>
 

--- a/desktop/src/renderer/components/project-view/ProjectHero.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectHero.tsx
@@ -94,6 +94,7 @@ function ExternalLink({ size = 14 }: { size?: number }) {
 
 // Git-branch glyph shared with ProjectSwitcher — lives in ./icons.tsx.
 import { GitBranchIcon } from './icons';
+import { Button } from '../ui';
 
 export function ProjectHero({
   project,
@@ -205,13 +206,9 @@ export function ProjectHero({
                 <span className="text-[13px] font-semibold text-[#44A05C]">Syncs across your devices</span>
                 {sync.lastSynced && <span className="text-xs text-fg-muted">Last synced {sync.lastSynced}</span>}
                 {sync.spaceId && (
-                  <button
-                    type="button"
-                    onClick={() => onSyncNow(sync.spaceId!)}
-                    className="px-2.5 py-1 rounded-md bg-panel border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors"
-                  >
+                  <Button variant="secondary" size="sm" onClick={() => onSyncNow(sync.spaceId!)}>
                     Sync now
-                  </button>
+                  </Button>
                 )}
               </>
             )}
@@ -220,13 +217,9 @@ export function ProjectHero({
                 <span className="text-[13px] font-semibold text-[#DD4444]">Sync isn't working</span>
                 {sync.errorMessage && <span className="text-xs text-fg-dim">{sync.errorMessage}</span>}
                 {sync.spaceId && (
-                  <button
-                    type="button"
-                    onClick={() => onSyncNow(sync.spaceId!)}
-                    className="px-2.5 py-1 rounded-md bg-panel border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors"
-                  >
+                  <Button variant="secondary" size="sm" onClick={() => onSyncNow(sync.spaceId!)}>
                     Try again
-                  </button>
+                  </Button>
                 )}
               </>
             )}
@@ -242,13 +235,11 @@ export function ProjectHero({
             {sync.dot.color === 'gray' && !sync.spaceId && (
               <>
                 <span className="text-[13px] font-semibold text-fg-2">Only on this computer</span>
-                <button
-                  type="button"
-                  onClick={onTurnOnSync}
-                  className="px-3 py-1 rounded-md bg-accent text-on-accent text-xs hover:opacity-90 transition-opacity"
-                >
+                {/* py-1 keeps this button compact inside the sync status strip;
+                    everything else (accent fill, radius, hover) comes from Button. */}
+                <Button onClick={onTurnOnSync} className="py-1">
                   Turn on sync for this project
-                </button>
+                </Button>
               </>
             )}
           </div>
@@ -276,23 +267,29 @@ export function ProjectHero({
               className="bg-inset text-fg text-xs rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
             />
           ) : (
-            <button type="button" onClick={() => setRenaming(true)} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors">
+            <Button variant="secondary" size="sm" onClick={() => setRenaming(true)}>
               Rename
-            </button>
+            </Button>
           )}
           {isElectron && (
-            <button
-              type="button"
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => void (window.claude as any).shell.openPath(project.path)}
-              className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors"
             >
               Open in File Explorer
-            </button>
+            </Button>
           )}
+          {/* WHY danger-outline (spec decision 67): "Remove from YouCoded" and
+              "Stop syncing" used to look neutral and only turn red on hover.
+              These are consequential enough that hover is the wrong moment to
+              find that out, so they read as destructive at rest. "Rename" above
+              stays neutral — being the only non-red one is what makes it read
+              as the safe action. */}
           {canRemove ? (
-            <button type="button" onClick={onRemove} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-[#DD4444] transition-colors">
+            <Button variant="danger-outline" size="sm" onClick={onRemove}>
               Remove from YouCoded
-            </button>
+            </Button>
           ) : syncedFolderName && sync?.stopped ? (
             // Already stopped (permanent) — no action to offer, just the state
             // (review #4: don't re-render a "Stop syncing" button for a project
@@ -305,17 +302,17 @@ export function ProjectHero({
                 <span className="text-[11px] text-fg-dim max-w-[22rem]">
                   Stop syncing “{shownName}”? The folder stays on all your devices, but changes will no longer sync between them. This can’t be undone from here.
                 </span>
-                <button type="button" onClick={() => void commitStop()} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-[#DD4444] transition-colors">
+                <Button variant="danger-outline" size="sm" onClick={() => void commitStop()}>
                   Stop syncing
-                </button>
-                <button type="button" onClick={() => setConfirmingStop(false)} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-fg transition-colors">
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => setConfirmingStop(false)}>
                   Cancel
-                </button>
+                </Button>
               </span>
             ) : (
-              <button type="button" onClick={() => setConfirmingStop(true)} className="px-2.5 py-1 rounded-md border border-edge-dim hover:border-edge text-xs text-fg-2 hover:text-[#DD4444] transition-colors">
+              <Button variant="danger-outline" size="sm" onClick={() => setConfirmingStop(true)}>
                 Stop syncing
-              </button>
+              </Button>
             )
           ) : (
             <span className="text-[11px] text-fg-faint">Managed by sync</span>
@@ -326,24 +323,20 @@ export function ProjectHero({
       {/* Right: Open repo (only when the project has a web URL) + New Conversation. */}
       <div className="shrink-0 flex items-center gap-2">
         {repo?.webUrl && (
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="lg"
             onClick={() => window.claude.shell.openExternal(repo.webUrl!)}
-            className="px-3 py-2 rounded-md bg-inset text-fg-2 hover:text-fg border border-edge-dim hover:border-edge text-[13px] inline-flex items-center gap-1.5 transition-colors"
             title={showRepoSlug ? `Open ${repo.owner}/${repo.name} on GitHub` : 'Open repository'}
           >
             <ExternalLink size={14} />
             Open repo
-          </button>
+          </Button>
         )}
         {/* The ONE accent use in this hero. */}
-        <button
-          type="button"
-          onClick={() => onNewConversation(project.path)}
-          className="px-4 py-2 rounded-md bg-accent text-on-accent text-[13px] hover:opacity-90 transition-opacity"
-        >
+        <Button size="lg" onClick={() => onNewConversation(project.path)}>
           New Conversation
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/desktop/src/renderer/components/project-view/ProjectSwitcher.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectSwitcher.tsx
@@ -29,7 +29,8 @@ interface ProjectSwitcherProps {
 
 // Shared glyphs — see ./icons.tsx. (The check is the active-project indicator,
 // NOT a status glyph.)
-import { SearchIcon, CheckIcon, PlusIcon, CloseIcon } from './icons';
+import { SearchIcon, CheckIcon, PlusIcon } from './icons';
+import { CloseButton } from '../ui';
 
 export function ProjectSwitcher({
   projects,
@@ -234,15 +235,14 @@ export function ProjectSwitcher({
                     removing a folder that's managed by sync is a deferred
                     move-out flow, not a simple un-list. */}
                 {onDeleteProject && !findSpaceFor(p.path, syncStatus ?? null) && (
-                  <button
-                    type="button"
-                    className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-6 h-6 rounded-md inline-flex items-center justify-center text-fg-muted hover:text-fg hover:bg-well"
+                  <CloseButton
+                    // w-6 h-6 survives as a className override: this is a hover-revealed
+                    // affordance sized to the row, not a panel-header closer.
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-6 h-6 rounded-md"
                     title={`Remove ${p.name} from YouCoded`}
-                    aria-label={`Remove ${p.name} from YouCoded`}
+                    label={`Remove ${p.name} from YouCoded`}
                     onClick={(e) => { e.stopPropagation(); onDeleteProject(p); }}
-                  >
-                    <CloseIcon size={14} />
-                  </button>
+                  />
                 )}
               </div>
             );

--- a/desktop/src/renderer/components/project-view/ProjectView.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectView.tsx
@@ -59,6 +59,7 @@ interface HeroRepo { webUrl?: string; owner?: string; name?: string }
 // its own copies of the same paths). GridIcon is the one glyph unique to this
 // file — the Artifacts segment icon.
 import { InfoIcon, ChatIcon, FolderIcon, DocIcon, SearchIcon } from './icons';
+import { Button } from '../ui';
 
 function GridIcon({ size = 15 }: { size?: number }) {
   return (
@@ -528,16 +529,16 @@ export function ProjectView(props: ProjectViewProps) {
       <header className="flex items-center gap-3 px-4 py-2.5 border-b border-edge shrink-0">
         <h2 className="text-base font-semibold text-fg shrink-0">Projects</h2>
         <div className="flex-1" />
-        <button
-          type="button"
-          className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-fg-muted hover:text-fg hover:bg-inset transition-colors shrink-0"
+        <Button
+          variant="ghost"
+          className="shrink-0"
           onClick={() => dispatch({ type: 'PROJECT_VIEW_CLOSED' })}
           title="Close Projects"
           aria-label="Close Projects"
         >
           <span className="text-[10px] tracking-wider uppercase">Esc</span>
           <span>Close</span>
-        </button>
+        </Button>
       </header>
 
       <div className="flex-1 flex overflow-hidden">
@@ -697,15 +698,18 @@ export function ProjectView(props: ProjectViewProps) {
                       />
                     )}
                   </div>
+                  {/* Was a pill (rounded-full). Spec decision 65 keeps pills only
+                      for floating overlay affordances — this sits in a toolbar row,
+                      so it takes the app's standard button radius. */}
                   {tab === 'artifacts' && (
-                    <button
-                      type="button"
-                      className="px-3 py-1.5 rounded-full text-[12.5px] bg-inset text-fg-2 border border-edge hover:text-fg hover:border-edge-dim transition-colors shrink-0"
+                    <Button
+                      variant="secondary"
+                      className="shrink-0"
                       onClick={addExternal}
                       title="Add an external file to this project"
                     >
                       + Add file
-                    </button>
+                    </Button>
                   )}
                 </div>
               )}
@@ -811,20 +815,19 @@ export function ProjectView(props: ProjectViewProps) {
               Also delete <code className="font-mono text-xs bg-inset px-1 rounded">.youcoded/artifacts.json</code> (artifact history)
             </label>
             <div className="flex gap-2 justify-end">
-              <button
-                type="button"
-                className="px-3 py-1.5 rounded-md border border-edge hover:bg-inset text-sm transition-colors"
+              <Button
+                variant="secondary"
+                size="lg"
                 onClick={() => { setDeletingProject(null); setAlsoDeleteSidecar(false); }}
               >
                 Cancel
-              </button>
-              <button
-                type="button"
-                className="px-3 py-1.5 rounded-md bg-red-600 text-white hover:bg-red-700 text-sm transition-colors"
-                onClick={confirmDelete}
-              >
+              </Button>
+              {/* Was a raw Tailwind bg-red-600. Spec decision 59: that stock red
+                  isn't the app's destructive colour and doesn't follow themes —
+                  the `danger` variant uses the theme's own destructive token. */}
+              <Button variant="danger" size="lg" onClick={confirmDelete}>
                 Remove
-              </button>
+              </Button>
             </div>
           </OverlayPanel>
         </>

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -118,6 +118,7 @@ function listDir(artifacts: ArtifactRecord[], dir: string, sortBy: FileSortKey):
 // Aliased: detail-tool-icons also exports a (different) FolderIcon used by the
 // Reveal button above.
 import { FolderIcon as FolderCardIcon, DocIcon, ImageIcon, SheetIcon, CodeGlyphIcon } from '../icons';
+import { Button } from '../../ui';
 
 // Tiny per-type glyph for the folder-card filename list — one icon per
 // fileTypeGroup, so the list rows read like a miniature file listing.
@@ -363,13 +364,12 @@ export function FilesTab({
             browsing shows only a partial list and can be slow. Conversations and
             Artifacts work normally either way.
           </p>
-          <button
-            type="button"
-            className="px-3.5 py-1.5 rounded-full text-[12.5px] bg-inset text-fg-2 border border-edge hover:text-fg hover:border-edge-dim transition-colors"
-            onClick={() => setForceScan(true)}
-          >
+          {/* Was a pill (rounded-full). Spec decision 65 reserves pills for
+              floating overlay affordances — this is an inline action inside the
+              gate message, so it uses the standard button radius. */}
+          <Button variant="secondary" onClick={() => setForceScan(true)}>
             Browse anyway
-          </button>
+          </Button>
         </div>
       )}
       {!loading && !gated && flat && flatResults.length === 0 && (

--- a/desktop/tests/context-popup.test.tsx
+++ b/desktop/tests/context-popup.test.tsx
@@ -67,7 +67,9 @@ describe('ContextPopup — main view', () => {
 
   it('calls onClose when the X button is clicked', () => {
     const { onClose } = renderPopup();
-    fireEvent.click(screen.getByLabelText('Close'));
+    // Label is "Close context panel", not a bare "Close" — CloseButton takes a
+    // `label` prop so each popup's ✕ has a distinct accessible name (change 76).
+    fireEvent.click(screen.getByLabelText('Close context panel'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -113,6 +115,8 @@ describe('ContextPopup — info view', () => {
     const { onClose } = renderPopup();
     fireEvent.click(screen.getByLabelText('What is this?'));
     // Explainer renders its own Close button; main-view header is not mounted when showInfo is true.
+    // This one is SettingsExplainer's CloseButton, which passes no `label` and so
+    // keeps the default "Close" — distinct from the main view's "Close context panel".
     fireEvent.click(screen.getByLabelText('Close'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Implements the button half of tranche 2, against the triage in
`docs/active/specs/2026-07-16-ui-consistency-design-spec.md` §11 (changes 52–78).

## What changed

~150 hand-rolled buttons across ~55 files now go through `components/ui/Button`, plus 29 icon-only
closers through `CloseButton`.

Clears app-wide: `hover:brightness-110` (invisible on Light/Crème's near-black accent),
`hover:opacity-90` (fades the label; on glow themes the fill fades out from under the pack's own
box-shadow), four competing radii, the last hardcoded `bg-blue-600` family, raw `#DD4444`/`#E55555`,
arbitrary `text-[Npx]` on buttons, and ~40 buttons with no focus ring at all.

**9 buttons that had no accessible name now have one**, enforced by `size="icon"`'s type signature
rather than by review.

## Behavior changes — not just visual

- **Five buttons had a dead hover** (`hover:bg-accent` over a `bg-accent` base) and were inert.
  They now respond: MovedGate "Resume on this device", GameLobby "Sign in with GitHub", GameOverlay
  "Rematch", ContributePopup Done ×2.
- **The send button** (`InputBar`) migrated. Geometry is unchanged and it deliberately keeps
  `bg-accent`, because community packs style it through that class — Halftone's glow comes from
  there, so a variant without it would silently drop the glow.
- **SyncPanel's confirm dialog** lost its `confirmColor: 'red' | 'blue'` prop. One call site,
  passing `"red"` — the whole blue branch was unreachable dead code.
- One test's selector updated (`context-popup`), not weakened: it used `getByLabelText('Close')` to
  find the ✕. The main ✕ now says "Close context panel"; the info-view ✕ comes from
  `SettingsExplainer` and still says "Close". Assertions unchanged.

## What this disproved

The spec claimed changes 1–14 were done. They weren't — `AccountSection`, `LocalModelsSection`,
`SettingsPanel` and `ConnectGithubModal` still held ~21 hand-rolled buttons with the full pattern
set, none of them in the audit's count because it excluded those files on the spec's word. Also
found two gaps in the approved ledger (change 62 missed a third skip-permissions Create button;
change 61 never covered ToolCard's AskUserQuestion pair). All recorded in spec §11.7.

## Deliberately NOT migrated

- **ToolCard's permission triad** keeps its status colors AND its `focusIdx` roving-selection ring.
  Arrow keys move real DOM focus there, so adding `FOCUS_RING` would paint a second ring on the
  selected button. Radius only. Commented in place.
- **The compact split button** keeps its joined clipped shape as a documented exception — per-half
  `rounded-lg` would break the seam.
- **Toggles, inputs, selects, radios, list rows, chips, segmented tabs, choice tiles, progress bars**
  — other changes, other tranches.

## Known, accepted

Skip-permissions "Create (Dangerous)" now looks identical to "Remove project" (filled `danger`,
Destin's call). Filled red in this app means "stop and read this", not strictly "this destroys
something"; `danger-outline` is the confirm-y tier.

## Verification

`tsc --noEmit` clean; **2659 tests pass**. Not visually verified in a dev instance — two eyeball
checks are queued for Destin (the `panel-glass` nav chips and AccountSection's Save button heights),
noted in spec §11.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)