### PR TITLE
fix(status): native sessions show their real model, not "Model Unknown"

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import HeaderBar from './components/HeaderBar';
 import InputBar, { type InputBarHandle } from './components/InputBar';
 import StatusBar from './components/StatusBar';
 import { MODELS, type ModelAlias } from './components/StatusBar';
+import { modelChipFor, supportsAliasCycling } from './components/model-chip';
 import FolderSwitcher from './components/FolderSwitcher';
 
 // Labels for the welcome-screen model picker (mirrors SessionStrip)
@@ -1776,6 +1777,10 @@ function AppInner() {
   const cycleModelRef = useRef<(() => void) | null>(null);
   const cycleModel = useCallback(() => {
     if (!sessionId) return;
+    // Native sessions can't cycle CC aliases — see supportsAliasCycling for the
+    // failure this prevents (a chip relabeled to a model the session isn't
+    // running, plus a stray write to the global model preference).
+    if (!supportsAliasCycling(sessions.find((s) => s.id === sessionId))) return;
     // currentModel may be 'unknown' — indexOf then legitimately returns -1,
     // which wraps to index 0 below, so cycling from an unknown state starts fresh.
     const idx = MODELS.indexOf(currentModel as ModelAlias);
@@ -1793,7 +1798,7 @@ function AppInner() {
     // verification is just a safety net. If verification later shows a
     // mismatch, the failure handler overwrites with the actual model.
     (window.claude as any).model?.setPreference(next);
-  }, [currentModel, sessionId, guardedPtySend]);
+  }, [currentModel, sessionId, guardedPtySend, sessions]);
   cycleModelRef.current = cycleModel;
 
   useEffect(() => {
@@ -2341,6 +2346,9 @@ function AppInner() {
   // Native sessions: permission modes are a harness policy (Phase 2), not a
   // PTY shift+tab cycle — hide the badge + cycle affordance for them.
   const isNativeSession = currentSession?.provider === 'native';
+  // What the StatusBar model chip renders — see model-chip.ts for why native
+  // sessions bypass the Claude Code alias matcher entirely.
+  const modelChip = modelChipFor(currentSession, currentModel);
   // A session with no map entry at all (a gap in the seeding paths above) reads
   // as 'unknown', not 'normal' — 'normal' would claim a specific, possibly wrong
   // permission posture instead of admitting YouCoded hasn't determined it yet.
@@ -2731,7 +2739,7 @@ function AppInner() {
                     if (!guardedPtySend(sessionId, '/sync\r')) return;
                     dispatch({ type: 'USER_PROMPT', sessionId, content: '/sync', timestamp: Date.now() });
                   } : undefined}
-                  model={currentModel}
+                  model={modelChip}
                   onCycleModel={cycleModel}
                   permissionMode={isNativeSession ? currentNativeMode : currentPermissionMode}
                   onCyclePermission={isNativeSession ? cycleNativePermission : cyclePermission}

--- a/desktop/src/renderer/components/StatusBar.tsx
+++ b/desktop/src/renderer/components/StatusBar.tsx
@@ -71,6 +71,38 @@ const MODEL_DISPLAY: Record<ModelAlias | 'unknown', { label: string; color: stri
   unknown:     { label: 'Model Unknown', color: '#DD4444', bg: 'rgba(221,68,68,0.15)', border: 'rgba(221,68,68,0.3)' },
 };
 
+/**
+ * What the model chip should render. A display-only union — see the `model`
+ * prop comment for why native models are NOT folded into ModelAlias.
+ *  - 'alias'   Claude Code session on a recognized model
+ *  - 'native'  native-runtime session; label is a prettified SessionInfo.model
+ *  - 'unknown' Claude Code session whose model couldn't be confirmed (error)
+ */
+export type ModelChip =
+  | { kind: 'alias'; alias: ModelAlias }
+  | { kind: 'native'; label: string; modelId: string }
+  | { kind: 'unknown' };
+
+/**
+ * Native chip color. `--tag-blue` is the one slot in the tag palette that
+ * collides with nothing else in this bar: gray/indigo/teal/fuchsia are the four
+ * CC aliases (teal is Haiku), red is both Unknown chips, and --accent/amber/
+ * salmon are permission modes. Themeable per the tag system rather than a fifth
+ * hardcoded hex; the fill/border formula is TagChip.tsx's, so native model chips
+ * and session tags read as one family.
+ */
+/** MODEL_DISPLAY row for the two Claude Code chip states. */
+function ccChipDisplay(model: Exclude<ModelChip, { kind: 'native' }>) {
+  return MODEL_DISPLAY[model.kind === 'unknown' ? 'unknown' : model.alias];
+}
+
+const NATIVE_CHIP = 'var(--tag-blue)';
+const nativeChipStyle = {
+  color: NATIVE_CHIP,
+  backgroundColor: `color-mix(in srgb, ${NATIVE_CHIP} 16%, transparent)`,
+  borderColor: `color-mix(in srgb, ${NATIVE_CHIP} 35%, transparent)`,
+};
+
 // Amber (#F2B33D) for AUTO matches CC's own banner color and visually sits
 // between 'auto-accept' (theme accent, mostly safe) and 'bypass' (salmon, no
 // safety checks) — increasing autonomy = warmer color.
@@ -159,11 +191,19 @@ interface Props {
   statusData: StatusData;
   onRunSync?: () => void;
   onOpenSync?: () => void;
-  // 'unknown' renders a distinct error-styled chip — App.tsx passes it whenever
-  // it can't confidently determine the session's real model/mode (unrecognized
-  // model id, missing/invalid data on resume or reconnect) instead of silently
-  // guessing a default, which would misrepresent what's actually running.
-  model?: ModelAlias | 'unknown';
+  // Display-only view of the session's model. 'unknown' renders a distinct
+  // error-styled chip — App.tsx passes it whenever it can't confidently
+  // determine a CLAUDE CODE session's real model (unrecognized model id,
+  // missing/invalid data on resume or reconnect) instead of silently guessing a
+  // default, which would misrepresent what's actually running.
+  //
+  // Native-runtime sessions never reach 'unknown': their bound model id is
+  // authoritative on SessionInfo.model, so App passes {kind:'native'} with a
+  // label. Keeping this a display-only union (rather than widening ModelAlias)
+  // is deliberate — ModelAlias also drives cycleModel, the `auto` permission
+  // gate, and the persisted model preference, none of which a third-party
+  // model id may leak into.
+  model?: ModelChip;
   onCycleModel?: () => void;
   // CC sessions pass a PermissionMode; native sessions pass a NativePermissionMode.
   // The chip renders identically for both — only the value + cycle handler differ.
@@ -679,28 +719,45 @@ export default function StatusBar({
     <div className="status-bar flex flex-wrap items-center gap-x-2 gap-y-1 px-2 sm:px-3 py-1 text-[10px] text-fg-muted">
       {/* Combined model + effort pill — clicking opens the full picker (same as /effort).
          Shift+Space still cycles models via the keyboard shortcut in App.tsx. */}
-      {model && (
+      {model && (model.kind === 'native' ? (
+        // Native runtime: the bound model id IS the truth, so this chip never
+        // shows an error state. The full id goes in the title because the label
+        // is a best-effort prettification (and CSS-truncated when long).
+        <button
+          onClick={onOpenModelPicker}
+          className="flex items-center px-1.5 py-0.5 rounded-sm border cursor-pointer hover:brightness-125 transition-colors max-w-[14rem] truncate"
+          style={nativeChipStyle}
+          title={`${model.modelId} — click to change model`}
+        >
+          {/* No effort segment: /effort and MAX_EFFORT_MODELS are Claude Code
+              concepts the native harness doesn't implement.
+              min-w-0 is load-bearing: a flex child defaults to min-width:auto
+              and won't shrink below its content, so `truncate` alone would let
+              a long GGUF name blow past the button's max-w instead of eliding. */}
+          <span className="truncate min-w-0">{model.label}</span>
+        </button>
+      ) : (
         <button
           onClick={onOpenModelPicker}
           className="flex items-center gap-1.5 px-1.5 py-0.5 rounded-sm border cursor-pointer hover:brightness-125 transition-colors"
           style={{
-            backgroundColor: MODEL_DISPLAY[model].bg,
-            color: MODEL_DISPLAY[model].color,
-            borderColor: MODEL_DISPLAY[model].border,
+            backgroundColor: ccChipDisplay(model).bg,
+            color: ccChipDisplay(model).color,
+            borderColor: ccChipDisplay(model).border,
           }}
-          title={model === 'unknown'
+          title={model.kind === 'unknown'
             ? "YouCoded couldn't confirm which model this session is using — click to set one explicitly"
             : 'Click to change model and effort (Shift+Space cycles model)'}
         >
-          <span>{MODEL_DISPLAY[model].label}</span>
-          {model !== 'unknown' && (
+          <span>{ccChipDisplay(model).label}</span>
+          {model.kind !== 'unknown' && (
             <>
               <span className="opacity-40">|</span>
               <span className="capitalize">{effort || 'auto'} Effort</span>
             </>
           )}
         </button>
-      )}
+      ))}
 
       {/* Fast mode chip — only rendered when on. Click opens the ModelPickerPopup. */}
       {fast && (

--- a/desktop/src/renderer/components/model-chip.ts
+++ b/desktop/src/renderer/components/model-chip.ts
@@ -1,0 +1,53 @@
+// src/renderer/components/model-chip.ts
+//
+// Pure derivation of the StatusBar model chip + the "may this session cycle CC
+// aliases?" predicate. Extracted from AppInner so both are testable without
+// rendering App, and so the native/Claude Code split lives in ONE place rather
+// than being re-derived at each consumer.
+import type { ModelAlias, ModelChip } from './StatusBar';
+import { nativeModelLabel } from './native-model-label';
+
+/** Minimal shape needed off SessionInfo — keeps this module free of IPC types. */
+export interface ModelChipSession {
+  provider?: string;
+  /** Native runtime: the bound provider model id. CC: the alias-ish model str. */
+  model?: string;
+}
+
+/**
+ * What the model chip should render for the active session.
+ *
+ * Native sessions read their bound model id straight off SessionInfo.model
+ * (authoritative, and kept live on every swap) instead of going through the
+ * Claude Code alias matcher — an OpenRouter slug or a local GGUF filename
+ * matches none of the four aliases, which is why every native session used to
+ * render the red "Model Unknown" error chip.
+ *
+ * Returns undefined when there is nothing honest to show: no session, or a
+ * native session whose binding hasn't landed yet (create in flight). A missing
+ * chip beats an error chip for a session that is merely new.
+ */
+export function modelChipFor(
+  session: ModelChipSession | undefined,
+  currentModel: ModelAlias | 'unknown',
+): ModelChip | undefined {
+  if (session?.provider === 'native') {
+    if (!session.model) return undefined;
+    return { kind: 'native', label: nativeModelLabel(session.model), modelId: session.model };
+  }
+  return currentModel === 'unknown' ? { kind: 'unknown' } : { kind: 'alias', alias: currentModel };
+}
+
+/**
+ * Whether Shift+Space / the alias cycle may act on this session.
+ *
+ * False for native sessions: they have no PTY, so `/model <alias>\r` goes
+ * nowhere (SessionManager.sendInput returns false for a worker-less session, and
+ * guardedPtySend discards that return value). Without this gate the cycle fell
+ * through to its optimistic writes and relabeled the chip with an alias the
+ * session is not running, while also writing that alias to the GLOBAL model
+ * preference. Native model changes go through native.setBinding in the picker.
+ */
+export function supportsAliasCycling(session: ModelChipSession | undefined): boolean {
+  return session?.provider !== 'native';
+}

--- a/desktop/src/renderer/components/native-model-label.ts
+++ b/desktop/src/renderer/components/native-model-label.ts
@@ -1,0 +1,97 @@
+// src/renderer/components/native-model-label.ts
+//
+// Turns a native-runtime model id into a short human label for the StatusBar
+// model chip. Native sessions bind to arbitrary provider model ids (OpenRouter
+// slugs, models.dev ids, local GGUF filenames, or whatever a user typed into an
+// openai-compatible endpoint), so there is no fixed alias list to match against
+// the way Claude Code sessions have (StatusBar's MODELS).
+//
+// Why a local heuristic instead of the picker's catalog labels: ModelCatalog is
+// network-backed (OpenRouter /api/v1/models + models.dev) behind a TTL'd disk
+// cache, it's async, it returns [] when no provider keys are set, and it has NO
+// rows at all for openai-compatible custom endpoints (the user types the id by
+// hand). A status chip that goes blank offline — or permanently blank on a
+// custom endpoint — is worse than an approximate label. The exact catalog label
+// stays where an async fetch and an empty state are already handled: the picker.
+//
+// The label is best-effort by design. Every caller MUST also surface the raw id
+// (the chip puts it in `title`), so an imperfect prettification is never lossy.
+
+/**
+ * Quantization / precision suffix on local GGUF builds — noise in a chip.
+ *
+ * Matched against the WHOLE trailing suffix rather than a post-split token,
+ * because quant tags carry their own `_` separators (`Q4_K_M`) and splitting
+ * first shreds them into `Q4`/`K`/`M`, which no per-token pattern can recognize.
+ * The leading `(?:^|[-_])` lets an id that is ONLY a quant tag match too.
+ */
+const QUANT_SUFFIX = /(?:^|[-_])(?:I?Q\d+(?:_[A-Z0-9]+)*|[BF]F?16|F32|FP\d+)$/i;
+
+/** Format tags that DO survive as standalone tokens after splitting. */
+const FORMAT_TOKEN = /^(?:GGUF|MLX)$/i;
+
+/** Weight-file extensions to drop before splitting. */
+const EXT = /\.(?:gguf|bin|safetensors|pt|pth)$/i;
+
+/** Tokens that should render upper-case rather than title-case. */
+const ACRONYMS = new Set(['gpt', 'ai', 'llm', 'moe', 'vl', 'r1', 'qwq', 'sdk', 'oss']);
+
+/**
+ * Vendor words that add nothing once the chip is already scoped to a model.
+ * `claude-sonnet-5` → "Sonnet 5", matching how the Claude Code chip renders a
+ * bare "Sonnet". Only stripped in LEADING position, so a model genuinely named
+ * e.g. `foo-claude` keeps it.
+ */
+const LEADING_NOISE = new Set(['claude', 'models', 'model']);
+
+/** Title-case one token, preserving anything that already carries case/digits
+ *  (`30B`, `A3B`, `Qwen3`, `4.5`) — lowercasing those reads as a typo. */
+function titleToken(tok: string): string {
+  if (ACRONYMS.has(tok.toLowerCase())) return tok.toUpperCase();
+  // Already mixed-case or contains a digit → the author's casing is intentional.
+  if (/[A-Z]/.test(tok) || /\d/.test(tok)) {
+    // Bare lowercase-with-digits (`gemini3`) still wants a capital.
+    return /^[a-z]/.test(tok) ? tok[0].toUpperCase() + tok.slice(1) : tok;
+  }
+  return tok[0].toUpperCase() + tok.slice(1);
+}
+
+/**
+ * `anthropic/claude-sonnet-5` → `Sonnet 5`
+ * `Qwen3-30B-A3B-Q4_K_M.gguf` → `Qwen3 30B A3B`
+ *
+ * Returns '' only for an empty/whitespace id — callers treat that as "no model
+ * bound" rather than rendering an empty chip.
+ */
+export function nativeModelLabel(modelId: string | undefined | null): string {
+  if (!modelId) return '';
+
+  // 1. Drop the vendor/org prefix: OpenRouter ids are `org/model`, and a local
+  //    path-like id may carry several segments. The last one is the model.
+  const tail = modelId.split('/').filter(Boolean).pop() ?? '';
+  if (!tail) return '';
+
+  // 2. Drop a weight-file extension.
+  const bare = tail.replace(EXT, '');
+
+  // 3. Strip the quantization suffix BEFORE splitting — see QUANT_SUFFIX. Loop
+  //    because stacked tags exist in the wild (`…-Q4_K_M-F16`).
+  let trimmed = bare;
+  for (;;) {
+    const next = trimmed.replace(QUANT_SUFFIX, '');
+    if (next === trimmed) break;
+    trimmed = next;
+  }
+
+  // 4. Split on both separators, then drop standalone format tags.
+  let tokens = trimmed.split(/[-_]+/).filter(Boolean).filter((t) => !FORMAT_TOKEN.test(t));
+
+  // 5. Strip leading vendor noise (only leading — see LEADING_NOISE).
+  while (tokens.length > 1 && LEADING_NOISE.has(tokens[0].toLowerCase())) tokens.shift();
+
+  // Everything was noise (e.g. a bare `Q4_K_M`) — fall back to the raw tail so
+  // the chip says SOMETHING recognizable rather than going blank.
+  if (tokens.length === 0) return bare;
+
+  return tokens.map(titleToken).join(' ');
+}

--- a/desktop/tests/model-chip.test.ts
+++ b/desktop/tests/model-chip.test.ts
@@ -1,0 +1,63 @@
+// desktop/tests/model-chip.test.ts
+import { describe, it, expect } from 'vitest';
+import { modelChipFor, supportsAliasCycling } from '../src/renderer/components/model-chip';
+
+const cc = (model?: string) => ({ provider: 'claude', model });
+const native = (model?: string) => ({ provider: 'native', model });
+
+describe('modelChipFor', () => {
+  // The bug this whole module exists for: every native session rendered the red
+  // "Model Unknown" error chip, because an OpenRouter/GGUF id matches none of
+  // the four Claude Code aliases and fell through to the 'unknown' sentinel.
+  it('renders a native session from its bound model id, never as unknown', () => {
+    expect(modelChipFor(native('anthropic/claude-sonnet-5'), 'unknown')).toEqual({
+      kind: 'native', label: 'Sonnet 5', modelId: 'anthropic/claude-sonnet-5',
+    });
+  });
+
+  it('keeps the raw id alongside the label so the chip can show it on hover', () => {
+    const chip = modelChipFor(native('Qwen3-30B-A3B-Q4_K_M.gguf'), 'unknown');
+    expect(chip).toEqual({ kind: 'native', label: 'Qwen3 30B A3B', modelId: 'Qwen3-30B-A3B-Q4_K_M.gguf' });
+  });
+
+  // A native session mid-create has no binding yet. That is not an error state,
+  // so it must not borrow the error chip.
+  it('renders no chip for a native session whose binding has not landed', () => {
+    expect(modelChipFor(native(undefined), 'unknown')).toBeUndefined();
+  });
+
+  it('ignores the CC alias entirely for native sessions', () => {
+    // currentModel is stale CC state; the native binding must win.
+    expect(modelChipFor(native('google/gemini-3-pro'), 'sonnet')).toEqual({
+      kind: 'native', label: 'Gemini 3 Pro', modelId: 'google/gemini-3-pro',
+    });
+  });
+
+  it('renders Claude Code sessions from the alias', () => {
+    expect(modelChipFor(cc('claude-sonnet-4-6'), 'sonnet')).toEqual({ kind: 'alias', alias: 'sonnet' });
+    expect(modelChipFor(cc(), 'opus[1m]')).toEqual({ kind: 'alias', alias: 'opus[1m]' });
+  });
+
+  // The error chip must SURVIVE for CC sessions — this fix narrows what counts
+  // as unknown, it does not delete the honest-error state.
+  it('still renders unknown for a Claude Code session whose model is unconfirmed', () => {
+    expect(modelChipFor(cc(), 'unknown')).toEqual({ kind: 'unknown' });
+    expect(modelChipFor(undefined, 'unknown')).toEqual({ kind: 'unknown' });
+  });
+});
+
+describe('supportsAliasCycling', () => {
+  // Regression: Shift+Space on a native session used to relabel the chip with a
+  // CC alias the session was not running (guardedPtySend discards sendInput's
+  // false return, so the optimistic writes ran anyway) and wrote that alias to
+  // the global model preference.
+  it('refuses native sessions', () => {
+    expect(supportsAliasCycling(native('anthropic/claude-sonnet-5'))).toBe(false);
+    expect(supportsAliasCycling(native(undefined))).toBe(false);
+  });
+
+  it('allows Claude Code sessions and an absent session', () => {
+    expect(supportsAliasCycling(cc('claude-sonnet-4-6'))).toBe(true);
+    expect(supportsAliasCycling(undefined)).toBe(true);
+  });
+});

--- a/desktop/tests/native-model-label.test.ts
+++ b/desktop/tests/native-model-label.test.ts
@@ -1,0 +1,51 @@
+// desktop/tests/native-model-label.test.ts
+import { describe, it, expect } from 'vitest';
+import { nativeModelLabel } from '../src/renderer/components/native-model-label';
+
+describe('nativeModelLabel', () => {
+  it('strips the vendor prefix and the redundant leading "claude"', () => {
+    expect(nativeModelLabel('anthropic/claude-sonnet-5')).toBe('Sonnet 5');
+    expect(nativeModelLabel('anthropic/claude-opus-4-8')).toBe('Opus 4 8');
+  });
+
+  it('title-cases plain hyphenated slugs', () => {
+    expect(nativeModelLabel('google/gemini-3-pro')).toBe('Gemini 3 Pro');
+    expect(nativeModelLabel('my-custom-endpoint-model')).toBe('My Custom Endpoint Model');
+  });
+
+  it('upper-cases known acronyms', () => {
+    expect(nativeModelLabel('openai/gpt-5.2')).toBe('GPT 5.2');
+    expect(nativeModelLabel('x-ai/grok-4.5')).toBe('Grok 4.5');
+  });
+
+  it('preserves author casing on tokens that already carry case or digits', () => {
+    expect(nativeModelLabel('Qwen3-30B-A3B')).toBe('Qwen3 30B A3B');
+    expect(nativeModelLabel('meta-llama/llama-4-70b-instruct')).toBe('Llama 4 70b Instruct');
+  });
+
+  it('drops weight-file extensions and quantization suffixes (local GGUF)', () => {
+    expect(nativeModelLabel('Qwen3-30B-A3B-Q4_K_M.gguf')).toBe('Qwen3 30B A3B');
+    expect(nativeModelLabel('mistral-7b-instruct-IQ4_XS.gguf')).toBe('Mistral 7b Instruct');
+    expect(nativeModelLabel('llama-3-8b-BF16.safetensors')).toBe('Llama 3 8b');
+  });
+
+  it('handles a local absolute-path-ish id by using the final segment', () => {
+    expect(nativeModelLabel('/models/local/phi-4-mini.gguf')).toBe('Phi 4 Mini');
+  });
+
+  // Guard the degenerate cases: the chip must never render blank for a bound
+  // model, because a blank chip is indistinguishable from "no session".
+  it('falls back to the bare tail when every token is noise', () => {
+    expect(nativeModelLabel('Q4_K_M.gguf')).toBe('Q4_K_M');
+  });
+
+  it('returns empty string only for a genuinely absent id', () => {
+    expect(nativeModelLabel(undefined)).toBe('');
+    expect(nativeModelLabel(null)).toBe('');
+    expect(nativeModelLabel('')).toBe('');
+  });
+
+  it('keeps a non-leading vendor word', () => {
+    expect(nativeModelLabel('foo-claude')).toBe('Foo Claude');
+  });
+});


### PR DESCRIPTION
## The bug

Every native-runtime session renders the red **"Model Unknown"** error chip, regardless of which model is actually bound. User-visible since `native.supported` flipped on in #160 (2026-07-16).

The chain, all four links intact on master:

1. `StatusBar.tsx:59` — `MODELS = ['haiku','sonnet','opus[1m]','fable']`, the four CC aliases.
2. `useActiveSessionModel.ts:54` — substring-matches the transcript model against only those. `anthropic/claude-sonnet-5` or a local GGUF name matches nothing → `null`.
3. `App.tsx:1909` — `if (!activeSessionModel) return;`, so `sessionModels` never gets an entry.
4. `App.tsx:415` — `?? 'unknown'` → `currentModel` is permanently `'unknown'`.

## The fix

Native sessions read `SessionInfo.model` instead of going through the CC alias matcher. It's authoritative and already kept live on every swap by `onNativeModelChanged` (`App.tsx:3039`) — `App.tsx:3036` already passes the same field to the picker, so **no new plumbing**.

I considered fixing `useActiveSessionModel` instead and rejected it: that hook reads `turn.model` off timeline entries, so it's empty until the first assistant turn lands, where `SessionInfo.model` is correct the moment the session exists.

## Also fixed: a worse adjacent bug

`cycleModel` (Shift+Space) had **no provider gate**, and the keyboard handler at `App.tsx:1804` fires it unconditionally. On a native session:

- `session-manager.ts:250` returns `false` (no worker), but **`guardedPtySend` discards `sendInput`'s return value** (`App.tsx:518-522`);
- so `if (!guardedPtySend(...)) return;` never bails, and execution reaches the optimistic writes;
- `indexOf('unknown')` → -1 → wraps to `MODELS[0]`, so the chip flips to a confident **"Haiku"** while the session runs an OpenRouter model;
- and `model.setPreference('haiku')` writes the **global** CC model preference.

A confidently wrong chip is worse than an honest error chip, so gating it belongs in this PR rather than after it.

## Notes for review

- **Why not the picker's catalog labels** (so the chip matches the picker exactly): `ModelCatalog` is network-backed (OpenRouter `/api/v1/models` + models.dev) behind a TTL'd disk cache, it's async, it returns `[]` with no provider keys, and it has **no rows at all** for `openai-compatible` custom endpoints (`model-catalog.ts:187` — the user types the id by hand). A status chip that goes blank offline or on a custom endpoint is worse than an approximate one. The label is best-effort and the **raw id always rides in the chip's `title`**.
- **`ModelChip` is display-only, not a widened `ModelAlias`.** `ModelAlias` also drives `cycleModel`, the `canAuto` gate (`App.tsx:2394`) and the persisted preference — a third-party model id must not leak into any of them.
- **Color is `var(--tag-blue)`** using TagChip's `color-mix` formula. It's the one tag slot colliding with nothing else in the bar — teal is Haiku, indigo is Opus, gray is Sonnet, fuchsia is Fable, red is both Unknown chips, and accent/amber/salmon are permission modes. Note this is a token where `MODEL_DISPLAY` uses raw hex per `desktop/CLAUDE.md`'s "status colors stay hardcoded" rule — but `PERMISSION_DISPLAY` directly below it already uses `var(--accent)`/`var(--fg-muted)`, so the file has been drifting token-ward already. Flagging rather than pretending the rule isn't there.
- **The error chip still works for CC sessions** — this narrows what counts as unknown, it doesn't delete the honest-error state. Pinned by a test.
- A native session **mid-create** (no binding yet) renders **no chip**, not an error chip.

## Out of scope, worth its own look

`guardedPtySend` silently discards `sendInput`'s `false` for **every** caller, not just this one. This PR gates the one caller where it caused a visible wrong state; the broader audit wants its own pass.

## Verification

- `tsc --noEmit` clean
- `vite build` clean
- Full suite: **2693 passed / 0 failed** (17 new)
- `npm run build` fails locally at electron-builder's rpm step (`Need executable 'rpmbuild'` — not installed on this machine); compilation and bundling both succeed, and CI's ubuntu runner packages it.

**Not yet eyeballed in a dev instance** — the chip's rendering (truncation on a long GGUF name, the blue against each theme) wants a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)