### PR TITLE
feat(sync): install the GitHub CLI on macOS and Linux instead of punting

### DIFF
--- a/desktop/src/main/github-auth.ts
+++ b/desktop/src/main/github-auth.ts
@@ -400,6 +400,13 @@ export async function installGh(
   execFn: ExecFn = defaultExec,
   detectWingetFn: () => Promise<{ installed: boolean; error?: string }> = detectWinget,
   platform: NodeJS.Platform = process.platform,
+  // Injected like every other I/O dependency in this module (see PURE-CORE /
+  // IO-SHELL in the header): the real default downloads + extracts a release
+  // archive, so tests MUST be able to substitute it or they'd hit the network.
+  installUserLocalFn: () => Promise<{ success: boolean; error?: string }> = async () => {
+    const { installGhUserLocal } = await import('./prerequisite-installer');
+    return installGhUserLocal();
+  },
 ): Promise<InstallGhResult> {
   if (platform === 'win32') {
     const winget = await detectWingetFn();
@@ -437,9 +444,20 @@ export async function installGh(
     return { ok: true };
   }
 
-  // No auto-install on macOS/Linux in v1 — surface the one-liner instead.
-  if (platform === 'darwin') {
-    return { ok: false, manual: 'brew install gh' };
+  // macOS/Linux: install gh into a user-local bin dir (no sudo, no Homebrew).
+  // This branch used to punt with a `manual:` one-liner, which dead-ended every
+  // non-Windows user of the sync wizard — a stock macOS has neither `gh` nor
+  // `brew`, so "brew install gh" was advice they couldn't act on (hit for real
+  // 2026-07-20 setting sync up on a fresh macOS install). The `manual:` strings
+  // survive as the FALLBACK when the automated install fails.
+  if (platform === 'darwin' || platform === 'linux') {
+    const result = await installUserLocalFn();
+    if (result.success) return { ok: true };
+    return {
+      ok: false,
+      error: result.error,
+      manual: platform === 'darwin' ? 'brew install gh' : 'See https://github.com/cli/cli#installation',
+    };
   }
   return { ok: false, manual: 'See https://github.com/cli/cli#installation' };
 }

--- a/desktop/src/main/prerequisite-installer.ts
+++ b/desktop/src/main/prerequisite-installer.ts
@@ -92,6 +92,13 @@ export interface DetectionResult {
 // ---------------------------------------------------------------------------
 
 const NODE_VERSION = 'v20.19.0';
+// Pinned, NOT "latest": the download URL interpolates the version into the
+// asset filename (gh_<ver>_macOS_arm64.zip), so there is no /latest/ URL that
+// yields a predictable name, and resolving it at runtime would make the
+// installer depend on the GitHub API being reachable and unauthenticated.
+// Bump deliberately; the only constraint is that the release still publishes
+// the macOS .zip / Linux .tar.gz assets this installer expects.
+const GH_VERSION = '2.96.0';
 const PATH_MARKER = '# Added by YouCoded first-run installer';
 
 /** Root dir for YouCoded-managed user-local tools (macOS: ~/Library/..., Linux: ~/.youcoded). */
@@ -105,6 +112,16 @@ function youcodedDataDir(): string {
 /** Where we extract Node's tarball (macOS + Linux). */
 export function userLocalNodeDir(): string {
   return path.join(youcodedDataDir(), 'node');
+}
+
+/**
+ * Bin dir for single-binary tools we install user-locally (currently just `gh`).
+ * Deliberately NOT `userLocalNodeBinDir()` — that dir is owned by the Node
+ * tarball extraction, which uses `--strip-components=1` into `userLocalNodeDir()`
+ * and would clobber anything else living there on a Node reinstall.
+ */
+export function userLocalToolsBinDir(): string {
+  return path.join(youcodedDataDir(), 'bin');
 }
 
 /** Node's bin dir (contains node, npm, npx — and later, claude from `npm i -g`). */
@@ -672,6 +689,101 @@ export async function installGit(): Promise<{ success: boolean; error?: string }
   } catch (err) {
     const msg = String(err);
     log('ERROR', 'prereq', 'Git install failed', { error: msg });
+    return { success: false, error: msg };
+  }
+}
+
+/**
+ * Install the GitHub CLI into a user-local bin dir (macOS + Linux only).
+ *
+ * `github-auth.ts` owns the gh install ENTRY POINT (`installGh`) and the
+ * Windows/winget branch; this function exists only to fill the macOS/Linux
+ * branch it used to punt on ("No auto-install on macOS/Linux in v1 — surface
+ * the one-liner instead"), which dead-ended every non-Windows user in the sync
+ * wizard. The download/extract/PATH machinery lives here because this module
+ * already owns `youcodedDataDir()`, `downloadFile()` and shell-profile PATH
+ * persistence. Call it via `github-auth.installGh()`, not directly.
+ *
+ * Deliberately does NOT use Homebrew (unlike `installRclone` in
+ * sync-setup-handlers.ts, which shells out to `brew` and therefore fails on any
+ * Mac without it) — a stock macOS has no `brew`, and telling a non-developer to
+ * install a package manager first is the exact dead end this removes.
+ *
+ * Archive shapes differ by platform and are NOT interchangeable (verified
+ * against the cli/cli releases API 2026-07-20): macOS publishes `.zip`, Linux
+ * publishes `.tar.gz`. Both unpack to `gh_<ver>_<plat>_<arch>/bin/gh`.
+ */
+export async function installGhUserLocal(): Promise<{ success: boolean; error?: string }> {
+  try {
+    log('INFO', 'prereq', 'Installing GitHub CLI...');
+
+    if (process.platform === 'darwin' || process.platform === 'linux') {
+      // gh's release assets use Go's arch tokens: amd64 (not x64) and arm64.
+      const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+      // gh names the macOS asset "macOS" (capitalised) and the Linux one "linux".
+      const platToken = process.platform === 'darwin' ? 'macOS' : 'linux';
+      const ext = process.platform === 'darwin' ? 'zip' : 'tar.gz';
+      const stem = `gh_${GH_VERSION}_${platToken}_${arch}`;
+      const archivePath = path.join(os.tmpdir(), `${stem}.${ext}`);
+
+      await downloadFile(
+        `https://github.com/cli/cli/releases/download/v${GH_VERSION}/${stem}.${ext}`,
+        archivePath,
+      );
+
+      // Extract to a scratch dir first, then copy out only the binary. Keeps
+      // the tools bin dir flat and avoids leaving the archive's LICENSE/man
+      // tree behind.
+      const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'youcoded-gh-'));
+      try {
+        if (ext === 'zip') {
+          // `unzip` ships with macOS; -o overwrites a partial from a retry.
+          await runCommand('unzip', ['-q', '-o', archivePath, '-d', scratch], { timeout: 300000 });
+        } else {
+          await runCommand('tar', ['-xzf', archivePath, '-C', scratch], { timeout: 300000 });
+        }
+
+        const extractedBin = path.join(scratch, stem, 'bin', 'gh');
+        if (!fs.existsSync(extractedBin)) {
+          // Fail loudly with the real path rather than letting the post-install
+          // detect() report a generic "not found" that hides the cause.
+          return {
+            success: false,
+            error: `GitHub CLI archive did not contain the expected binary at ${stem}/bin/gh`,
+          };
+        }
+
+        const binDir = userLocalToolsBinDir();
+        fs.mkdirSync(binDir, { recursive: true });
+        const dest = path.join(binDir, 'gh');
+        fs.copyFileSync(extractedBin, dest);
+        fs.chmodSync(dest, 0o755);
+      } finally {
+        fs.rmSync(scratch, { recursive: true, force: true });
+        fs.unlink(archivePath, () => {});
+      }
+
+      // Visible to this process AND to future shells / PTY sessions.
+      prependToProcessPath(userLocalToolsBinDir());
+      persistPathToShellProfiles(userLocalToolsBinDir());
+    } else {
+      return { success: false, error: `Unsupported platform for GitHub CLI install: ${process.platform}` };
+    }
+
+    refreshPath();
+    // Verify by running the binary we just placed, not by PATH lookup: PATH
+    // propagation into an already-running Electron process is exactly the
+    // failure installClaude() documents, and here we know the absolute path.
+    try {
+      const { stdout } = await runCommand(path.join(userLocalToolsBinDir(), 'gh'), ['--version']);
+      log('INFO', 'prereq', `GitHub CLI installed: ${stdout.trim().split('\n')[0]}`);
+    } catch (err) {
+      return { success: false, error: `GitHub CLI installed but would not run: ${String(err)}` };
+    }
+    return { success: true };
+  } catch (err) {
+    const msg = String(err);
+    log('ERROR', 'prereq', 'GitHub CLI install failed', { error: msg });
     return { success: false, error: msg };
   }
 }

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -774,26 +774,87 @@ function IcloudMissingHelp({ onRecheck }: { onRecheck: () => void }) {
 function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
   const claude = (window as any).claude;
   const os: DesktopOS = checkIsAndroid() ? 'other' : detectDesktopOS();
+  const [installing, setInstalling] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  // The app installs gh itself (user-local, no sudo/Homebrew) — the manual
+  // per-OS instructions below are the FALLBACK, shown only once an automated
+  // attempt has actually failed. Leading with a terminal command is what this
+  // whole flow exists to avoid: a stock macOS has no gh and no brew, so the
+  // old instructions-first version dead-ended non-developers (2026-07-20).
+  const handleInstallGh = async () => {
+    setInstalling(true);
+    setInstallError(null);
+    try {
+      // Reuses the Connect-GitHub modal's install path (`github:install-gh`)
+      // rather than a sync-specific one — same binary, same installer, and it
+      // already rides all four IPC parity surfaces.
+      const result = await claude.github.installGh();
+      if (result.ok) {
+        await onRecheck();
+      } else if (result.restartRequired) {
+        // Windows: gh is on disk but this process's PATH predates it. Restart
+        // is the deterministic fix (same contract as installClaude).
+        setInstallError(
+          result.error ||
+            "GitHub CLI was installed, but this app can't see it yet. Quit and reopen YouCoded, then tap Check Again.",
+        );
+      } else {
+        setInstallError(result.error || 'Installation failed');
+      }
+    } catch (e: any) {
+      setInstallError(e?.message || 'Installation failed');
+    }
+    setInstalling(false);
+  };
+
+  // Android has no desktop prerequisite installer to call — keep it on the
+  // manual path rather than offering a button that cannot work.
+  const canAutoInstall = !checkIsAndroid();
+
   return (
     <div className="pt-2 space-y-2">
       <div className="text-[11px] text-fg-dim">
         YouCoded needs GitHub's command-line tool (gh) to connect your account.
       </div>
-      {os === 'mac' && (
+
+      {canAutoInstall && !installError && (
+        <div className="space-y-2">
+          {/* Spinner matches the rclone install button: this advertises "about a
+              minute" right below it, and a motionless disabled button reads as hung. */}
+          <Button size="lg" onClick={handleInstallGh} disabled={installing}>
+            {installing && (
+              <span className="w-3 h-3 border-2 border-current/30 border-t-current rounded-full animate-spin" />
+            )}
+            {installing ? 'Installing...' : 'Install Now'}
+          </Button>
+          <div className="text-[10px] text-fg-muted">This usually takes about a minute.</div>
+        </div>
+      )}
+
+      {installError && (
+        <div className="text-[10px] text-destructive">
+          Couldn't install it automatically: {installError}
+        </div>
+      )}
+
+      {/* Manual instructions: only after an automated attempt failed (or on a
+          platform where we can't run one). */}
+      {(installError || !canAutoInstall) && os === 'mac' && (
         <div className="text-[10px] text-fg-muted space-y-1">
           <div>On macOS, the easiest way is Homebrew. In Terminal, run:</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">brew install gh</div>
           <div>No Homebrew? Download the installer from <button className="text-accent underline" onClick={() => claude.openExternal('https://cli.github.com')}>cli.github.com</button>.</div>
         </div>
       )}
-      {os === 'windows' && (
+      {(installError || !canAutoInstall) && os === 'windows' && (
         <div className="text-[10px] text-fg-muted space-y-1">
           <div>On Windows, download the installer from <button className="text-accent underline" onClick={() => claude.openExternal('https://cli.github.com')}>cli.github.com</button>.</div>
           <div>Or, if you use winget, open PowerShell and run:</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">winget install GitHub.cli</div>
         </div>
       )}
-      {os === 'linux' && (
+      {(installError || !canAutoInstall) && os === 'linux' && (
         <div className="text-[10px] text-fg-muted space-y-1">
           <div>On Linux, install with your package manager:</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">sudo apt install gh  # Debian/Ubuntu</div>
@@ -801,12 +862,14 @@ function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
           <div>Full instructions: <button className="text-accent underline" onClick={() => claude.openExternal('https://github.com/cli/cli/blob/trunk/docs/install_linux.md')}>install guide</button>.</div>
         </div>
       )}
-      {os === 'other' && (
+      {(installError || !canAutoInstall) && os === 'other' && (
         <div className="text-[10px] text-fg-muted">
           Install from <button className="text-accent underline" onClick={() => claude.openExternal('https://cli.github.com')}>cli.github.com</button>, then come back and tap "Check Again".
         </div>
       )}
-      <div className="text-[10px] text-fg-muted">After installing, come back and tap "Check Again".</div>
+      {(installError || !canAutoInstall) && (
+        <div className="text-[10px] text-fg-muted">After installing, come back and tap "Check Again".</div>
+      )}
       {/* Filled-grey (bg-inset) becomes the outline `secondary` — spec decision 60. */}
       <Button variant="secondary" onClick={onRecheck}>
         Check Again

--- a/desktop/tests/github-auth.test.ts
+++ b/desktop/tests/github-auth.test.ts
@@ -367,17 +367,59 @@ describe('installGh', () => {
     expect(r.error).toBe('winget is missing');
   });
 
-  test('macOS: returns a manual brew command, no auto-install', async () => {
+  // Behavior CHANGED 2026-07-20: macOS/Linux used to punt with a `manual:`
+  // one-liner and never attempt an install. A stock macOS has neither gh nor
+  // brew, so that advice was unactionable and dead-ended sync setup. These now
+  // pin: attempt the user-local install first, fall back to `manual:` only when
+  // it fails. The installer is injected so this never touches the network.
+  test('macOS: runs the user-local install and reports success', async () => {
     const exec = makeExec({});
-    const r = await installGh(exec, async () => ({ installed: true }), 'darwin');
+    const r = await installGh(exec, async () => ({ installed: true }), 'darwin', async () => ({
+      success: true,
+    }));
+    expect(r.ok).toBe(true);
+  });
+
+  test('macOS: falls back to the manual brew command when the install fails', async () => {
+    const exec = makeExec({});
+    const r = await installGh(exec, async () => ({ installed: true }), 'darwin', async () => ({
+      success: false,
+      error: 'download failed',
+    }));
     expect(r.ok).toBe(false);
+    expect(r.error).toBe('download failed');
     expect(r.manual).toContain('brew install gh');
   });
 
-  test('Linux: returns a manual docs pointer', async () => {
+  test('Linux: runs the user-local install and reports success', async () => {
     const exec = makeExec({});
-    const r = await installGh(exec, async () => ({ installed: true }), 'linux');
+    const r = await installGh(exec, async () => ({ installed: true }), 'linux', async () => ({
+      success: true,
+    }));
+    expect(r.ok).toBe(true);
+  });
+
+  test('Linux: falls back to the manual docs pointer when the install fails', async () => {
+    const exec = makeExec({});
+    const r = await installGh(exec, async () => ({ installed: true }), 'linux', async () => ({
+      success: false,
+      error: 'tar failed',
+    }));
     expect(r.ok).toBe(false);
     expect(r.manual).toContain('github.com/cli/cli');
+  });
+
+  // Guards the network-safety property itself: if someone drops the injected
+  // default back to a direct call, this test starts doing real I/O and the
+  // reviewer has no signal. Asserting the injected fn is actually consulted
+  // keeps the seam honest.
+  test('the injected installer is what gets called on non-Windows', async () => {
+    const exec = makeExec({});
+    let called = 0;
+    await installGh(exec, async () => ({ installed: true }), 'darwin', async () => {
+      called += 1;
+      return { success: true };
+    });
+    expect(called).toBe(1);
   });
 });


### PR DESCRIPTION
Option (A) from the ROADMAP entry *"Sync dead-ends on any machine without `gh`"*.

## Problem

Setting up sync on a stock macOS dead-ends. `gh` is absent (Xcode Command Line Tools install `git`, **not** `gh`), so `provisionGithubRemote` throws ENOENT and the wizard's only advice is `brew install gh` — unactionable on a Mac without Homebrew, and exactly the terminal step this product exists to avoid. Hit for real on 2026-07-20 setting sync up on a fresh Intel macOS VM; it took a hand-installed release tarball to get past it.

## What I found (and didn't build)

`github-auth.ts` **already** owns the gh install entry point and a working Windows/winget branch. It explicitly punted on the rest:

```js
// No auto-install on macOS/Linux in v1 — surface the one-liner instead.
if (platform === 'darwin') return { ok: false, manual: 'brew install gh' };
```

So this fills that branch rather than adding a parallel installer. **No new IPC** — the wizard reuses the existing `github:install-gh` channel, which already rides all four parity surfaces.

## Changes

- **`prerequisite-installer.ts`** — new `installGhUserLocal()`: downloads the official release archive, extracts just the binary into a user-local bin dir, persists that dir to PATH. No sudo, no admin prompt, no Homebrew, reusing the layout the Node tarball install established. Deliberately *not* `brew` — note `installRclone` shells out to Homebrew and fails on any Mac without it; that shape isn't copied.
- **`github-auth.installGh()`** — calls it for darwin/linux, keeping the `manual:` one-liners as the **fallback** when the automated install fails.
- **`SyncSetupWizard`** — leads with an Install Now button; per-OS manual instructions now appear only *after* an automated attempt fails.

## Verification

- **Real archives, not assumed** — checked against the cli/cli releases API and by downloading both: macOS publishes `.zip`, Linux `.tar.gz` (not interchangeable), both unpacking to `gh_<ver>_<plat>_<arch>/bin/gh`. Ran the extracted Linux binary (`gh version 2.96.0`) and confirmed the macOS one is a genuine `Mach-O arm64`.
- **Redirects** — the download URL's first hop is a `302`, which `downloadFile` already follows. A `307` would have silently failed.
- `npm test`: 2732 passed, `tsc --noEmit` clean.

## Behavior change to call out

Two tests pinned the old "no auto-install on macOS/Linux" contract and now pin attempt-then-fall-back. The user-local installer is **injected** into `installGh()` like every other IO dependency in that module, so those tests exercise the new branch without touching the network — plus a test asserting the injected fn is actually called, so nobody can quietly revert the seam and start doing real I/O in CI.

## Not addressed here

Option (B) — dropping `gh` entirely by using the token the app already mints. Still worth doing, but it needs the app to become a credential store, and `git` remains a prerequisite regardless, so this captures the user-facing win first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)