### PR TITLE
fix(ci): read dep versions off disk, not through the exports map

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -69,8 +69,12 @@ jobs:
         if: matrix.name == 'macos'
         shell: bash
         run: |
-          RG=$(node -p "require('@vscode/ripgrep/package.json').version")
-          CANVAS=$(node -p "require('@napi-rs/canvas/package.json').version")
+          # Read package.json off disk rather than require()-ing it: @vscode/ripgrep
+          # declares an "exports" map that only exposes ".", so requiring the
+          # subpath fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+          ver() { node -p "JSON.parse(require('fs').readFileSync('node_modules/$1/package.json','utf8')).version"; }
+          RG=$(ver @vscode/ripgrep)
+          CANVAS=$(ver @napi-rs/canvas)
           npm i --no-save --force \
             "@vscode/ripgrep-darwin-x64@$RG" \
             "@napi-rs/canvas-darwin-x64@$CANVAS"

--- a/.github/workflows/desktop-test-build.yml
+++ b/.github/workflows/desktop-test-build.yml
@@ -81,8 +81,12 @@ jobs:
         if: matrix.name == 'macos'
         shell: bash
         run: |
-          RG=$(node -p "require('@vscode/ripgrep/package.json').version")
-          CANVAS=$(node -p "require('@napi-rs/canvas/package.json').version")
+          # Read package.json off disk rather than require()-ing it: @vscode/ripgrep
+          # declares an "exports" map that only exposes ".", so requiring the
+          # subpath fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+          ver() { node -p "JSON.parse(require('fs').readFileSync('node_modules/$1/package.json','utf8')).version"; }
+          RG=$(ver @vscode/ripgrep)
+          CANVAS=$(ver @napi-rs/canvas)
           npm i --no-save --force \
             "@vscode/ripgrep-darwin-x64@$RG" \
             "@napi-rs/canvas-darwin-x64@$CANVAS"


### PR DESCRIPTION
Follow-up to #189. The darwin-x64 step failed on the first real run (1.3.0-beta.7):

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not
defined by "exports" in .../node_modules/@vscode/ripgrep/package.json
```

`@vscode/ripgrep` declares an `exports` map exposing only `"."`, so `require()`-ing the package.json subpath is blocked. Reading the file directly via `fs` sidesteps the export map.

Verified by running the literal shell snippet against a real node_modules — resolves `1.18.0` and `0.1.100`. The failure was reproduced locally first, so this isn't a speculative fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)