### PR TITLE
fix(artifacts): HTML preview renders blank after switching files

### DIFF
--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -140,6 +140,14 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
   useEffect(() => {
     if (!active) { setContent(null); return; }
     let cancelled = false;
+    // Fix: clear the PREVIOUS file's content before the read resolves. Without
+    // this, switching artifacts remounts the viewer (ViewerErrorBoundary is
+    // keyed by artifact.id) with stale content, so HtmlView's sandboxed iframe
+    // gets a srcDoc write for the old file and a second one milliseconds later
+    // for the new one — the aborted-then-restarted navigation leaves the frame
+    // permanently blank. ProjectView's FilesTab and ArtifactThumbnail already
+    // null-gate the same way; this drawer was the only one that didn't.
+    setContent(null);
     (window.claude as any).artifacts.get(projectRoot, active.id).then((res: any) => {
       if (cancelled) return;
       if (res && res.ok) setContent(res.content ?? null);

--- a/desktop/src/renderer/components/artifact-views/ActiveArtifactView.tsx
+++ b/desktop/src/renderer/components/artifact-views/ActiveArtifactView.tsx
@@ -63,6 +63,15 @@ export const ActiveArtifactView = forwardRef<ActiveArtifactHandle, ActiveArtifac
     setShowDiff(false);
   }, [content, artifact.id]);
 
+  // Fix: leave edit mode when the user switches to a DIFFERENT file. Edit mode
+  // used to survive the switch (only the draft reset), so file B opened in the
+  // editor holding whatever draft state file A left behind. Now that the host
+  // nulls content before re-reading, a save clicked during that gap would write
+  // an empty draft over the file — exiting edit mode closes that window.
+  useEffect(() => {
+    setEditing(false);
+  }, [artifact.id]);
+
   // ── Conflict detection: watch for concurrent agent edits while in edit mode ──
   useEffect(() => {
     if (!editing) return;

--- a/desktop/tests/artifacts/html-viewer-stale-content.test.tsx
+++ b/desktop/tests/artifacts/html-viewer-stale-content.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+// html-viewer-stale-content.test.tsx
+//
+// Pins the fix for the "second HTML preview renders blank" bug (2026-07-19).
+//
+// The viewer subtree is keyed by artifact.id (ViewerErrorBoundary), so switching
+// files remounts HtmlView with a FRESH <iframe>. If the host still holds the
+// previous file's content at that moment, the new iframe receives a srcDoc write
+// for the old document and a second one milliseconds later for the new one. That
+// aborted-then-restarted opaque-origin navigation leaves the frame permanently
+// white — which is why the FIRST html opened always worked (content started
+// null) but every subsequent one did not.
+//
+// The invariant: a viewer must NEVER be handed a different file's content. The
+// host nulls content before the read resolves, so HtmlView renders its Loading
+// state (no iframe at all) and the eventual iframe gets exactly one srcDoc.
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ArtifactContext } from '../../src/renderer/state/ArtifactContext';
+import { initialArtifactState } from '../../src/renderer/state/artifact-tracker';
+import type { ArtifactRecord } from '../../src/shared/artifacts/types';
+
+// theme-context reads localStorage / matchMedia / queryLocalFonts on mount and
+// doesn't export its raw Context, so mock the hook to the fields SessionDrawer
+// actually consumes.
+vi.mock('../../src/renderer/state/theme-context', () => ({
+  useTheme: () => ({
+    hideCodeAndConfigs: false,
+    setHideCodeAndConfigs: vi.fn(),
+    showDeletedArtifacts: false,
+    setShowDeletedArtifacts: vi.fn(),
+    drawerWidth: 420,
+    setDrawerWidth: vi.fn(),
+    resetDrawerWidth: vi.fn(),
+  }),
+}));
+
+import { SessionDrawer } from '../../src/renderer/components/SessionDrawer';
+
+const SESSION = 'sess-1';
+const ROOT = '/home/u/proj';
+
+function htmlArtifact(id: string, path: string): ArtifactRecord {
+  return {
+    id,
+    path,
+    kind: 'internal',
+    absolutePath: null,
+    lastModified: '2026-07-19T00:00:00.000Z',
+    status: 'created',
+    versions: [],
+    comments: [],
+    tags: [],
+  };
+}
+
+const PAGE_A = '<html><body><h1>Page A</h1></body></html>';
+const PAGE_B = '<html><body><h1>Page B</h1></body></html>';
+
+// Hand-resolved promises so the test controls exactly when each read lands —
+// the bug lives in the window between "switched file" and "new content arrived".
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+function renderDrawer(activeId: string) {
+  const state = {
+    ...initialArtifactState,
+    sessionArtifacts: {
+      [SESSION]: [htmlArtifact('a', 'a.html'), htmlArtifact('b', 'b.html')],
+    },
+    drawerOpenBySession: { [SESSION]: true },
+    activeArtifactBySession: { [SESSION]: activeId },
+  };
+  return render(
+    <ArtifactContext.Provider value={{ state, dispatch: vi.fn() }}>
+      <SessionDrawer
+        sessionId={SESSION}
+        projectRoot={ROOT}
+        projectId="proj-1"
+        projectName="proj"
+      />
+    </ArtifactContext.Provider>,
+  );
+}
+
+function iframeSrcDoc(container: HTMLElement): string | null {
+  const frame = container.querySelector('iframe');
+  return frame ? frame.getAttribute('srcdoc') : null;
+}
+
+describe('HTML artifact viewer — stale content across file switches', () => {
+  beforeEach(() => {
+    (window as any).claude = {
+      artifacts: {
+        get: vi.fn(),
+        checkExistence: vi.fn().mockResolvedValue({ ok: true, missingIds: [] }),
+        onChanged: undefined,
+      },
+    };
+  });
+
+  it('never shows the previous file’s content after switching artifacts', async () => {
+    const readA = deferred<any>();
+    (window as any).claude.artifacts.get.mockReturnValueOnce(readA.promise);
+
+    const { container, rerender } = renderDrawer('a');
+
+    await act(async () => { readA.resolve({ ok: true, content: PAGE_A }); });
+    expect(iframeSrcDoc(container)).toBe(PAGE_A);
+
+    // Switch to b.html but leave its read IN FLIGHT — this is the exact moment
+    // the bug manifested: the remounted iframe held Page A's srcDoc.
+    const readB = deferred<any>();
+    (window as any).claude.artifacts.get.mockReturnValueOnce(readB.promise);
+
+    const state = {
+      ...initialArtifactState,
+      sessionArtifacts: {
+        [SESSION]: [htmlArtifact('a', 'a.html'), htmlArtifact('b', 'b.html')],
+      },
+      drawerOpenBySession: { [SESSION]: true },
+      activeArtifactBySession: { [SESSION]: 'b' },
+    };
+    await act(async () => {
+      rerender(
+        <ArtifactContext.Provider value={{ state, dispatch: vi.fn() }}>
+          <SessionDrawer
+            sessionId={SESSION}
+            projectRoot={ROOT}
+            projectId="proj-1"
+            projectName="proj"
+          />
+        </ArtifactContext.Provider>,
+      );
+    });
+
+    // The regression assertion: no iframe carrying the OLD document. HtmlView
+    // renders its Loading state instead, so the frame that eventually mounts
+    // receives Page B as its one and only srcDoc.
+    expect(iframeSrcDoc(container)).not.toBe(PAGE_A);
+    expect(iframeSrcDoc(container)).toBeNull();
+
+    await act(async () => { readB.resolve({ ok: true, content: PAGE_B }); });
+    expect(iframeSrcDoc(container)).toBe(PAGE_B);
+  });
+});


### PR DESCRIPTION
## The bug

Open an HTML artifact → preview works. Click a different file, then back to that HTML (or any other HTML) → permanently white iframe.

## Cause

`SessionDrawer`'s content-loading effect cleared `content` only when there was **no** active artifact — never when switching *between* two:

```js
if (!active) { setContent(null); return; }   // ← only reset path
```

The viewer subtree is keyed by `artifact.id` (`ViewerErrorBoundary`), so a switch remounts `HtmlView` with a **fresh `<iframe>`** that receives the *previous* file's content as its first `srcDoc`, then the correct content milliseconds later. Aborting an in-flight `srcDoc` load and immediately re-navigating that sandboxed opaque-origin frame leaves it blank.

That's exactly why the **first** open always worked — `content` starts `null`, so the iframe got one and only one `srcDoc` write.

`FilesTab.tsx` (Project View) and `ArtifactThumbnail.tsx` both null-gate already and never showed the bug. The drawer was the only one of the three that didn't.

## Changes

- **`SessionDrawer.tsx`** — null `content` before the read resolves. `HtmlView` then renders its Loading state (no iframe at all) and the frame that eventually mounts gets a single correct `srcDoc`.
- **`ActiveArtifactView.tsx`** — exit edit mode when `artifact.id` changes. Edit mode previously survived a file switch (only the draft reset), so file B opened in the editor holding file A's state. With content now nulled before the re-read, a save clicked in that gap would write an empty draft over the file; leaving edit mode closes that window.

## Blast radius

- Non-HTML text viewers (`CodeView`/`MarkdownView`/`CsvView`) already render a Loading state for `content === null` — they just flash it on switch, matching Project View's existing behavior.
- Binary viewers (pdf/docx/xlsx/image) unaffected — they ignore `content` and load via `useArtifactBytes(absolutePath)`.
- The size chip (`SessionDrawer.tsx:553`) is gated on `content !== null`, so it blinks off during the read. Cosmetic.

## Verification

- New pin: `tests/artifacts/html-viewer-stale-content.test.tsx` drives a real `SessionDrawer` with hand-resolved reads, switches artifacts mid-flight, and asserts no iframe ever carries the old document. **Confirmed failing without the fix** (`expected '<h1>Page A</h1>…' not to be '<h1>Page A</h1>…'`) — this reproduced the reported symptom rather than just asserting the new behavior.
- Full suite: 2660 passed / 39 skipped. `tsc --noEmit` clean.
- Final click-between-two-HTMLs check left for Destin to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)