### PR TITLE
fix(ci): ship darwin-x64 binaries in the macOS x64 dmg

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -55,6 +55,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Keep in sync with desktop-test-build.yml's identical step.
+      # macos-latest runners are arm64, so `npm ci` installs only the darwin-arm64
+      # variant of any package that ships its binaries as per-platform
+      # optionalDependencies. electron-builder cuts BOTH the x64 and arm64 dmgs from
+      # this single node_modules tree (npmRebuild is false), so without this step the
+      # x64 dmg ships arm64 binaries: ripgrep throws "Could not find
+      # @vscode/ripgrep-darwin-x64" and kills the main process at launch, and
+      # @napi-rs/canvas (a pdfjs-dist dep) breaks PDF rendering. --force bypasses the
+      # os/cpu guard that would otherwise skip a foreign-arch package. Versions are
+      # read from the installed tree so a dependency bump can't silently desync them.
+      - name: Add darwin-x64 binaries for the x64 dmg
+        if: matrix.name == 'macos'
+        shell: bash
+        run: |
+          RG=$(node -p "require('@vscode/ripgrep/package.json').version")
+          CANVAS=$(node -p "require('@napi-rs/canvas/package.json').version")
+          npm i --no-save --force \
+            "@vscode/ripgrep-darwin-x64@$RG" \
+            "@napi-rs/canvas-darwin-x64@$CANVAS"
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/desktop-test-build.yml
+++ b/.github/workflows/desktop-test-build.yml
@@ -68,6 +68,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # macos-latest runners are arm64, so `npm ci` installs only the darwin-arm64
+      # variant of any package that ships its binaries as per-platform
+      # optionalDependencies. electron-builder cuts BOTH the x64 and arm64 dmgs from
+      # this single node_modules tree (npmRebuild is false), so without this step the
+      # x64 dmg ships arm64 binaries: ripgrep throws "Could not find
+      # @vscode/ripgrep-darwin-x64" and kills the main process at launch, and
+      # @napi-rs/canvas (a pdfjs-dist dep) breaks PDF rendering. --force bypasses the
+      # os/cpu guard that would otherwise skip a foreign-arch package. Versions are
+      # read from the installed tree so a dependency bump can't silently desync them.
+      - name: Add darwin-x64 binaries for the x64 dmg
+        if: matrix.name == 'macos'
+        shell: bash
+        run: |
+          RG=$(node -p "require('@vscode/ripgrep/package.json').version")
+          CANVAS=$(node -p "require('@napi-rs/canvas/package.json').version")
+          npm i --no-save --force \
+            "@vscode/ripgrep-darwin-x64@$RG" \
+            "@napi-rs/canvas-darwin-x64@$CANVAS"
+
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Problem

`1.3.0-beta.6` crashes at launch on Intel macOS:

> Error: Could not find @vscode/ripgrep-darwin-x64. Ensure optionalDependencies are installed for this platform (darwin-x64).

Reproduced on an Intel macOS VM. Verified by extracting the shipped x64 dmg — it contains only `@vscode/ripgrep-darwin-arm64`.

## Cause

`macos-latest` is an Apple Silicon runner. `npm ci` installs only the optionalDependency matching the build host, and `electron-builder` cuts **both** dmgs from that single `node_modules` tree (`npmRebuild: false`), so the x64 dmg gets arm64 binaries.

## Audit of the same bug class

Scanned every dependency for per-platform `optionalDependencies` and inspected the packaged app's native binaries:

| Package | Coverage in the x64 dmg | Status |
|---|---|---|
| `node-pty` | all prebuilds incl. `darwin-x64` | fine |
| `koffi` | all arch dirs incl. `darwin_x64` | fine |
| `@vscode/ripgrep` | `darwin-arm64` only | **fixed here** |
| `@napi-rs/canvas` | `darwin-arm64` only | **fixed here** |
| `@tailwindcss/oxide`, `lightningcss`, `rolldown` | n/a | devDeps, pruned by electron-builder |

`@napi-rs/canvas` (via `pdfjs-dist`) is a second, latent instance — it would have surfaced as "PDFs don't render on Intel Macs" rather than a launch crash.

macOS is the only multi-arch target; win/linux take the host arch on x64 runners.

## Blast radius

**No released version is affected.** The ripgrep dep landed in e42fb4a8 (2026-07-15), after v1.2.4 (2026-05-18) — confirmed by inspecting the shipped v1.2.4 x64 dmg, which has no `@vscode/` bundle. This would have broken the *next* release.

## Fix

Adds a macOS-only step to both workflows installing the darwin-x64 variants with `--force` (bypasses the os/cpu guard). Versions are read from the installed tree, so a dependency bump can't silently desync them.

Costs ~5 MB of foreign-arch binaries per dmg.

Considered and rejected: splitting the matrix onto a `macos-13` Intel runner — more architecturally honest, but GitHub is retiring `macos-13` and it'd hang the release pipeline on a sunsetting runner.

## Verification

- Ran the exact `npm i --no-save --force` on Linux: pulls genuine `Mach-O 64-bit x86_64` binaries, so the cross-arch fetch works off-platform.
- Both workflows parse; step sits between `Install dependencies` and `Run tests`.
- End-to-end confirmation still pending a `1.3.0-beta.7` dispatch + Intel VM launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)