### PR TITLE
fix(harness): resolve rgPath to asar.unpacked — Grep works in packaged app

### DIFF
--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -285,7 +285,10 @@ export const BashTool = defineTool({
       ctx.signal.addEventListener('abort', onAbort, { once: true });
       // If the signal already fired before we attached (once:true won't replay), kill now.
       if (ctx.signal.aborted) onAbort();
-      child.on('error', (err) => finish(`Failed to start shell: ${err.message}\n`, true));
+      // Async spawn failure (the path Windows takes for a bad cwd): name the
+      // shell + cwd actually used, not just Node's bare `spawn <cmd> <CODE>` —
+      // same diagnosability contract as the sync catch above.
+      child.on('error', (err) => finish(`Failed to start shell: ${err.message} (shell=${shell.cmd}; cwd=${startCwd})\n`, true));
       child.on('close', (code) => finish(code === 0 ? '' : `(exit code ${code})\n`, code !== 0, code));
     });
   },

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -215,11 +215,22 @@ export const BashTool = defineTool({
     const shell = getShell();
     const probe = tracksCwdFor(shell) && !/(\\|&&|\|\||\|)\s*$/.test(args.command);
     return new Promise((resolve) => {
-      const child = spawn(shell.cmd, [...shell.args, probe ? withCwdProbe(args.command) : args.command], {
-        cwd: startCwd,
-        windowsHide: true,
-        env: process.env,
-      });
+      // spawn() throws SYNCHRONOUSLY when the shell path or startCwd has a
+      // non-directory prefix (e.g. a stale/deleted tracked cwd that raced past
+      // the existsSync check above). That throw fires before the 'error' handler
+      // at the bottom of this executor can attach, so catch it here — otherwise
+      // it escapes to defineTool as a bare `Bash failed: spawn <CODE>`.
+      let child;
+      try {
+        child = spawn(shell.cmd, [...shell.args, probe ? withCwdProbe(args.command) : args.command], {
+          cwd: startCwd,
+          windowsHide: true,
+          env: process.env,
+        });
+      } catch (e: any) {
+        resolve({ text: `Failed to start shell: ${e?.message ?? e} (shell=${shell.cmd}; cwd=${startCwd})`, isError: true });
+        return;
+      }
       let out = '';
       // The 200KB cap below would drop the trailing sentinel on a chatty command
       // ("cd sub && <huge output>"), silently losing the cd. Keep a small rolling

--- a/desktop/src/main/harness/tools/grep.ts
+++ b/desktop/src/main/harness/tools/grep.ts
@@ -1,9 +1,30 @@
 // Bundled ripgrep (@vscode/ripgrep) — deterministic cross-platform search.
 import { spawn } from 'child_process';
-import { rgPath } from '@vscode/ripgrep';
+import { rgPath as bundledRgPath } from '@vscode/ripgrep';
+import * as fs from 'fs';
 import { z } from 'zod';
 import { defineTool } from './registry';
 import { resolveP } from './guards';
+
+/** Resolve the ripgrep binary the tool will actually spawn.
+ *
+ * WHY (the real `spawn ENOTDIR` root cause, 2026-07-20): in the packaged app,
+ * `@vscode/ripgrep` resolves `rgPath` via `createRequire(...).resolve()` to a
+ * path INSIDE `app.asar` — e.g.
+ *   /opt/YouCoded/resources/app.asar/node_modules/@vscode/ripgrep-linux-x64/bin/rg
+ * `app.asar` is a FILE, not a directory, so that path's prefix component is not
+ * a directory. `spawn()` therefore throws `spawn ENOTDIR` SYNCHRONOUSLY (before
+ * any 'error' handler can attach), which is why every Grep failed in the
+ * packaged app even after the earlier `cwd:` fix. electron-builder DOES unpack
+ * the binary to `app.asar.unpacked/` (it auto-unpacks executables), but nothing
+ * rewrote rgPath to point there. Mirror the pty-worker fix (session-manager.ts):
+ * prefer the unpacked sibling when it exists, else fall back to the bundled
+ * path (correct in dev, where there is no asar). Pure + exported for tests. */
+export function resolveRgPath(raw: string = bundledRgPath): string {
+  const unpacked = raw.replace(/app\.asar(?!\.unpacked)([/\\])/, `app.asar.unpacked$1`);
+  if (unpacked !== raw && fs.existsSync(unpacked)) return unpacked;
+  return raw;
+}
 
 export const GrepTool = defineTool({
   name: 'Grep',
@@ -26,13 +47,24 @@ export const GrepTool = defineTool({
     if (args.glob) rgArgs.push('--glob', args.glob);
     rgArgs.push('--', args.pattern, resolveP(args.path ?? '.', ctx.cwd));
     return new Promise((resolve) => {
-      // Fix: pass `cwd: ctx.cwd` explicitly. Grep was the only tool spawning a
-      // child with no `cwd`, so rg inherited the Electron main process's ambient
-      // cwd — which in the packaged app is not a usable directory for posix_spawn
-      // and failed every search with `spawn ENOTDIR`. ctx.cwd is the validated
-      // session cwd already used to resolve the search path above; the Bash tool
-      // passes it the same way (bash.ts) and works. Never inherit ambient cwd.
-      const child = spawn(rgPath, rgArgs, { cwd: ctx.cwd, windowsHide: true });
+      // Two spawn defenses, both learned from `spawn ENOTDIR` (2026-07-20):
+      //  1. `cwd: ctx.cwd` explicitly — never inherit the Electron main process's
+      //     ambient cwd (the original PR #172 fix; still correct).
+      //  2. `resolveRgPath()` — rewrite an inside-asar rgPath to the unpacked
+      //     binary (the ACTUAL root cause; see resolveRgPath above).
+      const rgBin = resolveRgPath();
+      // spawn() throws SYNCHRONOUSLY when the command path or cwd has a
+      // non-directory prefix (e.g. an inside-asar binary path). That throw happens
+      // before the 'error' handler below can attach, so it must be caught here —
+      // otherwise it escapes to defineTool as a context-free `Grep failed: spawn
+      // <CODE>` that hides which path/cwd was at fault.
+      let child;
+      try {
+        child = spawn(rgBin, rgArgs, { cwd: ctx.cwd, windowsHide: true });
+      } catch (e: any) {
+        resolve({ text: `Grep failed: could not start ripgrep (${e?.message ?? e}; rg=${rgBin}; cwd=${ctx.cwd}).`, isError: true });
+        return;
+      }
       let out = '';
       let err = '';
       child.stdout.on('data', (d) => {

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -25,7 +25,7 @@ import { WriteTool } from '../src/main/harness/tools/write';
 import { EditTool } from '../src/main/harness/tools/edit';
 import { BashTool } from '../src/main/harness/tools/bash';
 import { GlobTool } from '../src/main/harness/tools/glob';
-import { GrepTool } from '../src/main/harness/tools/grep';
+import { GrepTool, resolveRgPath } from '../src/main/harness/tools/grep';
 import { TodoWriteTool } from '../src/main/harness/tools/todo-write';
 import type { ToolContext } from '../src/main/harness/tools/types';
 
@@ -260,6 +260,20 @@ describe('Bash', () => {
     expect(r.text).toMatch(/timed out/i);
   });
 
+  it('a synchronous spawn throw resolves an error result (never escapes to defineTool)', async () => {
+    // Same sync-throw trap as Grep: spawn() throws before the 'error' handler can
+    // attach when startCwd has a non-directory prefix. ctx.cwd = a FILE forces it
+    // (bash.ts only guards shellCwd, falling back to ctx.cwd, so a file ctx.cwd
+    // reaches spawn). Without the try/catch this escaped as `Bash failed: spawn
+    // ENOTDIR`; pin that it now resolves a structured error naming the cwd.
+    const fileCwd = path.join(dir, 'not-a-dir.txt');
+    fs.writeFileSync(fileCwd, 'x');
+    const r = await BashTool.execute({ command: 'echo hi' }, makeCtx(fileCwd));
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/Failed to start shell/);
+    expect(r.text).toContain(fileCwd);
+  });
+
   // Scoped persistence (ROADMAP 2026-07-17). Before this, every call spawned
   // fresh at the session root and `cd` silently evaporated — the failure mode
   // that burned ~6 tool calls in the 2026-07-17 session.
@@ -464,6 +478,67 @@ describe('Grep', () => {
     expect(rgCall, 'expected a spawn call running ripgrep for the search').toBeTruthy();
     const opts = rgCall![2] as { cwd?: string };
     expect(opts?.cwd, 'rg must be spawned with an explicit cwd (ctx.cwd), not inherit ambient cwd').toBe(ctx.cwd);
+  });
+
+  it('resolveRgPath rewrites an inside-asar rgPath to the unpacked binary', () => {
+    // THE actual `spawn ENOTDIR` root cause (2026-07-20): in the packaged app,
+    // @vscode/ripgrep resolves rgPath INSIDE app.asar (a FILE), and spawn() of a
+    // command whose path prefix is a file throws ENOTDIR synchronously. The binary
+    // IS unpacked to app.asar.unpacked/ — the tool just has to point there. Pin
+    // the rewrite against BOTH separators and the no-op cases.
+    //
+    // Build a real on-disk fixture so the existsSync guard passes: mirror the
+    // packaged layout under a tmp dir (.../app.asar.unpacked/.../bin/rg).
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rgpath-'));
+    const asarPath = path.join(root, 'app.asar', 'node_modules', '@vscode', 'ripgrep-linux-x64', 'bin', 'rg');
+    const unpackedPath = path.join(root, 'app.asar.unpacked', 'node_modules', '@vscode', 'ripgrep-linux-x64', 'bin', 'rg');
+    fs.mkdirSync(path.dirname(unpackedPath), { recursive: true });
+    fs.writeFileSync(unpackedPath, '#!/bin/sh\n');
+    try {
+      expect(resolveRgPath(asarPath)).toBe(unpackedPath);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+    // Already-unpacked input is returned unchanged (no app.asar.unpacked.unpacked):
+    // the (?!\.unpacked) lookahead must not match. With no unpacked file on disk
+    // the guard falls through to returning the input, so this doubles as the pin.
+    const rootW = fs.mkdtempSync(path.join(os.tmpdir(), 'rgpath-w-'));
+    try {
+      const already = path.join(rootW, 'app.asar.unpacked', 'node_modules', '@vscode', 'ripgrep-linux-x64', 'bin', 'rg');
+      expect(resolveRgPath(already)).toBe(already);
+    } finally {
+      fs.rmSync(rootW, { recursive: true, force: true });
+    }
+  });
+
+  it('resolveRgPath falls back to the bundled path when no unpacked copy exists', () => {
+    // Dev checkout: no asar at all → returned unchanged.
+    const devPath = '/home/dev/youcoded/desktop/node_modules/@vscode/ripgrep-linux-x64/bin/rg';
+    expect(resolveRgPath(devPath)).toBe(devPath);
+    // Packaged-style path but the unpacked binary is ABSENT → keep the bundled
+    // path (spawn will error, but with the real path surfaced, not a silent
+    // rewrite). Uses a tmp dir so it can't collide with a real install.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rgpath-m-'));
+    try {
+      const missing = path.join(root, 'app.asar', 'node_modules', '@vscode', 'ripgrep-linux-x64', 'bin', 'rg');
+      expect(resolveRgPath(missing)).toBe(missing);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('a synchronous spawn throw resolves an error result (never escapes to defineTool)', async () => {
+    // spawn() throws SYNCHRONOUSLY when the command path or cwd has a non-directory
+    // prefix. cwd = a FILE is the easiest way to force it cross-platform. The
+    // 'error' handler (attached after spawn) cannot catch a sync throw, so without
+    // the try/catch this escaped as a context-free `Grep failed: spawn ENOTDIR`.
+    // Pin: the tool resolves a structured error that NAMES the failing cwd.
+    const fileCwd = path.join(dir, 'not-a-dir.txt');
+    fs.writeFileSync(fileCwd, 'x');
+    const r = await GrepTool.execute({ pattern: 'findme', output_mode: 'content' }, makeCtx(fileCwd));
+    expect(r.isError).toBe(true);
+    expect(r.text).toMatch(/could not start ripgrep/);
+    expect(r.text).toContain(fileCwd); // the offending path is surfaced, not hidden
   });
 });
 

--- a/desktop/tests/harness-tools-core.test.ts
+++ b/desktop/tests/harness-tools-core.test.ts
@@ -260,18 +260,19 @@ describe('Bash', () => {
     expect(r.text).toMatch(/timed out/i);
   });
 
-  it('a synchronous spawn throw resolves an error result (never escapes to defineTool)', async () => {
-    // Same sync-throw trap as Grep: spawn() throws before the 'error' handler can
-    // attach when startCwd has a non-directory prefix. ctx.cwd = a FILE forces it
-    // (bash.ts only guards shellCwd, falling back to ctx.cwd, so a file ctx.cwd
-    // reaches spawn). Without the try/catch this escaped as `Bash failed: spawn
-    // ENOTDIR`; pin that it now resolves a structured error naming the cwd.
+  it('a spawn-level failure resolves a structured error that names the cwd', async () => {
+    // A bad startCwd makes spawn fail. The PATH differs by platform: on POSIX a
+    // file-cwd throws SYNCHRONOUSLY (before the 'error' handler can attach — the
+    // trap the try/catch guards); on Windows the shell spawn fails ASYNCHRONOUSLY
+    // via 'error' (ENOENT). Either way the result must be a structured error that
+    // NAMES the offending cwd — never a context-free `Bash failed: spawn <CODE>`.
+    // (ctx.cwd = a FILE reaches spawn because bash.ts only guards shellCwd.)
     const fileCwd = path.join(dir, 'not-a-dir.txt');
     fs.writeFileSync(fileCwd, 'x');
     const r = await BashTool.execute({ command: 'echo hi' }, makeCtx(fileCwd));
     expect(r.isError).toBe(true);
     expect(r.text).toMatch(/Failed to start shell/);
-    expect(r.text).toContain(fileCwd);
+    expect(r.text).toContain(fileCwd); // named on BOTH the sync and async paths
   });
 
   // Scoped persistence (ROADMAP 2026-07-17). Before this, every call spawned


### PR DESCRIPTION
## Summary

The Grep tool was still failing with `spawn ENOTDIR` in the **packaged** app, despite PR #172 having "fixed" it by adding `cwd: ctx.cwd`. A root-cause pass found the cwd was never the real problem — **`rgPath` was.**

### Root cause

`@vscode/ripgrep` resolves `rgPath` via `createRequire(...).resolve('@vscode/ripgrep-<platform>/bin/rg')`. In the packaged app that resolves to a path **inside `app.asar`**:

```
/opt/YouCoded/resources/app.asar/node_modules/@vscode/ripgrep-linux-x64/bin/rg
```

`app.asar` is a **file**, not a directory, so the command path's prefix component isn't a directory. `spawn()` therefore throws `spawn ENOTDIR` **synchronously** — *before* the `'error'` handler (attached after `spawn`) can catch it. The throw escaped to `defineTool`, which formatted it as a context-free `Grep failed: spawn ENOTDIR`.

electron-builder **already unpacks** the binary to `app.asar.unpacked/` (it auto-unpacks executables) — nothing rewrote `rgPath` to point there. This is the same class of bug the pty-worker fix solved in `session-manager.ts:131`.

**Why dev/CI never caught it:** in a dev checkout there's no asar, so `rgPath` resolves to a real file and Grep works. The bug only manifests packaged. PR #172's investigation ruled out the search-path arg but never tested whether `rgPath` itself resolves inside the asar — the `ENOTDIR` was always the *command* path, not the `cwd`.

### Changes

- **`grep.ts`** — new exported `resolveRgPath()` rewrites an inside-asar `rgPath` to the unpacked sibling when it exists (guarded regex, no double-`.unpacked`), else falls back to the bundled path (correct in dev). Pure + exported for tests.
- **`grep.ts` + `bash.ts`** — wrap `spawn()` in `try/catch` so a synchronous throw resolves a structured error naming the offending path + cwd, instead of escaping as a bare `spawn <CODE>`. `bash.ts` had the identical latent too-late-`'error'`-handler ordering (spawn L218, handler L277).

The earlier `cwd:` fix is retained — it's still correct on its own; it just wasn't the cause of *this* bug.

### Verification

- **Control:** spawned the *unrewritten* inside-asar path → `spawn ENOTDIR` (byte-for-byte the production error), proving the bug is real.
- **Fix:** `resolveRgPath()` on a fake asar layout rewrites to the unpacked binary, and that binary spawns (exit 0, ripgrep 15.1.0).
- **Regression pins:** asar rewrite (forward sep, no-double-rewrite, missing-unpacked fallback) + sync-throw handling for both Grep and Bash.
- `43/43` harness-tools-core + `96` harness tests green, `tsc` clean.

### Note on end-to-end confirmation
The bug only reproduces in a **packaged** build (dev has no asar), so full confirmation needs this in a release/beta build. The unit + simulation coverage above pins the mechanism directly.

🤖 Generated with Claude Code