### PR TITLE
fix(chat): stop tool cards duplicating on transcript re-emit

### DIFF
--- a/desktop/src/renderer/state/__tests__/chat-reducer.test.ts
+++ b/desktop/src/renderer/state/__tests__/chat-reducer.test.ts
@@ -212,3 +212,87 @@ describe('chatReducer transcript replay dedup', () => {
     expect(state.get('sess-1')!.timeline.find((e) => e.kind === 'user')).toMatchObject({ pending: false });
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tool cards must not duplicate on re-emit. Unlike user/assistant text, the
+// watcher deliberately RE-EMITS tool-use for a repeated uuid (a rewritten CC
+// JSONL line may carry new tool_use blocks), so the reducer must absorb the
+// repeat structurally rather than by uuid — a uuid guard here would silently
+// swallow tools that arrive in a rewrite. See transcript-watcher.ts
+// readNewLines (~line 679).
+// ─────────────────────────────────────────────────────────────────────────
+describe('chatReducer tool card duplication', () => {
+  function initState(sessionId = 'sess-1'): ChatState {
+    return new Map([[sessionId, createSessionChatState()]]);
+  }
+
+  function cardCount(state: ChatState, toolUseId: string, sessionId = 'sess-1'): number {
+    // Count every rendered slot, not Map entries — AssistantTurnBubble maps
+    // group.toolIds → cards, so a doubled id is a doubled card on screen.
+    const groups = [...state.get(sessionId)!.toolGroups.values()];
+    return groups.flatMap((g) => g.toolIds).filter((id) => id === toolUseId).length;
+  }
+
+  const askAction = {
+    type: 'TRANSCRIPT_TOOL_USE' as const,
+    sessionId: 'sess-1',
+    uuid: 'line-uuid-1',
+    toolUseId: 'toolu_ask_1',
+    toolName: 'AskUserQuestion',
+    toolInput: { questions: [{ question: 'Which?', header: 'Pick', options: [] }] },
+  };
+
+  it('renders one card when the same tool_use is re-emitted (rewritten JSONL line)', () => {
+    let state = initState();
+    state = chatReducer(state, askAction);
+    state = chatReducer(state, askAction);
+    state = chatReducer(state, askAction);
+    expect(cardCount(state, 'toolu_ask_1')).toBe(1);
+  });
+
+  it('renders one card when a tool_use is re-emitted after the turn ended', () => {
+    // The stale-currentGroupId path: endTurn() clears currentGroupId, so a
+    // later re-emit used to mint a SECOND group + segment for the same tool.
+    let state = initState();
+    state = chatReducer(state, askAction);
+    state = chatReducer(state, {
+      type: 'TRANSCRIPT_TURN_COMPLETE', sessionId: 'sess-1', uuid: 'turn-1',
+    } as any);
+    state = chatReducer(state, askAction);
+    expect(cardCount(state, 'toolu_ask_1')).toBe(1);
+    expect(state.get('sess-1')!.toolGroups.size).toBe(1);
+  });
+
+  it('still renders a genuinely NEW tool that arrives in a rewritten line', () => {
+    // Guards against "fixing" this with a uuid guard: two different tools can
+    // share one line uuid when CC rewrites a growing assistant message.
+    let state = initState();
+    state = chatReducer(state, askAction);
+    state = chatReducer(state, {
+      ...askAction, toolUseId: 'toolu_bash_2', toolName: 'Bash',
+      toolInput: { command: 'ls' },
+    });
+    expect(cardCount(state, 'toolu_ask_1')).toBe(1);
+    expect(cardCount(state, 'toolu_bash_2')).toBe(1);
+  });
+
+  it('does not synthesize a second placeholder for a re-delivered requestId', () => {
+    // PERMISSION_REQUEST matches only 'running' tools, so a re-delivery after
+    // the tool flipped to awaiting-approval used to fall through and mint a
+    // duplicate perm-* card.
+    let state = initState();
+    state = chatReducer(state, askAction);
+    const perm = {
+      type: 'PERMISSION_REQUEST' as const,
+      sessionId: 'sess-1',
+      requestId: 'req-1',
+      toolName: 'AskUserQuestion',
+      input: askAction.toolInput,
+    };
+    state = chatReducer(state, perm as any);
+    state = chatReducer(state, perm as any);
+    expect(cardCount(state, 'toolu_ask_1')).toBe(1);
+    const synthetic = [...state.get('sess-1')!.toolCalls.keys()].filter((k) => k.startsWith('perm-'));
+    expect(synthetic).toHaveLength(0);
+  });
+});

--- a/desktop/src/renderer/state/chat-reducer.ts
+++ b/desktop/src/renderer/state/chat-reducer.ts
@@ -761,7 +761,26 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         );
       }
 
-      if (currentGroupId && toolGroups.has(currentGroupId)) {
+      // Fix: group placement must be IDEMPOTENT. The watcher deliberately
+      // re-emits tool-use on repeated uuids (CC rewrites the same JSONL line as
+      // the assistant message grows, and a rewrite may carry NEW tool_use
+      // blocks), relying on "the reducer dedupes by toolUseId" — true of the
+      // toolCalls Map above, but the group append below used to add the id a
+      // second time, rendering a duplicate ToolCard. Symptom was most visible
+      // on AskUserQuestion: AssistantTurnBubble hides awaiting-approval tools
+      // from groups, so both copies only became visible once answered.
+      // See transcript-watcher.ts readNewLines (~line 679) for the emit contract.
+      let existingGroupId: string | null = null;
+      for (const [gid, group] of toolGroups) {
+        if (group.toolIds.includes(action.toolUseId)) { existingGroupId = gid; break; }
+      }
+
+      if (existingGroupId) {
+        // Already placed by an earlier emit of this same tool — leave both the
+        // group and currentGroupId untouched, so a re-emit can't retarget where
+        // subsequent NEW tools land. (injectPlanSegment above is already
+        // idempotent by toolUseId, so ExitPlanMode needs no equivalent guard.)
+      } else if (currentGroupId && toolGroups.has(currentGroupId)) {
         // Add to existing group (no new segment needed)
         const group = toolGroups.get(currentGroupId)!;
         toolGroups.set(currentGroupId, {
@@ -942,6 +961,16 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       }
 
       if (!found) {
+        // Fix: never synthesize a SECOND placeholder for a requestId we already
+        // hold. The match loop above only considers 'running' tools, so a
+        // re-delivered PERMISSION_REQUEST for a tool already flipped to
+        // 'awaiting-approval' fell through to here and minted a duplicate card
+        // (the synthetic merge in TRANSCRIPT_TOOL_USE reclaims only one of
+        // them, orphaning the rest).
+        for (const tool of toolCalls.values()) {
+          if (tool.requestId === action.requestId) return state;
+        }
+
         // Permission hook arrived before transcript watcher — create synthetic tool entry
         const syntheticId = `perm-${action.requestId}`;
         toolCalls.set(syntheticId, {

--- a/docs/chat-reducer.md
+++ b/docs/chat-reducer.md
@@ -44,6 +44,22 @@ User timeline entries carry a `pending?: boolean` flag. `USER_PROMPT` always app
 
 Replaces the prior content-match-against-last-10-entries approach, which silently dropped legitimate rapid-fire duplicates (e.g. "yes" sent twice within five turns). Pending/confirmed correctly distinguishes "transcript confirms a send already shown" from "two distinct sends that happen to have identical text."
 
+### Tool cards dedup STRUCTURALLY, never by uuid
+
+`TRANSCRIPT_TOOL_USE` deliberately has **no `seenUuids` guard**, unlike `TRANSCRIPT_USER_MESSAGE` / `TRANSCRIPT_ASSISTANT_TEXT`. CC rewrites a JSONL line as the assistant message grows, and a rewrite can carry **new** `tool_use` blocks under the already-seen line uuid — so the watcher re-emits tool-use on repeats by design (`transcript-watcher.ts` `readNewLines`). A uuid guard here would silently swallow those tools; missing cards are far worse than doubled ones.
+<!-- verify: {"path": "youcoded/desktop/src/renderer/state/chat-reducer.ts", "contains": "group placement must be IDEMPOTENT"} -->
+
+Instead every write on this path is idempotent by `toolUseId`:
+
+- the `toolCalls` Map — `Map.set` overwrites;
+- **group placement** — the handler scans `toolGroups` for the id first and no-ops if already placed, so neither the append nor the new-group branch can double it. A re-emit must also leave `currentGroupId` untouched, or it would retarget where subsequent new tools land;
+- `injectPlanSegment` (ExitPlanMode) — dedups by `toolUseId`, updating in place so a later, fuller emit still refreshes content.
+
+`PERMISSION_REQUEST` matches only `running` tools, so a re-delivery for a tool already flipped to `awaiting-approval` would fall through to the synthetic-placeholder branch; it bails first if any tool already carries that `requestId`.
+<!-- verify: {"path": "youcoded/desktop/src/renderer/state/chat-reducer.ts", "contains": "never synthesize a SECOND placeholder"} -->
+
+Guard: `chat-reducer.test.ts` → "chatReducer tool card duplication". Historically this surfaced as **duplicate AskUserQuestion prompts appearing once answered** — `AssistantTurnBubble` hides `awaiting-approval` tools from groups (they render as a bottom bubble instead), so a doubled group entry stayed invisible until the answer cleared that status.
+
 ## Per-turn metadata
 
 `AssistantTurn` carries four fields populated from the JSONL transcript:
@@ -64,7 +80,7 @@ All four fields default to `null` on turn creation. The reducer's `TRANSCRIPT_TU
 - **`readNewLines` must isolate each emit in try/catch.** `session.offset` advances before the emit loop, so a throwing listener aborting the loop strands every subsequent chunk in the batch (next `readNewLines` reads from the advanced offset forward). A root cause of "rare Claude message not appearing." Keep the per-emit try/catch — do NOT collapse to a batch-level wrapper.
 - **`readNewLines` is SERIALIZED per session (`reading` flag + coalesced rerun)** (2026-07-10, both watchers). The read is async (stat → open → read) and triggered concurrently by fs.watch bursts, the global poll, and manual calls. Un-serialized, two overlapping reads consumed the same byte range (duplicate user bubbles, tool cards flapping back to `running`) and — because the read POSITION was re-evaluated after the first read advanced the offset while `bytesRead` was ignored — a short/empty second read decoded its zero-filled buffer into the partial-line carry, wedging NUL bytes in and dropping the next message at `JSON.parse`. The other root cause of "rare missing Claude message." Pinned in `transcript-watcher.test.ts → read integrity`.
 - **The incomplete-line carry is BYTES (`partialBytes: Buffer`), not a decoded string.** A string carry decodes each half of a multi-byte UTF-8 char to U+FFFD independently — emoji/CJK split across a read boundary garbled permanently. Stitch bytes before decoding. Don't "simplify" back to `partialLine: string`.
-- **`getHistory` replay dedups by uuid with the SAME semantics as the live path** (skip repeated `assistant-text`, first write wins; tool-use/result/turn-complete still emit). The reducer appends duplicates — there is no renderer-side dedup. If replay semantics change, change the live path in the same commit.
+- **`getHistory` replay dedups by uuid with the SAME semantics as the live path** (skip repeated `assistant-text`, first write wins; tool-use/result/turn-complete still emit). The reducer absorbs the re-emitted tool events structurally, not by uuid — see "Deduplication" below. If replay semantics change, change the live path in the same commit.
 - **`usePromptDetector` reads `getVisibleScreenText` (screen + margin), NOT the full scrollback; the classifier's IPC eval passes a 120-row tail.** Serializing the whole 1000+-row buffer per rAF flush was the top renderer CPU cost while streaming. The tail walk-back in `terminal-registry.getScreenText` never starts mid-wrapped-line — keep it. Load-bearing side effect: menus that scrolled into scrollback can no longer shadow a live Ink menu.
 - **SubagentWatcher polls are slow (5s) safety nets by design — the fast paths are event-driven.** `TranscriptWatcher` calls `kickScan()` when a parent Agent tool_use lands (instant discovery of the subagents dir/new files) and `settleByParent()` when the parent's tool-result lands (final read, then the per-file stat poll stops; fs.watch stays attached). Don't speed the polls up "for responsiveness" (regresses idle-CPU accumulation) and don't remove the kick/settle calls.
 - **`<local-command-stdout>`/`<local-command-stderr>` are STRIPPED ENTIRELY in `stripSystemTags` — DO NOT switch back to unwrapping.** CC writes these as dimmed status echoes. After every `/compact` it writes a follow-up user-type line `<local-command-stdout>[2mCompacted (ctrl+o to see full summary)[22m</local-command-stdout>`. Unwrapping let CC's echo reach `TRANSCRIPT_USER_MESSAGE`'s "no pending match" path, which BOTH appended a fake "Compacted…" user bubble AND set `isThinking:true` with no turn to ever clear it (chat permanently stuck thinking after compaction). Both TS and Kotlin parsers strip these entirely; `transcript-watcher.test.ts` pins the JSONL fixture line. Route any new slash-command output through a NEW event type — don't reintroduce the user-message path.


### PR DESCRIPTION
## The bug

Duplicate `AskUserQuestion` prompts in chat view — typically noticed right after answering one.

## Root cause

`transcript-watcher.ts` re-emits `tool-use` for a repeated line uuid **on purpose**: CC rewrites a JSONL line as the assistant message grows, and a rewrite can carry *new* `tool_use` blocks. Its comment states the contract it relies on — "the reducer dedupes by toolUseId."

That contract held for the `toolCalls` Map but **not** for group placement, which appended the id a second time — or, once `endTurn()` had cleared `currentGroupId`, minted an entire second group + segment. `AssistantTurnBubble` maps `group.toolIds → cards`, so either path renders an extra `ToolCard`.

It surfaced on `AskUserQuestion` specifically because `AssistantTurnBubble` hides `awaiting-approval` tools from groups (they render as a bottom bubble instead). The duplicate was already there while the prompt waited — it only became visible when the answer cleared that status, which is why it reads as answer-triggered.

## Fixes

- **`TRANSCRIPT_TOOL_USE`** scans `toolGroups` for the id and no-ops if already placed. It leaves `currentGroupId` untouched, so a re-emit can't retarget where subsequent *new* tools land.
- **`PERMISSION_REQUEST`** bails before synthesizing a placeholder when some tool already carries that `requestId`. The match loop only considers `running` tools, so a re-delivery after the flip to `awaiting-approval` fell through and minted a duplicate `perm-*` card.

`injectPlanSegment` was already idempotent by `toolUseId` — this brings tool groups in line with the precedent it set.

## The fix that was rejected

Adding a `seenUuids` guard to `TRANSCRIPT_TOOL_USE`, mirroring `TRANSCRIPT_USER_MESSAGE` / `TRANSCRIPT_ASSISTANT_TEXT`. It stops the duplicates and **silently swallows tools that arrive in a rewritten line** — the failure mode `a24aedaf` ("prevent rare message loss") already fixed once. Missing cards are worse than doubled ones and much harder to notice. The third new test pins that distinction so the shortcut isn't taken later.

## Verification

- `chat-reducer.test.ts` → "chatReducer tool card duplication", 4 new tests. **3 fail without this change**; the 4th (new tool in a rewritten line) passes either way by design — it guards the rejected approach.
- Full suite: **2716 passed**, 39 skipped. `tsc --noEmit` clean.
- `docs/chat-reducer.md` corrected — line 67 claimed "the reducer appends duplicates — there is no renderer-side dedup", which now contradicts the code. New subsection documents why this path dedups structurally rather than by uuid, with two `verify:` anchors.

Not runtime-verified in a dev instance — the behavior is fully covered by the reducer tests, and the visual symptom needs a live session to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)