### PR TITLE
fix(terminal): paint the bottom frame strip on framed themes

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2593,10 +2593,11 @@ function AppInner() {
             </div>
             <div
               // app-content: the chat/terminal content region. In framed
-              // terminal view it gets a --frame-edge bottom margin so xterm
-              // sits above the bottom frame strip (see globals.css). The
-              // terminal-panel overlay (below) is a child so it inherits the
-              // same inset and stays aligned with the frame.
+              // terminal view the bottom frame strip comes from chrome-glass's
+              // donut (--bottom-chrome-height) + the xterm grid lifted by
+              // --terminal-bottom-inset on TerminalView's container (NOT an
+              // .app-content margin — absolute children anchor to the padding
+              // box, so a margin here can't move them; see globals.css).
               className="app-content flex-1 overflow-hidden relative"
             >
               {/* Tier 2 of android-terminal-data-parity: xterm.js is the sole

--- a/desktop/src/renderer/components/TerminalView.tsx
+++ b/desktop/src/renderer/components/TerminalView.tsx
@@ -540,7 +540,12 @@ export default function TerminalView({ sessionId, visible }: Props) {
           // framed, 0 on floating), the same in both views → no toggle reflow.
           left: 'var(--terminal-side-inset, 0px)',
           right: 'var(--terminal-side-inset, 0px)',
-          bottom: 0,
+          // Bottom inset lifts the xterm grid above the bottom frame strip on
+          // framed themes (--terminal-bottom-inset = --frame-edge, set on
+          // terminal view in globals.css; 0 on floating/chat). Read directly
+          // here like the top/side insets — NOT via .app-content margin, which
+          // can't move this absolutely-positioned container (see globals.css).
+          bottom: 'var(--terminal-bottom-inset, 0px)',
           opacity: xtermOpacityStyle,
           // xterm renders cell rows to a canvas; if container height isn't a
           // whole multiple of cell height (typical — fonts round irregularly),

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -1483,20 +1483,45 @@ html[data-platform="electron"] {
    Floating themes have no side chrome, so they keep the default 0. */
 html[data-platform="electron"] body:not([data-chrome-style="floating"]):not([data-input-style="floating"]) {
   --terminal-side-inset: var(--frame-edge);
+  /* BOTTOM inset (theme-driven like --terminal-side-inset, NOT view-gated):
+     lifts the xterm grid above the bottom frame strip on framed themes so the
+     last row isn't painted under chrome-glass's donut edge. Set in BOTH views
+     so the terminal is one stable height across chat/terminal toggles — a
+     view-gated inset would resize the PTY per toggle and ConPTY would re-emit
+     its buffer. In chat view the terminal is visibility:hidden anyway, so the
+     extra 10px is invisible. Consumed by TerminalView's container `bottom`.
+     NOTE: a plain .app-content margin-bottom does NOT work here — TerminalView
+     + TerminalRightSlot are position:absolute; inset:0, anchored to .app-
+     content's PADDING box, so a margin never moves them (the strip stayed
+     hidden under xterm — the original 9d886d95 fix targeted the wrong
+     mechanism). Floating themes have no bottom strip → 0. */
+  --terminal-bottom-inset: var(--frame-edge);
 }
 html[data-platform="electron"][data-view-mode="terminal"] .chrome-glass {
   --bottom-chrome-height: var(--frame-edge);
-}
-html[data-platform="electron"][data-view-mode="terminal"] body:not([data-chrome-style="floating"]):not([data-input-style="floating"]) .app-content {
-  margin-bottom: var(--frame-edge);
+  /* ALSO override --bottom-chrome-total here. The base rule only sets
+     --bottom-chrome-height, expecting the base --bottom-chrome-total (defined
+     at :root scope as calc(--bottom-chrome-height + --vvp-offset)) to pick the
+     new height up. It does NOT: the inline `--bottom-chrome-height: 0px` that
+     useChromeMeasurements writes on <html> in terminal view (the bottom bar
+     collapses to height 0) is the value --bottom-chrome-total's var()
+     substitution resolves against, so the donut's bottom edge computed to
+     calc(0px + 0px) and the bottom frame strip never painted — the left/right
+     edges dead-ended at the window bottom (verified via CDP 2026-07-21:
+     --bottom-chrome-height computed 10px while --bottom-chrome-total computed
+     calc(0px + 0px) on the same element). Setting both vars at the SAME
+     specificity on the SAME element makes the substitution resolve 10px. */
+  --bottom-chrome-total: calc(var(--frame-edge) + var(--vvp-offset, 0px));
 }
 
 /* ─── Terminal-view right-slot overlay (Bug #2) ──────────────────────────
    TerminalRightSlot renders a framed-shell clone over the terminal so the
    artifact drawer / game pane are visible in terminal view (their real home
-   in ChatView's framed-shell is hidden there). It sits inside .app-content, so
-   it inherits the same --frame-edge bottom inset as the terminal and stays
-   aligned with the frame. The container + empty chat-pane spacer are
+   in ChatView's framed-shell is hidden there). It sits inside .app-content and
+   spans it via inset:0; its opaque .drawer-pane paints above chrome-glass
+   (z 11 vs 10), so the chrome-glass bottom strip reads around the drawer's
+   own bottom edge — the drawer doesn't need the xterm grid's bottom inset.
+   The container + empty chat-pane spacer are
    click-through so the terminal underneath stays interactive; only the
    .drawer-pane takes pointer events. No z-index on the shell: the drawer-pane
    keeps its base z-index:11 so it paints above chrome-glass (z 10) and the


### PR DESCRIPTION
## Problem
In terminal view on framed themes, the **bottom frame edge never rendered** — the left/right edges dead-ended at the window bottom / taskbar. The artifact and games panels *did* show a bottom edge, which made the terminal's missing one stand out.

## Root cause — two stacked bugs

**1. The xterm grid painted over the strip.** The earlier fix (`9d886d95`) added `margin-bottom: var(--frame-edge)` to `.app-content`, but `TerminalView` + `TerminalRightSlot` are `position: absolute; inset: 0`, anchored to `.app-content`'s **padding box** — a margin on the parent can't move them. So the terminal ran to the window's bottom edge and covered the strip.

**2. The strip itself never painted.** The chrome-glass donut's bottom edge is driven by `--bottom-chrome-total`. The terminal rule only set `--bottom-chrome-height`, expecting the base `--bottom-chrome-total` (= `--bottom-chrome-height + --vvp-offset`) to pick it up. **It doesn't** — `useChromeMeasurements` writes an inline `--bottom-chrome-height: 0px` on `<html>` in terminal view (the bottom bar collapses to height 0), and *that* inline value is what `--bottom-chrome-total`'s `var()` substitution resolves against. Verified via CDP: on the same `.chrome-glass` element, `--bottom-chrome-height` computed `10px` while `--bottom-chrome-total` computed `calc(0px + 0px)` — so the clip-path's bottom edge sat at the window bottom.

## Fix
- **`TerminalView.tsx`** — container `bottom` → `var(--terminal-bottom-inset, 0px)`, lifting the grid above the strip. Mirrors the existing top/side inset pattern.
- **`globals.css`** —
  - New `--terminal-bottom-inset: var(--frame-edge)` on framed themes, set in **both** views so the terminal keeps one stable height across chat↔terminal toggles (no PTY reflow; floating themes → 0). Replaces the dead `.app-content` margin.
  - Set `--bottom-chrome-total` in the **same** terminal-view rule as `--bottom-chrome-height`, at the same specificity, so both resolve to `10px` together. Documented why the base-rule substitution can't be relied on.
- **`App.tsx`** — updated the stale comment describing the old margin mechanism.

## Verification
- **Live (dev instance, framed theme, terminal view):** bottom strip now closes the frame; last xterm row sits just above it. Confirmed by Destin.
- **CDP:** `--bottom-chrome-total` now computes `calc(10px + 0px)` (was `calc(0px + 0px)`).
- **Floating themes:** unchanged (both overrides opt out via `:not([data-chrome-style="floating"])`).
- **Suite:** all green except `tests/artifacts/artifact-store.test.ts` CAS-retry, which **fails on clean master too** — pre-existing and unrelated (flagged to Destin separately).

## Known trade-offs (reviewed with Destin)
- The `--bottom-chrome-total` override duplicates the base formula's shape with `--frame-edge` substituted in, deliberately — re-referencing `--bottom-chrome-height` would re-introduce the var-substitution ambiguity. Comment at the site explains the coupling.
- Hidden terminal in chat view is 10px shorter (invisible; same trade-off as the existing side insets).