### PR TITLE
themes: let a theme control its scanline intensity

### DIFF
--- a/desktop/src/renderer/themes/theme-engine.ts
+++ b/desktop/src/renderer/themes/theme-engine.ts
@@ -102,17 +102,19 @@ const LEGACY_EFFECT_IDS = ['effect-vignette', 'effect-noise', 'effect-scanlines'
 
 /** Builds a single consolidated overlay div with combined backgrounds for all effects.
  *  Reduces compositor layers from 3 to 1 compared to the previous per-effect divs. */
-function applyEffects(effects: ThemeEffects | undefined): void {
-  // Remove any legacy per-effect divs from previous theme applications
-  for (const id of LEGACY_EFFECT_IDS) document.getElementById(id)?.remove();
-
-  if (!effects) {
-    document.getElementById(EFFECTS_OVERLAY_ID)?.remove();
-    return;
-  }
-
+/**
+ * The pure half of applyEffects: which background layers an effects block
+ * produces, and at what size. Exported so the layer STRINGS can be pinned by a
+ * test — applyEffects itself only exists to poke the DOM, and the scanline
+ * alpha silently drifted out of sync with the theme-builder preview precisely
+ * because nothing could assert on it.
+ */
+export function buildEffectLayers(
+  effects: ThemeEffects | undefined,
+): { backgrounds: string[]; sizes: string[] } {
   const backgrounds: string[] = [];
   const sizes: string[] = [];
+  if (!effects) return { backgrounds, sizes };
 
   // Vignette — opacity baked into radial gradient endpoint
   const vignetteVal = effects.vignette ?? 0;
@@ -121,9 +123,25 @@ function applyEffects(effects: ThemeEffects | undefined): void {
     sizes.push('100% 100%');
   }
 
-  // Scanlines — opacity baked into gradient colors (0.08 base * line alpha)
+  // Scanlines — line alpha is (theme base opacity x 0.15 line alpha).
+  //
+  // Fix: read --scanline-opacity instead of baking the product as the literal
+  // 0.012. `scan-lines` is a bare boolean in ThemeEffects — unlike vignette and
+  // noise, which are numeric intensities interpolated around it — so a theme had
+  // no way to say how strong its scanlines should be. The theme-builder Kit
+  // ships an intensity slider that writes `:root { --scanline-opacity: N }` into
+  // custom_css; because this rule contained no var() at all, that slider visibly
+  // worked in the Kit preview and did nothing in the shipped theme.
+  //
+  // The 0.08 fallback reproduces the previous literal exactly (0.08 * 0.15 =
+  // 0.012), so every existing theme renders unchanged. Custom properties resolve
+  // at computed-value time, so it does not matter that custom_css is injected
+  // before this runs, nor that this ends up in an inline style.
   if (effects['scan-lines']) {
-    backgrounds.push('repeating-linear-gradient(0deg, transparent, transparent 1px, rgba(0,0,0,0.012) 1px, rgba(0,0,0,0.012) 2px)');
+    const lineAlpha = 'calc(var(--scanline-opacity, 0.08) * 0.15)';
+    backgrounds.push(
+      `repeating-linear-gradient(0deg, transparent, transparent 1px, rgb(0 0 0 / ${lineAlpha}) 1px, rgb(0 0 0 / ${lineAlpha}) 2px)`,
+    );
     sizes.push('100% 100%');
   }
 
@@ -134,6 +152,15 @@ function applyEffects(effects: ThemeEffects | undefined): void {
     backgrounds.push(`url("${noiseSvg}")`);
     sizes.push('200px 200px');
   }
+
+  return { backgrounds, sizes };
+}
+
+function applyEffects(effects: ThemeEffects | undefined): void {
+  // Remove any legacy per-effect divs from previous theme applications
+  for (const id of LEGACY_EFFECT_IDS) document.getElementById(id)?.remove();
+
+  const { backgrounds, sizes } = buildEffectLayers(effects);
 
   if (backgrounds.length === 0) {
     document.getElementById(EFFECTS_OVERLAY_ID)?.remove();

--- a/desktop/tests/theme-engine.test.ts
+++ b/desktop/tests/theme-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTokenCSS, buildShapeCSS, buildBackgroundStyle, buildLayoutAttrs, buildPatternStyle, computeOverlayTokens } from '../src/renderer/themes/theme-engine';
+import { buildTokenCSS, buildShapeCSS, buildBackgroundStyle, buildLayoutAttrs, buildPatternStyle, computeOverlayTokens, buildEffectLayers } from '../src/renderer/themes/theme-engine';
 
 const TOKENS = {
   canvas: '#0D0F1A', panel: '#141726', inset: '#1F2440', well: '#0D0F1A',
@@ -175,5 +175,55 @@ describe('computeOverlayTokens — --link / --link-hover', () => {
     // Rule 15: nothing a component consumes may fall back to :root.
     expect(derive(TOKENS)['--link']).toBeTruthy();
     expect(derive(TOKENS)['--link-hover']).toBeTruthy();
+  });
+});
+
+describe('buildEffectLayers', () => {
+  // A theme's scanline strength has to reach the shipped theme. `scan-lines` is
+  // a bare boolean, so the only channel is a CSS custom property set from
+  // custom_css — which is exactly what the theme-builder Kit's intensity slider
+  // writes. When this rule baked its alpha as the literal 0.012, the slider
+  // worked in the Kit preview and silently did nothing in the real app. A
+  // literal here would regress that invisibly, so pin the var.
+  it('drives scanline alpha from --scanline-opacity, not a literal', () => {
+    const { backgrounds } = buildEffectLayers({ 'scan-lines': true });
+    expect(backgrounds).toHaveLength(1);
+    expect(backgrounds[0]).toContain('var(--scanline-opacity');
+    expect(backgrounds[0]).not.toMatch(/rgba?\(0,\s*0,\s*0,\s*0\.012\)/);
+  });
+
+  it('falls back to the historical 0.08 base, so existing themes are unchanged', () => {
+    // 0.08 * 0.15 == 0.012, the literal this replaced.
+    const { backgrounds } = buildEffectLayers({ 'scan-lines': true });
+    expect(backgrounds[0]).toContain('calc(var(--scanline-opacity, 0.08) * 0.15)');
+  });
+
+  it('emits nothing when no effect is enabled', () => {
+    expect(buildEffectLayers(undefined)).toEqual({ backgrounds: [], sizes: [] });
+    expect(buildEffectLayers({}).backgrounds).toHaveLength(0);
+    expect(buildEffectLayers({ 'scan-lines': false }).backgrounds).toHaveLength(0);
+    expect(buildEffectLayers({ vignette: 0, noise: 0 }).backgrounds).toHaveLength(0);
+  });
+
+  it('interpolates vignette and noise intensities', () => {
+    const { backgrounds, sizes } = buildEffectLayers({ vignette: 0.3, noise: 0.05 });
+    expect(backgrounds[0]).toContain('rgba(0,0,0,0.3)');
+    expect(backgrounds[1]).toContain("opacity='0.05'");
+    expect(sizes).toEqual(['100% 100%', '200px 200px']);
+  });
+
+  it('keeps backgrounds and sizes index-aligned across every combination', () => {
+    // They are joined into two parallel CSS lists; a length mismatch would
+    // silently shift every layer's background-size onto the wrong layer.
+    const combos = [
+      { vignette: 0.2 },
+      { 'scan-lines': true },
+      { noise: 0.1 },
+      { vignette: 0.2, 'scan-lines': true, noise: 0.1 },
+    ];
+    for (const c of combos) {
+      const { backgrounds, sizes } = buildEffectLayers(c);
+      expect(sizes).toHaveLength(backgrounds.length);
+    }
   });
 });


### PR DESCRIPTION
Found while reviewing the `/theme-builder` skill end to end (wecoded-marketplace #47-#49).

## The problem

`scan-lines` is a bare boolean in `ThemeEffects` — unlike `vignette` and `noise`, which are numeric intensities interpolated into their layers. So a theme had no way to say how strong its scanlines should be, and `applyEffects` baked the alpha as the literal `rgba(0,0,0,0.012)`.

The theme-builder Kit ships a scanline intensity slider. With no manifest field to write to, it emits `:root { --scanline-opacity: N }` into the theme's `custom_css` — which nothing read, because the rule contained no `var()` at all.

**So the slider visibly worked in the Kit preview and silently did nothing in the shipped theme.** That's the worst version of the bug: the user watches the control respond, and then gets none of it.

## The fix

```diff
-backgrounds.push('repeating-linear-gradient(0deg, transparent, transparent 1px, rgba(0,0,0,0.012) 1px, rgba(0,0,0,0.012) 2px)');
+const lineAlpha = 'calc(var(--scanline-opacity, 0.08) * 0.15)';
+backgrounds.push(
+  `repeating-linear-gradient(0deg, transparent, transparent 1px, rgb(0 0 0 / ${lineAlpha}) 1px, rgb(0 0 0 / ${lineAlpha}) 2px)`,
+);
```

`0.08 * 0.15 = 0.012`, the literal it replaces, so **every existing theme renders unchanged**. Custom properties resolve at computed-value time, so it doesn't matter that `custom_css` is injected before `applyEffects` runs, nor that this ends up in an inline style.

## Why there's a refactor attached

`applyEffects` was module-private and untested — it poked the DOM and returned nothing. That's exactly why this alpha could drift out of sync with the theme-builder preview unnoticed. Its pure half is now `buildEffectLayers()`, and the tests pin:

- the scanline layer references `--scanline-opacity` (not a literal)
- the fallback still matches the historical `0.012`
- `backgrounds` and `sizes` stay index-aligned — they're joined into two parallel CSS lists, so a length mismatch would shift every layer's `background-size` onto the wrong layer

Confirmed 2 tests fail when the literal is restored.

## Verification

Full desktop suite: **2681 passed, 39 skipped**. Typecheck clean.

Once this ships, the Kit's intensity slider takes effect in built themes with no change needed on the skill side — it already writes the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)