### PR TITLE
feat(ui): tranche 2 input half — toggles, fields, selects, and the InputGroup pattern

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -20,7 +20,7 @@ const WELCOME_MODEL_LABELS: Record<string, string> = {
 };
 import ErrorBoundary from './components/ErrorBoundary';
 import { Scrim, OverlayPanel } from './components/overlays/Overlay';
-import { Button } from './components/ui';
+import { Button, Toggle } from './components/ui';
 import GamePanel from './components/game/GamePanel';
 import TerminalRightSlot from './components/TerminalRightSlot';
 import { ChatProvider, useChatDispatch, useChatStore } from './state/chat-context';
@@ -2828,15 +2828,23 @@ function AppInner() {
                   )}
                   <div className="flex items-center justify-between">
                     <label className="text-[10px] uppercase tracking-wider text-fg-muted">Skip Permissions</label>
-                    <button
-                      onClick={() => setWelcomeDangerous(!welcomeDangerous)}
-                      className={`w-8 h-4.5 rounded-full relative transition-colors ${welcomeDangerous ? 'bg-[#DD4444]' : 'bg-inset'}`}
-                    >
-                      <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${welcomeDangerous ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-                    </button>
+                    {/* Was a hand-rolled 32x18 track with a raw #DD4444 on-state; now
+                        the shared Toggle on the danger tone, so theme packs can restyle
+                        it (changes 15/17). The <label> beside it isn't bound to this
+                        control, so it carries its own aria-label. */}
+                    <Toggle
+                      checked={welcomeDangerous}
+                      onChange={setWelcomeDangerous}
+                      tone="danger"
+                      aria-label="Skip Permissions"
+                    />
                   </div>
+                  {/* Warning text was a raw text-[#DD4444] hex — the THIRD copy of
+                      this same string (ResumeBrowser and SessionStrip have the
+                      others). Change 17 puts it on the destructive token so it
+                      tracks the toggle above it under a community theme. */}
                   {welcomeDangerous && (
-                    <p className="text-[10px] text-[#DD4444]">Claude will execute tools without asking for approval.</p>
+                    <p className="text-[10px] text-destructive">Claude will execute tools without asking for approval.</p>
                   )}
                   <div className="flex gap-2">
                     {/* secondary, not ghost: this was the filled-grey family

--- a/desktop/src/renderer/components/AccountSection.tsx
+++ b/desktop/src/renderer/components/AccountSection.tsx
@@ -6,7 +6,7 @@ import { useAccount } from '../state/account-context';
 import type { MarketplaceUser } from '../../main/marketplace-auth-store';
 import type { BlockRow } from '../state/marketplace-api-client';
 import SettingsRow from './SettingsRow';
-import { Button } from './ui';
+import { Button, InputGroup } from './ui';
 
 // Settings → Account section. One self-contained row-button + popup, mounted in
 // both the Desktop and Android settings stacks. Auth-token state and mutations
@@ -508,22 +508,26 @@ function EditAccountBody({
         <label htmlFor="account-display-name" className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">
           Display name
         </label>
-        <div className="flex items-center gap-2">
-          <input
+        {/* Change 77: Save moved INSIDE the field. Besides matching the spec, this
+            removes the height mismatch the button migration introduced — a button
+            sitting alongside a field no longer has to match its height, because
+            it's now a child of the field's own bordered wrapper. */}
+        <InputGroup size="md">
+          <InputGroup.Field
             id="account-display-name"
             aria-label="Display name"
             value={nameDraft}
             onChange={(e) => { setNameDraft(e.target.value); setNameSaved(false); }}
-            className="flex-1 text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
           />
           <Button
+            size="sm"
             onClick={() => void saveName()}
             aria-label="Save display name"
             disabled={nameSaving || nameDraft.trim().length === 0}
           >
             {nameSaving ? 'Saving…' : 'Save'}
           </Button>
-        </div>
+        </InputGroup>
         {nameError && <p className="text-[10px] text-red-500">{nameError}</p>}
         {nameSaved && !nameError && <p className="text-[10px] text-fg-muted">Saved</p>}
       </section>
@@ -533,25 +537,29 @@ function EditAccountBody({
         <label htmlFor="account-handle" className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">
           Handle
         </label>
-        <div className="flex items-center gap-2">
-          <div className="flex-1 flex items-center bg-inset border border-edge-dim rounded-lg px-3 py-2 focus-within:border-accent">
-            <span className="text-xs text-fg-muted select-none">@</span>
-            <input
-              id="account-handle"
-              aria-label="Handle"
-              value={handleDraft}
-              onChange={(e) => {
-                setHandleDraft(e.target.value);
-                setHandleSaved(false);
-                // Editing the draft invalidates an armed confirm — the warning
-                // refers to committing a specific value.
-                setHandleConfirming(false);
-              }}
-              className="flex-1 text-xs bg-transparent text-fg focus:outline-none ml-0.5"
-            />
-          </div>
+        {/* Change 77: this was already a hand-rolled InputGroup (bordered wrapper +
+            borderless input) with Save alongside; now it's the real primitive with
+            Save inside, so the button no longer has to height-match the field.
+            The leading "@" carries the wrapper's left padding and the field drops
+            its own, keeping the tight "@handle" spacing the hand-rolled version had. */}
+        <InputGroup size="md">
+          <span className="pl-3 text-xs text-fg-muted select-none">@</span>
+          <InputGroup.Field
+            id="account-handle"
+            aria-label="Handle"
+            className="pl-0"
+            value={handleDraft}
+            onChange={(e) => {
+              setHandleDraft(e.target.value);
+              setHandleSaved(false);
+              // Editing the draft invalidates an armed confirm — the warning
+              // refers to committing a specific value.
+              setHandleConfirming(false);
+            }}
+          />
           {!handleConfirming && (
             <Button
+              size="sm"
               onClick={onSaveHandleClick}
               aria-label="Save handle"
               disabled={handleSaving || trimmedHandle.length === 0 || handleUnchanged}
@@ -559,7 +567,7 @@ function EditAccountBody({
               {handleSaving ? 'Saving…' : 'Save'}
             </Button>
           )}
-        </div>
+        </InputGroup>
 
         {/* Handle-change consequences + explicit confirm (existing handle only). */}
         {handleConfirming && (
@@ -625,6 +633,12 @@ function EditAccountBody({
             <label htmlFor="account-delete-confirm" className="block text-[10px] text-fg-muted">
               Type <span className="font-semibold text-fg">delete</span> to confirm
             </label>
+            {/* Deliberately NOT migrated to <TextInput>: this field already IS the
+                FIELD recipe except for its red focus border, which is a danger-zone
+                signal. FIELD focuses to accent, and a `focus:border-red-500`
+                className can't reliably win over `focus:border-accent` (Tailwind
+                resolves same-plugin utilities by its own source order, not ours —
+                see the CONFLICT_GROUPS note in ui/Button.tsx). Left hand-rolled. */}
             <input
               id="account-delete-confirm"
               aria-label="Type delete to confirm"

--- a/desktop/src/renderer/components/CommandDrawer.tsx
+++ b/desktop/src/renderer/components/CommandDrawer.tsx
@@ -199,7 +199,14 @@ export default function CommandDrawer({ open, searchMode, externalFilter, onSele
         </div>
 
         {/* Search bar — read-only mirror in search mode (InputBar drives the
-             filter), interactive in browse mode (compass button) */}
+             filter), interactive in browse mode (compass button).
+             Deliberately NOT migrated to <InputGroup> (change 77): this is a
+             mode-switching composite, not a field with a submit. In search mode
+             the <input> is swapped for a read-only <span> mirror and the wrapper
+             takes an onClick, neither of which InputGroup models; and the two
+             trailing icon buttons are navigation (Library, Marketplace), not
+             field actions. Left hand-rolled on purpose — revisit only with a
+             deliberate design decision, not as a sweep. */}
         <div className="px-4 pb-3">
           <div
             className="flex items-center gap-2 bg-well rounded-lg px-3 py-2 border border-edge-dim"

--- a/desktop/src/renderer/components/ContentFindBar.tsx
+++ b/desktop/src/renderer/components/ContentFindBar.tsx
@@ -7,6 +7,7 @@
 // overlay) — otherwise its own text (the match counter) would be walked and
 // matched by the search.
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { TextInput } from './ui';
 
 function highlightsSupported(): boolean {
   return typeof CSS !== 'undefined' && 'highlights' in CSS && typeof (window as any).Highlight === 'function';
@@ -110,8 +111,16 @@ export function ContentFindBar({ containerRef, onClose, resetKey, highlightName 
 
   return (
     <div className={`absolute ${positionClassName} z-20 flex items-center gap-1 px-1.5 py-1 rounded-lg bg-panel border border-edge shadow-lg`}>
-      <input
+      {/* Change 20: this was the gray-focus variant (bg-canvas + rounded-md +
+          focus:border-fg-muted) — all three retired by the shared FIELD surface.
+          Enter / Shift+Enter / Escape handling and the autofocus ref are unchanged.
+          The prev/next/close buttons beside it are navigation, not a submit, so
+          this stays a plain field rather than an InputGroup. */}
+      <TextInput
         ref={inputRef}
+        size="sm"
+        aria-label={placeholder}
+        className="w-[150px]"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={(e) => {
@@ -119,7 +128,6 @@ export function ContentFindBar({ containerRef, onClose, resetKey, highlightName 
           else if (e.key === 'Escape') { e.preventDefault(); onClose(); }
         }}
         placeholder={placeholder}
-        className="bg-canvas text-fg text-xs px-2 py-1 rounded-md w-[150px] outline-none border border-edge focus:border-fg-muted"
       />
       <span className="text-[11px] text-fg-muted tabular-nums text-center px-1 min-w-[40px]">{shown}</span>
       {/* Lucide-style SVGs (stroke currentColor) — the app's icon convention;

--- a/desktop/src/renderer/components/ContextPopup.tsx
+++ b/desktop/src/renderer/components/ContextPopup.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, Textarea } from './ui';
 import { useEscClose } from '../hooks/use-esc-close';
 import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './SettingsExplainer';
 
@@ -153,13 +153,19 @@ export default function ContextPopup({
                   <label htmlFor="compact-instructions" className="block text-xs font-medium text-fg-muted tracking-wider uppercase">
                     Keep these priorities (optional)
                   </label>
-                  <textarea
+                  {/* Change 42: this was the `border-edge rounded-sm focus:ring-1`
+                      recipe — the losing one of the two. It becomes FIELD:
+                      border-edge-dim, rounded-lg, and focus by border rather than
+                      ring. resize-none is the primitive's default. The Back /
+                      Compact buttons stay in the row BELOW, so no InputGroup. */}
+                  <Textarea
                     id="compact-instructions"
+                    size="md"
+                    className="w-full"
                     value={instructions}
                     onChange={(e) => setInstructions(e.target.value)}
                     placeholder="e.g. keep code decisions and architecture; drop debugging output"
                     rows={3}
-                    className="w-full px-2 py-1.5 text-xs bg-inset border border-edge rounded-sm text-fg focus:outline-none focus:ring-1 focus:ring-accent resize-none"
                     autoFocus
                   />
                   <div className="flex gap-2">

--- a/desktop/src/renderer/components/EngineCard.tsx
+++ b/desktop/src/renderer/components/EngineCard.tsx
@@ -4,7 +4,7 @@
 // Class idioms (text sizes, bg-well surface, accent buttons, border-edge-dim)
 // mirror ProvidersSection's own rows so the card reads as part of the section.
 import React, { useEffect, useState } from 'react';
-import { Button } from './ui';
+import { Button, TextInput } from './ui';
 
 interface EngineStatusView {
   installed: boolean;
@@ -147,9 +147,14 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
           {/* Context-length knob. Commits on Enter or blur. */}
           <div className="flex items-center justify-between gap-2">
             <label htmlFor="engine-context-size" className="text-[11px] text-fg-dim">Context length (tokens)</label>
-            <input
+            {/* Change 20: the shared field surface. type="number" (plus min/step
+                and the busy-disabled state) passes straight through — TextInput is
+                deliberately not restricted to type="text". size="sm" matches the
+                px-2.5 py-1.5 this input already used. */}
+            <TextInput
               id="engine-context-size"
               type="number"
+              size="sm"
               min={1024}
               step={1024}
               value={ctxDraft ?? ''}
@@ -157,7 +162,7 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
               onChange={(e) => setCtxDraft(e.target.value === '' ? null : Number(e.target.value))}
               onBlur={() => void commitContext()}
               onKeyDown={(e) => { if (e.key === 'Enter') void commitContext(); }}
-              className="w-24 text-xs bg-inset border border-edge-dim rounded-lg px-2.5 py-1.5 text-fg focus:outline-none focus:border-accent disabled:opacity-60"
+              className="w-24"
             />
           </div>
 

--- a/desktop/src/renderer/components/FirstRunView.tsx
+++ b/desktop/src/renderer/components/FirstRunView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import type { FirstRunState, PrerequisiteState } from '../../shared/first-run-types';
 import BrailleSpinner from './BrailleSpinner';
 import { describeStep } from './first-run/describe-step';
-import { Button } from './ui';
+import { Button, TextInput } from './ui';
 
 /* ------------------------------------------------------------------ */
 /*  StatusIcon                                                        */
@@ -115,12 +115,19 @@ function AuthScreen({
         </button>
       ) : (
         <div className="flex flex-col items-center gap-3 w-full">
-          <input
+          {/* Change 20: bg-well + rounded-md → the shared FIELD surface (password
+              fields route through TextInput too; type is preserved). NOT an
+              InputGroup — the Verify button sits below, with the key-handling
+              disclaimer between it and the field. aria-label added: the field had
+              only a placeholder for a name. */}
+          <TextInput
             type="password"
+            size="md"
+            aria-label="Anthropic API key"
+            className="w-full"
             placeholder="sk-ant-..."
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
-            className="w-full px-3 py-2 rounded-md bg-well border border-edge text-fg text-sm placeholder:text-fg-faint focus:outline-none focus:border-accent"
           />
           <p className="text-xs text-fg-muted text-center leading-relaxed">
             Your key is passed directly to Claude Code and stored in its secure config.

--- a/desktop/src/renderer/components/HandlePrompt.tsx
+++ b/desktop/src/renderer/components/HandlePrompt.tsx
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
 import { useAccount } from '../state/account-context';
-import { Button } from './ui';
+import { Button, InputGroup } from './ui';
 
 // Persisted "don't nag me again" flag. Set on skip (and on ESC, which is the
 // same as skip), never set when the user actually claims a handle.
@@ -112,27 +112,30 @@ function HandlePromptPopup({
             </p>
           </div>
 
-          <div className="flex items-center gap-2">
-            <div className="flex-1 flex items-center bg-inset border border-edge-dim rounded-lg px-3 py-2 focus-within:border-accent">
-              <span className="text-xs text-fg-muted select-none">@</span>
-              <input
-                id="handle-prompt-input"
-                aria-label="Handle"
-                autoFocus
-                value={draft}
-                onChange={(e) => { setDraft(e.target.value); setError(null); }}
-                onKeyDown={(e) => { if (e.key === 'Enter' && draft.trim().length > 0 && !saving) void save(); }}
-                className="flex-1 text-xs bg-transparent text-fg focus:outline-none ml-0.5"
-              />
-            </div>
+          {/* Change 77: same migration as Settings → Account's handle field, which
+              this duplicates. Save moves inside the field, so the `py-2` that
+              existed only to height-match the input beside it is gone. "Skip for
+              now" is a cancel, not a submit, so per the sub-rule it stays outside
+              (it already sits below as its own full-width button). */}
+          <InputGroup size="md">
+            <span className="pl-3 text-xs text-fg-muted select-none">@</span>
+            <InputGroup.Field
+              id="handle-prompt-input"
+              aria-label="Handle"
+              className="pl-0"
+              autoFocus
+              value={draft}
+              onChange={(e) => { setDraft(e.target.value); setError(null); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' && draft.trim().length > 0 && !saving) void save(); }}
+            />
             <Button
+              size="sm"
               onClick={() => void save()}
               disabled={saving || draft.trim().length === 0}
-              className="py-2"
             >
               {saving ? 'Saving…' : 'Save'}
             </Button>
-          </div>
+          </InputGroup>
           {/* Plain words for status, never glyphs. */}
           {error && <p className="text-[10px] text-red-500">{error}</p>}
 

--- a/desktop/src/renderer/components/ImportProjectModal.tsx
+++ b/desktop/src/renderer/components/ImportProjectModal.tsx
@@ -5,7 +5,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button } from './ui';
+import { Button, TextInput } from './ui';
 
 interface Props {
   sourcePath: string;
@@ -127,12 +127,18 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
             <div className="mt-1 text-xs text-fg-dim">
               The folder itself moves — anything pointing at the old location (shortcuts, open terminals, editors) will need the new path.
             </div>
-            <label className="block mt-3 text-[10px] uppercase tracking-wide text-fg-muted">Project name</label>
-            <input
+            {/* htmlFor/id pair added: the label was floating unassociated, so
+                screen readers announced this field with no name. */}
+            <label htmlFor="import-project-name" className="block mt-3 text-[10px] uppercase tracking-wide text-fg-muted">Project name</label>
+            {/* Shared TextInput (change 20). Stays a plain field, NOT an
+                InputGroup: the "Move and sync" button lives in the modal footer
+                below, not inline beside the field. */}
+            <TextInput
+              id="import-project-name"
               value={name}
               onChange={e => setName(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter') void confirm(); }}
-              className="mt-1 w-full bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
+              className="mt-1 w-full"
               autoFocus
             />
             {error && <div role="alert" className="mt-2 text-xs text-red-500">{error}</div>}

--- a/desktop/src/renderer/components/LocalModelsSection.tsx
+++ b/desktop/src/renderer/components/LocalModelsSection.tsx
@@ -9,7 +9,7 @@
 // plain-word status (never ●◐○ glyphs), consequence-gated destructive actions.
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import EngineCard from './EngineCard';
-import { Button } from './ui';
+import { Button, InputGroup } from './ui';
 import type {
   CuratedModel, QuantOption, FitEstimate, DownloadProgress,
   InstalledLocalModel, DetectedEndpoint, HFSearchHit,
@@ -196,26 +196,29 @@ function ModelBrowser({
       <p className="text-xs text-fg font-medium mb-2.5">Models</p>
 
       {/* Search — filters recommended/installed locally, searches Hugging Face. */}
-      <div className="relative mb-3">
-        <input
+      {/* Change 77: the clear-X was already an inside-the-field action, faked with
+          `absolute` positioning plus a hand-tuned pr-8 to keep the text off it.
+          InputGroup makes it a real inline child, so the reserved space can no
+          longer drift out of sync with the icon. */}
+      <InputGroup className="w-full mb-3">
+        <InputGroup.Field
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search models (e.g. qwen, llama)…"
           aria-label="Search models"
-          className="w-full text-xs bg-inset border border-edge-dim rounded-lg pl-3 pr-8 py-2 text-fg focus:outline-none focus:border-accent"
         />
         {query && (
           <button
             onClick={() => setQuery('')}
             aria-label="Clear search"
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-fg-muted hover:text-fg"
+            className="shrink-0 px-1 text-fg-muted hover:text-fg"
           >
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         )}
-      </div>
+      </InputGroup>
 
       {curated === null || installed === null ? (
         <p className="text-[11px] text-fg-muted px-1">Loading…</p>

--- a/desktop/src/renderer/components/ModelPickerPopup.tsx
+++ b/desktop/src/renderer/components/ModelPickerPopup.tsx
@@ -4,7 +4,7 @@ import type { ModelAlias } from './StatusBar';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { FastIcon } from './Icons';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button, CloseButton, FOCUS_RING } from './ui';
+import { Button, CloseButton, TextInput, Toggle, FOCUS_RING } from './ui';
 
 // Model + effort + fast picker. Replaces the cycle-only status bar chip with
 // a full picker. Invoked by:
@@ -317,11 +317,14 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
             <CloseButton onClick={onClose} label="Close model picker" />
           </div>
           <div className="px-5 pt-3">
-            <input
+            {/* Change 20: the shared field surface. No submit button belongs
+                inside it — the list below filters as you type. */}
+            <TextInput
               value={nativeSearch}
               onChange={(e) => setNativeSearch(e.target.value)}
               placeholder="Search models…"
-              className="w-full bg-inset text-fg text-sm rounded px-3 py-1.5 border border-edge outline-none focus:border-accent"
+              aria-label="Search models"
+              className="w-full"
             />
           </div>
           <div className="p-5 pt-3 overflow-y-auto space-y-4">
@@ -451,14 +454,15 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
                   </div>
                   <div className="text-xs text-fg-muted">Same model, faster output streaming</div>
                 </div>
-                <button
-                  onClick={handleFastToggle}
-                  className={`shrink-0 w-8 h-4 rounded-full transition-colors relative ${fast ? 'bg-green-600' : 'bg-inset border border-edge-dim'}`}
-                  role="switch"
-                  aria-checked={fast}
-                >
-                  <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${fast ? 'left-4' : 'left-0.5'}`} />
-                </button>
+                {/* Was a fifth hand-rolled toggle geometry (32x16) with a
+                    hardcoded green-600 on-state. One geometry now, and the
+                    on-state is the theme's accent (changes 15/16). It already
+                    had role="switch" but no accessible name. */}
+                <Toggle
+                  checked={fast}
+                  onChange={handleFastToggle}
+                  aria-label="Fast mode"
+                />
               </div>
             </section>
           </div>

--- a/desktop/src/renderer/components/ModelProvidersPopup.tsx
+++ b/desktop/src/renderer/components/ModelProvidersPopup.tsx
@@ -9,7 +9,7 @@ import LocalModelsSection from './LocalModelsSection';
 import type { FirstRunState } from '../../shared/first-run-types';
 import type { ProviderStatus } from '../../shared/provider-types';
 import SettingsRow from './SettingsRow';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, InputGroup, TextInput } from './ui';
 
 // Settings → Model Providers. One settings row that opens an L2 popup gathering
 // every engine/provider surface in one place: Claude Code (the default engine),
@@ -416,7 +416,10 @@ function ConnectOpenRouterModal({
             <li>Paste the key below and press Connect.</li>
           </ol>
 
-          <input
+          {/* Change 20 only. NOT an InputGroup: Connect/Cancel sit in the modal
+              footer BELOW the field, which is explicitly the shape change 77 does
+              not convert. */}
+          <TextInput
             type="password"
             autoFocus
             value={keyDraft}
@@ -424,7 +427,7 @@ function ConnectOpenRouterModal({
             onKeyDown={(e) => { if (e.key === 'Enter') void save(); }}
             placeholder="Paste your OpenRouter API key"
             aria-label="OpenRouter API key"
-            className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
+            className="w-full"
           />
 
           {note && (
@@ -624,16 +627,23 @@ function SearchProvidersBlock() {
 
               {isEditing && !row.hasKey && (
                 <div className="mt-2 space-y-2">
-                  <input
-                    type="password"
-                    autoFocus
-                    value={draft}
-                    onChange={(e) => setDraft(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') void save(row.id); }}
-                    placeholder={`Paste your ${row.label} API key`}
-                    aria-label={`${row.label} API key`}
-                    className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
-                  />
+                  {/* Change 77: Save moves INSIDE the field. Cancel stays outside
+                      (one action per field), and so does the "Get a free key"
+                      link, which is a navigation aid rather than a field action. */}
+                  <InputGroup className="w-full">
+                    <InputGroup.Field
+                      type="password"
+                      autoFocus
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') void save(row.id); }}
+                      placeholder={`Paste your ${row.label} API key`}
+                      aria-label={`${row.label} API key`}
+                    />
+                    <Button size="sm" onClick={() => void save(row.id)} disabled={busy || draft.trim().length === 0}>
+                      {busy ? 'Checking…' : 'Save'}
+                    </Button>
+                  </InputGroup>
                   <div className="flex items-center justify-between gap-2">
                     <button
                       onClick={() => void (window as any).claude.shell.openExternal(meta.url)}
@@ -641,14 +651,9 @@ function SearchProvidersBlock() {
                     >
                       Get a free key
                     </button>
-                    <div className="flex gap-2">
-                      <Button variant="secondary" size="sm" onClick={() => { setEditing(null); setDraft(''); }}>
-                        Cancel
-                      </Button>
-                      <Button size="sm" onClick={() => void save(row.id)} disabled={busy || draft.trim().length === 0}>
-                        {busy ? 'Checking…' : 'Save'}
-                      </Button>
-                    </div>
+                    <Button variant="secondary" size="sm" onClick={() => { setEditing(null); setDraft(''); }}>
+                      Cancel
+                    </Button>
                   </div>
                 </div>
               )}

--- a/desktop/src/renderer/components/PerformancePopup.tsx
+++ b/desktop/src/renderer/components/PerformancePopup.tsx
@@ -3,7 +3,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import type { ExplainerSection } from './SettingsExplainer';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, Toggle } from './ui';
 
 // Explainer copy lives here as a const because it pairs tightly with the
 // controls above it — both are about GPU choice. Sections render inline in
@@ -112,18 +112,23 @@ export default function PerformancePopup({
           <div className="px-4 py-4 space-y-4">
             <p className="text-xs text-fg-2">GPU choice affects performance.</p>
 
-            {/* Toggle row — switch role for accessibility, matches the
-                project's binary-settings pattern (e.g. PreferencesPopup). */}
-            <button
-              type="button"
-              role="switch"
-              aria-checked={saved}
-              onClick={handleToggle}
-              className="w-full text-left flex items-start gap-3 p-3 rounded-lg hover:bg-inset transition-colors"
+            {/* Toggle row. This was a whole-row <button role="switch"> whose
+                indicator was a hand-rolled 16x16 SQUARE — it announced itself as a
+                switch but looked like a checkbox. It's the shared <Toggle> now
+                (change 15), on the right like every other settings row.
+
+                The row stays clickable (bigger touch target — this renderer is also
+                the Android UI), but a <button> can't legally contain another one, so
+                the wrapper is a div. The guard below drops clicks that originated on
+                the Toggle itself, which would otherwise fire handleToggle twice and
+                cancel out. */}
+            <div
+              onClick={(e) => {
+                if ((e.target as HTMLElement).closest('[role="switch"]')) return;
+                handleToggle();
+              }}
+              className="w-full text-left flex items-start gap-3 p-3 rounded-lg hover:bg-inset transition-colors cursor-pointer"
             >
-              <span className={`mt-0.5 inline-block w-4 h-4 rounded border ${
-                saved ? 'bg-accent border-accent' : 'border-edge'
-              }`} />
               <span className="flex-1">
                 <span className="block text-sm text-fg">Prefer power saving</span>
                 <span className="block text-xs text-fg-muted mt-0.5">
@@ -131,7 +136,13 @@ export default function PerformancePopup({
                   but UI animations may stutter.
                 </span>
               </span>
-            </button>
+              <Toggle
+                checked={saved}
+                onChange={handleToggle}
+                aria-label="Prefer power saving"
+                className="mt-0.5"
+              />
+            </div>
 
             {needsRestart && (
               <div className="px-3 py-2 rounded-lg bg-inset flex items-center justify-between gap-3">

--- a/desktop/src/renderer/components/PreferencesPopup.tsx
+++ b/desktop/src/renderer/components/PreferencesPopup.tsx
@@ -4,7 +4,7 @@ import { Scrim, OverlayPanel } from './overlays/Overlay';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useTheme } from '../state/theme-context';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, Toggle, TextInput, Textarea } from './ui';
 
 // Native replacement for Claude Code's /config TUI. Reads/writes fields in
 // ~/.claude/settings.json via the settings:* IPC bridge.
@@ -190,12 +190,15 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced }: Prop
               <label className="block text-xs font-medium text-fg-muted tracking-wider uppercase mb-2">
                 Output Style
               </label>
-              <input
-                type="text"
+              {/* Shared FIELD surface (change 20) — was its own rounded/px-3 py-1.5
+                  recipe. The uppercase <label> above has no htmlFor, so the field
+                  carries its own accessible name. */}
+              <TextInput
                 value={prefs.outputStyle}
                 onChange={(e) => save('outputStyle', e.target.value)}
                 placeholder="e.g. concise, explanatory"
-                className="w-full bg-inset border border-edge-dim rounded px-3 py-1.5 text-sm text-fg placeholder:text-fg-faint focus:outline-none focus:border-accent"
+                aria-label="Output Style"
+                className="w-full"
               />
               <p className="text-[11px] text-fg-muted mt-1.5">Preset name that tunes Claude's response style. Leave blank for default.</p>
             </section>
@@ -227,12 +230,15 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced }: Prop
               <label className="block text-xs font-medium text-fg-muted tracking-wider uppercase mb-2">
                 System Prompt
               </label>
-              <textarea
+              {/* Same FIELD surface as the input above (change 20). resize-none was
+                  already the behavior here and is the Textarea default. */}
+              <Textarea
                 value={prefs.systemPrompt}
                 onChange={(e) => save('systemPrompt', e.target.value)}
                 placeholder="Instructions appended to every session..."
                 rows={4}
-                className="w-full bg-inset border border-edge-dim rounded px-3 py-2 text-sm text-fg placeholder:text-fg-faint focus:outline-none focus:border-accent resize-none"
+                aria-label="System Prompt"
+                className="w-full"
               />
               <p className="text-[11px] text-fg-muted mt-1.5">Applied globally. Leave blank to use Claude Code defaults.</p>
             </section>
@@ -270,14 +276,10 @@ function ToggleRow({ label, desc, checked, onChange }: { label: string; desc: st
         <div className="text-sm text-fg">{label}</div>
         <div className="text-xs text-fg-muted">{desc}</div>
       </div>
-      <button
-        onClick={() => onChange(!checked)}
-        className={`shrink-0 w-8 h-4 rounded-full transition-colors relative ${checked ? 'bg-green-600' : 'bg-inset border border-edge-dim'}`}
-        role="switch"
-        aria-checked={checked}
-      >
-        <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${checked ? 'left-4' : 'left-0.5'}`} />
-      </button>
+      {/* Was a hand-rolled 32x16 track with a green-600 on-state; one geometry and
+          the app accent now (changes 15/16). role="switch"/aria-checked come from
+          the primitive; aria-label gives it the name the row text couldn't. */}
+      <Toggle checked={checked} onChange={onChange} aria-label={label} />
     </div>
   );
 }

--- a/desktop/src/renderer/components/ProvidersSection.tsx
+++ b/desktop/src/renderer/components/ProvidersSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button } from './ui';
+import { Button, InputGroup, Select, TextInput, Toggle } from './ui';
 import type { ProviderStatus, ProviderConfig, ProviderType } from '../../shared/provider-types';
 
 // Settings → Providers section (Phase 1 Plan A, Task 13). Lets the user add,
@@ -103,6 +103,11 @@ const ADD_TYPE_OPTIONS: { value: ProviderType; label: string; needsBaseUrl?: boo
   { value: 'google', label: 'Google' },
   { value: 'openai-compatible', label: 'Custom endpoint (OpenAI-compatible)', needsBaseUrl: true },
 ];
+
+// The same list in the shape <Select> wants. Built once at module scope (not per
+// render) so the dropdown's open-effect isn't handed a brand-new options array
+// on every keystroke in the form beside it.
+const ADD_TYPE_SELECT_OPTIONS = ADD_TYPE_OPTIONS.map((o) => ({ value: o.value as string, label: o.label }));
 
 // `embedded`: rendered inside the Model Providers popup's "OpenRouter/API"
 // section, which supplies its own heading + a dedicated OpenRouter connect flow
@@ -273,16 +278,17 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
 
         {/* Enable/disable toggle — hidden for the dormant local engine (nothing
             to enable in Plan A). */}
+        {/* Change 19: the hand-rolled 32x18 switch becomes the shared Toggle (one
+            36x20 geometry app-wide). It also gains a real accessible name — the
+            old button announced only aria-pressed with no label at all. */}
         {!isLocal && (
-          <button
-            onClick={() => void toggleEnabled()}
+          <Toggle
+            checked={provider.enabled}
+            onChange={() => void toggleEnabled()}
             disabled={busy}
-            aria-pressed={provider.enabled}
-            className={`w-8 h-4.5 rounded-full relative transition-colors shrink-0 disabled:opacity-60 ${provider.enabled ? 'bg-accent' : 'bg-inset'}`}
+            aria-label={`Enable ${provider.label}`}
             title={provider.enabled ? 'Enabled' : 'Disabled'}
-          >
-            <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${provider.enabled ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-          </button>
+          />
         )}
       </div>
 
@@ -314,19 +320,23 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
       {/* Key input — revealed on Add/Replace key. */}
       {keyOpen && (
         <div className="mt-2 flex items-center gap-2">
-          <input
-            type="password"
-            autoFocus
-            value={keyDraft}
-            onChange={(e) => setKeyDraft(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') void saveKey(); }}
-            placeholder="Paste API key"
-            aria-label={`${provider.label} API key`}
-            className="flex-1 text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
-          />
-          <Button onClick={() => void saveKey()} disabled={busy || keyDraft.trim().length === 0} className="py-2">
-            {busy ? 'Saving…' : 'Save'}
-          </Button>
+          {/* Change 77: Save moves INSIDE the field. Cancel deliberately stays
+              OUTSIDE — a field carries one action; two buttons inside it stop the
+              thing reading as a field at all. */}
+          <InputGroup className="flex-1">
+            <InputGroup.Field
+              type="password"
+              autoFocus
+              value={keyDraft}
+              onChange={(e) => setKeyDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void saveKey(); }}
+              placeholder="Paste API key"
+              aria-label={`${provider.label} API key`}
+            />
+            <Button size="sm" onClick={() => void saveKey()} disabled={busy || keyDraft.trim().length === 0}>
+              {busy ? 'Saving…' : 'Save'}
+            </Button>
+          </InputGroup>
           <Button variant="secondary" onClick={() => { setKeyOpen(false); setKeyDraft(''); }} className="py-2">
             Cancel
           </Button>
@@ -415,30 +425,29 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
     <div className="space-y-2 rounded-lg bg-inset border border-edge-dim p-3">
       <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Add provider</h4>
 
-      {/* Type */}
+      {/* Type — change 21: the native <select> is gone. A native option list is
+          drawn by the OS, so a themed app dropped an OS-blue menu out of it;
+          <Select> renders the list itself. The old <label htmlFor> can't point at
+          a <button> trigger, so the name moves onto the control as aria-label. */}
       <div className="space-y-1">
-        <label htmlFor="add-provider-type" className="text-[10px] text-fg-muted">Type</label>
-        <select
-          id="add-provider-type"
+        <p className="text-[10px] text-fg-muted">Type</p>
+        <Select
+          options={ADD_TYPE_SELECT_OPTIONS}
           value={type}
-          onChange={(e) => setType(e.target.value as ProviderType)}
-          className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
-        >
-          {ADD_TYPE_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
+          onChange={(v) => setType(v as ProviderType)}
+          aria-label="Provider type"
+        />
       </div>
 
       {/* Label */}
       <div className="space-y-1">
         <label htmlFor="add-provider-label" className="text-[10px] text-fg-muted">Name</label>
-        <input
+        <TextInput
           id="add-provider-label"
           value={label}
           onChange={(e) => setLabel(e.target.value)}
           placeholder="e.g. My OpenAI"
-          className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
+          className="w-full"
         />
       </div>
 
@@ -446,12 +455,12 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
       {needsBaseUrl && (
         <div className="space-y-1">
           <label htmlFor="add-provider-baseurl" className="text-[10px] text-fg-muted">Base URL</label>
-          <input
+          <TextInput
             id="add-provider-baseurl"
             value={baseUrl}
             onChange={(e) => setBaseUrl(e.target.value)}
             placeholder="http://localhost:11434/v1"
-            className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
+            className="w-full"
           />
         </div>
       )}
@@ -459,13 +468,13 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
       {/* Optional key */}
       <div className="space-y-1">
         <label htmlFor="add-provider-key" className="text-[10px] text-fg-muted">API key (optional)</label>
-        <input
+        <TextInput
           id="add-provider-key"
           type="password"
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
           placeholder="Paste API key"
-          className="w-full text-xs bg-inset border border-edge-dim rounded-lg px-3 py-2 text-fg focus:outline-none focus:border-accent"
+          className="w-full"
         />
       </div>
 

--- a/desktop/src/renderer/components/QuickChips.tsx
+++ b/desktop/src/renderer/components/QuickChips.tsx
@@ -4,7 +4,7 @@ import { isAndroid } from '../platform';
 import { useSkills } from '../state/skill-context';
 import type { ChipConfig } from '../../shared/types';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, TextInput, Textarea } from './ui';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 
@@ -342,18 +342,26 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
               <div className="bg-inset border border-edge-dim rounded-lg p-2.5 space-y-2">
                 {/* Custom chip form */}
                 <div className="space-y-1.5">
-                  <input
+                  {/* Shared field surface (change 20). The .slice() caps stay on the
+                      handlers — they are the real length limit, not decoration. */}
+                  <TextInput
+                    size="sm"
                     value={customLabel}
                     onChange={(e) => setCustomLabel(e.target.value.slice(0, 20))}
                     placeholder="Label (max 20 chars)"
-                    className="w-full px-2 py-1 text-[11px] bg-well border border-edge-dim rounded-md text-fg placeholder:text-fg-faint focus:outline-none focus:border-accent"
+                    aria-label="Chip label"
+                    className="w-full"
                   />
-                  <textarea
+                  {/* Textarea primitive (change 42); resize-none is its default, so
+                      the old explicit class is no longer needed. */}
+                  <Textarea
+                    size="sm"
                     value={customPrompt}
                     onChange={(e) => setCustomPrompt(e.target.value.slice(0, 500))}
                     placeholder="Prompt text"
                     rows={2}
-                    className="w-full px-2 py-1 text-[11px] bg-well border border-edge-dim rounded-md text-fg placeholder:text-fg-faint focus:outline-none focus:border-accent resize-none"
+                    aria-label="Chip prompt"
+                    className="w-full"
                   />
                   <div className="flex gap-2">
                     <Button

--- a/desktop/src/renderer/components/ResumeBrowser.tsx
+++ b/desktop/src/renderer/components/ResumeBrowser.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom';
 import { MODELS, type ModelAlias } from './StatusBar';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
-import { Button } from './ui';
+import { Button, Toggle } from './ui';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
 import { SkipPermissionsInfoTooltip } from './SkipPermissionsInfoTooltip';
@@ -484,15 +484,22 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 Skip Permissions
                 <SkipPermissionsInfoTooltip />
               </label>
-              <button
-                onClick={() => setResumeDangerous(!resumeDangerous)}
-                className={`w-8 h-4.5 rounded-full relative transition-colors ${resumeDangerous ? 'bg-[#DD4444]' : 'bg-inset'}`}
-              >
-                <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${resumeDangerous ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-              </button>
+              {/* Shared Toggle (change 15). Its "danger" tone replaces the raw
+                  #DD4444 hex this used to hard-code, so themes can restyle it.
+                  aria-label added because the adjacent <label> was never
+                  associated with the control — screen readers announced nothing. */}
+              <Toggle
+                checked={resumeDangerous}
+                onChange={setResumeDangerous}
+                tone="danger"
+                aria-label="Skip Permissions"
+              />
             </div>
+            {/* Warning text was a raw text-[#DD4444] hex. Change 17 moves it onto
+                the same token as the toggle beside it, so a community theme
+                restyling its red doesn't leave the two out of sync. */}
             {resumeDangerous && (
-              <p className="text-[10px] text-[#DD4444]">Claude will execute tools without asking for approval.</p>
+              <p className="text-[10px] text-destructive">Claude will execute tools without asking for approval.</p>
             )}
           </>
         ) : (
@@ -503,12 +510,12 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
         {detachAvailable && (
           <div className="flex items-center justify-between">
             <label className="text-[10px] uppercase tracking-wider text-fg-muted">Launch in New Window</label>
-            <button
-              onClick={() => setResumeLaunchInNewWindow(!resumeLaunchInNewWindow)}
-              className={`w-8 h-4.5 rounded-full relative transition-colors ${resumeLaunchInNewWindow ? 'bg-accent' : 'bg-inset'}`}
-            >
-              <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${resumeLaunchInNewWindow ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-            </button>
+            {/* Shared Toggle (change 15) — same accent on-state as before. */}
+            <Toggle
+              checked={resumeLaunchInNewWindow}
+              onChange={setResumeLaunchInNewWindow}
+              aria-label="Launch in New Window"
+            />
           </div>
         )}
 
@@ -666,13 +673,14 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                   in SessionStrip, but accent-colored to signal "on" rather than "danger". */}
               <div className="flex items-center gap-2">
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted">Show Complete</label>
-                <button
-                  onClick={() => setShowComplete(!showComplete)}
-                  className={`w-8 h-4.5 rounded-full relative transition-colors ${showComplete ? 'bg-accent' : 'bg-inset'}`}
-                  aria-pressed={showComplete}
-                >
-                  <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${showComplete ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-                </button>
+                {/* Shared Toggle (change 15). role="switch" + aria-checked comes
+                    from the primitive, which is strictly better than the
+                    aria-pressed this used to carry. */}
+                <Toggle
+                  checked={showComplete}
+                  onChange={setShowComplete}
+                  aria-label="Show Complete"
+                />
               </div>
             </div>
             <div className="flex items-center gap-2 bg-inset rounded-lg px-3 py-2 border border-edge-dim">

--- a/desktop/src/renderer/components/RuntimeBinding.tsx
+++ b/desktop/src/renderer/components/RuntimeBinding.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { isAndroid, isRemoteMode } from '../platform';
 import { PRESETS } from '../../shared/harness-manifest';
+import { Select, TextInput } from './ui';
 
 // The two built-in native harness presets (personality profiles, not capability
 // tiers). A native session is stamped with one at create time; it drives the
@@ -250,40 +251,45 @@ export function RuntimeBindingFields({
             <>
               <div>
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Provider</label>
-                <select
+                {/* Change 21: no native <select> — its option list is drawn by the
+                    OS, so a themed app dropped an OS-blue menu out of it. The
+                    <label> above is not associated (it never had an htmlFor), so
+                    the name is carried by aria-label. */}
+                <Select
+                  options={nb.readyProviders.map((p) => ({ value: p.id, label: p.label }))}
                   value={nb.selectedProviderId}
-                  onChange={(e) => {
-                    const pid = e.target.value;
+                  onChange={(pid) => {
                     const firstModel = nb.modelCatalog.find((m) => m.providerId === pid)?.id ?? '';
                     nb.setBinding({ providerId: pid, modelId: firstModel });
                   }}
-                  className="w-full bg-inset text-fg text-xs rounded-sm px-2 py-1 border border-edge"
-                >
-                  {nb.readyProviders.map((p) => (
-                    <option key={p.id} value={p.id}>{p.label}</option>
-                  ))}
-                </select>
+                  size="sm"
+                  aria-label="Provider"
+                />
               </div>
               <div>
                 <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
                 {nb.needsFreeformModel ? (
-                  <input
+                  <TextInput
                     type="text"
+                    size="sm"
                     value={nb.selectedModelId}
                     placeholder="e.g. llama3.1"
+                    aria-label="Model"
                     onChange={(e) => nb.setBinding({ providerId: nb.selectedProviderId, modelId: e.target.value })}
-                    className="w-full bg-inset text-fg text-xs rounded-sm px-2 py-1 border border-edge"
+                    className="w-full"
                   />
                 ) : (
-                  <select
+                  // Change 21. The whole provider catalog is passed through
+                  // UNCAPPED — for an OpenRouter-style provider that is dozens of
+                  // entries, and Select's own menu already scrolls and scrolls the
+                  // current value into view on open.
+                  <Select
+                    options={nb.providerModels.map((m) => ({ value: m.id, label: m.label }))}
                     value={nb.selectedModelId}
-                    onChange={(e) => nb.setBinding({ providerId: nb.selectedProviderId, modelId: e.target.value })}
-                    className="w-full bg-inset text-fg text-xs rounded-sm px-2 py-1 border border-edge"
-                  >
-                    {nb.providerModels.map((m) => (
-                      <option key={m.id} value={m.id}>{m.label}</option>
-                    ))}
-                  </select>
+                    onChange={(modelId) => nb.setBinding({ providerId: nb.selectedProviderId, modelId })}
+                    size="sm"
+                    aria-label="Model"
+                  />
                 )}
               </div>
 

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -17,7 +17,7 @@ import type { ArtifactRecord } from '../../shared/artifacts/types';
 import { categorizeArtifact } from '../../shared/artifacts/categorization';
 import { getPlatform } from '../platform';
 import { formatRelativeTime } from '../utils/format-time';
-import { CloseButton } from './ui';
+import { CloseButton, TextInput } from './ui';
 
 type SortKey = 'recent' | 'name' | 'type';
 
@@ -358,11 +358,17 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
       </div>
       {/* Search + sort */}
       <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-edge-dim shrink-0">
-        <input
+        {/* Shared TextInput (change 20). Retires the gray `focus:border-fg-muted`
+            focus and the `bg-canvas` field surface for the app-wide field look;
+            flex-1/min-w-0 stay because this input shares its row with the sort
+            <select>. */}
+        <TextInput
+          size="sm"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search files"
-          className="flex-1 min-w-0 bg-canvas border border-edge rounded text-[11px] text-fg px-2 py-1 outline-none focus:border-fg-muted"
+          aria-label="Search files"
+          className="flex-1 min-w-0"
         />
         <select
           value={sortBy}

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { SessionStatusColor } from './StatusDot';
-import { Button } from './ui';
+import { Button, Toggle } from './ui';
 import { isAndroid, isRemoteMode } from '../platform';
 import { MODELS, type ModelAlias } from './StatusBar';
 import FolderSwitcher from './FolderSwitcher';
@@ -1042,26 +1042,33 @@ export default function SessionStrip({
                   Skip Permissions
                   <SkipPermissionsInfoTooltip />
                 </label>
-                <button
-                  onClick={() => setDangerous(!dangerous)}
-                  className={`w-8 h-4.5 rounded-full relative transition-colors ${dangerous ? 'bg-[#DD4444]' : 'bg-inset'}`}
-                >
-                  <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${dangerous ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-                </button>
+                {/* Shared Toggle (change 15). The "danger" tone replaces the raw
+                    #DD4444 hex, so community themes can restyle it. aria-label
+                    added — the neighbouring <label> was never wired to the
+                    control, so it announced as an unnamed button. */}
+                <Toggle
+                  checked={dangerous}
+                  onChange={setDangerous}
+                  tone="danger"
+                  aria-label="Skip Permissions"
+                />
               </div>
+              {/* Warning text was a raw text-[#DD4444] hex. Change 17 moves it onto
+                  the same token as the toggle beside it, so a community theme
+                  restyling its red doesn't leave the two out of sync. */}
               {dangerous && (
-                <p className="text-[10px] text-[#DD4444]">Claude will execute tools without asking for approval.</p>
+                <p className="text-[10px] text-destructive">Claude will execute tools without asking for approval.</p>
               )}
               {/* Launch in new window — hidden on platforms without multi-window support */}
               {detachAvailable && (
                 <div className="flex items-center justify-between">
                   <label className="text-[10px] uppercase tracking-wider text-fg-muted">Launch in New Window</label>
-                  <button
-                    onClick={() => setLaunchInNewWindow(!launchInNewWindow)}
-                    className={`w-8 h-4.5 rounded-full relative transition-colors ${launchInNewWindow ? 'bg-accent' : 'bg-inset'}`}
-                  >
-                    <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${launchInNewWindow ? 'left-[calc(100%-16px)]' : 'left-0.5'}`} />
-                  </button>
+                  {/* Shared Toggle (change 15) — same accent on-state as before. */}
+                  <Toggle
+                    checked={launchInNewWindow}
+                    onChange={setLaunchInNewWindow}
+                    aria-label="Launch in New Window"
+                  />
                 </div>
               )}
               {/* Skip-permissions sessions get the FILLED danger variant (spec §11,

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -25,7 +25,9 @@ import AccountSection from './AccountSection';
 import ModelProvidersSection from './ModelProvidersPopup';
 import SettingsRow from './SettingsRow';
 import { formatVersionLine } from '../../shared/version-line';
-import { Button } from './ui';
+// UiToggle is aliased because this file still exports its own `Toggle` (the
+// compat wrapper below) that AboutPopup imports by that name.
+import { Button, Toggle as UiToggle, TextInput, InputGroup } from './ui';
 
 // Both are Vite `define` substitutions, so they're constants at module scope.
 // The typeof guard covers paths where the define isn't applied (unit tests).
@@ -280,22 +282,27 @@ export default function SettingsPanel({ open, onClose, onSendInput, hasActiveSes
 }
 
 // ─── Toggle component (shared) ──────────────────────────────────────────────
-// Exported so AboutPopup's analytics opt-out toggle can reuse the same pill
-// styling — matches the skip-permissions / approve-all toggles in this file.
+// Was a hand-rolled 32x16 track (green-600 on / red-600 for danger) with its own
+// knob math; now a thin wrapper over the shared <Toggle> primitive so there is
+// one 36x20 geometry app-wide (changes 15-17). Kept as a named export — and with
+// its original `enabled`/`onToggle`/`color` signature — because AboutPopup's
+// analytics opt-out imports `Toggle` from this file.
+//
+// color="red" maps to tone="danger" (the theme's destructive token, replacing the
+// raw red-600); the default maps to the app accent, replacing green-600.
 
-export function Toggle({ enabled, onToggle, color = 'green' }: { enabled: boolean; onToggle: () => void; color?: 'green' | 'red' }) {
-  const bg = enabled
-    ? color === 'red' ? 'bg-red-600' : 'bg-green-600'
-    : 'bg-inset';
+export function Toggle({ enabled, onToggle, color = 'green', label }: { enabled: boolean; onToggle: () => void; color?: 'green' | 'red'; label?: string }) {
   return (
-    <button
-      onClick={onToggle}
-      className={`w-8 h-4 rounded-full transition-colors relative ${bg}`}
-    >
-      <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
-        enabled ? 'left-4' : 'left-0.5'
-      }`} />
-    </button>
+    <UiToggle
+      checked={enabled}
+      // The primitive hands back the next state; every call site here is a plain
+      // flip, so we discard it and keep the existing zero-arg handlers intact.
+      onChange={() => onToggle()}
+      tone={color === 'red' ? 'danger' : 'default'}
+      // None of these switches had an accessible name before (a <button> inside a
+      // <label> does not inherit one); call sites pass the visible row text.
+      aria-label={label}
+    />
   );
 }
 
@@ -411,7 +418,7 @@ function SoundCategorySection({ category, label, description, dotColor }: {
           {dotColor && <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />}
           <span className="text-xs text-fg font-medium">{label}</span>
         </div>
-        <Toggle enabled={enabled} onToggle={handleToggle} />
+        <Toggle enabled={enabled} onToggle={handleToggle} label={label} />
       </div>
       <p className="text-[10px] text-fg-muted mb-2">{description}</p>
       {enabled && (
@@ -767,7 +774,7 @@ function BuddyButton() {
             <div className="px-4 py-4">
               <div className="flex items-center justify-between">
                 <span className="text-xs text-fg font-medium">Show buddy floater</span>
-                <Toggle enabled={enabled} onToggle={toggle} />
+                <Toggle enabled={enabled} onToggle={toggle} label="Show buddy floater" />
               </div>
               <p className="text-[10px] text-fg-muted mt-2">A small always-on-top mascot that stays visible even when the app is minimized.</p>
               {enabled && dismissed && (
@@ -1006,7 +1013,7 @@ function RemoteButton({
 
                       <label className="flex items-center justify-between py-2 cursor-pointer">
                         <span className="text-xs text-fg-2">Enabled</span>
-                        <Toggle enabled={!!config?.enabled} onToggle={onToggleEnabled} />
+                        <Toggle enabled={!!config?.enabled} onToggle={onToggleEnabled} label="Remote access server enabled" />
                       </label>
 
                       <div className="py-2">
@@ -1016,16 +1023,19 @@ function RemoteButton({
                             <span className="text-[10px] text-green-400">Set</span>
                           )}
                         </div>
-                        <div className="flex gap-1">
-                          <input
+                        {/* The Set button moves INSIDE the field (change 77): this is a
+                            field with a single submit action, which is exactly the
+                            InputGroup shape. The field also loses its bg-well surface,
+                            rounded-sm radius, and gray focus:border-fg-muted. */}
+                        <InputGroup size="sm">
+                          <InputGroup.Field
                             type="password"
                             placeholder={config?.hasPassword ? 'Change password...' : 'Set password...'}
                             value={newPassword}
                             onChange={(e) => onSetNewPassword(e.target.value)}
                             onKeyDown={(e) => e.key === 'Enter' && onSetPassword()}
-                            className="flex-1 px-2 py-1 rounded-sm bg-well border border-edge-dim text-xs text-fg focus:outline-none focus:border-fg-muted"
+                            aria-label="Remote access password"
                           />
-                          {/* sm keeps this level with the text input it sits beside. */}
                           <Button
                             variant="secondary"
                             size="sm"
@@ -1034,7 +1044,7 @@ function RemoteButton({
                           >
                             {passwordStatus === 'saved' ? '✓' : passwordStatus === 'saving' ? '...' : 'Set'}
                           </Button>
-                        </div>
+                        </InputGroup>
                       </div>
 
                       <div className="py-2">
@@ -1156,7 +1166,7 @@ function RemoteButton({
 
                           <label className="flex items-center justify-between py-2 cursor-pointer">
                             <span className="text-xs text-fg-2">Skip password on Tailscale</span>
-                            <Toggle enabled={!!config?.trustTailscale} onToggle={onToggleTailscaleTrust} />
+                            <Toggle enabled={!!config?.trustTailscale} onToggle={onToggleTailscaleTrust} label="Skip password on Tailscale" />
                           </label>
                         </>
                       ) : (
@@ -1254,6 +1264,7 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
           enabled={defaults.skipPermissions}
           onToggle={() => onDefaultsChange({ skipPermissions: !defaults.skipPermissions })}
           color="red"
+          label="Skip Permissions"
         />
       </div>
       {defaults.skipPermissions && (
@@ -1284,7 +1295,7 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
                   <p className="text-[10px] text-fg-dim font-medium">Auto-approve all</p>
                   <p className="text-[9px] text-fg-faint">Silently approve all protected requests</p>
                 </div>
-                <Toggle enabled={overrides.approveAll} onToggle={handleApproveAllToggle} color="red" />
+                <Toggle enabled={overrides.approveAll} onToggle={handleApproveAllToggle} color="red" label="Auto-approve all" />
               </div>
 
               {/* Separator */}
@@ -1301,7 +1312,7 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
                     <p className="text-[10px] text-fg-dim font-medium">{label}</p>
                     <p className="text-[9px] text-fg-faint">{description}</p>
                   </div>
-                  <Toggle enabled={overrides[key]} onToggle={() => updateOverride(key, !overrides[key])} />
+                  <Toggle enabled={overrides[key]} onToggle={() => updateOverride(key, !overrides[key])} label={`Auto-approve ${label}`} />
                 </div>
               ))}
             </div>
@@ -1489,9 +1500,14 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
                       <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">Close-session prompt</h3>
                       <p className="text-[10px] text-fg-faint mt-0.5">Show tag options when closing a session</p>
                     </div>
-                    <button
-                      onClick={() => {
-                        const next = !closePromptDisabled;
+                    {/* Was a hand-rolled 32x18 track with an inline var(--accent)
+                        background; one geometry now (change 16). The state is stored
+                        INVERTED (closePromptDisabled), so `checked` is the negation —
+                        the switch reads as "show the prompt". */}
+                    <UiToggle
+                      checked={!closePromptDisabled}
+                      onChange={(show) => {
+                        const next = !show;
                         setClosePromptDisabled(next);
                         if (next) {
                           localStorage.setItem(CLOSE_PROMPT_SUPPRESS_KEY, '1');
@@ -1499,11 +1515,8 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
                           localStorage.removeItem(CLOSE_PROMPT_SUPPRESS_KEY);
                         }
                       }}
-                      className="w-8 h-4.5 rounded-full relative transition-colors shrink-0"
-                      style={{ backgroundColor: closePromptDisabled ? 'var(--inset)' : 'var(--accent)' }}
-                    >
-                      <span className={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform ${closePromptDisabled ? 'left-0.5' : 'left-[calc(100%-16px)]'}`} />
-                    </button>
+                      aria-label="Close-session prompt"
+                    />
                   </div>
                 </section>
                 </div>
@@ -1882,44 +1895,54 @@ function ConnectToDesktopButton() {
                     </div>
                   ) : (
                     <div className="space-y-3 bg-inset/50 rounded-lg p-3">
+                      {/* All four fields were the same bg-well / rounded-sm /
+                          focus:border-fg-muted recipe; they're the shared FIELD surface
+                          now (change 20). The Cancel + Save row below stays outside as a
+                          form footer — it sits under the whole form, not beside one
+                          field, so it is NOT an InputGroup. */}
                       <div>
                         <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Device Name</label>
-                        <input
-                          type="text"
+                        <TextInput
+                          size="sm"
                           value={formName}
                           onChange={e => setFormName(e.target.value)}
                           placeholder="My Desktop"
-                          className="w-full px-2 py-1.5 rounded-sm bg-well border border-edge-dim text-xs text-fg focus:outline-none focus:border-fg-muted"
+                          aria-label="Device Name"
+                          className="w-full"
                         />
                       </div>
                       <div>
                         <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Host / IP</label>
-                        <input
-                          type="text"
+                        <TextInput
+                          size="sm"
                           value={formHost}
                           onChange={e => setFormHost(e.target.value)}
                           placeholder="100.x.x.x"
-                          className="w-full px-2 py-1.5 rounded-sm bg-well border border-edge-dim text-xs text-fg focus:outline-none focus:border-fg-muted"
+                          aria-label="Host / IP"
+                          className="w-full"
                         />
                       </div>
                       <div>
                         <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Port</label>
-                        <input
-                          type="text"
+                        <TextInput
+                          size="sm"
                           value={formPort}
                           onChange={e => setFormPort(e.target.value)}
                           placeholder="9900"
-                          className="w-full px-2 py-1.5 rounded-sm bg-well border border-edge-dim text-xs text-fg focus:outline-none focus:border-fg-muted"
+                          aria-label="Port"
+                          className="w-full"
                         />
                       </div>
                       <div>
                         <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Password</label>
-                        <input
+                        <TextInput
+                          size="sm"
                           type="password"
                           value={formPassword}
                           onChange={e => setFormPassword(e.target.value)}
                           placeholder="Remote access password"
-                          className="w-full px-2 py-1.5 rounded-sm bg-well border border-edge-dim text-xs text-fg focus:outline-none focus:border-fg-muted"
+                          aria-label="Remote access password"
+                          className="w-full"
                         />
                       </div>
                       <div className="flex gap-2">

--- a/desktop/src/renderer/components/SkillEditor.tsx
+++ b/desktop/src/renderer/components/SkillEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import type { SkillEntry } from '../../shared/types';
 import { useSkills } from '../state/skill-context';
 import { Scrim, OverlayPanel } from './overlays/Overlay';
-import { Button } from './ui';
+import { Button, Select, TextInput } from './ui';
 import { useEscClose } from '../hooks/use-esc-close';
 
 interface SkillEditorProps {
@@ -99,11 +99,12 @@ export default function SkillEditor({ skillId, onClose }: SkillEditorProps) {
         {/* Name */}
         <label className="block mb-3">
           <span className="text-[10px] font-medium text-fg-muted tracking-wider">NAME</span>
-          <input
-            type="text"
+          {/* Shared field surface (change 20) — the hand-rolled recipe here used
+              bg-well + placeholder-fg-muted; FIELD is bg-inset + fg-faint. */}
+          <TextInput
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="mt-1 w-full bg-well border border-edge-dim rounded-lg px-3 py-2 text-sm text-fg placeholder-fg-muted outline-none focus:border-accent transition-colors"
+            className="mt-1 w-full"
             placeholder="Skill name"
           />
         </label>
@@ -111,30 +112,32 @@ export default function SkillEditor({ skillId, onClose }: SkillEditorProps) {
         {/* Description */}
         <label className="block mb-3">
           <span className="text-[10px] font-medium text-fg-muted tracking-wider">DESCRIPTION</span>
-          <input
-            type="text"
+          {/* Same migration as NAME above (change 20). Stays a single-line input —
+              it was never a textarea. */}
+          <TextInput
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="mt-1 w-full bg-well border border-edge-dim rounded-lg px-3 py-2 text-sm text-fg placeholder-fg-muted outline-none focus:border-accent transition-colors"
+            className="mt-1 w-full"
             placeholder="Short description"
           />
         </label>
 
         {/* Category */}
-        <label className="block mb-5">
+        {/* Was a native <select> (change 21): its option list is OS-drawn, so the
+            open menu ignored the theme entirely. <Select> renders the list itself.
+            The wrapper is a <div>, not a <label> — a <label> can't name a
+            <button>, which is what the Select trigger is, so the accessible name
+            moves to aria-label instead. */}
+        <div className="block mb-5">
           <span className="text-[10px] font-medium text-fg-muted tracking-wider">CATEGORY</span>
-          <select
+          <Select
+            options={categories}
             value={category}
-            onChange={(e) => setCategory(e.target.value as SkillEntry['category'])}
-            className="mt-1 w-full bg-well border border-edge-dim rounded-lg px-3 py-2 text-sm text-fg outline-none focus:border-accent transition-colors"
-          >
-            {categories.map((c) => (
-              <option key={c.value} value={c.value}>
-                {c.label}
-              </option>
-            ))}
-          </select>
-        </label>
+            onChange={(v) => setCategory(v as SkillEntry['category'])}
+            aria-label="Category"
+            className="mt-1"
+          />
+        </div>
 
         {/* Buttons */}
         <div className="flex gap-2">

--- a/desktop/src/renderer/components/SkipPermissionsInfoTooltip.tsx
+++ b/desktop/src/renderer/components/SkipPermissionsInfoTooltip.tsx
@@ -67,7 +67,11 @@ export function SkipPermissionsInfoTooltip() {
               If you want to turn those extra protections off too, you can do it under <span className="text-fg">Settings → Defaults → Skip Permissions → Advanced</span>. They're left on by default because they're the last line of defense against a serious mistake.
             </p>
 
-            <p className="text-xs font-semibold text-[#DD4444] mt-2.5 mb-1.5">What could go wrong</p>
+            {/* Was a raw text-[#DD4444] hex. Same change-17 reasoning as the
+                skip-permissions warnings elsewhere: this heading is danger
+                messaging, so it rides the theme's destructive token rather than
+                a fixed red a community pack can't touch. */}
+            <p className="text-xs font-semibold text-destructive mt-2.5 mb-1.5">What could go wrong</p>
             <div className="space-y-1">
               <div className="flex items-start gap-1.5 text-[11px] text-fg-2 leading-snug">
                 <span className="shrink-0 mt-px">·</span>

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, TextInput, Toggle } from './ui';
 import type { SyncWarning } from '../../main/sync-state';
 import { deriveSyncState, type SyncDisplayState } from '../state/sync-display-state';
 import { createPortal } from 'react-dom';
@@ -997,17 +997,21 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                           {offError && <div className="text-[11px] mt-0.5 leading-relaxed text-red-500">{offError}</div>}
                         </div>
                       </div>
-                      {/* Enable toggle — reuses the 36×20 green switch markup. */}
-                      <button
-                        role="switch"
-                        aria-checked={toggleOn}
+                      {/* Enable toggle — migrated to the shared Toggle (spec changes
+                          15/16). The geometry is unchanged (this row's 36x20 IS the
+                          primitive's), but the on-state moves off hardcoded green-600
+                          onto the theme accent, and the disabled dimming now comes from
+                          the primitive instead of the local opacity-50/cursor-wait pair.
+                          onChange gets the NEXT value, so we pass it straight through
+                          — same flip direction the old !enabled click had, because
+                          `checked` is toggleOn (= enabling || enabled). */}
+                      <Toggle
+                        checked={toggleOn}
+                        onChange={(next) => void handleSpacesEnable(next)}
                         disabled={enabling}
-                        onClick={() => void handleSpacesEnable(!enabled)}
-                        className={`relative w-9 h-5 rounded-full transition-colors shrink-0 mt-0.5 ${toggleOn ? 'bg-green-600' : 'bg-inset'} ${enabling ? 'opacity-50 cursor-wait' : 'cursor-pointer'}`}
+                        className="mt-0.5"
                         title={enabled ? 'Cross-device sync on — click to turn off' : 'Cross-device sync off — click to turn on'}
-                      >
-                        <div className="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-all" style={{ left: toggleOn ? '18px' : '2px' }} />
-                      </button>
+                      />
                     </div>
                     {/* Action tucked under the reason — same box, no divider. */}
                     {cta && <div className="mt-2 flex items-center gap-2 pl-[18px]">{cta}</div>}
@@ -1146,15 +1150,16 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                       <p className="text-[11px] text-fg-muted mt-1 leading-relaxed">{sub}</p>
                     </div>
                     {/* Master toggle: pause-all / resume-all / reveal picker (handleAdditionalToggle). */}
-                    <button
-                      role="switch"
-                      aria-checked={masterOn}
-                      onClick={() => void handleAdditionalToggle()}
-                      className={`relative w-9 h-5 rounded-full transition-colors shrink-0 mt-0.5 cursor-pointer ${masterOn ? 'bg-green-600' : 'bg-inset'}`}
+                    {/* Shared Toggle (spec changes 15/16) — same 36x20 geometry, but the
+                        on-state is the theme accent instead of hardcoded green-600.
+                        handleAdditionalToggle derives the direction itself from the
+                        backend list, so the `next` value it's handed is ignored. */}
+                    <Toggle
+                      checked={masterOn}
+                      onChange={() => void handleAdditionalToggle()}
+                      className="mt-0.5"
                       title={masterOn ? 'Additional backups on — click to pause all' : 'Additional backups off — click to turn on'}
-                    >
-                      <div className="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-all" style={{ left: masterOn ? '18px' : '2px' }} />
-                    </button>
+                    />
                   </div>
 
                   {/* Backend rows — shown whenever any exist (kept visible even when paused,
@@ -1590,7 +1595,13 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
             <div className="flex items-center justify-between gap-2">
               <div className="min-w-0 flex items-center gap-1.5">
                 {editingId === d.id ? (
-                  <input
+                  /* Shared FIELD surface (spec change 20) — `sm` because this is an
+                     inline edit inside a compact list row. min-w-0 stays: it lets the
+                     input shrink inside the flex row instead of forcing overflow.
+                     aria-label added — the input replaces the name button on click,
+                     so there was nothing naming it for a screen reader. */
+                  <TextInput
+                    size="sm"
                     value={draft}
                     autoFocus
                     onChange={(e) => setDraft(e.target.value)}
@@ -1599,7 +1610,8 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
                       if (e.key === 'Escape') setEditingId(null); // cancel — no rename
                     }}
                     onBlur={() => commitRename(d.id)}
-                    className="bg-inset text-fg text-xs rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none min-w-0"
+                    aria-label={`Rename ${d.name}`}
+                    className="min-w-0"
                   />
                 ) : (
                   // Click the name to edit — it's just a nickname, so no confirm gate.
@@ -1749,11 +1761,16 @@ function EditBackendForm({
         <div className="px-4 py-4 space-y-4">
         <div>
           <label className="block text-[10px] text-fg-muted mb-1">Name</label>
-          <input
-            type="text"
+          {/* Shared FIELD surface (spec change 20). The visible label above isn't
+              wired up with htmlFor, so aria-label gives it the same name. Left as a
+              plain field rather than an InputGroup: its Save button sits at the very
+              bottom of the form, below the read-only config rows — a footer action,
+              not a field action (spec §11.9 excludes that shape). */}
+          <TextInput
             value={label}
             onChange={(e) => setLabel(e.target.value)}
-            className="w-full px-2 py-1.5 rounded-md bg-inset border border-edge-dim text-xs text-fg focus:border-accent focus:outline-none"
+            aria-label="Name"
+            className="w-full"
           />
         </div>
 

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, TextInput, Toggle } from './ui';
 import { isAndroid as checkIsAndroid } from '../platform';
 import { useEscClose } from '../hooks/use-esc-close';
 import { useScrollFade } from '../hooks/useScrollFade';
@@ -351,12 +351,17 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
           {/* Name */}
           <div>
             <label className="block text-[10px] text-fg-muted mb-1">Give this backup a name</label>
-            <input
-              type="text"
+            {/* Migrated to the shared TextInput (spec change 20): the hand-rolled
+                bg-inset/rounded-md/focus recipe is now the one FIELD surface, so
+                every text box in the app focuses and rounds the same way. The
+                visible label above isn't wired to this input with htmlFor, so
+                aria-label gives screen readers the same name sighted users see. */}
+            <TextInput
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               placeholder={`My ${BACKEND_LABELS[backendType]}`}
-              className="w-full px-2 py-1.5 rounded-md bg-inset border border-edge-dim text-xs text-fg placeholder-fg-faint focus:border-accent focus:outline-none"
+              aria-label="Give this backup a name"
+              className="w-full"
               autoFocus
             />
             <div className="text-[10px] text-fg-faint mt-0.5">This is just for you — to tell your backups apart.</div>
@@ -366,12 +371,14 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
           {backendType === 'drive' && (
             <div>
               <label className="block text-[10px] text-fg-muted mb-1">Folder in Google Drive</label>
-              <input
-                type="text"
+              {/* Shared FIELD surface (spec change 20). aria-label mirrors the
+                  visible label, which isn't linked via htmlFor. */}
+              <TextInput
                 value={driveFolder}
                 onChange={(e) => setDriveFolder(e.target.value)}
                 placeholder="Claude"
-                className="w-full px-2 py-1.5 rounded-md bg-inset border border-edge-dim text-xs text-fg placeholder-fg-faint focus:border-accent focus:outline-none"
+                aria-label="Folder in Google Drive"
+                className="w-full"
               />
               <div className="text-[10px] text-fg-faint mt-0.5">
                 We'll create a folder called "{driveFolder || 'Claude'}" in your Drive if it doesn't exist.
@@ -395,12 +402,15 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
                   <div className="text-xs text-fg font-medium">Create a new private repository</div>
                   {repoMode === 'create' && (
                     <div className="mt-1.5">
-                      <input
-                        type="text"
+                      {/* Shared FIELD surface (spec change 20). This input sits inside
+                          the radio's <label>, so without an explicit aria-label a screen
+                          reader would announce the radio's whole sentence as its name. */}
+                      <TextInput
                         value={repoName}
                         onChange={(e) => setRepoName(e.target.value)}
                         placeholder="claude-sync"
-                        className="w-full px-2 py-1.5 rounded-md bg-inset border border-edge-dim text-xs text-fg placeholder-fg-faint focus:border-accent focus:outline-none"
+                        aria-label="New repository name"
+                        className="w-full"
                       />
                       {ghUsername && (
                         <div className="text-[10px] text-fg-faint mt-0.5">
@@ -425,12 +435,14 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
                   <div className="text-xs text-fg font-medium">Use an existing repository</div>
                   {repoMode === 'existing' && (
                     <div className="mt-1.5">
-                      <input
-                        type="text"
+                      {/* Shared FIELD surface (spec change 20). Same nested-label
+                          reason as above for the explicit aria-label. */}
+                      <TextInput
                         value={repoUrl}
                         onChange={(e) => setRepoUrl(e.target.value)}
                         placeholder="https://github.com/you/repo"
-                        className="w-full px-2 py-1.5 rounded-md bg-inset border border-edge-dim text-xs text-fg placeholder-fg-faint focus:border-accent focus:outline-none"
+                        aria-label="Existing repository URL"
+                        className="w-full"
                       />
                       <div className="text-[10px] text-fg-faint mt-0.5">Paste the full URL of your private repository.</div>
                     </div>
@@ -451,13 +463,17 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
           {/* Auto-sync toggle */}
           <div className="pt-1">
             <label className="flex items-center gap-2 cursor-pointer">
-              <button
-                onClick={() => setSyncEnabled(!syncEnabled)}
-                className={`relative w-8 h-4 rounded-full transition-colors shrink-0 ${syncEnabled ? 'bg-green-600' : 'bg-inset'}`}
-              >
-                <div className="absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-sm transition-all"
-                  style={{ left: syncEnabled ? '18px' : '2px' }} />
-              </button>
+              {/* Migrated to the shared Toggle (spec changes 15/16). Was a hand-rolled
+                  32x16 switch with a hardcoded green-600 on-state and no aria at all;
+                  the primitive is the one 36x20 geometry, paints the on-state in the
+                  user's theme accent, and carries role="switch" + aria-checked. The
+                  aria-label repeats the sentence beside it — the wrapping <label>
+                  can't name a <button>, so without it the switch is unnamed. */}
+              <Toggle
+                checked={syncEnabled}
+                onChange={setSyncEnabled}
+                aria-label="Back up automatically after changes"
+              />
               <span className="text-xs text-fg">Back up automatically after changes</span>
             </label>
             <div className="text-[10px] text-fg-faint mt-0.5 ml-10">

--- a/desktop/src/renderer/components/ThemeScreen.tsx
+++ b/desktop/src/renderer/components/ThemeScreen.tsx
@@ -7,7 +7,7 @@ import SettingsExplainer, { InfoIconButton, type ExplainerSection } from './Sett
 import type { LoadedTheme } from '../themes/theme-types';
 import { useScrollFade } from '../hooks/useScrollFade';
 import { useEscClose } from '../hooks/use-esc-close';
-import { Button, CloseButton } from './ui';
+import { Button, CloseButton, Select, Toggle } from './ui';
 
 // Plain-language explainer for the Appearance popup. Shown when the user taps
 // the (i) icon in the popup header — see ThemeScreen's `showInfo` state.
@@ -48,6 +48,10 @@ const APPEARANCE_EXPLAINER: { intro: string; sections: ExplainerSection[] } = {
 };
 
 const PARTICLE_OPTIONS = ['none', 'rain', 'dust', 'ember', 'snow', 'custom'] as const;
+
+// Shape PARTICLE_OPTIONS for the shared <Select> (change 21). Labels stay the
+// raw preset names so the visible text is unchanged from the old <option> list.
+const PARTICLE_SELECT_OPTIONS = PARTICLE_OPTIONS.map((p) => ({ value: p, label: p }));
 
 function roundnessToShape(value: number) {
   const sm  = Math.round(value * 8);
@@ -252,12 +256,14 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
             <p className="text-xs text-fg-2">Reduce Visual Effects</p>
             <p className="text-[10px] text-fg-faint">Disables particles, blur, and animations</p>
           </div>
-          <button
-            onClick={() => setReducedEffects(!reducedEffects)}
-            className={`w-9 h-5 rounded-full transition-colors relative ${reducedEffects ? 'bg-accent' : 'bg-edge'}`}
-          >
-            <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${reducedEffects ? 'left-[18px]' : 'left-0.5'}`} />
-          </button>
+          {/* Was a hand-rolled 36x20 switch (change 15): same geometry, but the
+              shared Toggle also carries role="switch" + aria-checked, which this
+              one never had — a screen reader read it as an unlabelled button. */}
+          <Toggle
+            checked={reducedEffects}
+            onChange={(next) => setReducedEffects(next)}
+            aria-label="Reduce Visual Effects"
+          />
         </div>
 
         {/* Message timestamps toggle */}
@@ -266,12 +272,12 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
             <p className="text-xs text-fg-2">Message Timestamps</p>
             <p className="text-[10px] text-fg-faint">Show time sent in each chat bubble</p>
           </div>
-          <button
-            onClick={() => setShowTimestamps(!showTimestamps)}
-            className={`w-9 h-5 rounded-full transition-colors relative ${showTimestamps ? 'bg-accent' : 'bg-edge'}`}
-          >
-            <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${showTimestamps ? 'left-[18px]' : 'left-0.5'}`} />
-          </button>
+          {/* Same migration as the toggle above (change 15). */}
+          <Toggle
+            checked={showTimestamps}
+            onChange={(next) => setShowTimestamps(next)}
+            aria-label="Message Timestamps"
+          />
         </div>
         </div>
       </div>
@@ -411,13 +417,21 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
             </div>
             <div className="flex items-center justify-between">
               <span className="text-xs text-fg-2">Particles</span>
-              <select
-                value={theme.effects?.particles ?? 'none'}
-                onChange={e => updateParticles(e.target.value)}
-                className="bg-inset text-fg-2 text-[10px] rounded-sm border border-edge-dim px-2 py-0.5"
-              >
-                {PARTICLE_OPTIONS.map(p => <option key={p} value={p}>{p}</option>)}
-              </select>
+              {/* Was a native <select> (change 21). A native select's option list is
+                  drawn by the OS, so the open menu showed the OS blue-highlight
+                  styling inside a themed app — styling the closed trigger alone
+                  couldn't fix that. <Select> renders the list itself.
+                  The width wrapper keeps the row's right-hand control from
+                  stretching: the Select trigger is w-full by design. */}
+              <div className="w-32 shrink-0">
+                <Select
+                  size="sm"
+                  options={PARTICLE_SELECT_OPTIONS}
+                  value={theme.effects?.particles ?? 'none'}
+                  onChange={updateParticles}
+                  aria-label="Particles"
+                />
+              </div>
             </div>
           </div>
         )}

--- a/desktop/src/renderer/components/development/BugReportPopup.tsx
+++ b/desktop/src/renderer/components/development/BugReportPopup.tsx
@@ -9,7 +9,7 @@ import { createPortal } from 'react-dom';
 import { useEffect, useState } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
-import { Button } from '../ui';
+import { Button, Textarea } from '../ui';
 
 interface Props {
   open: boolean;
@@ -192,11 +192,17 @@ function DescribeScreen({ kind, setKind, description, setDescription, onContinue
           </button>
         ))}
       </div>
-      <textarea
+      {/* Change 42: this was already the target recipe (border-edge-dim, rounded-lg,
+          focus:border-accent), so migrating it is mostly a de-duplication —
+          bg-inset/50 becomes the shared bg-inset and the padding picks up the one
+          field scale. Continue stays BELOW the field, so no InputGroup here. */}
+      <Textarea
+        size="md"
+        className="w-full h-32"
+        aria-label="Describe the bug or feature"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
         placeholder="What's happening? (Or what would you like to see?)"
-        className="w-full h-32 p-2 text-xs bg-inset/50 border border-edge-dim rounded-lg resize-none focus:outline-none focus:border-accent"
       />
       <Button
         disabled={description.trim().length < 10 || busy}
@@ -224,10 +230,16 @@ function ReviewScreen({ kind, summary, logTail, setLogTail, onEdit, onSubmit, on
               ))}
             </div>
           )}
-          <textarea
+          {/* Change 42: same migration as the describe screen. `sm` (11px) is the
+              nearest field size to the old text-[10px] — the scale has no 10px
+              field step, and arbitrary text-[Npx] is retired (see globals.css).
+              font-mono is kept: this is a log tail and column alignment matters. */}
+          <Textarea
+            size="sm"
+            className="w-full h-32 mt-2 font-mono"
+            aria-label="Logs to include"
             value={logTail}
             onChange={(e) => setLogTail(e.target.value)}
-            className="w-full h-32 mt-2 p-2 text-[10px] font-mono bg-inset/50 border border-edge-dim rounded-lg resize-none focus:outline-none focus:border-accent"
           />
         </details>
       )}

--- a/desktop/src/renderer/components/game/GameChat.tsx
+++ b/desktop/src/renderer/components/game/GameChat.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useGameState } from '../../state/game-context';
 import { GameConnection } from '../../state/game-types';
+import { TextInput } from '../ui';
 
 interface Props {
   connection: GameConnection;
@@ -65,14 +66,20 @@ export default function GameChat({ connection }: Props) {
 
       {/* Input */}
       <div className="px-3 py-2 border-t border-edge shrink-0">
-        <input
+        {/* Change 20: bg-well + the gray focus (`focus:border-fg-dim`) → the shared
+            FIELD surface. Enter-to-send and the 200-char cap are unchanged. NOT an
+            InputGroup: this composer has no visible submit button to move inside —
+            Enter is the only way to send. */}
+        <TextInput
           type="text"
+          size="md"
+          aria-label="Game chat message"
+          className="w-full"
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Say something..."
           maxLength={200}
-          className="w-full bg-well border border-edge rounded-lg px-3 py-1.5 text-xs text-fg placeholder-fg-muted outline-none focus:border-fg-dim transition-colors"
         />
       </div>
     </div>

--- a/desktop/src/renderer/components/game/GameLobby.tsx
+++ b/desktop/src/renderer/components/game/GameLobby.tsx
@@ -4,7 +4,7 @@ import { useAccount } from '../../state/account-context';
 import BrailleSpinner from '../BrailleSpinner';
 import { GameConnection } from '../../state/game-types';
 import { mergeFriends, statusLabel } from './friends-data';
-import { Button } from '../ui';
+import { Button, InputGroup } from '../ui';
 import type { FriendRow, RequestsPayload } from '../../state/marketplace-api-client';
 
 // Local mirror of the renderer/main ApiResult shape (useIpc.ts declares it but
@@ -453,29 +453,32 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
       {/* Add a friend by handle */}
       <div className="px-3 py-3 border-b border-edge flex flex-col gap-2">
         <div className="text-[10px] uppercase tracking-wider text-fg-muted">Add a friend</div>
-        <div className="flex gap-2">
-          <input
+        {/* Change 77: "Send request" moves INSIDE the field. It was left
+            `variant="secondary" size="lg"` purely so it would height-match the
+            input sitting beside it — inside the field there is nothing to
+            height-match, so it goes back to the primary it always semantically
+            was (this is the submit for the field it lives in).
+            Change 20 also applies to the field itself: bg-well and the gray
+            focus (`focus:border-fg-dim`) are both retired by the shared surface. */}
+        <InputGroup size="md">
+          <InputGroup.Field
             type="text"
+            aria-label="Friend's handle"
             value={addHandle}
             // Handles are lowercase — normalize as the user types so the exact-match
             // lookup on the Worker doesn't 404 on a stray capital.
             onChange={(e) => setAddHandle(e.target.value.toLowerCase())}
             onKeyDown={(e) => { if (e.key === 'Enter') void submitAddFriend(); }}
             placeholder="friend's handle"
-            className="flex-1 bg-well border border-edge rounded-lg px-3 py-2 text-sm text-fg placeholder-fg-muted outline-none focus:border-fg-dim transition-colors"
           />
-          {/* Filled-grey (`bg-inset`) was an unofficial second secondary style; it
-              collapses into the primitive's outlined `secondary`. `lg` matches the
-              height of the handle input next to it. */}
           <Button
-            variant="secondary"
-            size="lg"
+            size="sm"
             onClick={() => void submitAddFriend()}
             disabled={!addHandle.trim() || addPending}
           >
             Send request
           </Button>
-        </div>
+        </InputGroup>
         {addFeedback && (
           <p className={`text-xs ${addFeedback.ok ? 'text-green-400' : 'text-red-400'}`}>{addFeedback.text}</p>
         )}

--- a/desktop/src/renderer/components/marketplace/MarketplaceFilterBar.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceFilterBar.tsx
@@ -11,7 +11,7 @@
 
 import React, { useState } from "react";
 import { Scrim, OverlayPanel } from "../overlays/Overlay";
-import { Button } from "../ui";
+import { Button, InputGroup, TextInput } from "../ui";
 import { useEscClose } from "../../hooks/use-esc-close";
 import { useNarrowViewport } from "../../hooks/use-narrow-viewport";
 
@@ -63,29 +63,37 @@ export default function MarketplaceFilterBar({ value, onChange }: Props) {
     const count = activeFilterCount(value);
     return (
       <>
-        {/* Single rounded pill: leading magnifier icon, borderless input, trailing
-            filter button — same in-row pattern as InputBar's send button. The
-            outer wrapper carries the border + focus ring; the input itself is
-            transparent so focus styling reads as one element. */}
+        {/* Leading magnifier icon, borderless input, trailing filter button. This
+            box was the PRECEDENT for the InputGroup primitive (change 77), so it
+            now uses it rather than hand-rolling the shape. The one deliberate
+            change: focus was `focus-within:ring-2 focus-within:ring-accent` and is
+            now the wrapper's `focus-within:border-accent` — fields focus by border,
+            never a ring (the ring belongs to buttons). */}
         <div className="layer-surface sticky top-0 z-20 p-2">
-          <div className="flex items-center bg-inset border border-edge rounded-md focus-within:ring-2 focus-within:ring-accent">
-            <span className="pl-2.5 pr-1 text-fg-muted shrink-0" aria-hidden>
+          <InputGroup size="md">
+            <span className="pl-2.5 text-fg-muted shrink-0" aria-hidden>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="11" cy="11" r="7" />
                 <line x1="21" y1="21" x2="16.65" y2="16.65" />
               </svg>
             </span>
-            <input
+            {/* pl-0 so the text sits next to the magnifier rather than a second
+                indent — the wrapper's own gap-1 supplies the separation. */}
+            <InputGroup.Field
               type="search"
+              aria-label="Search the marketplace"
               placeholder="Search…"
+              className="pl-0"
               value={value.query}
               onChange={(e) => onChange({ ...value, query: e.target.value })}
-              className="flex-1 min-w-0 bg-transparent border-0 outline-none px-2 py-1.5 text-sm text-fg placeholder:text-fg-muted"
             />
+            {/* Left hand-rolled on purpose: icon-only with an absolutely positioned
+                count badge, which <Button> doesn't model. mr-1 dropped — the
+                InputGroup wrapper already insets its action with pr-1. */}
             <button
               type="button"
               onClick={() => setSheetOpen(true)}
-              className="shrink-0 relative p-2 mr-1 rounded-md text-fg-2 hover:text-fg hover:bg-edge-dim"
+              className="shrink-0 relative p-2 rounded-md text-fg-2 hover:text-fg hover:bg-edge-dim"
               aria-label={count > 0 ? `Filters (${count} active)` : 'Filters'}
               title={count > 0 ? `Filters (${count} active)` : 'Filters'}
             >
@@ -100,7 +108,7 @@ export default function MarketplaceFilterBar({ value, onChange }: Props) {
                 </span>
               )}
             </button>
-          </div>
+          </InputGroup>
         </div>
         {sheetOpen && (
           <FilterSheet
@@ -137,12 +145,17 @@ export default function MarketplaceFilterBar({ value, onChange }: Props) {
         <Chip active={value.meta.has("picks")} onClick={() => toggleMulti("meta", "picks")}>Featured picks</Chip>
       </ChipGroup>
       <div className="w-full sm:w-auto sm:ml-auto">
-        <input
+        {/* The wide layout's search box — unified with the compact one above onto
+            the shared FIELD surface. Same deliberate swap: focus ring → focus
+            border. Only the width utilities survive as a layout extra. */}
+        <TextInput
           type="search"
+          size="md"
+          aria-label="Search the marketplace"
           placeholder="Search…"
           value={value.query}
           onChange={(e) => onChange({ ...value, query: e.target.value })}
-          className="bg-inset border border-edge rounded-md px-3 py-1.5 text-sm text-fg placeholder:text-fg-muted focus:outline-none focus:ring-2 focus:ring-accent w-full sm:w-48"
+          className="w-full sm:w-48"
         />
       </div>
     </div>

--- a/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
+++ b/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
@@ -24,7 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
-import { Button, CloseButton } from '../ui';
+import { Button, CloseButton, Textarea } from '../ui';
 import { useEscClose } from '../../hooks/use-esc-close';
 import { useAccount } from '../../state/account-context';
 import { useMarketplaceStats } from '../../state/marketplace-stats-context';
@@ -285,14 +285,21 @@ export default function RatingSubmitModal({
               >
                 Review <span className="text-fg-faint">(optional)</span>
               </label>
-              <textarea
+              {/* Change 42: onto the shared FIELD surface — this was the
+                  `focus:ring-1` recipe, which the primitive replaces with a focus
+                  border. resize-none is the primitive's default, so it's dropped
+                  here rather than repeated. The Submit button stays in the footer
+                  row BELOW the field (not an InputGroup — change 77 is only for
+                  actions that belong inside the field). */}
+              <Textarea
                 id="review-text"
+                size="md"
+                className="w-full"
                 value={reviewText}
                 onChange={e => setReviewText(e.target.value.slice(0, MAX_REVIEW_CHARS))}
                 rows={3}
                 maxLength={MAX_REVIEW_CHARS}
                 placeholder="Share your experience with this plugin…"
-                className="w-full rounded-lg bg-inset border border-edge text-sm text-fg placeholder:text-fg-faint resize-none px-3 py-2 focus:outline-none focus:ring-1 focus:ring-accent"
               />
               {/* Character counter — shows remaining only when text is present */}
               {reviewText.length > 0 && (

--- a/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
+++ b/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
@@ -24,7 +24,7 @@ import React, {
   useCallback,
 } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
-import { Button, CloseButton } from '../ui';
+import { Button, CloseButton, Textarea } from '../ui';
 import { useEscClose } from '../../hooks/use-esc-close';
 import { useAccount } from '../../state/account-context';
 import { REPORT_REASON_MAX } from '../../state/marketplace-constants';
@@ -180,15 +180,21 @@ function ReportDialog({ reviewerLogin, onClose, onSubmit }: ReportDialogProps) {
               >
                 Reason <span className="text-fg-faint">(optional)</span>
               </label>
-              <textarea
+              {/* Change 42: onto the shared FIELD surface. The hand-rolled
+                  disabled:opacity-60 is dropped in favour of the primitive's own
+                  disabled treatment (opacity-50 + not-allowed cursor), so the
+                  mid-submit dim matches every other disabled field in the app.
+                  Report button stays in the footer row below — not an InputGroup. */}
+              <Textarea
                 id="report-reason"
+                size="md"
+                className="w-full"
                 value={reason}
                 onChange={e => setReason(e.target.value.slice(0, REPORT_REASON_MAX))}
                 rows={3}
                 maxLength={REPORT_REASON_MAX}
                 placeholder={`Why are you reporting ${displayName}'s review?`}
                 disabled={inFlight}
-                className="w-full rounded-lg bg-inset border border-edge text-sm text-fg placeholder:text-fg-faint resize-none px-3 py-2 focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-60"
               />
               {/* Character counter — shows remaining when text is present */}
               {reason.length > 0 && (

--- a/desktop/src/renderer/components/project-view/AddProjectModal.tsx
+++ b/desktop/src/renderer/components/project-view/AddProjectModal.tsx
@@ -10,7 +10,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { useEscClose } from '../../hooks/use-esc-close';
 import ImportProjectModal from '../ImportProjectModal';
-import { Button } from '../ui';
+import { Button, InputGroup } from '../ui';
 
 interface Props {
   onClose: () => void;
@@ -134,26 +134,27 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
             <div className="mt-3 rounded-lg border border-edge p-3">
               <div className="text-[13px] font-semibold text-fg">Start something new</div>
               <div className="mt-0.5 text-xs text-fg-dim">Creates an empty project in YouCoded that syncs across your devices.</div>
-              <div className="mt-2 flex items-center gap-2">
+              {/* Change 77: Create submits this field, so it moves INSIDE the
+                  field rather than sitting alongside it. Cancel stays in the
+                  modal footer — only the submit goes inside. */}
+              <InputGroup className="mt-2">
                 {/* No autoFocus (deliberate): the choose step presents two co-equal
                     choices — auto-focusing would bias toward create-new and pre-arm Enter. */}
-                <input
+                <InputGroup.Field
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   onKeyDown={(e) => { if (e.key === 'Enter') void createNew(); }}
                   placeholder="Project name…"
-                  className="flex-1 bg-inset text-fg text-sm rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
+                  aria-label="Project name"
                 />
-                {/* py-1 keeps the button the same height as the name input beside it. */}
                 <Button
-                  size="lg"
-                  className="py-1"
+                  size="sm"
                   onClick={() => void createNew()}
                   disabled={busy || !name.trim()}
                 >
                   {busy ? 'Creating…' : 'Create'}
                 </Button>
-              </div>
+              </InputGroup>
             </div>
 
             {/* Choice 2: existing folder → step 2 */}

--- a/desktop/src/renderer/components/project-view/ContextEditorOverlay.tsx
+++ b/desktop/src/renderer/components/project-view/ContextEditorOverlay.tsx
@@ -21,6 +21,7 @@ import {
 // Plain-text load-timing label — shared with ContextTab (context-labels.ts).
 import { timingLabel } from './context-labels';
 import { getPlatform } from '../../platform';
+import { Textarea } from '../ui';
 
 interface ContextEditorOverlayProps {
   project: { path: string };
@@ -252,11 +253,17 @@ export function ContextEditorOverlay({ project, file, onClose }: ContextEditorOv
             <p className="text-sm text-red-500 max-w-md text-center">{loadError}</p>
           </div>
         ) : editing ? (
-          <textarea
+          /* Shared Textarea (change 20). Retires the `focus:ring-1` focus ring
+             for the app-wide border-colour focus; resize-none is the
+             primitive's default so it no longer needs stating. Layout
+             (flex-1/min-h-0) and the monospace treatment stay — this edits a
+             raw context file. */
+          <Textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             spellCheck={false}
-            className="flex-1 min-h-0 w-full resize-none font-mono text-xs leading-relaxed bg-inset border border-edge rounded p-3 text-fg focus:outline-none focus:ring-1 focus:ring-accent"
+            aria-label={`Edit ${file.label}`}
+            className="flex-1 min-h-0 w-full font-mono leading-relaxed"
           />
         ) : (
           <div className="flex-1 min-h-0 overflow-auto">

--- a/desktop/src/renderer/components/project-view/ProjectHero.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectHero.tsx
@@ -94,7 +94,7 @@ function ExternalLink({ size = 14 }: { size?: number }) {
 
 // Git-branch glyph shared with ProjectSwitcher — lives in ./icons.tsx.
 import { GitBranchIcon } from './icons';
-import { Button } from '../ui';
+import { Button, TextInput } from '../ui';
 
 export function ProjectHero({
   project,
@@ -258,13 +258,17 @@ export function ProjectHero({
             hides for synced projects (move-out-of-sync is a deferred flow). */}
         <div className="mt-3 flex flex-wrap items-center gap-2">
           {renaming ? (
-            <input
+            /* Shared TextInput (change 20). Stays a plain field, not an
+               InputGroup — this one commits on Enter/blur and has no submit
+               button to put inside. */
+            <TextInput
+              size="sm"
               value={nickname}
               autoFocus
+              aria-label="Project nickname"
               onChange={(e) => setNickname(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') void commitRename(); if (e.key === 'Escape') { setNickname(project.name); setRenaming(false); } }}
               onBlur={() => void commitRename()}
-              className="bg-inset text-fg text-xs rounded px-2 py-1 border border-edge-dim focus:border-accent outline-none"
             />
           ) : (
             <Button variant="secondary" size="sm" onClick={() => setRenaming(true)}>

--- a/desktop/src/renderer/components/tags/NoteEditor.tsx
+++ b/desktop/src/renderer/components/tags/NoteEditor.tsx
@@ -1,5 +1,6 @@
 // src/renderer/components/tags/NoteEditor.tsx
 import React, { useEffect, useRef, useState } from 'react';
+import { Textarea } from '../ui';
 
 export const NOTE_MAX = 8000;
 
@@ -26,14 +27,22 @@ export function NoteEditor({ value, onSave, placeholder = 'Add a note…' }: {
   const commit = () => { if (draft !== value) onSave(draft); };
   return (
     <div className="flex flex-col gap-1">
-      <textarea
+      {/* Change 42: onto the shared FIELD surface. `resizable` is passed on purpose —
+          this note box genuinely IS drag-resizable today (it was `resize-y`), and
+          the explicit resize-y className keeps it vertical-only; the primitive's
+          `resizable` escape hatch otherwise falls back to the browser default of
+          resizing in both axes, which would let it overflow its container. */}
+      <Textarea
+        size="sm"
+        resizable
+        className="w-full resize-y"
+        aria-label={placeholder}
         value={draft}
         maxLength={NOTE_MAX}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
         placeholder={placeholder}
         rows={3}
-        className="w-full resize-y rounded-sm bg-inset text-fg text-[11px] px-2 py-1.5 border border-edge-dim focus:border-accent outline-none"
       />
       {remaining < 500 && (
         <span className="text-[9px] self-end text-fg-faint">{remaining} left</span>

--- a/desktop/src/renderer/components/tags/TagPicker.tsx
+++ b/desktop/src/renderer/components/tags/TagPicker.tsx
@@ -4,6 +4,7 @@ import type { TagRecord } from '../../../shared/tags';
 import { TAG_COLORS, DEFAULT_TAG_COLOR, TagColor } from '../../../shared/tags';
 import { TagRegistryApi } from '../../hooks/useTagRegistry';
 import { TagChip } from './TagChip';
+import { Button, InputGroup, TextInput } from '../ui';
 
 export function TagPicker({ appliedIds, onToggle, registry }: {
   appliedIds: Set<string>;
@@ -29,20 +30,26 @@ export function TagPicker({ appliedIds, onToggle, registry }: {
 
   return (
     <div className="flex flex-col gap-1.5">
-      <input
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        onKeyDown={(e) => { if (e.key === 'Enter' && canCreate) { e.preventDefault(); handleCreate(); } }}
-        placeholder="Search or create a tag…"
-        className="w-full rounded-sm bg-inset text-fg text-[11px] px-2 py-1 border border-edge-dim focus:border-accent outline-none"
-      />
-      <div className="max-h-48 overflow-y-auto flex flex-col gap-0.5">
+      {/* Change 77: the Create action moves from a list row into the field itself.
+          Enter still creates (same onKeyDown), and the button stays conditional on
+          canCreate. The row used to echo the typed name (+ Create “x”); inside the
+          field that echo is redundant visually, so it survives as the aria-label —
+          screen-reader users still hear which tag they're about to create. */}
+      <InputGroup size="sm">
+        <InputGroup.Field
+          aria-label="Search or create a tag"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && canCreate) { e.preventDefault(); handleCreate(); } }}
+          placeholder="Search or create a tag…"
+        />
         {canCreate && (
-          <button onClick={handleCreate}
-            className="text-left px-2 py-1 text-[11px] rounded-sm hover:bg-inset text-accent">
-            + Create “{query.trim()}”
-          </button>
+          <Button size="sm" onClick={handleCreate} aria-label={`Create tag ${query.trim()}`}>
+            Create
+          </Button>
         )}
+      </InputGroup>
+      <div className="max-h-48 overflow-y-auto flex flex-col gap-0.5">
         {visible.map((t) => (
           <TagRow key={t.id} tag={t} applied={appliedIds.has(t.id)}
             editing={editing === t.id}
@@ -81,9 +88,11 @@ function TagRow({ tag, applied, editing, onToggle, onEdit, registry }: {
       </div>
       {editing && (
         <div className="ml-5 mr-1 mb-1 flex flex-col gap-1.5 p-2 rounded-sm bg-inset border border-edge-dim">
-          <input value={label} onChange={(e) => setLabel(e.target.value)}
-            onBlur={() => { if (label.trim() && label !== tag.label) registry.update(tag.id, { label: label.trim() }); }}
-            className="rounded-sm bg-canvas text-fg text-[11px] px-1.5 py-1 border border-edge-dim outline-none" />
+          {/* Change 20: bg-canvas + rounded-sm + no focus state → the shared FIELD
+              surface. aria-label added — this rename box previously had no
+              accessible name at all. */}
+          <TextInput size="sm" aria-label="Tag label" value={label} onChange={(e) => setLabel(e.target.value)}
+            onBlur={() => { if (label.trim() && label !== tag.label) registry.update(tag.id, { label: label.trim() }); }} />
           <div className="flex flex-wrap gap-1">
             {TAG_COLORS.map((c) => (
               <button key={c} onClick={() => registry.update(tag.id, { color: c as TagColor })}

--- a/desktop/src/renderer/components/ui/InputGroup.tsx
+++ b/desktop/src/renderer/components/ui/InputGroup.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { FIELD_SURFACE, FIELD_TEXT, FIELD_SIZE, type FieldSize } from './field';
+
+/**
+ * A field with its action INSIDE it (change 77, spec §11.9).
+ *
+ * Destin, deciding this: "for all text fields that have a submit/copy, I like the
+ * button to be inside the field instead of alongside it."
+ *
+ * Why this can't just be a `className` on TextInput
+ * -------------------------------------------------
+ * The plain FIELD puts the border AND `focus:border-accent` on the <input>. Here
+ * the border moves to a wrapper and the input goes bare — so if the focus rule
+ * stayed on the input there would be no visible focus state at all (a borderless
+ * element has no border to recolor). The wrapper takes `focus-within:border-accent`
+ * instead. That's a structural difference, not a styling one, which is why this is
+ * its own primitive rather than a variant.
+ *
+ * The pattern was already in the app before this primitive existed —
+ * MarketplaceFilterBar's search box is exactly this shape. We standardized on it
+ * rather than inventing a new one.
+ *
+ * Usage
+ * -----
+ *   <InputGroup size="md">
+ *     <InputGroup.Field value={name} onChange={...} placeholder="Display name" />
+ *     <Button size="sm" onClick={save}>Save</Button>
+ *   </InputGroup>
+ *
+ * Sub-rule (spec §11.9): when a field has both a submit AND a Cancel, only the
+ * SUBMIT goes inside. Cancel is not a field action, and two buttons inside stop
+ * the thing reading as a field at all.
+ *
+ * NOT for: modal footers where the button sits below the field (~19 sites match
+ * an `<input>`-near-`<button>` grep but are this shape — don't sweep by grep), or
+ * the chat composer, which is its own species.
+ */
+
+export type InputGroupProps = {
+  /** Drives the padding of the bare <input> inside — see InputGroup.Field. */
+  size?: FieldSize;
+  /** Dims the whole group. The disabled state belongs to the wrapper here,
+   *  because the border being dimmed is most of what "disabled" looks like. */
+  disabled?: boolean;
+  className?: string;
+  children: React.ReactNode;
+};
+
+/** React context so InputGroup.Field inherits size without prop drilling at each site. */
+const SizeContext = React.createContext<FieldSize>('md');
+
+function InputGroupRoot({ size = 'md', disabled, className = '', children }: InputGroupProps) {
+  return (
+    <SizeContext.Provider value={size}>
+      <div
+        className={[
+          FIELD_SURFACE,
+          'flex items-center gap-1',
+          // The action sits inset from the border rather than flush against it.
+          'pr-1',
+          // The focus state the bare input can't express on its own.
+          'focus-within:border-accent',
+          disabled ? 'opacity-50 cursor-not-allowed' : '',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .trim()}
+      >
+        {children}
+      </div>
+    </SizeContext.Provider>
+  );
+}
+
+export type InputGroupFieldProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'size'
+> & {
+  /** Overrides the size inherited from the enclosing InputGroup. */
+  size?: FieldSize;
+};
+
+/**
+ * The bare input. Carries the padding and text treatment but no border, no
+ * background, and no focus outline — the wrapper owns all three.
+ */
+const InputGroupField = React.forwardRef<HTMLInputElement, InputGroupFieldProps>(
+  function InputGroupField({ size, className = '', type = 'text', ...rest }, ref) {
+    const inherited = React.useContext(SizeContext);
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={[
+          'flex-1 min-w-0 bg-transparent border-0 outline-none',
+          FIELD_TEXT,
+          FIELD_SIZE[size ?? inherited],
+          'disabled:cursor-not-allowed',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .trim()}
+        {...rest}
+      />
+    );
+  },
+);
+
+export const InputGroup = Object.assign(InputGroupRoot, { Field: InputGroupField });
+
+export default InputGroup;

--- a/desktop/src/renderer/components/ui/field.ts
+++ b/desktop/src/renderer/components/ui/field.ts
@@ -17,9 +17,21 @@
  * Spec: docs/active/specs/2026-07-16-ui-consistency-design-spec.md §1.3
  */
 
+import { mergeClasses } from './Button';
+
+/**
+ * The surface itself — background, border, radius. Split out because InputGroup
+ * (change 77) puts these on a WRAPPER while the input inside goes bare; without
+ * the split the two would drift apart the first time either is edited.
+ */
+export const FIELD_SURFACE = 'bg-inset border border-edge-dim rounded-lg';
+
+/** The text treatment — shared by a bare input and a bordered one alike. */
+export const FIELD_TEXT = 'text-fg placeholder:text-fg-faint';
+
 /** Focus is a border color change, never a ring — the ring belongs to buttons. */
 export const FIELD =
-  'bg-inset border border-edge-dim rounded-lg text-fg placeholder:text-fg-faint ' +
+  `${FIELD_SURFACE} ${FIELD_TEXT} ` +
   'focus:outline-none focus:border-accent ' +
   // Disabled fields already exist (EngineCard's context-length input, InputBar's
   // composer, ReportReviewButton) and would otherwise lose their affordance.
@@ -33,5 +45,11 @@ export const FIELD_SIZE: Record<FieldSize, string> = {
 };
 
 export function fieldClasses(size: FieldSize = 'md', className = ''): string {
-  return [FIELD, FIELD_SIZE[size], className].filter(Boolean).join(' ').trim();
+  // Goes through mergeClasses for the same reason buttonClasses does: Tailwind
+  // resolves two competing utilities by CSS SOURCE order, not by the order they
+  // appear in the class attribute. Plain concatenation meant a caller passing
+  // `text-sm` or `px-4` got whichever one Tailwind happened to emit later —
+  // which is how tranche 0's pills silently rendered as rounded rectangles
+  // (§10.3). Fields had the same latent bug until this call was added.
+  return mergeClasses([FIELD, FIELD_SIZE[size]].join(' '), className).trim();
 }

--- a/desktop/src/renderer/components/ui/index.ts
+++ b/desktop/src/renderer/components/ui/index.ts
@@ -19,8 +19,11 @@ export type { CloseButtonProps } from './CloseButton';
 export { Toggle } from './Toggle';
 export type { ToggleProps, ToggleTone } from './Toggle';
 
-export { FIELD, FIELD_SIZE, fieldClasses } from './field';
+export { FIELD, FIELD_SURFACE, FIELD_TEXT, FIELD_SIZE, fieldClasses } from './field';
 export type { FieldSize } from './field';
+
+export { InputGroup } from './InputGroup';
+export type { InputGroupProps, InputGroupFieldProps } from './InputGroup';
 
 export { TextInput } from './TextInput';
 export type { TextInputProps } from './TextInput';

--- a/desktop/src/renderer/index.tsx
+++ b/desktop/src/renderer/index.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/globals.css';
 import App from './App';
+import { Button, TextInput } from './components/ui';
 
 // Apply theme before React mounts to prevent FOUC (flash of unstyled content)
 const storedTheme = localStorage.getItem('youcoded-theme') || 'midnight';
@@ -68,20 +69,29 @@ function LoginScreen({ onLogin }: { onLogin: (password: string) => Promise<void>
     <div className="flex items-center justify-center h-full bg-panel text-fg">
       <form onSubmit={handleSubmit} className="flex flex-col gap-3 w-72">
         <h1 className="text-xl font-bold text-center mb-2">YouCoded Remote</h1>
-        <input
+        {/* Was a hand-rolled field with gray focus (`focus:border-fg-muted`) — the
+            exact paradigm change 20 retires. Fields focus by accent border now. */}
+        <TextInput
           type="password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="px-3 py-2 rounded-sm bg-inset border border-edge text-sm focus:outline-none focus:border-fg-muted"
           autoFocus
           disabled={loading}
         />
-        <button type="submit" disabled={loading} className="px-3 py-2 rounded-sm bg-blue-600 hover:bg-blue-500 text-sm font-medium disabled:opacity-50">
+        {/* Was `bg-blue-600 hover:bg-blue-500` — a hardcoded blue that ignored the
+            theme entirely. The button sweep missed this file because the remote
+            login screen lives in index.tsx, not components/. The button stays
+            BELOW the field rather than inside it (change 77): this is a stacked
+            submit form, not a field with an inline action. */}
+        <Button type="submit" disabled={loading} size="lg" className="justify-center">
           {loading ? 'Connecting...' : 'Connect'}
-        </button>
+        </Button>
+        {/* Error text was `text-red-400`. Same pixel today (the app remaps
+            red-400 to #DD4444), but the token is what community packs can
+            restyle. */}
         {error && (
-          <p className="text-red-400 text-xs text-center">{error}</p>
+          <p className="text-destructive text-xs text-center">{error}</p>
         )}
       </form>
     </div>

--- a/desktop/tests/ui-primitives.test.tsx
+++ b/desktop/tests/ui-primitives.test.tsx
@@ -24,7 +24,8 @@ import { SegmentedTabs } from '../src/renderer/components/ui/SegmentedTabs';
 import { ProgressBar } from '../src/renderer/components/ui/ProgressBar';
 import { Toast } from '../src/renderer/components/ui/Toast';
 import { LoadingState, EmptyState, ErrorState, FieldError } from '../src/renderer/components/ui/states';
-import { FIELD } from '../src/renderer/components/ui/field';
+import { FIELD, FIELD_SURFACE } from '../src/renderer/components/ui/field';
+import { InputGroup } from '../src/renderer/components/ui/InputGroup';
 
 // jsdom does not implement scrollIntoView. Select uses it to bring the current
 // value into view when a long catalog opens; every real browser and the Android
@@ -328,6 +329,93 @@ describe('field surface', () => {
   it('Textarea can opt back into resizing', () => {
     const { container } = render(<Textarea resizable />);
     expect(container.querySelector('textarea')!.className).not.toContain('resize-none');
+  });
+});
+
+describe('InputGroup (change 77 — the action goes inside the field)', () => {
+  it('moves the focus state to the wrapper', () => {
+    // The whole reason this is a primitive and not a className: the input inside
+    // is borderless, so `focus:border-accent` on it would paint nothing. If this
+    // assertion ever fails, focusing one of these fields shows NO focus state.
+    const { container } = render(
+      <InputGroup>
+        <InputGroup.Field />
+      </InputGroup>,
+    );
+    const wrapper = container.firstElementChild!;
+    expect(wrapper.className).toContain('focus-within:border-accent');
+    expect(wrapper.className).toContain('border-edge-dim');
+  });
+
+  it('gives the wrapper the surface and the input none of it', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroup.Field />
+      </InputGroup>,
+    );
+    const wrapper = container.firstElementChild!;
+    const input = container.querySelector('input')!;
+
+    expect(wrapper.className).toContain('bg-inset');
+    // The input must stay bare or you get a border inside a border.
+    expect(input.className).toContain('bg-transparent');
+    expect(input.className).toContain('border-0');
+    expect(input.className).not.toContain('bg-inset');
+  });
+
+  it('passes its size down to the field without prop drilling', () => {
+    const { container } = render(
+      <InputGroup size="sm">
+        <InputGroup.Field />
+      </InputGroup>,
+    );
+    // sm padding, from FIELD_SIZE — same scale as every other field.
+    expect(container.querySelector('input')!.className).toContain('px-2.5');
+  });
+
+  it('lets a field override the inherited size', () => {
+    const { container } = render(
+      <InputGroup size="sm">
+        <InputGroup.Field size="md" />
+      </InputGroup>,
+    );
+    expect(container.querySelector('input')!.className).toContain('px-3');
+  });
+
+  it('keeps the native input type', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroup.Field type="password" />
+      </InputGroup>,
+    );
+    expect(container.querySelector('input')!).toHaveAttribute('type', 'password');
+  });
+
+  it('lets a caller override a field size deterministically', () => {
+    // fieldClasses goes through mergeClasses for the same reason buttonClasses
+    // does — Tailwind resolves competing utilities by CSS source order, so plain
+    // concatenation left the winner up to emission order. If this regresses, a
+    // caller passing text-sm/px-4 gets a coin flip, not an override.
+    const { container } = render(<TextInput size="md" className="text-sm px-4" />);
+    const cls = container.querySelector('input')!.className;
+    expect(cls).toContain('text-sm');
+    expect(cls).toContain('px-4');
+    expect(cls).not.toContain('text-xs');
+    expect(cls).not.toContain('px-3');
+  });
+
+  it('keeps non-conflicting base classes when overriding', () => {
+    const { container } = render(<TextInput className="text-sm" />);
+    const cls = container.querySelector('input')!.className;
+    // Colors and the focus rule are a different group — they must survive.
+    expect(cls).toContain('bg-inset');
+    expect(cls).toContain('focus:border-accent');
+  });
+
+  it('shares one surface definition with the plain field', () => {
+    // FIELD_SURFACE is split out of FIELD precisely so a bordered field and a
+    // grouped one can't drift apart. Pin that they still agree.
+    expect(FIELD).toContain(FIELD_SURFACE);
   });
 });
 


### PR DESCRIPTION
Completes tranche 2 of the UI consistency spec. The button half shipped in #181; this is toggles, text fields, dropdowns, and the new inside-field action pattern.

Changes **15–17, 19–21, 42, 77**. 42 files, 2668 tests green.

## New primitive: `InputGroup` (change 77)

Destin's rule: *"for all text fields that have a submit/copy, I like the button to be inside the field instead of alongside it."*

This could not be a `className` on `TextInput`. The plain `FIELD` puts the border **and** `focus:border-accent` on the `<input>` itself — move the border to a wrapper and the input goes bare, and that focus rule paints nothing. The wrapper takes `focus-within:border-accent` instead. `FIELD_SURFACE` is split out of `FIELD` so a bordered field and a grouped one can't drift apart, pinned by a test.

Applied to 9 sites. `MarketplaceFilterBar` already implemented this shape by hand and was the precedent; it now uses the primitive.

## A latent bug fixed along the way

`fieldClasses` concatenated its `className` instead of merging it, while `buttonClasses` has used `mergeClasses` since tranche 0. Tailwind resolves competing utilities by **CSS source order**, not class-attribute order — so a caller passing `text-sm` or `px-4` got whichever Tailwind emitted later, not an override. This is exactly what made tranche 0's pills silently render as rounded rectangles (§10.3). Fields carried the same bug until now.

## Behavior changes, not just appearance

- **~20 toggles gained an accessible name.** Most were bare `<button>`s inside a `<label>` — which names nothing, because a `<label>` can't name a button. Several announced as `aria-pressed` rather than `role="switch"`.
- **Four `<label>` wrappers became `<div>` + `aria-label`** where they wrapped a `Select` trigger, for the same reason.
- **`PerformancePopup`'s GPU control announced as a switch but rendered a 16×16 square.** Now a real toggle; its row wrapper became a `div` since a button can't nest a button, with a guard so a click on the toggle doesn't fire the handler twice.
- **Four `text-sm` fields became `text-xs`** — the approved field scale is 12/11px, and 14px was off-scale. This is a visible shrink on two marketplace search boxes; flagged for eyeball review.
- **A sync toggle's `cursor-wait` became `cursor-not-allowed`** during provisioning. Semantically slightly worse (busy ≠ forbidden) but the primitive's disabled variant wins the cascade.

## Deliberately not migrated

- **`SessionDrawer`'s sort `<select>`** — folds into `FileFilterPopover` under change 38.
- **Change 78 (folder picker → dropdown) is deferred**, with reasoning in spec §11.10. `projectFolder` is a single string and there is no recents list anywhere in the app, so a `Select` would need a new settings key, IPC, a cap and an eviction policy. That's a feature, not a migration — the only item in this tranche that would grow scope.
- **Three spec-listed InputGroup sites don't exist in that shape.** QuickChips is a two-field form with a footer (`addCustom` requires both fields); the add-provider and Android add-device submits sit below three and four fields respectively; `LocalModelsSection` has no endpoint field at all. All verified in code, not assumed. Spec corrections recorded.
- **`CommandDrawer`'s search** is a mode-switching composite (the input swaps for a read-only mirror `<span>`), and its trailing buttons are navigation. Needs a design call, not a sweep.
- **`AccountSection`'s delete-confirm input** keeps `focus:border-red-500` as a deliberate danger-zone signal.
- Radios, checkboxes, ranges, and color inputs — different changes.

## Found outside the sweep

`index.tsx` — the remote-access login screen — still had a hardcoded `bg-blue-600` button and a `focus:border-fg-muted` password field. The button half missed it because that sweep covered `components/`, not the renderer root. That was the last hardcoded blue.

## Latent bugs found and left alone (roadmap material)

- Sync wizard: two text inputs nested inside a radio's `<label>`, so clicking the field can re-trigger the radio.
- `ProjectView`'s search pill focuses to `border-edge-dim` over a resting `border-edge` — a focus state with *less* contrast than resting.
- `LocalModelsSection.PartialRow.resume()` silently no-ops when Hugging Face is unreachable; every sibling in that file has an explicit error line.
- `RatingSubmitModal.handleInstallAndRate` discards the caught error and reports a hardcoded "Network error — try again", which `docs/error-message-standards.md` forbids. `handleSubmit` directly above it does it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)