### PR TITLE
fix(ui): make Button mergeClasses padding groups per-axis

### DIFF
--- a/desktop/src/renderer/components/ui/Button.test.tsx
+++ b/desktop/src/renderer/components/ui/Button.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { mergeClasses, buttonClasses } from './Button';
+
+// WHY: mergeClasses is a hand-rolled stand-in for tailwind-merge (see the long
+// comment above CONFLICT_GROUPS in Button.tsx). A 2026-07-20 bug had its single
+// padding group treating px- and py- as interchangeable, so the welcome CTAs
+// (`<Button size="lg" className="px-8 ...">`) silently rendered with NO vertical
+// padding — buttons collapsed to text height in the beta build even though the
+// size token said py-2. These tests pin the per-axis independence that fix
+// restored, plus the p-N shorthand's cross-axis behavior.
+//
+// Assertions compare whole tokens (split + toContain), never substrings —
+// "py-2" is a substring of "py-2.5" and substring checks false-positive on it.
+
+function tokens(s: string): string[] {
+  return s.split(/\s+/).filter(Boolean);
+}
+
+describe('mergeClasses padding conflict groups', () => {
+  it('keeps base py- when the override only sets px- (the welcome-CTA regression)', () => {
+    // lg base is "text-sm px-4 py-2". Overriding px must not drop py.
+    const t = tokens(mergeClasses('text-sm px-4 py-2', 'px-8 text-base'));
+    expect(t).toContain('py-2');
+    expect(t).toContain('px-8');
+    expect(t).not.toContain('px-4');
+    expect(t).toContain('text-base');
+    expect(t).not.toContain('text-sm');
+  });
+
+  it('keeps base px- when the override only sets py-', () => {
+    const t = tokens(mergeClasses('text-sm px-4 py-2', 'py-2.5'));
+    expect(t).toContain('px-4');
+    expect(t).toContain('py-2.5');
+    expect(t).not.toContain('py-2');
+  });
+
+  it('lets a p-N shorthand override beat both base px- and py-', () => {
+    const t = tokens(mergeClasses('text-sm px-4 py-2', 'p-4'));
+    expect(t).toContain('p-4');
+    expect(t).not.toContain('px-4');
+    expect(t).not.toContain('py-2');
+  });
+
+  it('lets axis overrides beat a base p-N shorthand', () => {
+    const t = tokens(mergeClasses('p-2 text-sm', 'py-3'));
+    expect(t).toContain('py-3');
+    expect(t).not.toContain('p-2');
+    expect(t).toContain('text-sm');
+  });
+
+  it('still treats same-axis overrides as conflicts (py- replaces py-)', () => {
+    const t = tokens(mergeClasses('px-4 py-2', 'py-3'));
+    expect(t).toContain('py-3');
+    expect(t).not.toContain('py-2');
+    expect(t).toContain('px-4');
+  });
+});
+
+describe('buttonClasses end-to-end', () => {
+  it('size=lg with a wider px- override keeps vertical padding', () => {
+    // Mirrors App.tsx welcome "New Session": panel-glass w-full px-8 text-base
+    const t = tokens(buttonClasses('primary', 'lg', 'panel-glass w-full px-8 text-base'));
+    expect(t).toContain('py-2');
+    expect(t).toContain('px-8');
+    expect(t).toContain('text-base');
+    expect(t).toContain('bg-accent');
+    expect(t).toContain('panel-glass');
+  });
+
+  it('size=lg with an explicit py- override uses the override', () => {
+    const t = tokens(buttonClasses('secondary', 'lg', 'panel-glass w-full px-6 py-3'));
+    expect(t).toContain('py-3');
+    expect(t).not.toContain('py-2');
+    expect(t).toContain('px-6');
+  });
+});

--- a/desktop/src/renderer/components/ui/Button.tsx
+++ b/desktop/src/renderer/components/ui/Button.tsx
@@ -108,25 +108,47 @@ const CONFLICT_GROUPS: readonly RegExp[] = [
   /^rounded(-|$)/,
   // Font SIZE only — must not swallow text-on-accent / text-fg-2 (colors).
   /^text-(4xs|3xs|2xs|xs|sm|base|lg|xl)$/,
-  /^p[xytrbl]?-/,
+  // Fix: split padding into per-axis groups. The old single /^p[xytrbl]?-/
+  // group treated px- and py- as interchangeable, so a caller passing
+  // className="px-8" (wider horizontal padding) silently DROPPED the size's
+  // py-2 — buttons rendered at text height with no vertical padding. Hit the
+  // welcome-screen CTAs (App.tsx "New Session"/"Resume Session") and
+  // SyncPanel's Save button. Regression pinned by Button.test.tsx.
+  /^px-/,
+  /^py-/,
+  /^pt-/,
+  /^pr-/,
+  /^pb-/,
+  /^pl-/,
   /^w-/,
   /^h-/,
   /^gap-/,
   /^font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)$/,
 ];
 
+/** Returns the conflict groups a single class token belongs to. The p-N
+ *  shorthand sets padding on all four sides, so it belongs to every padding
+ *  group — overriding it must beat base px-/py-/pt-/etc., and vice versa. */
+function groupsFor(token: string): RegExp[] {
+  if (/^p-\d/.test(token)) return CONFLICT_GROUPS.filter((re) => re.source.startsWith('^p'));
+  const g = CONFLICT_GROUPS.find((re) => re.test(token));
+  return g ? [g] : [];
+}
+
 /** Drops base tokens whose group the caller has overridden, then appends theirs. */
 export function mergeClasses(base: string, override: string): string {
   const overrides = override.split(/\s+/).filter(Boolean);
   if (overrides.length === 0) return base;
 
+  const overrideGroups = new Set(overrides.flatMap(groupsFor));
+
   const kept = base
     .split(/\s+/)
     .filter(Boolean)
     .filter((token) => {
-      const group = CONFLICT_GROUPS.find((re) => re.test(token));
-      if (!group) return true;
-      return !overrides.some((o) => group.test(o));
+      const groups = groupsFor(token);
+      if (groups.length === 0) return true;
+      return !groups.some((g) => overrideGroups.has(g));
     });
 
   return [...kept, ...overrides].join(' ');


### PR DESCRIPTION
## Problem
The welcome-screen **New Session** / **Resume Session** CTAs — and SyncPanel's **Save** button — rendered at text height (no vertical padding) in the beta build, even though `size="lg"` specifies `py-2`.

## Root cause
`mergeClasses` (the hand-rolled tailwind-merge stand-in in `Button.tsx`) had a **single** padding conflict group `/^p[xytrbl]?-/`. It treated `px-` and `py-` as interchangeable, so a caller widening a button with `className="... px-8"` silently **dropped** the size's `py-2`. The `px-` override matched the one padding group, so the base `py-` token was discarded. Buttons collapsed to their text line-box.

This only bites callers that pass `px-` **without** `py-`. Audited: exactly three sites (welcome New/Resume, SyncPanel Save).

## Fix
Split padding into per-axis conflict groups (`px-`, `py-`, `pt/pr/pb/pl-`), and made the `p-N` shorthand belong to **all** padding groups so it still overrides both axes. An `px-`-only override now preserves the size's vertical padding.

## Verification
- **Pinning test** `Button.test.tsx` (7 tests): per-axis independence, `p-N` cross-axis shorthand, and the exact welcome-CTA regression (`buttonClasses('primary','lg','panel-glass w-full px-8 text-base')` keeps `py-2`). Assertions compare whole tokens, not substrings (`"py-2"` is a substring of `"py-2.5"`).
- **Full suite:** 2863 passed / 262 files.
- **Live:** verified in the dev instance — welcome CTAs render at correct height.

## Rule
`.claude/rules/react-renderer.md` gains a *Control primitives* section documenting the per-axis invariant + a `verify:` anchor on `Button.tsx`, so `/audit` flags drift.

## Note for review
The SyncPanel **Save** button will get slightly taller too — it had the same bug. That's the intended fix, not a regression.