### PR TITLE
fix(engine): stop adopting orphaned llama-server + reliably kill engine on quit

### DIFF
--- a/desktop/src/main/engine/engine-supervisor.ts
+++ b/desktop/src/main/engine/engine-supervisor.ts
@@ -9,7 +9,7 @@
 // passes through here — each call bumps lastActivity and holds an inFlight
 // count until its response BODY is fully read (streams count as active for
 // their whole duration; a 10-minute generation must not be killed mid-stream).
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, ChildProcess, execFileSync } from 'child_process';
 import * as fs from 'fs';
 import { EventEmitter } from 'events';
 import type { EngineModel, EngineModelState, EngineRunState } from '../../shared/engine-types';
@@ -29,6 +29,11 @@ export interface EngineSupervisorOpts {
   sleepIdleSeconds?: number; // per-model auto-sleep; default 300 (5 min)
   modelPollMs?: number;      // /models state poll cadence when idle; default 1500
   modelPollLoadingMs?: number; // faster cadence while a model is loading; default 400
+  /** Test seam: resolve the PID listening on `port` (Linux). Default: ss + /proc scan. */
+  pidOnPort?: (port: number) => number | null;
+  /** Test seam: resolve a PID's executable path (for the stale-engine reaper).
+   *  Default: readlink /proc/<pid>/exe. */
+  exeForPid?: (pid: number) => string | null;
 }
 
 // Keep at most 2 models resident: the router's LRU default (4) can overcommit
@@ -45,6 +50,61 @@ const SLEEP_IDLE_SECONDS = 300;
 // stop retrying until the user acts (EngineCard's Restart button).
 const STRIKE_LIMIT = 3;
 const STRIKE_WINDOW_MS = 5 * 60_000;
+
+/** Resolve the PID of the process listening on a localhost port. Linux-only:
+ *  prefers `ss -ltnp`, falls back to scanning /proc/net/tcp + process fd socket
+ *  inodes. Returns null on any other platform or when no listener is found —
+ *  callers treat null as "unknown", never "safe". */
+function defaultPidOnPort(port: number): number | null {
+  if (process.platform !== 'linux') return null;
+  try {
+    const out = execFileSync('ss', ['-ltnp'], { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] });
+    const line = out.split('\n').find((l) => l.includes(`:${port} `) || l.endsWith(`:${port}`));
+    const m = line && /pid=(\d+)/.exec(line);
+    if (m) return parseInt(m[1], 10);
+  } catch { /* ss missing/failed — fall through to the /proc scan */ }
+  return pidOnPortViaProc(port);
+}
+
+/** /proc-only port→PID: find the socket inode for the LISTEN port in
+ *  /proc/net/tcp(6), then the process whose fd links to that inode. */
+function pidOnPortViaProc(port: number): number | null {
+  const hex = ':' + port.toString(16).toUpperCase().padStart(4, '0');
+  const inode = listenInodeForPort(hex);
+  if (!inode) return null;
+  let pids: string[];
+  try { pids = fs.readdirSync('/proc'); } catch { return null; }
+  for (const pid of pids) {
+    if (!/^\d+$/.test(pid)) continue;
+    let fds: string[];
+    try { fds = fs.readdirSync(`/proc/${pid}/fd`); } catch { continue; } // perms / raced exit
+    for (const fd of fds) {
+      try {
+        if (fs.readlinkSync(`/proc/${pid}/fd/${fd}`) === `socket:[${inode}]`) return parseInt(pid, 10);
+      } catch { /* raced fd close */ }
+    }
+  }
+  return null;
+}
+
+function listenInodeForPort(hexPort: string): string | null {
+  for (const f of ['/proc/net/tcp', '/proc/net/tcp6']) {
+    let lines: string[];
+    try { lines = fs.readFileSync(f, 'utf8').split('\n'); } catch { continue; }
+    for (const line of lines.slice(1)) {
+      const cols = line.trim().split(/\s+/);
+      // cols[1]=local_address (hexIP:hexPort), cols[3]=state ('0A' = LISTEN), cols[9]=inode
+      if (cols.length > 9 && cols[1]?.endsWith(hexPort) && cols[3] === '0A') return cols[9];
+    }
+  }
+  return null;
+}
+
+/** Resolve a PID's executable path via /proc/<pid>/exe; null when unreadable
+ *  (raced exit, perms) — callers treat null as "unknown", never "safe". */
+function defaultExeForPid(pid: number): string | null {
+  try { return fs.readlinkSync(`/proc/${pid}/exe`); } catch { return null; }
+}
 
 export class EngineSupervisor extends EventEmitter {
   private child: ChildProcess | null = null;
@@ -133,6 +193,15 @@ export class EngineSupervisor extends EventEmitter {
       );
     }
 
+    // Reap a stale orphan squatting on our fixed port BEFORE we spawn (2026-07-20).
+    // Without a single-instance lock, a previous run's llama-server can outlive the app
+    // (the old quit path lost the SIGTERM race) and keep the port bound. Our child then
+    // can't bind, and — before the identity guard above — we'd have adopted the orphan.
+    // If the listener is a llama-server that is NOT our live child, kill it so this
+    // spawn gets the port. Linux-only; elsewhere the port conflict surfaces as the
+    // child's startup exit (unchanged behavior).
+    this.reapStaleEngineOnPort();
+
     const child = spawn(
       this.opts.binaryPath,
       [
@@ -186,7 +255,14 @@ export class EngineSupervisor extends EventEmitter {
     while (Date.now() < deadline && !exitedDuringStartup) {
       try {
         const res = await fetchImpl(`${this.rootUrl()}/health`, { method: 'GET' });
-        if (res.ok) {
+        // Identity guard (2026-07-20): /health answering "ok" is NOT proof that the
+        // server we just spawned is the one listening. An orphaned llama-server from
+        // a previous run keeps our fixed port bound, so our child fails to bind and
+        // dies while the ORPHAN answers /health. Without this guard we would adopt
+        // the orphan — and later count ITS death as OUR crash (the false "engine
+        // crashed repeatedly" strike-out). Only accept when the listener is our child
+        // (or identity can't be determined, e.g. non-Linux — fall through as before).
+        if (res.ok && this.isOurChildOnPort(child)) {
           this.state = 'running';
           this.touch();
           child.off('exit', startupExitListener);
@@ -216,6 +292,33 @@ export class EngineSupervisor extends EventEmitter {
       );
     }
     throw new Error(`The local engine did not start within ${Math.round(readyDeadlineMs / 1000)} seconds.`);
+  }
+
+  /** Is the process listening on our port the child we just spawned? Returns
+   *  true when identity can't be determined (non-Linux, or ss/proc unavailable)
+   *  so we don't regress platforms without the mapping — the guard only ever
+   *  REJECTS a confidently-foreign listener; it never blocks an unknown one.
+   *  This is what stops us adopting an orphaned engine on our fixed port. */
+  private isOurChildOnPort(child: ChildProcess): boolean {
+    if (process.platform !== 'linux') return true; // no port→PID mapping — assume ours
+    if (child.pid == null) return true;            // not assigned yet — can't disprove
+    const pid = (this.opts.pidOnPort ?? defaultPidOnPort)(this.opts.port);
+    if (pid == null) return true;                  // unknown — don't block on a non-answer
+    return pid === child.pid;
+  }
+
+  /** Kill a llama-server squatting on our port that is NOT our live child (a stale
+   *  orphan from a previous run). Best-effort + Linux-only; never throws, and never
+   *  touches our own child or a non-llama process. Runs before spawn so this instance
+   *  can actually bind the fixed port instead of adopting the orphan. */
+  private reapStaleEngineOnPort(): void {
+    if (process.platform !== 'linux') return;
+    const pid = (this.opts.pidOnPort ?? defaultPidOnPort)(this.opts.port);
+    if (pid == null) return;                       // nothing (identifiably) on the port
+    if (this.child && this.child.pid === pid) return; // our own live child — leave it
+    const exe = (this.opts.exeForPid ?? defaultExeForPid)(pid);
+    if (exe == null || !exe.includes('llama-server')) return; // not confirmably our engine — never kill it
+    try { process.kill(pid, 'SIGKILL'); } catch { /* already gone / not ours to kill */ }
   }
 
   private onExit(code: number | null): void {
@@ -255,16 +358,33 @@ export class EngineSupervisor extends EventEmitter {
     }
     this.intentionalShutdown = true;
     const child = this.child;
-    child.kill();
-    await new Promise<void>((resolve) => {
-      let done = false;
-      const finish = () => { if (!done) { done = true; clearTimeout(timer); resolve(); } };
-      child.once('exit', finish);
-      const timer = setTimeout(finish, 2_000); // best-effort — don't hang app quit
-    });
+    // Escalating kill (2026-07-20): a single SIGTERM is why engines leaked past app
+    // quit — llama-server can ignore/stall on TERM (mid-write, stuck in a CUDA/Vulkan
+    // call), the 2s timer fired, app.quit() won the race, and the orphaned server kept
+    // our port bound for the NEXT instance to wrongly adopt. TERM → wait → KILL the
+    // survivor, then wait for the exit that KILL guarantees. Still bounded so a
+    // wedged child can't hang quit: total worst case ~3s.
+    child.kill('SIGTERM');
+    const exited = await this.waitForExit(child, 1_500);
+    if (!exited) {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      await this.waitForExit(child, 1_500);
+    }
     this.child = null;
     this.state = 'stopped';
     this.emit('status-changed');
+  }
+
+  /** Resolve true if `child` exits within `ms`, false on timeout (timer unref'd so
+   *  it can't hold the process open). */
+  private waitForExit(child: ChildProcess, ms: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (exited: boolean) => { if (!done) { done = true; clearTimeout(timer); resolve(exited); } };
+      child.once('exit', () => finish(true));
+      const timer = setTimeout(() => finish(false), ms);
+      timer.unref?.();
+    });
   }
 
   // ---- idle accounting -------------------------------------------------

--- a/desktop/src/main/engine/engine-supervisor.ts
+++ b/desktop/src/main/engine/engine-supervisor.ts
@@ -51,22 +51,84 @@ const SLEEP_IDLE_SECONDS = 300;
 const STRIKE_LIMIT = 3;
 const STRIKE_WINDOW_MS = 5 * 60_000;
 
-/** Resolve the PID of the process listening on a localhost port. Linux-only:
- *  prefers `ss -ltnp`, falls back to scanning /proc/net/tcp + process fd socket
- *  inodes. Returns null on any other platform or when no listener is found —
- *  callers treat null as "unknown", never "safe". */
+/** Resolve the PID of the process listening on a localhost port, cross-platform:
+ *  Linux `ss` (+ /proc fallback), macOS `lsof`, Windows `netstat`. Returns null
+ *  when the tool is missing/unparseable or no listener is found — callers treat
+ *  null as "unknown", never "safe", so a non-answer never blocks startup. */
 function defaultPidOnPort(port: number): number | null {
-  if (process.platform !== 'linux') return null;
-  try {
-    const out = execFileSync('ss', ['-ltnp'], { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] });
-    const line = out.split('\n').find((l) => l.includes(`:${port} `) || l.endsWith(`:${port}`));
-    const m = line && /pid=(\d+)/.exec(line);
-    if (m) return parseInt(m[1], 10);
-  } catch { /* ss missing/failed — fall through to the /proc scan */ }
-  return pidOnPortViaProc(port);
+  switch (process.platform) {
+    case 'linux': {
+      try {
+        const out = execFileSync('ss', ['-ltnp'], { encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] });
+        const pid = parseSsListenerPid(out, port);
+        if (pid != null) return pid;
+      } catch { /* ss missing/failed — fall through to the /proc scan */ }
+      return pidOnPortViaProc(port);
+    }
+    case 'darwin': {
+      // -nP: no DNS/port-name lookups (fast); -sTCP:LISTEN: listeners only; -F p: PID-only output.
+      const out = runTool('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-F', 'p']);
+      return out ? parseLsofPid(out) : null;
+    }
+    case 'win32': {
+      const out = runTool('netstat', ['-ano', '-p', 'tcp']);
+      return out ? parseNetstatListenerPid(out, port) : null;
+    }
+    default:
+      return null;
+  }
 }
 
-/** /proc-only port→PID: find the socket inode for the LISTEN port in
+function runTool(file: string, args: string[]): string | null {
+  try {
+    return execFileSync(file, args, { encoding: 'utf8', timeout: 4000, windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    return null; // tool missing, non-zero exit, or timeout — all non-fatal (unknown).
+  }
+}
+
+// ---- pure parsers (unit-tested; no shell in tests) ----
+
+/** Linux `ss -ltnp` → PID of the process listening on `port`. Port match is exact
+ *  (`:9920` must not match a `:992` query) and anchored to the LOCAL address column
+ *  so a foreign/peer address can't false-match. */
+export function parseSsListenerPid(stdout: string, port: number): number | null {
+  for (const line of stdout.split('\n')) {
+    if (!line.includes('LISTEN')) continue;
+    const cols = line.trim().split(/\s+/);
+    // ss -ltnp columns: State Recv-Q Send-Q Local:Port Peer:Port Process
+    const local = cols[3] ?? '';
+    const m = local.match(/:(\d+)$/);
+    if (m && parseInt(m[1], 10) === port) {
+      const p = /pid=(\d+)/.exec(line);
+      if (p) return parseInt(p[1], 10);
+    }
+  }
+  return null;
+}
+
+/** macOS `lsof -F p` output → PID. With `-F p`, PID lines are `p<pid>`. */
+export function parseLsofPid(stdout: string): number | null {
+  const line = stdout.split('\n').find((l) => /^p\d+$/.test(l.trim()));
+  return line ? parseInt(line.trim().slice(1), 10) : null;
+}
+
+/** Windows `netstat -ano -p tcp` → PID of the LISTENING socket on `port`.
+ *  Row shape: `  TCP    127.0.0.1:9920    0.0.0.0:0    LISTENING    12345`. */
+export function parseNetstatListenerPid(stdout: string, port: number): number | null {
+  for (const line of stdout.split('\n')) {
+    if (!/LISTENING/i.test(line)) continue;
+    const cols = line.trim().split(/\s+/);
+    // cols: [TCP, local, foreign, state, pid]
+    if (cols.length >= 5 && cols[1]?.endsWith(`:${port}`)) {
+      const pid = parseInt(cols[cols.length - 1], 10);
+      if (Number.isFinite(pid)) return pid;
+    }
+  }
+  return null;
+}
+
+/** Linux /proc-only port→PID: find the socket inode for the LISTEN port in
  *  /proc/net/tcp(6), then the process whose fd links to that inode. */
 function pidOnPortViaProc(port: number): number | null {
   const hex = ':' + port.toString(16).toUpperCase().padStart(4, '0');
@@ -100,10 +162,28 @@ function listenInodeForPort(hexPort: string): string | null {
   return null;
 }
 
-/** Resolve a PID's executable path via /proc/<pid>/exe; null when unreadable
- *  (raced exit, perms) — callers treat null as "unknown", never "safe". */
+/** Resolve a PID's executable path / image name, cross-platform — used by the
+ *  stale-engine reaper to confirm the squatter is actually llama-server before
+ *  killing it. Returns null when undeterminable — callers treat null as
+ *  "unknown", never "safe", so an unconfirmable process is never killed. */
 function defaultExeForPid(pid: number): string | null {
-  try { return fs.readlinkSync(`/proc/${pid}/exe`); } catch { return null; }
+  switch (process.platform) {
+    case 'linux':
+      try { return fs.readlinkSync(`/proc/${pid}/exe`); } catch { return null; }
+    case 'darwin': {
+      const out = runTool('ps', ['-p', String(pid), '-o', 'comm=']);
+      const name = out?.split('\n')[0]?.trim();
+      return name || null;
+    }
+    case 'win32': {
+      // Image name only (llama-server.exe) — enough to confirm it's our engine.
+      const out = runTool('tasklist', ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH']);
+      const m = out && /^"([^"]+)"/.exec(out.trim());
+      return m ? m[1] : null;
+    }
+    default:
+      return null;
+  }
 }
 
 export class EngineSupervisor extends EventEmitter {
@@ -198,8 +278,8 @@ export class EngineSupervisor extends EventEmitter {
     // (the old quit path lost the SIGTERM race) and keep the port bound. Our child then
     // can't bind, and — before the identity guard above — we'd have adopted the orphan.
     // If the listener is a llama-server that is NOT our live child, kill it so this
-    // spawn gets the port. Linux-only; elsewhere the port conflict surfaces as the
-    // child's startup exit (unchanged behavior).
+    // spawn gets the port. Where the port→PID tool is unavailable the reaper is a
+    // no-op and the conflict simply surfaces as the child's startup exit (unchanged).
     this.reapStaleEngineOnPort();
 
     const child = spawn(
@@ -261,7 +341,7 @@ export class EngineSupervisor extends EventEmitter {
         // dies while the ORPHAN answers /health. Without this guard we would adopt
         // the orphan — and later count ITS death as OUR crash (the false "engine
         // crashed repeatedly" strike-out). Only accept when the listener is our child
-        // (or identity can't be determined, e.g. non-Linux — fall through as before).
+        // (or identity can't be determined on this platform — fall through as before).
         if (res.ok && this.isOurChildOnPort(child)) {
           this.state = 'running';
           this.touch();
@@ -295,12 +375,11 @@ export class EngineSupervisor extends EventEmitter {
   }
 
   /** Is the process listening on our port the child we just spawned? Returns
-   *  true when identity can't be determined (non-Linux, or ss/proc unavailable)
-   *  so we don't regress platforms without the mapping — the guard only ever
-   *  REJECTS a confidently-foreign listener; it never blocks an unknown one.
-   *  This is what stops us adopting an orphaned engine on our fixed port. */
+   *  true when identity can't be determined (the platform's port→PID tool is
+   *  missing/unparseable) so we never regress a platform we can't inspect — the
+   *  guard only ever REJECTS a confidently-foreign listener; it never blocks an
+   *  unknown one. This is what stops us adopting an orphaned engine on our port. */
   private isOurChildOnPort(child: ChildProcess): boolean {
-    if (process.platform !== 'linux') return true; // no port→PID mapping — assume ours
     if (child.pid == null) return true;            // not assigned yet — can't disprove
     const pid = (this.opts.pidOnPort ?? defaultPidOnPort)(this.opts.port);
     if (pid == null) return true;                  // unknown — don't block on a non-answer
@@ -308,11 +387,10 @@ export class EngineSupervisor extends EventEmitter {
   }
 
   /** Kill a llama-server squatting on our port that is NOT our live child (a stale
-   *  orphan from a previous run). Best-effort + Linux-only; never throws, and never
-   *  touches our own child or a non-llama process. Runs before spawn so this instance
-   *  can actually bind the fixed port instead of adopting the orphan. */
+   *  orphan from a previous run). Best-effort; never throws, and never touches our
+   *  own child or a process we can't confirm is llama-server. Runs before spawn so
+   *  this instance can actually bind the fixed port instead of adopting the orphan. */
   private reapStaleEngineOnPort(): void {
-    if (process.platform !== 'linux') return;
     const pid = (this.opts.pidOnPort ?? defaultPidOnPort)(this.opts.port);
     if (pid == null) return;                       // nothing (identifiably) on the port
     if (this.child && this.child.pid === pid) return; // our own live child — leave it

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -3296,8 +3296,11 @@ export function registerIpcHandlers(
     return { ok: true, missingIds: results.filter((x): x is string => x !== null) };
   });
 
-  // Return cleanup function for use during app shutdown
-  return function cleanup() {
+  // Return cleanup function for use during app shutdown. It returns the engine-stop
+  // promise so main's quit handler can AWAIT the llama-server teardown before
+  // app.quit() — the old fire-and-forget `void` let quit win the race and orphaned
+  // the engine, which kept the port bound for the next instance to wrongly adopt.
+  return function cleanup(): Promise<void> {
     stopThemeWatcher();
     clearInterval(statusInterval);
     clearInterval(usageRefreshInterval);
@@ -3307,7 +3310,8 @@ export function registerIpcHandlers(
     // is synchronous and callers don't await it, so this mirrors the async
     // stopSyncSpaces() teardown pattern in main.ts window-all-closed.
     void nativeHost.destroyAll().catch(() => {});
-    void engineManager.stopAll().catch(() => {}); // never leave an orphaned llama-server on quit
+    // Awaited by the caller: never leave an orphaned llama-server on quit.
+    const engineStopped = engineManager.stopAll().catch(() => {});
     for (const [id, watcher] of topicWatchers) {
       if (typeof (watcher as fs.FSWatcher).close === 'function') {
         (watcher as fs.FSWatcher).close();
@@ -3318,5 +3322,6 @@ export function registerIpcHandlers(
     topicWatchers.clear();
     lastTopics.clear();
     sessionIdMap.clear();
+    return engineStopped;
   };
 }

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -112,7 +112,7 @@ let mainWindow: BrowserWindow | null = null;
 // Assigned once during setup; `createAppWindow` uses it to hide the buddy
 // when the last main window closes (spec §7.6).
 let buddyManagerRef: BuddyWindowManager | null = null;
-let cleanupIpcHandlers: (() => void) | null = null;
+let cleanupIpcHandlers: (() => Promise<void>) | null = null;
 // Plan 2b Task 8: the conversation-lease client + this install's device identity.
 // Constructed inside createWindow (before registerIpcHandlers) but referenced
 // again in the app-ready sync block, so they live at module scope. The holder
@@ -1714,7 +1714,10 @@ app.whenReady().then(async () => {
 });
 
 app.on('window-all-closed', () => {
-  if (cleanupIpcHandlers) cleanupIpcHandlers();
+  // Capture the engine-stop promise: cleanup() starts llama-server teardown and we
+  // must let it finish before app.quit(), else the engine outlives the app and keeps
+  // the fixed port bound for the next instance to wrongly adopt (2026-07-20 fix).
+  const engineStopped = cleanupIpcHandlers ? cleanupIpcHandlers() : Promise.resolve();
   destroySocialHandlers(); // tear down the presence WebSocket + its timers
   sessionManager.destroyAll();
   hookRelay.stop();
@@ -1731,5 +1734,10 @@ app.on('window-all-closed', () => {
   try { leaseClient?.destroy(); } catch {}
   // Stop sync service — clears timer, releases locks, removes .app-sync-active marker
   try { setSyncService(null); } catch {}
-  app.quit();
+  // Wait for the engine to actually die, but never let a wedged teardown hang quit:
+  // race the teardown against a 4s cap (supervisor's own SIGTERM→SIGKILL bound is ~3s).
+  void Promise.race([
+    engineStopped,
+    new Promise<void>((r) => setTimeout(r, 4_000)),
+  ]).finally(() => app.quit());
 });

--- a/desktop/tests/engine-supervisor.test.ts
+++ b/desktop/tests/engine-supervisor.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import type { ChildProcess } from 'child_process';
-import { EngineSupervisor } from '../src/main/engine/engine-supervisor';
+import {
+  EngineSupervisor,
+  parseSsListenerPid,
+  parseLsofPid,
+  parseNetstatListenerPid,
+} from '../src/main/engine/engine-supervisor';
 
 const mockSpawn = vi.fn();
 vi.mock('child_process', async (orig) => ({
@@ -412,5 +417,43 @@ describe('EngineSupervisor', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---- cross-platform port→PID parsers (pure; no shell) ----
+// These pin the output shapes of the per-platform tools the orphan-guard and
+// stale-engine reaper rely on, so a parsing regression can't silently re-open
+// the "adopt a foreign engine" hole on macOS/Windows.
+describe('port→PID parsers', () => {
+  it('parseSsListenerPid: Linux ss -ltnp output → PID', () => {
+    const out = [
+      'State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process',
+      'LISTEN 0      511    127.0.0.1:9920      0.0.0.0:*     users:(("llama-server",pid=111523,fd=20))',
+      'LISTEN 0      511    127.0.0.1:9900      0.0.0.0:*     users:(("node",pid=777,fd=25))',
+    ].join('\n');
+    expect(parseSsListenerPid(out, 9920)).toBe(111523);
+    expect(parseSsListenerPid(out, 9900)).toBe(777);
+    expect(parseSsListenerPid(out, 1234)).toBeNull(); // not listening
+    // Exact-match: a query for a PREFIX port must not match a longer listening port.
+    expect(parseSsListenerPid(out, 992)).toBeNull();  // ':992' ≠ ':9920'
+    expect(parseSsListenerPid(out, 99)).toBeNull();   // ':99'  ≠ ':9900'/':9920'
+  });
+
+  it('parseLsofPid: macOS lsof -F p output → PID', () => {
+    expect(parseLsofPid('p4821\nf3\n')).toBe(4821);
+    expect(parseLsofPid('')).toBeNull();
+    expect(parseLsofPid('COMMAND  PID USER\n')).toBeNull();
+  });
+
+  it('parseNetstatListenerPid: Windows netstat -ano → PID of LISTENING socket', () => {
+    const out = [
+      '  Proto  Local Address          Foreign Address        State           PID',
+      '  TCP    127.0.0.1:9920         0.0.0.0:0              LISTENING       22234',
+      '  TCP    127.0.0.1:9920         127.0.0.1:55000        ESTABLISHED     999', // not LISTENING — ignored
+      '  TCP    0.0.0.0:9900           0.0.0.0:0              LISTENING       5555',
+    ].join('\n');
+    expect(parseNetstatListenerPid(out, 9920)).toBe(22234);
+    expect(parseNetstatListenerPid(out, 9900)).toBe(5555);
+    expect(parseNetstatListenerPid(out, 4321)).toBeNull();
   });
 });

--- a/desktop/tests/engine-supervisor.test.ts
+++ b/desktop/tests/engine-supervisor.test.ts
@@ -312,4 +312,105 @@ describe('EngineSupervisor', () => {
     expect(mockSpawn).toHaveBeenCalledTimes(2); // spawned a fresh server, didn't reuse the dying one
     expect(sup.status()).toBe('running');
   });
+
+  // ---- engine-lifecycle fix (2026-07-20): no adopting orphans, real quit kill ----
+
+  it('does NOT adopt a foreign process answering /health on our port (orphan guard)', async () => {
+    const child = makeFakeChild();
+    (child as any).pid = 4242;
+    mockSpawn.mockReturnValue(child);
+    // /health answers ok immediately, but the port is held by a DIFFERENT pid (9999) —
+    // an orphaned engine. The supervisor must NOT mark running against it; our child
+    // (which couldn't bind) exits, so we surface the startup failure instead.
+    sup = makeSupervisor(healthAfter(0), {
+      pidOnPort: () => 9999, // foreign listener
+      readyDeadlineMs: 500, readyPollMs: 10,
+    });
+    const p = sup.ensureRunning();
+    setImmediate(() => child.emit('exit', 1)); // bind-failed child dies
+    await expect(p).rejects.toThrow();          // never resolves a URL to the orphan
+    expect(sup.status()).toBe('stopped');
+  });
+
+  it('DOES mark running when the /health listener IS our spawned child', async () => {
+    const child = makeFakeChild();
+    (child as any).pid = 4242;
+    mockSpawn.mockReturnValue(child);
+    sup = makeSupervisor(healthAfter(0), { pidOnPort: () => 4242 }); // our own child
+    const base = await sup.ensureRunning();
+    expect(base).toBe('http://127.0.0.1:9999/v1');
+    expect(sup.status()).toBe('running');
+  });
+
+  it('reaps a stale llama-server squatting on the port BEFORE spawning', async () => {
+    const child = makeFakeChild();
+    (child as any).pid = 4242;
+    mockSpawn.mockReturnValue(child);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    try {
+      // Port is held by orphan pid 9999 (a llama-server). After the reaper SIGKILLs it,
+      // our spawned child (4242) takes the port — pidOnPort reflects the handoff.
+      let portHolder: number | null = 9999;
+      killSpy.mockImplementation(((pid: number, sig: string) => {
+        if (pid === 9999 && sig === 'SIGKILL') portHolder = 4242;
+        return true;
+      }) as any);
+      sup = makeSupervisor(healthAfter(0), {
+        pidOnPort: () => portHolder,
+        exeForPid: (pid: number) => (pid === 9999 ? '/x/engine/llama-b9992/llama-server' : null),
+      });
+      const base = await sup.ensureRunning();
+      expect(killSpy).toHaveBeenCalledWith(9999, 'SIGKILL'); // orphan reaped before spawn
+      expect(base).toBe('http://127.0.0.1:9999/v1');          // then our child is adopted
+      expect(sup.status()).toBe('running');
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it('never kills a NON-llama process holding the port (reaper is conservative)', async () => {
+    const child = makeFakeChild();
+    (child as any).pid = 4242;
+    mockSpawn.mockReturnValue(child);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    try {
+      // Port held by pid 9999, but it's some other app (not llama-server) — must NOT kill.
+      sup = makeSupervisor(vi.fn(async () => { throw new Error('ECONNREFUSED'); }), {
+        pidOnPort: () => 9999,
+        exeForPid: () => '/usr/bin/nginx',
+        readyDeadlineMs: 100, readyPollMs: 10,
+      });
+      await expect(sup.ensureRunning()).rejects.toThrow();
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it('stop() escalates SIGTERM → SIGKILL when the child ignores TERM', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = makeFakeChild();
+      // Child ignores SIGTERM entirely (never exits on it) — simulates a wedged server.
+      const killCalls: string[] = [];
+      (child as any).kill = vi.fn((sig: string) => {
+        killCalls.push(sig);
+        if (sig === 'SIGKILL') setImmediate(() => child.emit('exit', 137));
+        return true;
+      });
+      mockSpawn.mockReturnValue(child);
+      sup = makeSupervisor(healthAfter(0));
+      await sup.ensureRunning();
+      expect(sup.status()).toBe('running');
+
+      const stopP = sup.stop();
+      await vi.advanceTimersByTimeAsync(1_600); // past the TERM grace window
+      await vi.advanceTimersByTimeAsync(100);   // let the KILL exit land
+      await stopP;
+      expect(killCalls).toEqual(['SIGTERM', 'SIGKILL']);
+      expect(sup.status()).toBe('stopped');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## What was wrong

The **"engine crashed repeatedly"** strike-out could be **falsely triggered**, and the **model loading indicator** silently broke — both from one engine-lifecycle bug.

There's no single-instance lock, and the quit path fired `void engineManager.stopAll()` (fire-and-forget) so `app.quit()` won the race: a `llama-server` from a previous run could **outlive the app** and keep the **fixed engine port (9920)** bound. The next instance spawned its own child, which couldn't bind and died — but the readiness poll only checked `GET /health` for `res.ok`, **with no identity check** — so the *orphan* answered and the new instance **adopted** it.

That produced two symptoms (both reported):
- The instance counted the adopted engine's death as **its own crash** (3 in 5 min → the erroneous "crashed repeatedly" screen). No real malfunction needed — just a quit/idle on the wrong process.
- The **loading indicator** (N GB / M GB) broke because per-model state/byte updates came from a process the instance didn't own.

Confirmed live on a Strix Halo Linux box: orphaned router (parent = systemd) holding port 9920, spawned model-load children on behalf of a freshly-relaunched beta instance.

## The fix (Linux; other platforms unchanged / fall through as before)

- **Identity guard** — only mark `running` when the process listening on our port is the child we just spawned. Port→PID via `ss -ltnp` with a `/proc/net/tcp` + fd-inode fallback. Never blocks when identity is undeterminable (non-Linux) — it only *rejects* a confidently-foreign listener.
- **Reap stale engine** — before spawning, SIGKILL a confirmably-`llama-server` process squatting on our port that isn't our live child. Conservative: never kills a non-llama process or our own child.
- **Real quit kill** — `_stop()` escalates SIGTERM → SIGKILL (bounded ~3s) so a wedged server can't ignore TERM and leak; `main`'s `window-all-closed` now **awaits** the engine teardown (raced against a 4s cap) instead of fire-and-forget.

## Tests

New regression coverage in `engine-supervisor.test.ts`:
- foreign process answering `/health` is **not** adopted
- our own spawned child **is** adopted
- stale llama-server is reaped before spawn
- a **non-llama** process holding the port is never killed
- stop() escalates SIGTERM → SIGKILL when the child ignores TERM

20/20 supervisor tests pass. Full desktop suite green except a pre-existing, unrelated flake in `artifact-store.test.ts` (CAS retry timing; passes in isolation; untouched by this change).

## Notes / follow-ups (not in this PR)

- The 4 GB unified-memory APU "dedicated VRAM" mis-detection in `gpu-detector.ts` is real but minor and **not** the crash cause — left for a separate change.
- A **single-instance lock** would prevent the port collision at the source, but is a deliberate behavioral decision (power users may run multiple windows) — out of scope here.
- "Run in background" (keep models serving external tools after close) captured as a ROADMAP idea, not implemented.

## Pre-merge review notes (for full context)

- **Quit may take up to ~4s in the worst case.** Quit now waits for the engine to die (SIGTERM→SIGKILL, ~3s) before `app.quit()`, raced against a 4s cap. A healthy engine SIGTERMs in <1s so most users see no change; a model mid-load can add a couple seconds to window close. This is the intended cost of not orphaning the engine.
- **Two-instance behavior change (deliberate).** There's no single-instance lock, so a user *can* launch two instances. Before, the second instance would brokenly *adopt* the first's engine on the shared port; now its startup reaps the first's engine (a confirmable llama-server that isn't its own child) and takes the port — the first instance then observes its engine die. That's *more correct* than the buggy adoption, but two instances still can't truly share one fixed-port engine. Making that work is the separate single-instance-lock / background-serve conversation, not this PR.
- **macOS/Windows parsers are format-verified, not hardware-verified.** `lsof`/`netstat` output shapes are pinned by unit tests from documented formats, but were only *executed* on Linux. The beta CI matrix (Windows + macOS legs) exercises the build there; runtime port→PID on those platforms is the remaining unknown and degrades gracefully (returns "unknown" → guard passes through, never blocks) if a tool is missing/unparseable.
- **Linux resolver verified live.** Both the `ss` path and the `/proc` fallback were run against a real spawned `llama-server` and returned the correct own-child PID, so the guard does not false-reject a legitimate engine on Linux.
