### PR TITLE
fix: four flaky desktop tests — one real data-loss bug, two partially-applied fixes

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/artifacts/ArtifactStore.kt
+++ b/app/src/main/kotlin/com/youcoded/app/artifacts/ArtifactStore.kt
@@ -105,6 +105,28 @@ fun readSidecar(projectRoot: String): ReadResult {
 }
 
 /**
+ * Advance [candidate] past [expected] when the two would collide. Mirrors
+ * bumpPastExpected() in desktop/src/main/artifacts/artifact-store.ts — see that
+ * file for the full rationale.
+ *
+ * Short version: updatedAt is the CAS comparand and it has millisecond
+ * resolution, so two writers inside one millisecond used to leave the on-disk
+ * token identical to the value a concurrent reader had already read. That
+ * reader's CAS then passed on stale data (ABA) and clobbered the other record.
+ * Making every committed write strictly increase the token removes the race.
+ *
+ * Unlike the TS side, this compares parsed Instants rather than strings:
+ * Instant.toString() omits trailing zero sub-second digits, so its output is
+ * NOT fixed-width and lexicographic comparison would be wrong.
+ */
+private fun bumpPastExpected(candidate: String, expected: String?): String {
+    if (expected == null) return candidate
+    val exp = try { Instant.parse(expected) } catch (_: Exception) { return candidate }
+    val cand = try { Instant.parse(candidate) } catch (_: Exception) { return candidate }
+    return if (cand.isAfter(exp)) candidate else exp.plusMillis(1).toString()
+}
+
+/**
  * Write [next] to the sidecar, guarded by CAS on [expectedUpdatedAt].
  * Returns committed=false on CAS conflict (caller should re-read and retry).
  */
@@ -114,6 +136,9 @@ fun writeSidecar(
     next:              ProjectSidecar,
 ): Boolean {
     val path = File(projectRoot, SIDECAR_RELATIVE).absolutePath
+    // Enforced here, not in callers, so every Android sidecar writer inherits
+    // it — same placement as the TS writeSidecar.
+    next.updatedAt = bumpPastExpected(next.updatedAt, expectedUpdatedAt)
     val json = next.toJson().toString(2)
     val result = casWrite(
         target            = path,

--- a/desktop/src/main/artifacts/artifact-store.ts
+++ b/desktop/src/main/artifacts/artifact-store.ts
@@ -28,12 +28,50 @@ export async function readSidecar(projectRoot: string): Promise<ReadResult> {
   }
 }
 
+/**
+ * Advance `updatedAt` past `expected` when the two would collide.
+ *
+ * Fix (lost update): `updatedAt` is the CAS comparand, and it is a
+ * millisecond-resolution ISO timestamp. Two writers landing inside the SAME
+ * millisecond used to leave the on-disk token byte-identical to the value a
+ * concurrent reader had already read — so that reader's CAS check passed on a
+ * value that had in fact changed underneath it (classic ABA) and its stale copy
+ * clobbered the other writer's record. Both callers got `committed: true` and
+ * one artifact silently vanished; measured at ~50% of same-millisecond pairs.
+ *
+ * Guaranteeing the written token is strictly greater than the one the writer
+ * read makes every successful write strictly increase the on-disk token (a
+ * commit only happens when on-disk === expected). A stale reader can then never
+ * match, so ABA is impossible. The +1ms floor also makes this robust to a
+ * backwards wall-clock jump, which a plain `now` comparand is not.
+ *
+ * Compares PARSED times, not strings. toISOString() output is fixed-width, but
+ * a sidecar synced from Android carries Java Instant.toString(), which omits
+ * trailing zero sub-second digits ("…:36Z") — so lexicographic comparison would
+ * be wrong on exactly the cross-device files this guard has to protect.
+ * Unparseable input (hand-edited sidecar) falls through untouched rather than
+ * throwing; the CAS check itself still rejects the write.
+ */
+function bumpPastExpected(candidate: string, expected: string | null): string {
+  if (expected === null) return candidate;
+  const expMs = Date.parse(expected);
+  const candMs = Date.parse(candidate);
+  if (Number.isNaN(expMs) || Number.isNaN(candMs)) return candidate;
+  if (candMs > expMs) return candidate;
+  return new Date(expMs + 1).toISOString();
+}
+
 export async function writeSidecar(
   projectRoot: string,
   expectedUpdatedAt: string | null,
   next: ProjectSidecar
 ): Promise<{ committed: boolean }> {
   const path = join(projectRoot, SIDECAR_RELATIVE);
+  // Enforced HERE rather than in each caller so every sidecar writer inherits
+  // it (appendVersion, removeArtifactRecord, renameArtifact, the ipc-handlers
+  // comment/tag paths, and sync-spaces import-project). The in-memory object is
+  // updated too, so a caller that keeps using `next` matches what is on disk.
+  next.updatedAt = bumpPastExpected(next.updatedAt, expectedUpdatedAt);
   const json = JSON.stringify(next, null, 2);
   const result = await casWrite(
     path,

--- a/desktop/src/main/artifacts/artifact-store.ts
+++ b/desktop/src/main/artifacts/artifact-store.ts
@@ -69,8 +69,13 @@ export async function writeSidecar(
   const path = join(projectRoot, SIDECAR_RELATIVE);
   // Enforced HERE rather than in each caller so every sidecar writer inherits
   // it (appendVersion, removeArtifactRecord, renameArtifact, the ipc-handlers
-  // comment/tag paths, and sync-spaces import-project). The in-memory object is
-  // updated too, so a caller that keeps using `next` matches what is on disk.
+  // manualIncludes/excludes paths, and sync-spaces import-project).
+  //
+  // This mutates `next`, so on a COMMITTED write the caller's in-memory object
+  // matches disk. On a CAS conflict it does not — `next` then carries a
+  // timestamp that was never written. Every caller re-reads the sidecar before
+  // retrying rather than reusing the object, so nothing observes that; a future
+  // caller that retries with the same object must re-read too.
   next.updatedAt = bumpPastExpected(next.updatedAt, expectedUpdatedAt);
   const json = JSON.stringify(next, null, 2);
   const result = await casWrite(

--- a/desktop/src/main/sync-service.ts
+++ b/desktop/src/main/sync-service.ts
@@ -107,9 +107,13 @@ export class SyncService extends EventEmitter {
   // Hourly daily-snapshot poll (see SNAPSHOT_POLL_INTERVAL_MS). Cleared in stop().
   private snapshotTimer: NodeJS.Timeout | null = null;
 
-  constructor() {
+  // `home` is a TEST-ONLY override. Production passes nothing and keeps the
+  // os.homedir() behavior; tests pass a tmp dir so they never touch the real
+  // ~/.claude (which a running YouCoded owns — see sync-state.ts's
+  // setClaudeDirForTests for the full story).
+  constructor(home: string = os.homedir()) {
     super();
-    this.claudeDir = path.join(os.homedir(), '.claude');
+    this.claudeDir = path.join(home, '.claude');
     this.configPath = path.join(this.claudeDir, 'toolkit-state', 'config.json');
     this.localConfigPath = path.join(this.claudeDir, 'toolkit-state', 'config.local.json');
     this.syncMarkerPath = path.join(this.claudeDir, 'toolkit-state', '.sync-marker');

--- a/desktop/src/main/sync-state.ts
+++ b/desktop/src/main/sync-state.ts
@@ -128,14 +128,45 @@ export interface SyncConfig {
 
 // --- Paths ---
 
-const claudeDir = path.join(os.homedir(), '.claude');
-const configPath = path.join(claudeDir, 'toolkit-state', 'config.json');
-const syncMarkerPath = path.join(claudeDir, 'toolkit-state', '.sync-marker');
-const backupMetaPath = path.join(claudeDir, 'backup-meta.json');
-const syncWarningsPath = path.join(claudeDir, '.sync-warnings');
-const syncWarningsJsonPath = path.join(claudeDir, '.sync-warnings.json');
-const syncLockDir = path.join(claudeDir, 'toolkit-state', '.sync-lock');
-const backupLogPath = path.join(claudeDir, 'backup.log');
+// `let`, not `const`, so setClaudeDirForTests() can re-point them. These are
+// still resolved once at module load in production — behavior is unchanged.
+let claudeDir: string;
+let configPath: string;
+let syncMarkerPath: string;
+let backupMetaPath: string;
+let syncWarningsPath: string;
+let syncWarningsJsonPath: string;
+let syncLockDir: string;
+let backupLogPath: string;
+
+function resolvePaths(home: string): void {
+  claudeDir = path.join(home, '.claude');
+  configPath = path.join(claudeDir, 'toolkit-state', 'config.json');
+  syncMarkerPath = path.join(claudeDir, 'toolkit-state', '.sync-marker');
+  backupMetaPath = path.join(claudeDir, 'backup-meta.json');
+  syncWarningsPath = path.join(claudeDir, '.sync-warnings');
+  syncWarningsJsonPath = path.join(claudeDir, '.sync-warnings.json');
+  syncLockDir = path.join(claudeDir, 'toolkit-state', '.sync-lock');
+  backupLogPath = path.join(claudeDir, 'backup.log');
+}
+resolvePaths(os.homedir());
+
+/**
+ * TEST-ONLY seam. Re-points this module's paths at a throwaway home.
+ *
+ * Without it these paths are frozen from os.homedir() at module load, so
+ * sync-warnings-lifecycle.test.ts read and wrote the developer's REAL
+ * ~/.claude/.sync-warnings.json — writeWarnings([]) deletes that file. That is
+ * both a live-app hazard (a running YouCoded owns it) and the actual source of
+ * the intermittent failure: SyncService.runHealthCheck() writes an OFFLINE
+ * warning to the same path at app launch, and the suite asserts no OFFLINE
+ * warning survives. Setting process.env.HOME does NOT work here — the static
+ * import is hoisted above any assignment, and os.homedir() reads USERPROFILE
+ * rather than HOME on Windows.
+ */
+export function setClaudeDirForTests(home: string): void {
+  resolvePaths(home);
+}
 
 /** Per-backend sync marker path, used for tracking individual push times. */
 function perBackendMarkerPath(backendId: string): string {

--- a/desktop/tests/artifacts/artifact-store.test.ts
+++ b/desktop/tests/artifacts/artifact-store.test.ts
@@ -115,6 +115,52 @@ describe('appendVersion', () => {
     const sidecar = await readSidecar(projectRoot) as ProjectSidecar;
     expect(sidecar.artifacts).toHaveLength(3);
   });
+
+  // Pins the same-millisecond CAS ABA fix. The single-shot case above only
+  // caught it ~1 run in 3 (it needs both writes inside one millisecond), which
+  // read as a flaky test for months; at 60 iterations the old code loses a
+  // record essentially every run. If this ever goes red again, a writer is
+  // producing an updatedAt that does NOT advance past the value it read.
+  it('concurrent appends never lose a record (same-millisecond CAS)', async () => {
+    for (let i = 0; i < 60; i++) {
+      const root = mkdtempSync(join(tmpdir(), 'as-aba-'));
+      await appendVersion(root, sample.projectId, sample.name, {
+        path: 'a.md', kind: 'internal', absolutePath: null,
+        sessionId: 's', type: 'create', author: 'agent',
+      });
+      await Promise.all([
+        appendVersion(root, sample.projectId, sample.name, {
+          path: 'b.md', kind: 'internal', absolutePath: null,
+          sessionId: 's', type: 'create', author: 'agent',
+        }),
+        appendVersion(root, sample.projectId, sample.name, {
+          path: 'c.md', kind: 'internal', absolutePath: null,
+          sessionId: 's', type: 'create', author: 'agent',
+        }),
+      ]);
+      const s = await readSidecar(root) as ProjectSidecar;
+      expect(s.artifacts.map((a) => a.path).sort()).toEqual(['a.md', 'b.md', 'c.md']);
+    }
+  });
+
+  // The invariant the fix rests on, asserted directly: a committed write always
+  // leaves a token strictly greater than the one the writer read. Without this,
+  // a concurrent reader holding the old token passes CAS on stale data.
+  it('a committed write always advances updatedAt past the expected token', async () => {
+    await appendVersion(projectRoot, sample.projectId, sample.name, {
+      path: 'a.md', kind: 'internal', absolutePath: null,
+      sessionId: 's', type: 'create', author: 'agent',
+    });
+    const before = (await readSidecar(projectRoot)) as ProjectSidecar;
+    // Same-millisecond write: hand back a timestamp that has NOT moved.
+    const next = { ...before, updatedAt: before.updatedAt };
+    const res = await writeSidecar(projectRoot, before.updatedAt, next);
+    expect(res.committed).toBe(true);
+    const after = (await readSidecar(projectRoot)) as ProjectSidecar;
+    expect(after.updatedAt > before.updatedAt).toBe(true);
+    // The in-memory object the caller still holds matches disk.
+    expect(next.updatedAt).toBe(after.updatedAt);
+  });
 });
 
 describe('appendVersion — read semantics + artifact id', () => {

--- a/desktop/tests/artifacts/artifact-store.test.ts
+++ b/desktop/tests/artifacts/artifact-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { readSidecar, writeSidecar, appendVersion, removeArtifactRecord } from '../../src/main/artifacts/artifact-store';
@@ -140,6 +140,8 @@ describe('appendVersion', () => {
       ]);
       const s = await readSidecar(root) as ProjectSidecar;
       expect(s.artifacts.map((a) => a.path).sort()).toEqual(['a.md', 'b.md', 'c.md']);
+      // 60 iterations x every run x CI — clean up rather than leak temp dirs.
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/desktop/tests/artifacts/artifact-store.test.ts
+++ b/desktop/tests/artifacts/artifact-store.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { readSidecar, writeSidecar, appendVersion, removeArtifactRecord } from '../../src/main/artifacts/artifact-store';
 import type { ProjectSidecar } from '../../src/shared/artifacts/types';
 import sample from '../../../shared-fixtures/artifacts/sample-sidecar.json';
+
+// The 60-iteration concurrency loop below does real fs work (mkdtemp, fsync,
+// rename, rm x60) and takes ~1.3s locally — under vitest's default 5000ms
+// testTimeout, but only ~4x headroom, and fs work is exactly what inflates
+// under a loaded parallel pool. Bounding the file explicitly keeps this PR from
+// trading one load-dependent budget for another.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 describe('readSidecar', () => {
   let projectRoot: string;

--- a/desktop/tests/global-setup.ts
+++ b/desktop/tests/global-setup.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Resets the suite-wide HOME sandbox (see vitest.config.ts) exactly ONCE per
+// run, before any worker starts.
+//
+// This deliberately does NOT live in vitest.config.ts: that module is evaluated
+// in more than one process, so wiping there deletes the directory out from
+// under workers that are already writing to it — observed as
+// "ENOENT: rename '<sandbox>/.claude/youcoded-skills.json.tmp'" mid-run.
+// globalSetup is the only hook that runs once, before everything.
+export default function setup() {
+  const testHome = path.join(os.tmpdir(), 'youcoded-vitest-home');
+  // Fresh each run: a sandbox carrying state from a previous run would make
+  // tests pass or fail based on what ran before, which is the failure mode this
+  // whole sandbox exists to remove.
+  fs.rmSync(testHome, { recursive: true, force: true });
+  fs.mkdirSync(path.join(testHome, '.claude'), { recursive: true });
+}

--- a/desktop/tests/harness-stall-watchdog.test.ts
+++ b/desktop/tests/harness-stall-watchdog.test.ts
@@ -5,9 +5,11 @@
 // finish, and no error — so without a watchdog the turn hangs forever with the
 // spinner up. The watchdog warns after `stallWarningMs`, then after a further
 // `stallCountdownMs` of silence auto-retries ONCE (when nothing had streamed) or
-// surfaces a session-error. These use tiny watchdog timings (test hook) + REAL
-// timers so there's no fake-timer/microtask juggling against live stream reads.
-import { describe, it, expect } from 'vitest';
+// surfaces a session-error. These use shortened watchdog timings (test hook) +
+// REAL timers so there's no fake-timer/microtask juggling against live stream
+// reads. "Shortened", NOT tiny — see STALL_MS for why that distinction cost a
+// Windows CI run.
+import { describe, it, expect, vi } from 'vitest';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import { HarnessSession, type HarnessSessionOpts } from '../src/main/harness/harness-session';
 import type { HarnessManifest } from '../src/shared/harness-manifest';
@@ -64,6 +66,14 @@ const STALL_MS = 250;
 // stay far below the window, or a scheduling hiccup between chunks fires the
 // watchdog and fails a never-warns assertion. 4ms spacing vs a 400ms window.
 const STREAMING_WINDOW_MS = 400;
+
+// Raising the watchdog budgets moved the risk rather than removing it: the
+// both-attempts-stall case now spends warn+countdown twice = ~1.0s of REAL time
+// against vitest's default 5000ms testTimeout, i.e. ~5x headroom on a file that
+// previously had ~300x. That is the same too-tight-budget bet this PR exists to
+// kill, just one level up. Bound the test explicitly so only the watchdog
+// constants above govern the outcome.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 const HARNESS: HarnessManifest = {
   schema: 1, id: 'agent', name: 'Agent', systemPrompt: 'sys', tools: [],

--- a/desktop/tests/harness-stall-watchdog.test.ts
+++ b/desktop/tests/harness-stall-watchdog.test.ts
@@ -40,6 +40,31 @@ function modelFromStreams(makers: Array<() => ReadableStream>) {
   });
 }
 
+// One named knob for the watchdog budget, deliberately generous.
+//
+// This was 15ms, which took Windows CI red on PR #185 with "expected length 1
+// but got 2" and then passed on a plain re-run (ROADMAP :176). Nothing here
+// asserts on wall-clock — only on the ORDER and COUNT of events — so the budget
+// exists purely to be longer than the work, and a tight one buys nothing but
+// flakes. Two things made 15ms untenable:
+//
+//   1. Windows' default timer resolution is ~15.6ms, so a setTimeout(15) fires
+//      on the first tick AT OR PAST the budget. The warning timer and the
+//      retry's first chunk landed in the same tick and the winner was scheduler
+//      noise — hence Windows-only and re-run-green.
+//   2. Measured headroom on an idle 32-core Linux box was thin anyway: sweeping
+//      the budget, a spurious second warning first appears at 10ms and is the
+//      majority outcome by 3ms. 15ms was ~4x the ideal path.
+//
+// 250ms is ~16x the Windows tick and ~60x the measured ideal path, and costs
+// the file well under two seconds. Do NOT tighten these back toward the
+// event-loop noise floor to save milliseconds.
+const STALL_MS = 250;
+// The "keeps emitting" case needs the opposite margin: its chunk SPACING must
+// stay far below the window, or a scheduling hiccup between chunks fires the
+// watchdog and fails a never-warns assertion. 4ms spacing vs a 400ms window.
+const STREAMING_WINDOW_MS = 400;
+
 const HARNESS: HarnessManifest = {
   schema: 1, id: 'agent', name: 'Agent', systemPrompt: 'sys', tools: [],
   permissionPolicy: 'ask', limits: { maxTokens: 256 },
@@ -49,8 +74,9 @@ function makeOpts(over: Partial<HarnessSessionOpts>): HarnessSessionOpts {
     sessionId: 's-1', cwd: 'C:/x', harness: HARNESS,
     binding: { providerId: 'openrouter', modelId: 'm' },
     retryDelays: [1, 1, 1],
-    // Tiny watchdog so the suite runs in ~tens of ms on real timers.
-    stallWarningMs: 15, stallCountdownMs: 15,
+    // Real timers (see the file header) with a budget that machine load cannot
+    // close — see STALL_MS.
+    stallWarningMs: STALL_MS, stallCountdownMs: STALL_MS,
     ...over,
   } as HarnessSessionOpts;
 }
@@ -76,7 +102,7 @@ describe('HarnessSession — streaming inactivity watchdog', () => {
     // A stall warning was surfaced, promising a retry.
     const warns = stallWarnings(events);
     expect(warns).toHaveLength(1);
-    expect(warns[0].data.stallWarning).toEqual({ retryInMs: 15, willRetry: true });
+    expect(warns[0].data.stallWarning).toEqual({ retryInMs: STALL_MS, willRetry: true });
     // The retry produced the real answer and the turn completed normally.
     const text = events.find((e) => e.type === 'assistant-text');
     expect(text?.data.text).toBe('recovered');
@@ -120,7 +146,7 @@ describe('HarnessSession — streaming inactivity watchdog', () => {
   });
 
   it('a stream that keeps emitting (slower than the warn window) NEVER trips the watchdog', async () => {
-    // Chunks spaced 4ms apart, warn window 40ms → the watchdog is re-armed on
+    // Chunks spaced 4ms apart, warn window 400ms → the watchdog is re-armed on
     // every chunk and never fires. No stall warning, clean completion.
     const model = new MockLanguageModelV4({
       doStream: async () => ({
@@ -130,7 +156,7 @@ describe('HarnessSession — streaming inactivity watchdog', () => {
         }),
       }),
     });
-    const session = new HarnessSession(makeOpts({ stallWarningMs: 40, stallCountdownMs: 40 }), async () => model as any);
+    const session = new HarnessSession(makeOpts({ stallWarningMs: STREAMING_WINDOW_MS, stallCountdownMs: STREAMING_WINDOW_MS }), async () => model as any);
     const events = collect(session);
     await session.send('go');
 

--- a/desktop/tests/home-isolation.test.ts
+++ b/desktop/tests/home-isolation.test.ts
@@ -1,0 +1,56 @@
+// Guards the suite-wide HOME sandbox configured in vitest.config.ts.
+//
+// Why this file exists: sync-warnings-lifecycle.test.ts spent months reading
+// and DELETING the developer's real ~/.claude/.sync-warnings.json — a file a
+// running YouCoded owns and rewrites at launch. It surfaced as an intermittent
+// failure (ROADMAP :130), not as an obvious "this test edits production",
+// because the test file never referenced the home directory: sync-state.ts
+// resolved it internally at import time.
+//
+// vitest.config.ts now points HOME/USERPROFILE at a throwaway dir so that class
+// of mistake cannot reach real state. That redirect is invisible — nothing else
+// fails if someone deletes it during a config cleanup — so these assertions
+// exist to make its removal loud and self-explaining.
+import { describe, it, expect } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+describe('test-suite home isolation', () => {
+  it('os.homedir() resolves to the sandbox, not the real home', () => {
+    // The check that matters: every module resolving a path from os.homedir()
+    // — directly or several imports deep — must land in the sandbox.
+    expect(os.homedir()).toBe(path.join(os.tmpdir(), 'youcoded-vitest-home'));
+  });
+
+  it('the sandbox is not the developer real home', () => {
+    const real = process.env.YOUCODED_REAL_HOME;
+    expect(real, 'YOUCODED_REAL_HOME missing — vitest.config.ts env block changed').toBeTruthy();
+    expect(os.homedir()).not.toBe(real);
+  });
+
+  it('writing ~/.claude state cannot escape the sandbox', () => {
+    // End-to-end proof rather than a restatement of the config: resolve a path
+    // the way the app's modules do, write to it, and confirm the bytes landed
+    // in the sandbox and NOT in the real home.
+    const claudeDir = path.join(os.homedir(), '.claude');
+    const probe = path.join(claudeDir, '.home-isolation-probe');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(probe, 'probe');
+    try {
+      expect(fs.existsSync(probe)).toBe(true);
+      const realProbe = path.join(process.env.YOUCODED_REAL_HOME!, '.claude', '.home-isolation-probe');
+      expect(fs.existsSync(realProbe)).toBe(false);
+    } finally {
+      fs.rmSync(probe, { force: true });
+    }
+  });
+
+  it('HOME and USERPROFILE agree, so the redirect holds on every platform', () => {
+    // os.homedir() reads HOME on POSIX and USERPROFILE on Windows. Setting only
+    // one would sandbox one CI leg and leave the other pointed at real state —
+    // the worst outcome, because it would look green where it was tested.
+    expect(process.env.HOME).toBe(os.homedir());
+    expect(process.env.USERPROFILE).toBe(os.homedir());
+  });
+});

--- a/desktop/tests/subagent-watcher.test.ts
+++ b/desktop/tests/subagent-watcher.test.ts
@@ -49,6 +49,14 @@ function wait(ms = 50): Promise<void> {
 const SETTLE_MS = 5_000;   // in-process: watcher read + emit
 const WATCH_MS = 15_000;   // fs.watch/stat-poll delivery of an external write
 
+// ...and the second knob, without which the ceilings above are fiction: a file
+// with no vi.setConfig inherits vitest's DEFAULT 5000ms testTimeout, so a
+// 15_000ms vi.waitFor can never actually wait 15s — the test dies at 5s first.
+// Same gap that kept sync-spaces-engine.test.ts flaking on macOS after PR #180
+// raised its poll ceiling and nothing else. One bounds the poll, one bounds the
+// test; both are required.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
 describe('SubagentWatcher', () => {
   let tmpRoot: string;
   let subagentsDir: string;

--- a/desktop/tests/sync-spaces-engine.test.ts
+++ b/desktop/tests/sync-spaces-engine.test.ts
@@ -37,6 +37,16 @@ afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
 // inline third arg on it() silently overrides vi.setConfig — the #163 trap).
 const WAIT_MS = 60_000;
 
+// The knob above bounds the vi.waitFor POLLING. It does NOT bound the test, and
+// without this line the file inherits vitest's default 5000ms testTimeout — so
+// every 60s wait above was in fact capped at 5s and PR #180's ceiling was
+// unreachable. That is the "Test timed out in 5000ms" macOS flake on PR #181
+// (ROADMAP :252): #180 replaced the six inline `{ timeout: 5000 }` literals here
+// but never added the setConfig its two sibling files got in #163
+// (sync-spaces-project-discovery.test.ts:23, sync-spaces-git-transport.test.ts
+// :18). Both knobs are required — one bounds the poll, one bounds the test.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
 describe('SpaceSyncEngine', () => {
   it('debounces file changes into one sync (pull then push)', async () => {
     const t = fakeTransport();

--- a/desktop/tests/sync-warnings-lifecycle.test.ts
+++ b/desktop/tests/sync-warnings-lifecycle.test.ts
@@ -9,20 +9,28 @@ import {
   clearWarningsByBackend,
   clearWarningsByCode,
   dismissWarning,
+  setClaudeDirForTests,
 } from '../src/main/sync-state';
 import type { SyncWarning } from '../src/main/sync-state';
 
-// Redirect HOME so the real ~/.claude isn't touched.
+// A throwaway home for this suite. The old header claimed HOME was redirected
+// "before the module is imported" — it never was: nothing assigned HOME, and a
+// static import is hoisted above any assignment anyway. So every assertion here
+// ran against the developer's REAL ~/.claude/.sync-warnings.json, which
+// writeWarnings([]) deletes.
+//
+// That is what made 'clearWarningsByCode removes only matching code' flaky
+// (ROADMAP :130): SyncService.runHealthCheck() writes an OFFLINE warning to
+// that exact file when a YouCoded instance launches, and this suite asserts no
+// OFFLINE warning survives. It was never module-load ORDER — no other suite
+// writes warnings — it was a second process sharing one real file.
 const tmpHome = path.join(os.tmpdir(), `sync-warnings-test-${Date.now()}`);
 const claudeDir = path.join(tmpHome, '.claude');
 const warningsPath = path.join(claudeDir, '.sync-warnings.json');
 
+setClaudeDirForTests(tmpHome);
+
 beforeEach(() => {
-  // sync-state.ts computes paths from os.homedir() at module-load time,
-  // so tests here work by redirecting HOME before the module is imported.
-  // If a previous test already imported the module, the path is frozen —
-  // re-importing via vi.resetModules() would be required for full isolation.
-  // For this suite we just ensure the claude dir exists under the same prefix.
   fs.mkdirSync(claudeDir, { recursive: true });
   try { fs.unlinkSync(warningsPath); } catch {}
 });
@@ -44,15 +52,13 @@ function mkWarning(overrides: Partial<SyncWarning> = {}): SyncWarning {
 }
 
 describe('sync warning store', () => {
-  // NOTE: These tests exercise the helpers against the real home-dir path
-  // because the module is imported unconditionally. We assert behavior
-  // against the file the helpers write to. Clean up on each run.
+  // These run against the throwaway home wired up at the top of the file, so
+  // no other process can write the file underneath them.
 
   it('readWarnings returns [] when file missing', async () => {
-    const result = await readWarnings();
-    expect(Array.isArray(result)).toBe(true);
-    // We can't assert [] strictly because a previous run may have left state —
-    // instead verify round-trip works.
+    // Now assertable exactly: with a private home there is no leftover state
+    // from a previous run or from a live app.
+    expect(await readWarnings()).toEqual([]);
   });
 
   it('writeWarnings → readWarnings round-trip', async () => {
@@ -130,9 +136,10 @@ describe('dismissWarning', () => {
 
 describe('cleanupStaleBackendErrorFiles', () => {
   it('removes leftover .sync-error-* files', async () => {
-    // Pokes at the shared ~/.claude/toolkit-state/ dir like the rest of this file.
-    // Safe because .sync-error-* files are retired and never otherwise written.
-    const toolkitStateDir = path.join(os.homedir(), '.claude', 'toolkit-state');
+    // Uses the same throwaway home as the rest of the file. This previously
+    // wrote .sync-error-* files into the developer's REAL ~/.claude/
+    // toolkit-state/ — harmless in effect, but it is a live app's directory.
+    const toolkitStateDir = path.join(tmpHome, '.claude', 'toolkit-state');
     fs.mkdirSync(toolkitStateDir, { recursive: true });
 
     const staleA = path.join(toolkitStateDir, '.sync-error-drive-test-stale-a');
@@ -145,7 +152,7 @@ describe('cleanupStaleBackendErrorFiles', () => {
     // Call the migration helper directly rather than invoking start(), which
     // would also kick off a network pull and timeout the test.
     const { SyncService } = await import('../src/main/sync-service');
-    const svc = new SyncService();
+    const svc = new SyncService(tmpHome);
     try {
       svc.cleanupStaleBackendErrorFiles();
       expect(fs.existsSync(staleA)).toBe(false);

--- a/desktop/tests/transcript-watcher.test.ts
+++ b/desktop/tests/transcript-watcher.test.ts
@@ -21,6 +21,14 @@ const wait = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 const SETTLE_MS = 5_000;   // in-process: watcher read + emit
 const WATCH_MS = 15_000;   // fs.watch/stat-poll delivery of an external write
 
+// ...and the second knob, without which the ceilings above are fiction: a file
+// with no vi.setConfig inherits vitest's DEFAULT 5000ms testTimeout, so a
+// 15_000ms vi.waitFor can never actually wait 15s — the test dies at 5s first.
+// Same gap that kept sync-spaces-engine.test.ts flaking on macOS after PR #180
+// raised its poll ceiling and nothing else. One bounds the poll, one bounds the
+// test; both are required.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
+
 // ---------------------------------------------------------------------------
 // parseTranscriptLine
 // ---------------------------------------------------------------------------

--- a/desktop/vitest.config.ts
+++ b/desktop/vitest.config.ts
@@ -1,12 +1,41 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import fs from 'fs';
+import os from 'os';
 import react from '@vitejs/plugin-react';
+
+// A throwaway HOME for the whole suite.
+//
+// The developer's real ~/.claude is a RUNNING YouCoded's live state — the app
+// reads and writes .sync-warnings.json, toolkit-state/, backup.log while it is
+// open. A test that reaches it is both editing production and racing a second
+// process, which is exactly how sync-warnings-lifecycle.test.ts came to fail
+// intermittently for months (ROADMAP :130).
+//
+// Note what that bug looked like: the TEST FILE never mentioned the home
+// directory at all. sync-state.ts resolved it internally at import time. So no
+// amount of reviewing test files would have caught it, and a detection-based
+// tripwire would have reported it as a mystery diff. Redirecting HOME instead
+// makes the whole class structurally impossible: os.homedir() reads HOME on
+// POSIX and USERPROFILE on Windows, so every module resolving a path from it —
+// directly or three imports deep — lands in the sandbox.
+//
+// Reset once per run by tests/global-setup.ts — NOT here. This module is
+// evaluated in more than one process, so wiping at config load races workers
+// that are already writing into the sandbox. The mkdir below is idempotent and
+// safe to repeat; it exists so the directory is present even if globalSetup is
+// bypassed (e.g. an editor running a single file).
+// Pinned by tests/home-isolation.test.ts; delete that test and this becomes
+// silently load-bearing for nothing.
+const TEST_HOME = path.join(os.tmpdir(), 'youcoded-vitest-home');
+fs.mkdirSync(path.join(TEST_HOME, '.claude'), { recursive: true });
 
 export default defineConfig({
   // Fix: include the React plugin so TSX test files (JSX transform) compile correctly
   plugins: [react()],
   test: {
     include: ['tests/**/*.{test,spec}.{ts,tsx}', 'src/**/*.{test,spec}.{ts,tsx}'],
+    globalSetup: ['tests/global-setup.ts'],
     // Fix: use jsdom for .tsx test files (React components) so DOM APIs are available;
     // plain .ts files (main-process logic) stay in 'node' via environmentMatchGlobs.
     environment: 'node',
@@ -16,6 +45,14 @@ export default defineConfig({
     alias: {
       // Stub Electron APIs so main-process imports don't crash in Node.js
       electron: path.resolve(__dirname, 'tests/__mocks__/electron.ts'),
+    },
+    // Both vars: os.homedir() consults HOME on POSIX and USERPROFILE on Windows.
+    // YOUCODED_REAL_HOME lets the isolation guard prove the redirect actually
+    // moved (it cannot read the original HOME once overridden).
+    env: {
+      HOME: TEST_HOME,
+      USERPROFILE: TEST_HOME,
+      YOUCODED_REAL_HOME: os.homedir(),
     },
   },
 });


### PR DESCRIPTION
`npm test` gates the Build step, so a random red test means no macOS .dmg and a failed beta dispatch. It also trains sessions to re-run until green. This clears the four flakes on the ROADMAP — but they were **not** one family, and one of them was not a test problem at all.

## What each one actually was

**`artifact-store.test.ts` "retries on CAS conflict" (ROADMAP :68) — a real lost-update bug in `appendVersion`.**
`updatedAt` is the CAS comparand and has millisecond resolution. Two writers in the same millisecond left the on-disk token byte-identical to the value the other writer had already read, so its CAS passed on stale data (ABA) and clobbered the first record. Both callers got `committed: true`; one artifact silently vanished. Measured **149/300** same-millisecond pairs. The test was right and the code was wrong — it fails on `toHaveLength(3)`, a lost record, not a failed retry. It only catches the bug when the scheduler packs both writes into one millisecond, which is why it read as flaky, and why it fails *more* on a fast idle machine and *less* under load — the opposite of the family it was filed with. Fixed in `writeSidecar` so all five sidecar writers inherit it; mirrored on Android, which carries the same CAS model and writes the same file.

**`sync-warnings-lifecycle` (ROADMAP :130) — the stated root cause was wrong.**
The entry blames module-load order freezing HOME. The suite never redirected HOME at all: nothing assigned it, and the static import is hoisted above any assignment that might have. Its `tmpHome` consts were dead. So every assertion ran against the developer's **real** `~/.claude/.sync-warnings.json`, which `writeWarnings([])` deletes. The failing case asserts no `OFFLINE` warning survives — and `SyncService.runHealthCheck()` writes exactly an OFFLINE warning to exactly that path when a YouCoded instance launches. It is a second *process* sharing one real file, not test ordering; no other suite writes warnings. That also explains why it is seen locally with the app running and not on CI. Fixed with a test-only seam on both modules that froze a real path.

**`harness-stall-watchdog` (ROADMAP :176) — confirmed as diagnosed, now quantified.**
15ms budget. Windows' timer resolution is ~15.6ms, so `setTimeout(15)` fires on the first tick at or past the budget — the warning timer and the retry's first chunk land in the same tick and scheduler noise picks the winner (hence Windows-only, green on re-run). Sweeping the budget on an idle 32-core Linux box, a spurious second warning first appears at 10ms and is the majority outcome by 3ms, so 15ms was only ~4x the ideal path. Now 250ms.

**`sync-spaces-engine` (ROADMAP :252) — the partially-applied fix.**
PR #180 replaced this file's six `{ timeout: 5000 }` literals with `WAIT_MS = 60_000`, but that bounds the vi.waitFor **poll**, not the test. With no `vi.setConfig` the file inherited vitest's default 5000ms `testTimeout`, so every 60s wait was really capped at 5s and #180's ceiling was unreachable. Its two sibling files got the setConfig in #163; this one was missed. One line.

## Found while sweeping

`subagent-watcher` and `transcript-watcher` have the identical gap — `WATCH_MS = 15_000` with no setConfig — and are exactly the files ROADMAP :130 names as the family's remaining victims. So #163 was partially applied the same way #180 was. Fixed. A repo-wide sweep for "poll ceiling above the file's effective test ceiling" now returns nothing.

## Verification

- 4 consecutive clean full-suite runs (2830 passed, 261 files) + `tsc --noEmit` clean.
- Both new artifact-store pinning tests verified **red** with the fix reverted; the pre-existing "retries on CAS conflict" test passed in that same run, confirming it is the weak 1-in-3 detector.
- The 5000ms ceiling proved directly: a file with no setConfig doing `vi.waitFor({timeout: 60_000})` dies with exactly `Test timed out in 5000ms` — the PR #181 macOS message. With setConfig added, a 7s test in that file passes.
- Real `~/.claude` confirmed untouched after four full suite runs.
- **Kotlin is verified by CI only** (android-ci.yml runs `./gradlew test` + `assembleDebug` on `fix/**`). Gradle was not run locally: building in a worktree with symlinked node_modules would let `build-web-ui.sh`'s `npm ci` wipe the main checkout's dependencies.

## Not fixed here

`casWrite` skips the CAS check entirely when `expectedUpdatedAt === null`, so two concurrent *creates* can still clobber each other. Making creation strict ("must not exist") would break the corruption-recovery path, which deliberately passes null to overwrite a corrupt sidecar. Separate change; nothing in these four flakes depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)