### PR TITLE
feat(github): convert publishing, bug reports, and PR lookup to the shared github-client

### DIFF
--- a/desktop/src/main/dev-tools.ts
+++ b/desktop/src/main/dev-tools.ts
@@ -498,9 +498,11 @@ export type SubmitResult =
   | { ok: false; fallbackUrl: string };
 
 /**
- * Submit a GitHub issue via the `gh` CLI when authenticated, otherwise
- * fall back to a prefilled browser URL. The fallback path lets the user
- * review and submit in their browser themselves.
+ * Submit a GitHub issue via the shared github-client (REST — app token or gh
+ * token, Phase 3 2026-07-22, no gh CLI required), otherwise fall back to a
+ * prefilled browser URL. The fallback path lets the user review and submit
+ * in their browser themselves, and stays the guaranteed exit for machines
+ * with no GitHub credential at all.
  *
  * WHY: Body is assembled here (main process) using the canonical
  * buildIssueBody helper so the Environment line contains the real
@@ -518,55 +520,30 @@ export async function submitIssue(args: SubmitArgs): Promise<SubmitResult> {
     platform: 'desktop',
     os: `${os.platform()} ${os.release()}`,
   });
-
-  const ghAuthed = await isGhAuthenticated();
-  if (!ghAuthed) {
-    return { ok: false, fallbackUrl: buildPrefillUrl({ title: args.title, body, label: args.label }) };
-  }
-
-  const tmpFile = path.join(
-    os.tmpdir(),
-    `youcoded-issue-${Date.now()}-${process.pid}.md`,
-  );
-  await fs.promises.writeFile(tmpFile, body, 'utf8');
+  const fallbackUrl = buildPrefillUrl({ title: args.title, body, label: args.label });
 
   try {
-    const gh = resolveCmd('gh');
-    const stdout: string = await new Promise((resolve, reject) => {
-      execFile(
-        gh.command,
-        [
-          'issue', 'create',
-          '--repo', 'itsdestin/youcoded',
-          '--title', args.title,
-          '--body-file', tmpFile,
-          '--label', args.label,
-          '--label', 'youcoded-app:reported',
-        ],
-        { timeout: 30_000, maxBuffer: 1024 * 1024, shell: gh.shell },
-        (err, out) => (err ? reject(err) : resolve(String(out || ''))),
-      );
-    });
-    const url = (stdout.match(/https:\/\/github\.com\/[^\s]+/) || [''])[0].trim();
-    if (!url) {
-      // gh succeeded but didn't print a URL we can parse — treat as opaque success.
-      return { ok: true, url: 'https://github.com/itsdestin/youcoded/issues' };
-    }
-    return { ok: true, url };
-  } catch {
-    return { ok: false, fallbackUrl: buildPrefillUrl({ title: args.title, body, label: args.label }) };
-  } finally {
-    fs.promises.unlink(tmpFile).catch(() => undefined);
-  }
-}
+    const { getGithubClient } = await import('./github-client');
+    const client = getGithubClient();
+    const token = client ? await client.getToken().catch(() => null) : null;
+    if (!client || !token) return { ok: false, fallbackUrl };
 
-async function isGhAuthenticated(): Promise<boolean> {
-  const { command, shell } = resolveCmd('gh');
-  return new Promise((resolve) => {
-    execFile(command, ['auth', 'status'], { timeout: 5_000, shell }, (err) => {
-      resolve(!err);
+    // Labels must exist on itsdestin/youcoded (ipc-bridge rule) — the REST
+    // create applies them in the same call the old `gh issue create` did.
+    const res = await client.api('POST', '/repos/itsdestin/youcoded/issues', {
+      title: args.title,
+      body,
+      labels: [args.label, 'youcoded-app:reported'],
     });
-  });
+    if (res.status === 201 && res.json?.html_url) {
+      return { ok: true, url: String(res.json.html_url) };
+    }
+    return { ok: false, fallbackUrl };
+  } catch {
+    // Any failure (expired token, offline, rate limit) degrades to the
+    // browser prefill — issue reporting must never dead-end.
+    return { ok: false, fallbackUrl };
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/desktop/src/main/github-client.ts
+++ b/desktop/src/main/github-client.ts
@@ -133,6 +133,19 @@ export interface GithubClient {
   /** Create (or adopt, when it already exists) a private repo; returns its
    *  https clone URL. Replaces `gh repo create/view`. */
   createPrivateRepo(name: string): Promise<string>;
+  /**
+   * Generic REST call for the gh-CLI conversions (publishing forks/branches/
+   * contents/PRs, issue creation, PR search). Returns {status, json} — the
+   * CALLER interprets non-2xx statuses (a 422 can be "already exists" =
+   * success). Throws only: coded not-connected (no token, unless
+   * `anonymous: true` — the search API works unauthenticated at 60 req/hr),
+   * coded auth-expired on 401, and named transport errors. The token rides
+   * the Authorization header only — never the path, body, or any error.
+   */
+  api(method: string, apiPath: string, body?: object, opts?: { anonymous?: boolean }): Promise<{ status: number; json: any }>;
+  /** GET /user → login for the CURRENT token. Throws coded not-connected /
+   *  auth-expired — replaces `gh api user --jq .login` in the publishers. */
+  fetchAuthedLogin(): Promise<string>;
 }
 
 /** On-disk shape of <userData>/github-token.json. `data` is base64: of the
@@ -235,13 +248,15 @@ export function createGithubClient(opts: GithubClientOpts): GithubClient {
   // REST
   // -------------------------------------------------------------------------
 
-  async function rest(token: string, method: string, apiPath: string, body?: object): Promise<{ status: number; json: any }> {
+  async function rest(token: string | null, method: string, apiPath: string, body?: object): Promise<{ status: number; json: any }> {
     let res: Awaited<ReturnType<FetchLike>>;
     try {
       res = await fetchFn(`https://api.github.com${apiPath}`, {
         method,
         headers: {
-          Authorization: `token ${token}`,
+          // token may be null only on anonymous calls (search API) — the
+          // Authorization header is simply omitted then.
+          ...(token ? { Authorization: `token ${token}` } : {}),
           Accept: 'application/vnd.github+json',
           'User-Agent': 'YouCoded',
           ...(body ? { 'Content-Type': 'application/json' } : {}),
@@ -256,6 +271,24 @@ export function createGithubClient(opts: GithubClientOpts): GithubClient {
     }
     const json = await res.json().catch(() => null);
     return { status: res.status, json };
+  }
+
+  async function api(method: string, apiPath: string, body?: object, apiOpts?: { anonymous?: boolean }): Promise<{ status: number; json: any }> {
+    const info = await getToken();
+    if (!info && !apiOpts?.anonymous) throw notConnectedError();
+    const out = await rest(info?.token ?? null, method, apiPath, body);
+    // 401 with a token = the credential is dead — every caller wants the same
+    // typed "reconnect" signal, so centralize it. (Anonymous 401s can't happen;
+    // anonymous rate-limit rejections are 403 and stay caller-interpreted.)
+    if (out.status === 401 && info) throw authExpiredError();
+    return out;
+  }
+
+  async function fetchAuthedLogin(): Promise<string> {
+    const user = await api('GET', '/user');
+    const login = user.json?.login ? String(user.json.login) : null;
+    if (!login) throw new Error(`GitHub could not identify this account (HTTP ${user.status})`);
+    return login;
   }
 
   async function createPrivateRepo(name: string): Promise<string> {
@@ -288,7 +321,7 @@ export function createGithubClient(opts: GithubClientOpts): GithubClient {
     throw new Error(`GitHub could not create repository "${name}" (HTTP ${created.status})${detail}`);
   }
 
-  return { setToken, clearToken, getToken, status, createPrivateRepo };
+  return { setToken, clearToken, getToken, status, createPrivateRepo, api, fetchAuthedLogin };
 }
 
 // ---------------------------------------------------------------------------

--- a/desktop/src/main/github-fork-publish.ts
+++ b/desktop/src/main/github-fork-publish.ts
@@ -1,0 +1,166 @@
+/**
+ * github-fork-publish.ts — the shared fork → branch → upload → PR pipeline
+ * behind "Publish to marketplace" (skills) and "Publish theme".
+ *
+ * WHY THIS MODULE EXISTS (Phase 3, 2026-07-22 sync-setup overhaul)
+ * ----------------------------------------------------------------
+ * Both publishers used to shell out to the `gh` CLI with near-identical
+ * fork/branch/contents/PR sequences — which dead-ended on any machine without
+ * gh (at the product's social pillar), and passed file content as `-f
+ * content=<base64>` argv on the skill path, silently breaking on Windows's
+ * ~32 KB command-line limit for any file past a few KB. Going through the
+ * shared github-client REST surface fixes both classes at once: no gh
+ * required (app token or gh token via the client's acquisition order), and
+ * request bodies have no argv limit.
+ *
+ * The client owns all token handling — this module never sees the token, so
+ * the hygiene wall (never in errors/logs/argv) holds by construction.
+ */
+
+import { getGithubClient, type GithubClient } from './github-client';
+
+export interface PublishFile {
+  /** Path inside the repo, e.g. `themes/<slug>/manifest.json`. */
+  repoPath: string;
+  /** File content, already base64-encoded (the Contents API contract). */
+  contentBase64: string;
+}
+
+export interface ForkPublishArgs {
+  /** e.g. 'itsdestin/wecoded-themes' */
+  upstreamRepo: string;
+  branchName: string;
+  files: PublishFile[];
+  prTitle: string;
+  /** A string, or a builder receiving the resolved authed login — both
+   *  publishers default their Author line to it (old `gh api user` parity). */
+  prBody: string | ((username: string) => string);
+  client?: GithubClient | null;
+  /** Injectable for tests — real default waits between fork-readiness retries. */
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+export interface ForkPublishResult {
+  prUrl: string;
+  prNumber: number;
+  /** The authed login — callers reuse it for author fields / cache busting. */
+  username: string;
+}
+
+/** PR number from a GitHub PR URL; 0 when unparsable (display-only field). */
+export function extractPRNumber(prUrl: string): number {
+  const m = prUrl.match(/\/pull\/(\d+)/);
+  return m ? Number(m[1]) : 0;
+}
+
+const FORK_READY_RETRIES = 5;
+const FORK_READY_DELAY_MS = 2000;
+
+export async function forkPublish(args: ForkPublishArgs): Promise<ForkPublishResult> {
+  const client = args.client ?? getGithubClient();
+  const sleep = args.sleepFn ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  if (!client) {
+    // main.ts registers the client at startup; null here is a wiring
+    // regression — but the user still needs an actionable message.
+    throw new Error('Not connected to GitHub — connect your GitHub account in the Sync settings');
+  }
+
+  // 1. Who are we? (Also the fork owner.) Throws the coded not-connected /
+  // sign-in-expired errors — shown verbatim by the publish UIs.
+  const username = await client.fetchAuthedLogin();
+
+  const upstream = args.upstreamRepo;
+  const forkRepo = `${username}/${upstream.split('/')[1]}`;
+
+  // 2. Ensure the fork exists. POST /forks is idempotent (an existing fork
+  // returns 202 with the fork object, same as creation) and ASYNC — a brand
+  // new fork can take a few seconds to materialize, which is why branch
+  // creation below retries on 404 instead of trusting this response.
+  const fork = await client.api('POST', `/repos/${upstream}/forks`);
+  if (fork.status >= 400) {
+    const detail = fork.json?.message ? `: ${String(fork.json.message)}` : '';
+    throw new Error(`Could not fork ${upstream} (HTTP ${fork.status})${detail}`);
+  }
+
+  // 3. Upstream default-branch head — the base for our branch.
+  const ref = await client.api('GET', `/repos/${upstream}/git/ref/heads/main`);
+  const baseSha = ref.json?.object?.sha ? String(ref.json.object.sha) : null;
+  if (!baseSha) {
+    throw new Error(`Could not read ${upstream} (HTTP ${ref.status}) — check your internet connection and that the repository exists`);
+  }
+
+  // 4. Create (or force-reset) the branch on the fork. 404 = the fork from
+  // step 2 hasn't finished materializing — retry briefly. 422 = branch
+  // already exists (a previous publish attempt) — force it back to base so
+  // the upload starts from a clean slate.
+  let branchReady = false;
+  for (let attempt = 0; attempt < FORK_READY_RETRIES && !branchReady; attempt++) {
+    const create = await client.api('POST', `/repos/${forkRepo}/git/refs`, {
+      ref: `refs/heads/${args.branchName}`,
+      sha: baseSha,
+    });
+    if (create.status === 201) { branchReady = true; break; }
+    if (create.status === 422) {
+      const patch = await client.api('PATCH', `/repos/${forkRepo}/git/refs/heads/${args.branchName}`, {
+        sha: baseSha,
+        force: true,
+      });
+      if (patch.status === 200) { branchReady = true; break; }
+      const detail = patch.json?.message ? `: ${String(patch.json.message)}` : '';
+      throw new Error(`Could not prepare the publish branch (HTTP ${patch.status})${detail}`);
+    }
+    if (create.status === 404) { await sleep(FORK_READY_DELAY_MS); continue; }
+    const detail = create.json?.message ? `: ${String(create.json.message)}` : '';
+    throw new Error(`Could not create the publish branch (HTTP ${create.status})${detail}`);
+  }
+  if (!branchReady) {
+    throw new Error(`Your fork of ${upstream} is still being created on GitHub — wait a few seconds and try again`);
+  }
+
+  // 5. Upload every file via the Contents API. Bodies ride the HTTP request —
+  // no argv, no Windows command-line limit. A 422 usually means the file
+  // already exists on the branch (previous attempt) → fetch its sha, update.
+  for (const file of args.files) {
+    const put = await client.api('PUT', `/repos/${forkRepo}/contents/${file.repoPath}`, {
+      message: `Add ${file.repoPath}`,
+      content: file.contentBase64,
+      branch: args.branchName,
+    });
+    if (put.status === 200 || put.status === 201) continue;
+    const existing = await client.api('GET', `/repos/${forkRepo}/contents/${encodeURI(file.repoPath)}?ref=${encodeURIComponent(args.branchName)}`);
+    const sha = existing.json?.sha ? String(existing.json.sha) : null;
+    if (sha) {
+      const update = await client.api('PUT', `/repos/${forkRepo}/contents/${file.repoPath}`, {
+        message: `Update ${file.repoPath}`,
+        content: file.contentBase64,
+        sha,
+        branch: args.branchName,
+      });
+      if (update.status === 200 || update.status === 201) continue;
+    }
+    const detail = put.json?.message ? ` (${String(put.json.message)})` : '';
+    throw new Error(`Failed to upload ${file.repoPath}${detail}`);
+  }
+
+  // 6. Open the PR against upstream. 422 "already exists" = a previous
+  // attempt's PR is still open — find and return it (success, not failure).
+  const pr = await client.api('POST', `/repos/${upstream}/pulls`, {
+    title: args.prTitle,
+    body: typeof args.prBody === 'function' ? args.prBody(username) : args.prBody,
+    head: `${username}:${args.branchName}`,
+    base: 'main',
+  });
+  if (pr.status === 201 && pr.json?.html_url) {
+    const prUrl = String(pr.json.html_url);
+    return { prUrl, prNumber: typeof pr.json.number === 'number' ? pr.json.number : extractPRNumber(prUrl), username };
+  }
+  if (pr.status === 422) {
+    const list = await client.api('GET', `/repos/${upstream}/pulls?head=${encodeURIComponent(`${username}:${args.branchName}`)}&state=open`);
+    const first = Array.isArray(list.json) ? list.json[0] : null;
+    if (first?.html_url) {
+      return { prUrl: String(first.html_url), prNumber: typeof first.number === 'number' ? first.number : 0, username };
+    }
+  }
+  const detail = pr.json?.message ? `: ${String(pr.json.message)}` : '';
+  throw new Error(`Failed to create the pull request (HTTP ${pr.status})${detail}`);
+}

--- a/desktop/src/main/skill-provider.ts
+++ b/desktop/src/main/skill-provider.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { scanSkills } from './skill-scanner';
 import { SkillConfigStore } from './skill-config-store';
 import { encodeSkillLink, decodeSkillLink } from './skill-share';
@@ -17,12 +15,6 @@ import type {
   SkillEntry, SkillDetailView, SkillFilters, ChipConfig,
   MetadataOverride, SkillProvider,
 } from '../shared/types';
-
-const execFileAsync = promisify(execFile);
-
-// Resolve gh CLI path at module load (mirrors theme-marketplace-provider.ts)
-let ghPath = 'gh';
-try { const w = require('which'); ghPath = w.sync('gh'); } catch { /* use bare 'gh' */ }
 
 const CLAUDE_PLUGINS_ROOT = path.join(os.homedir(), '.claude', 'plugins');
 
@@ -447,59 +439,10 @@ export class LocalSkillProvider implements SkillProvider {
       throw new Error('Only user-created skills can be published to the marketplace');
     }
 
-    // 1. Verify gh CLI auth
-    let username: string;
-    try {
-      const { stdout } = await execFileAsync(ghPath, ['api', 'user', '--jq', '.login']);
-      username = stdout.trim();
-      if (!username) throw new Error('Empty username');
-    } catch {
-      throw new Error('GitHub CLI not authenticated. Run `gh auth login` first.');
-    }
-
     const UPSTREAM_REPO = 'itsdestin/wecoded-marketplace';
     const branchName = `plugin/${id}`;
 
-    // 2. Fork the marketplace repo (idempotent — gh returns existing fork)
-    try {
-      await execFileAsync(ghPath, ['repo', 'fork', UPSTREAM_REPO, '--clone=false'], { timeout: 30000 });
-    } catch (err: any) {
-      if (err.code === 'ENOENT') throw new Error('gh CLI not found');
-      // gh repo fork returns exit 0 even if fork exists; only throw on real errors
-    }
-
-    const FORK_REPO = `${username}/wecoded-marketplace`;
-
-    // 3. Get the default branch SHA from upstream
-    let baseSha: string;
-    try {
-      const { stdout } = await execFileAsync(ghPath, [
-        'api', `repos/${UPSTREAM_REPO}/git/ref/heads/main`, '--jq', '.object.sha',
-      ]);
-      baseSha = stdout.trim();
-    } catch {
-      throw new Error('Failed to read upstream repo. Does itsdestin/wecoded-marketplace exist?');
-    }
-
-    // Create branch on the fork (or update if it already exists)
-    try {
-      await execFileAsync(ghPath, [
-        'api', `repos/${FORK_REPO}/git/refs`, '-X', 'POST',
-        '-f', `ref=refs/heads/${branchName}`,
-        '-f', `sha=${baseSha}`,
-      ]);
-    } catch {
-      try {
-        await execFileAsync(ghPath, [
-          'api', `repos/${FORK_REPO}/git/refs/heads/${branchName}`, '-X', 'PATCH',
-          '-f', `sha=${baseSha}`, '-f', 'force=true',
-        ]);
-      } catch (err: any) {
-        throw new Error(`Failed to create branch: ${err.message}`);
-      }
-    }
-
-    // 4. Collect plugin files, filtering out sensitive content
+    // 1. Collect plugin files, filtering out sensitive content
     const filesToUpload: { repoPath: string; localPath: string }[] = [];
     const allFiles = await this.walkPluginDirectory(pluginDir);
 
@@ -526,86 +469,47 @@ export class LocalSkillProvider implements SkillProvider {
       throw new Error('No files to upload (all files were filtered as sensitive)');
     }
 
-    // 5. Upload files via GitHub Contents API
+    // 2. Base64 the contents up front. Bodies ride the REST request (Phase 3,
+    // 2026-07-22) — the old `gh api -f content=<base64>` argv form silently
+    // broke on Windows's ~32 KB command-line limit for any file past a few KB.
+    const publishFiles: import('./github-fork-publish').PublishFile[] = [];
     for (const file of filesToUpload) {
       const raw = await fs.promises.readFile(file.localPath);
-      const content = raw.toString('base64');
-
-      try {
-        await execFileAsync(ghPath, [
-          'api', `repos/${FORK_REPO}/contents/${file.repoPath}`, '-X', 'PUT',
-          '-f', `message=Add ${file.repoPath}`,
-          '-f', `content=${content}`,
-          '-f', `branch=${branchName}`,
-        ], { timeout: 30000 });
-      } catch {
-        // File may already exist — update it (need the sha)
-        try {
-          const { stdout: existingFile } = await execFileAsync(ghPath, [
-            'api', `repos/${FORK_REPO}/contents/${file.repoPath}`,
-            '-q', '.sha', '-H', 'Accept: application/vnd.github.v3+json',
-            '--method', 'GET', '-f', `ref=${branchName}`,
-          ]);
-          await execFileAsync(ghPath, [
-            'api', `repos/${FORK_REPO}/contents/${file.repoPath}`, '-X', 'PUT',
-            '-f', `message=Update ${file.repoPath}`,
-            '-f', `content=${content}`,
-            '-f', `sha=${existingFile.trim()}`,
-            '-f', `branch=${branchName}`,
-          ], { timeout: 30000 });
-        } catch {
-          throw new Error(`Failed to upload ${file.repoPath}`);
-        }
-      }
+      publishFiles.push({ repoPath: file.repoPath, contentBase64: raw.toString('base64') });
     }
 
     // 6. Create the PR
-    const prTitle = `[Plugin] ${skill.displayName || id}`;
-    const prBody = [
-      `## New Plugin: ${skill.displayName || id}`,
-      '',
-      skill.description ? `> ${skill.description}` : '',
-      '',
-      `- **Author:** ${skill.author || username}`,
-      `- **Type:** ${skill.type || 'plugin'}`,
-      `- **Category:** ${skill.category || 'other'}`,
-      `- **Plugin ID:** \`${id}\``,
-      '',
-      `### What it does`,
-      skill.description || '_No description provided_',
-      '',
-      `### Files`,
-      filesToUpload.map(f => `- \`${f.repoPath}\``).join('\n'),
-      '',
-      '_Submitted via YouCoded Marketplace_',
-    ].join('\n');
-
-    try {
-      const { stdout: prUrlRaw } = await execFileAsync(ghPath, [
-        'pr', 'create',
-        '--repo', UPSTREAM_REPO,
-        '--head', `${username}:${branchName}`,
-        '--title', prTitle,
-        '--body', prBody,
-      ], { timeout: 30000 });
-      return { prUrl: prUrlRaw.trim() };
-    } catch (err: any) {
-      // If PR already exists, try to get its URL
-      if (err.stderr?.includes('already exists')) {
-        try {
-          const { stdout: existingPr } = await execFileAsync(ghPath, [
-            'pr', 'list',
-            '--repo', UPSTREAM_REPO,
-            '--head', `${username}:${branchName}`,
-            '--json', 'url', '--jq', '.[0].url',
-          ]);
-          if (existingPr.trim()) {
-            return { prUrl: existingPr.trim() };
-          }
-        } catch { /* fall through */ }
-      }
-      throw new Error(`Failed to create PR: ${err.stderr || err.message}`);
-    }
+    // 3. Fork → branch → upload → PR through the shared github-client pipeline
+    // (Phase 3, 2026-07-22 — no gh CLI required; its plain-language coded
+    // errors surface verbatim in the publish UI). The Author line prefers the
+    // skill's own author and falls back to the authed login forkPublish
+    // resolves — same behavior as the old `gh api user` call.
+    const { forkPublish } = await import('./github-fork-publish');
+    const result = await forkPublish({
+      upstreamRepo: UPSTREAM_REPO,
+      branchName,
+      files: publishFiles,
+      prTitle: `[Plugin] ${skill.displayName || id}`,
+      prBody: (username) => [
+        `## New Plugin: ${skill.displayName || id}`,
+        '',
+        skill.description ? `> ${skill.description}` : '',
+        '',
+        `- **Author:** ${skill.author || username}`,
+        `- **Type:** ${skill.type || 'plugin'}`,
+        `- **Category:** ${skill.category || 'other'}`,
+        `- **Plugin ID:** \`${id}\``,
+        '',
+        `### What it does`,
+        skill.description || '_No description provided_',
+        '',
+        `### Files`,
+        filesToUpload.map(f => `- \`${f.repoPath}\``).join('\n'),
+        '',
+        '_Submitted via YouCoded Marketplace_',
+      ].join('\n'),
+    });
+    return { prUrl: result.prUrl };
   }
 
   /** Recursively walk a plugin directory and return all file paths. */

--- a/desktop/src/main/theme-marketplace-provider.ts
+++ b/desktop/src/main/theme-marketplace-provider.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { execFile, spawn } from 'child_process';
-import { promisify } from 'util';
 import type {
   ThemeRegistryIndex,
   ThemeRegistryEntry,
@@ -13,12 +11,6 @@ import { THEMES_DIR, listUserThemes, userThemeManifest } from './theme-watcher';
 import { synthesizeLocalThemeEntries, type LocalThemeRecord } from './local-theme-synthesizer';
 import { generateThemePreview } from './theme-preview-generator';
 import { SkillConfigStore } from './skill-config-store';
-
-const execFileAsync = promisify(execFile);
-
-// Resolve gh CLI path at module load
-let ghPath = 'gh';
-try { const w = require('which'); ghPath = w.sync('gh'); } catch { /* use bare 'gh' */ }
 
 // Registry is fetched from this URL (GitHub Pages or raw GitHub)
 const REGISTRY_URL =
@@ -36,30 +28,6 @@ const MAX_THEME_SIZE_BYTES = 10 * 1024 * 1024;
 // CI rule — any file over this will be rejected at PR review anyway, so we
 // surface it as a clear pre-flight error instead of a cryptic mid-upload failure.
 const MAX_PUBLISH_FILE_BYTES = 10 * 1024 * 1024;
-
-/**
- * Invoke `gh api ... --input -` with a JSON body piped via stdin.
- *
- * Why: passing large base64 asset content as `-f content=<base64>` args blows
- * past Windows's ~32 KB argv limit for any file more than a few KB, and the
- * failure surfaces as an opaque "Failed to upload". Stdin has no length limit,
- * so this bypasses the whole class of argv-length bugs.
- */
-function ghApiWithBody(ghBin: string, args: string[], body: string, timeoutMs = 60000): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(ghBin, [...args, '--input', '-'], { timeout: timeoutMs });
-    let stdout = '';
-    let stderr = '';
-    proc.stdout?.on('data', (d) => { stdout += d.toString(); });
-    proc.stderr?.on('data', (d) => { stderr += d.toString(); });
-    proc.on('error', reject);
-    proc.on('close', (code) => {
-      if (code === 0) resolve(stdout);
-      else reject(new Error(`gh api exited ${code}: ${stderr.trim() || stdout.trim()}`));
-    });
-    proc.stdin?.end(body);
-  });
-}
 
 // Slug must be kebab-case: lowercase letters, digits, hyphens only
 const SAFE_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -338,12 +306,10 @@ export class ThemeMarketplaceProvider {
 
   /**
    * Publish a user theme to the wecoded-themes repo via GitHub PR.
-   * Requires `gh` CLI to be authenticated.
    *
-   * Flow:
-   * 1. Verify gh auth
-   * 2. Fork itsdestin/wecoded-themes (idempotent — gh handles existing forks)
-   * 3. Create a branch, commit theme files, push, and open a PR
+   * Phase 3 (2026-07-22): goes through the shared github-client / forkPublish
+   * REST pipeline — no `gh` CLI required. Token acquisition (app store → gh)
+   * and the coded plain-language auth errors live in the client.
    */
   async publishTheme(
     slug: string,
@@ -366,64 +332,13 @@ export class ThemeMarketplaceProvider {
       throw new Error('Cannot publish a theme installed from the marketplace');
     }
 
-    // 1. Verify gh CLI auth
-    let username: string;
-    try {
-      const { stdout } = await execFileAsync(ghPath, ['api', 'user', '--jq', '.login']);
-      username = stdout.trim();
-      if (!username) throw new Error('Empty username');
-    } catch {
-      throw new Error('GitHub CLI not authenticated. Run `gh auth login` first.');
-    }
-
     const UPSTREAM_REPO = 'itsdestin/wecoded-themes';
     const isUpdate = !!opts.existingEntry;
     const branchName = isUpdate
       ? `update-theme/${slug}-${Date.now()}`
       : `theme/${slug}`;
 
-    // 2. Fork the themes repo (idempotent — gh returns existing fork)
-    try {
-      await execFileAsync(ghPath, ['repo', 'fork', UPSTREAM_REPO, '--clone=false'], { timeout: 30000 });
-    } catch (err: any) {
-      // gh repo fork returns exit code 0 even if fork exists; only throw on real errors
-      if (err.code === 'ENOENT') throw new Error('gh CLI not found');
-    }
-
-    const FORK_REPO = `${username}/wecoded-themes`;
-
-    // 3. Use the GitHub API to create/update files on a branch
-    // First, get the default branch SHA
-    let baseSha: string;
-    try {
-      const { stdout } = await execFileAsync(ghPath, [
-        'api', `repos/${UPSTREAM_REPO}/git/ref/heads/main`, '--jq', '.object.sha',
-      ]);
-      baseSha = stdout.trim();
-    } catch {
-      throw new Error('Failed to read upstream repo. Does itsdestin/wecoded-themes exist?');
-    }
-
-    // Create the branch on the fork
-    try {
-      await execFileAsync(ghPath, [
-        'api', `repos/${FORK_REPO}/git/refs`, '-X', 'POST',
-        '-f', `ref=refs/heads/${branchName}`,
-        '-f', `sha=${baseSha}`,
-      ]);
-    } catch {
-      // Branch may already exist — try to update it
-      try {
-        await execFileAsync(ghPath, [
-          'api', `repos/${FORK_REPO}/git/refs/heads/${branchName}`, '-X', 'PATCH',
-          '-f', `sha=${baseSha}`, '-F', 'force=true',
-        ]);
-      } catch (err: any) {
-        throw new Error(`Failed to create branch: ${err.message}`);
-      }
-    }
-
-    // 4. Use the local preview.png if it's already fresh (theme-builder generates
+    // Use the local preview.png if it's already fresh (theme-builder generates
     //    it via wecoded-themes/scripts/generate-previews.js at finalize). Falling
     //    back to BrowserWindow capture only when the local file is missing or
     //    stale keeps the canonical Playwright-rendered preview as the source
@@ -509,102 +424,47 @@ export class ThemeMarketplaceProvider {
       );
     }
 
-    // 6. Upload files via GitHub Contents API.
-    // Content is piped as a JSON body via stdin (not argv) to avoid Windows's
-    // ~32 KB command-line limit — see ghApiWithBody() comment.
+    // 6. Base64 all contents (bodies ride the REST request — no argv limits,
+    // the class of bug ghApiWithBody used to work around), then run the shared
+    // fork → branch → upload → PR pipeline.
+    const publishFiles: import('./github-fork-publish').PublishFile[] = [];
     for (const file of filesToUpload) {
-      let content: string;
-      if (file.repoPath.endsWith('manifest.json') && file.localPath === manifestPath) {
-        content = Buffer.from(JSON.stringify(cleanManifest, null, 2)).toString('base64');
-      } else {
-        const raw = await fs.promises.readFile(file.localPath);
-        content = raw.toString('base64');
-      }
-
-      const putArgs = ['api', `repos/${FORK_REPO}/contents/${file.repoPath}`, '-X', 'PUT'];
-      const createBody = JSON.stringify({
-        message: `Add ${file.repoPath}`,
-        content,
-        branch: branchName,
-      });
-
-      try {
-        await ghApiWithBody(ghPath, putArgs, createBody);
-      } catch {
-        // File may already exist on the branch — fetch its sha and update.
-        try {
-          const { stdout: existingFile } = await execFileAsync(ghPath, [
-            'api', `repos/${FORK_REPO}/contents/${file.repoPath}`,
-            '-q', '.sha', '-H', 'Accept: application/vnd.github.v3+json',
-            '--method', 'GET', '-f', `ref=${branchName}`,
-          ]);
-          const updateBody = JSON.stringify({
-            message: `Update ${file.repoPath}`,
-            content,
-            sha: existingFile.trim(),
-            branch: branchName,
-          });
-          await ghApiWithBody(ghPath, putArgs, updateBody);
-        } catch (err: any) {
-          throw new Error(`Failed to upload ${file.repoPath}: ${err?.message || 'unknown error'}`);
-        }
-      }
+      const content = (file.repoPath.endsWith('manifest.json') && file.localPath === manifestPath)
+        ? Buffer.from(JSON.stringify(cleanManifest, null, 2)).toString('base64')
+        : (await fs.promises.readFile(file.localPath)).toString('base64');
+      publishFiles.push({ repoPath: file.repoPath, contentBase64: content });
     }
 
-    // 6. Create the PR
     const prTitle = isUpdate
       ? `[Theme Update] ${manifest.name || slug}`
       : `[Theme] ${manifest.name || slug}`;
 
-    const prBody = [
-      isUpdate
-        ? `## Theme Update: ${manifest.name || slug}`
-        : `## New Theme: ${manifest.name || slug}`,
-      '',
-      manifest.description ? `> ${manifest.description}` : '',
-      '',
-      `- **Author:** ${manifest.author || username}`,
-      `- **Mode:** ${manifest.dark ? 'Dark' : 'Light'}`,
-      `- **Slug:** \`${slug}\``,
-      `- **Content hash:** \`${contentHash}\``,
-      '',
-      isUpdate
-        ? '_Update submitted via YouCoded Theme Marketplace_'
-        : '_Submitted via YouCoded Theme Marketplace_',
-    ].join('\n');
-
-    try {
-      const { stdout: prUrlRaw } = await execFileAsync(ghPath, [
-        'pr', 'create',
-        '--repo', UPSTREAM_REPO,
-        '--head', `${username}:${branchName}`,
-        '--title', prTitle,
-        '--body', prBody,
-      ], { timeout: 30000 });
-      const prUrl = prUrlRaw.trim();
-      this.invalidatePRStatus(slug, username);
-      this.invalidateRegistryCache();
-      return { prUrl, prNumber: extractPRNumber(prUrl) };
-    } catch (err: any) {
-      // If PR already exists, try to get its URL
-      if (err.stderr?.includes('already exists')) {
-        try {
-          const { stdout: existingPr } = await execFileAsync(ghPath, [
-            'pr', 'list',
-            '--repo', UPSTREAM_REPO,
-            '--head', `${username}:${branchName}`,
-            '--json', 'url', '--jq', '.[0].url',
-          ]);
-          if (existingPr.trim()) {
-            const prUrl = existingPr.trim();
-            this.invalidatePRStatus(slug, username);
-            this.invalidateRegistryCache();
-            return { prUrl, prNumber: extractPRNumber(prUrl) };
-          }
-        } catch { /* fall through */ }
-      }
-      throw new Error(`Failed to create PR: ${err.stderr || err.message}`);
-    }
+    const { forkPublish } = await import('./github-fork-publish');
+    const result = await forkPublish({
+      upstreamRepo: UPSTREAM_REPO,
+      branchName,
+      files: publishFiles,
+      prTitle,
+      prBody: (username) => [
+        isUpdate
+          ? `## Theme Update: ${manifest.name || slug}`
+          : `## New Theme: ${manifest.name || slug}`,
+        '',
+        manifest.description ? `> ${manifest.description}` : '',
+        '',
+        `- **Author:** ${manifest.author || username}`,
+        `- **Mode:** ${manifest.dark ? 'Dark' : 'Light'}`,
+        `- **Slug:** \`${slug}\``,
+        `- **Content hash:** \`${contentHash}\``,
+        '',
+        isUpdate
+          ? '_Update submitted via YouCoded Theme Marketplace_'
+          : '_Submitted via YouCoded Theme Marketplace_',
+      ].join('\n'),
+    });
+    this.invalidatePRStatus(slug, result.username);
+    this.invalidateRegistryCache();
+    return { prUrl: result.prUrl, prNumber: result.prNumber };
   }
 
   // Lazily-constructed PR lookup — initialized on first use so the module is
@@ -667,19 +527,22 @@ export class ThemeMarketplaceProvider {
     }
 
     // Resolve author: prefer the local manifest (it's the source of truth for
-    // who authored the theme). Fall back to gh auth so a manifest with no
-    // author still gets a reasonable answer.
+    // who authored the theme). Fall back to the github-client's authed login
+    // (app token or gh — Phase 3) so a manifest with no author still gets a
+    // reasonable answer.
     let author: string;
     try {
       const manifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf-8'));
       if (typeof manifest.author === 'string' && manifest.author.length > 0) {
         author = manifest.author;
       } else {
-        const { stdout } = await execFileAsync(ghPath, ['api', 'user', '--jq', '.login'], { timeout: 5000 });
-        author = stdout.trim();
+        const { getGithubClient } = await import('./github-client');
+        const client = getGithubClient();
+        if (!client) return { kind: 'unknown', reason: 'GitHub not connected' };
+        author = await client.fetchAuthedLogin();
       }
     } catch {
-      return { kind: 'unknown', reason: 'gh not authenticated' };
+      return { kind: 'unknown', reason: 'GitHub not connected' };
     }
 
     // All four lookups are independent — parallelize.
@@ -780,11 +643,4 @@ export class ThemeMarketplaceProvider {
       // Non-critical — continue without caching
     }
   }
-}
-
-/** Pull the numeric PR id out of a github.com PR url. Throws on malformed input. */
-function extractPRNumber(url: string): number {
-  const m = url.match(/\/pull\/(\d+)/);
-  if (!m) throw new Error(`Could not parse PR number from ${url}`);
-  return Number(m[1]);
 }

--- a/desktop/src/main/theme-pr-lookup.ts
+++ b/desktop/src/main/theme-pr-lookup.ts
@@ -1,6 +1,11 @@
 // theme-pr-lookup.ts
-// Thin wrapper around `gh pr list` to check whether a theme submission has an
-// open or recently-merged PR in the wecoded-themes repo.
+// Checks whether a theme submission has an open or recently-merged PR in the
+// wecoded-themes repo, via the GitHub search API (Phase 3, 2026-07-22 — was a
+// `gh pr list` wrapper; REST removes the gh dependency and, when a token is
+// available through the github-client, lifts the rate limit from 60/hr
+// anonymous to 5,000/hr authed. Anonymous still WORKS — a machine with no
+// GitHub credential merely degrades on rate limits, where the old gh path
+// returned null unconditionally).
 //
 // Used by publish-state-resolver to bridge the post-merge / pre-registry-CI
 // window: after a PR merges, the registry hasn't rebuilt yet, so the theme
@@ -8,29 +13,22 @@
 // covers that gap.
 //
 // Both methods cache per (slug, author) pair for ttlMs (default 60s) so rapid
-// navigation between theme details doesn't thrash the gh CLI. On any failure
-// (gh missing, not authed, network down) they return null — callers treat that
-// as "no PR found" and decide separately whether to surface a degraded-mode
-// warning.
+// navigation between theme details doesn't thrash the API. On any failure
+// (network down, rate-limited, expired token) they return null — callers
+// treat that as "no PR found" and decide separately whether to surface a
+// degraded-mode warning.
 
-import { execFile as _execFile } from 'child_process';
-import { promisify } from 'util';
+import { getGithubClient } from './github-client';
+import type { FetchLike } from './github-auth';
 
 const REPO = 'itsdestin/wecoded-themes';
 const DEFAULT_TTL_MS = 60_000;
 // How far back to look when searching for recently-merged PRs.
 const MERGED_WINDOW_MIN = 5;
-// Per-call timeout for the gh binary. If gh hangs (auth prompt, dead network,
-// DNS stall) we'd otherwise freeze the publish-state resolver — the renderer
-// UI would sit on "Checking publish status…" forever.
-const GH_TIMEOUT_MS = 5000;
-
-// Promisified execFile that always passes a timeout option. child_process
-// kills the child with SIGTERM after `timeout` ms, which causes the promise
-// to reject — runAndParseFirst then degrades to `null`.
-const _execFileAsync = promisify(_execFile);
-const defaultExecFile = (bin: string, args: string[]) =>
-  _execFileAsync(bin, args, { timeout: GH_TIMEOUT_MS }) as unknown as Promise<{ stdout: string }>;
+// Per-call timeout. If the API hangs (dead network, DNS stall) we'd otherwise
+// freeze the publish-state resolver — the renderer UI would sit on "Checking
+// publish status…" forever.
+const LOOKUP_TIMEOUT_MS = 5000;
 
 export interface PRRef {
   number: number;
@@ -43,29 +41,38 @@ interface CacheEntry {
 }
 
 export interface ThemePRLookupOpts {
-  /** Injectable execFile for testing — defaults to promisified child_process.execFile */
-  execFile?: (bin: string, args: string[]) => Promise<{ stdout: string }>;
+  /** Injectable fetch for testing — defaults to global fetch with a timeout. */
+  fetchFn?: FetchLike;
+  /** Injectable token source — defaults to the github-client singleton
+   *  (null = anonymous search, which still works at 60 req/hr). */
+  getToken?: () => Promise<string | null>;
   /** Cache TTL in milliseconds — defaults to 60 000 */
   ttlMs?: number;
   /** Monotonic clock injectable for tests — defaults to Date.now */
   now?: () => number;
-  /** Path to the gh binary — defaults to 'gh' (resolved via PATH) */
-  ghPath?: string;
 }
+
+const defaultFetch: FetchLike = (url, init) =>
+  fetch(url, { ...(init as RequestInit), signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS) });
+
+const defaultGetToken = async (): Promise<string | null> => {
+  try { return (await getGithubClient()?.getToken())?.token ?? null; }
+  catch { return null; }
+};
 
 export class ThemePRLookup {
   private openCache = new Map<string, CacheEntry>();
   private mergedCache = new Map<string, CacheEntry>();
-  private execFile: (bin: string, args: string[]) => Promise<{ stdout: string }>;
+  private fetchFn: FetchLike;
+  private getToken: () => Promise<string | null>;
   private ttlMs: number;
   private now: () => number;
-  private ghPath: string;
 
   constructor(opts: ThemePRLookupOpts = {}) {
-    this.execFile = opts.execFile ?? defaultExecFile;
+    this.fetchFn = opts.fetchFn ?? defaultFetch;
+    this.getToken = opts.getToken ?? defaultGetToken;
     this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
     this.now = opts.now ?? Date.now;
-    this.ghPath = opts.ghPath ?? 'gh';
   }
 
   /** Bust the cache for a specific (slug, author) pair — call after submitting or merging. */
@@ -77,17 +84,8 @@ export class ThemePRLookup {
 
   /** Returns the first open PR matching (slug, author), or null if none / on error. */
   async findOpenPR(slug: string, author: string): Promise<PRRef | null> {
-    return this.cached(this.openCache, `${author}/${slug}`, async () => {
-      const args = [
-        'pr', 'list',
-        '--repo', REPO,
-        '--author', author,
-        '--state', 'open',
-        '--search', slug,
-        '--json', 'number,url',
-      ];
-      return this.runAndParseFirst(args);
-    });
+    return this.cached(this.openCache, `${author}/${slug}`, async () =>
+      this.searchFirst(`repo:${REPO} is:pr state:open author:${author} ${slug}`));
   }
 
   /**
@@ -99,17 +97,10 @@ export class ThemePRLookup {
    */
   async findRecentlyMergedPR(slug: string, author: string): Promise<PRRef | null> {
     return this.cached(this.mergedCache, `${author}/${slug}`, async () => {
-      // ISO timestamp for "5 minutes ago" — gh supports merged:>=<ISO8601> in --search
+      // ISO timestamp for "5 minutes ago" — the search API supports the same
+      // merged:>=<ISO8601> qualifier gh's --search forwarded to it.
       const cutoff = new Date(this.now() - MERGED_WINDOW_MIN * 60_000).toISOString();
-      const args = [
-        'pr', 'list',
-        '--repo', REPO,
-        '--author', author,
-        '--state', 'merged',
-        '--search', `${slug} merged:>=${cutoff}`,
-        '--json', 'number,url',
-      ];
-      return this.runAndParseFirst(args);
+      return this.searchFirst(`repo:${REPO} is:pr is:merged author:${author} merged:>=${cutoff} ${slug}`);
     });
   }
 
@@ -127,21 +118,30 @@ export class ThemePRLookup {
     return value;
   }
 
-  private async runAndParseFirst(args: string[]): Promise<PRRef | null> {
+  /** GET /search/issues for the query; first hit as a PRRef, null on anything else. */
+  private async searchFirst(query: string): Promise<PRRef | null> {
     try {
-      const { stdout } = await this.execFile(this.ghPath, args);
-      const arr: unknown = JSON.parse(stdout || '[]');
-      if (
-        Array.isArray(arr) &&
-        arr.length > 0 &&
-        typeof (arr[0] as any)?.number === 'number'
-      ) {
-        const first = arr[0] as { number: number; url: unknown };
-        return { number: first.number, url: String(first.url) };
+      const token = await this.getToken();
+      const res = await this.fetchFn(
+        `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&per_page=1`,
+        {
+          method: 'GET',
+          headers: {
+            // Anonymous when no token — search allows it (rate-limited).
+            ...(token ? { Authorization: `token ${token}` } : {}),
+            Accept: 'application/vnd.github+json',
+            'User-Agent': 'YouCoded',
+          },
+        },
+      );
+      const json: any = await res.json().catch(() => null);
+      const first = Array.isArray(json?.items) ? json.items[0] : null;
+      if (first && typeof first.number === 'number') {
+        return { number: first.number, url: String(first.html_url ?? '') };
       }
       return null;
     } catch {
-      // gh not installed, not authed, network error, or unexpected JSON — degrade gracefully
+      // Network error, rate-limited, timeout — degrade gracefully.
       return null;
     }
   }

--- a/desktop/tests/dev-ipc-handlers.test.ts
+++ b/desktop/tests/dev-ipc-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as os from 'os';
 import { readLogTail } from '../src/main/dev-tools';
 
@@ -22,12 +22,17 @@ vi.mock('fs', () => ({
 // Mock os so home-dir redaction and tmpdir resolve predictably in tests.
 // WHY: submitIssue now calls os.platform() and os.release() to build the
 // Environment line in the issue body — those must be included in the mock.
-vi.mock('os', () => ({
-  homedir: vi.fn(() => '/home/alice'),
-  tmpdir: vi.fn(() => '/tmp'),
-  platform: vi.fn(() => 'linux'),
-  release: vi.fn(() => '5.15.0'),
-}));
+vi.mock('os', () => {
+  const api = {
+    homedir: vi.fn(() => '/home/alice'),
+    tmpdir: vi.fn(() => '/tmp'),
+    platform: vi.fn(() => 'linux'),
+    release: vi.fn(() => '5.15.0'),
+  };
+  // `default` too: the github-client import chain (logger.ts) uses the
+  // default-import form (`import os from 'os'`), not named imports.
+  return { ...api, default: api };
+});
 vi.mock('child_process', () => ({
   execFile: vi.fn(),
   // spawn mock default: stub with no-op streams. Tests that exercise spawn
@@ -157,6 +162,31 @@ describe('summarizeIssue', () => {
 });
 
 import { submitIssue } from '../src/main/dev-tools';
+import { setGithubClient } from '../src/main/github-client';
+
+// Phase 3 (2026-07-22): submitIssue posts through the shared github-client
+// (REST) instead of the gh CLI. Tests drive it by registering a FAKE client
+// singleton — the browser-prefill fallback remains the no-credential path.
+function fakeGithubClient(opts: {
+  token?: string | null;
+  issueStatus?: number;
+  issueUrl?: string;
+  apiThrows?: boolean;
+}) {
+  const apiCalls: Array<{ method: string; path: string; body: any }> = [];
+  const client: any = {
+    getToken: async () => (opts.token === null ? null : { token: opts.token ?? 'gho_x', source: 'app' }),
+    api: async (method: string, path: string, body?: any) => {
+      apiCalls.push({ method, path, body });
+      if (opts.apiThrows) throw new Error('boom');
+      return {
+        status: opts.issueStatus ?? 201,
+        json: { html_url: opts.issueUrl ?? 'https://github.com/itsdestin/youcoded/issues/42' },
+      };
+    },
+  };
+  return { client, apiCalls };
+}
 
 // Minimal SubmitArgs using the new raw-fields contract (body is now built in
 // the main process by buildIssueBody using app.getVersion() + os info).
@@ -177,66 +207,60 @@ const SUBMIT_FEATURE: import('../src/main/dev-tools').SubmitArgs = {
 };
 
 describe('submitIssue', () => {
-  it('returns the issue URL when gh is authed and create succeeds', async () => {
-    vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], _o: any, cb: any) => {
-      // First call: gh auth status — exit 0
-      if (args[0] === 'auth' && args[1] === 'status') {
-        cb(null, 'Logged in', '');
-      } else if (args[0] === 'issue' && args[1] === 'create') {
-        cb(null, 'https://github.com/itsdestin/youcoded/issues/42\n', '');
-      }
-      return {} as any;
-    }) as any);
+  it('returns the issue URL when a GitHub token exists and the REST create succeeds', async () => {
+    const { client, apiCalls } = fakeGithubClient({});
+    setGithubClient(client);
     const out = await submitIssue(SUBMIT_BUG);
     expect(out.ok).toBe(true);
     expect((out as any).url).toBe('https://github.com/itsdestin/youcoded/issues/42');
+    // One REST POST to the issues endpoint, labels intact (the labels must
+    // exist on itsdestin/youcoded — ipc-bridge rule).
+    expect(apiCalls).toHaveLength(1);
+    expect(apiCalls[0].method).toBe('POST');
+    expect(apiCalls[0].path).toBe('/repos/itsdestin/youcoded/issues');
+    expect(apiCalls[0].body.labels).toEqual(['bug', 'youcoded-app:reported']);
   });
 
-  it('returns a fallback URL when gh auth status fails', async () => {
-    vi.mocked(execFile).mockImplementation(((_c: string, args: string[], _o: any, cb: any) => {
-      if (args[0] === 'auth' && args[1] === 'status') {
-        cb(new Error('not authenticated'), '', 'You are not logged in');
-      }
-      return {} as any;
-    }) as any);
+  it('returns a fallback URL when no GitHub credential exists anywhere', async () => {
+    const { client } = fakeGithubClient({ token: null });
+    setGithubClient(client);
     const out = await submitIssue(SUBMIT_BUG);
     expect(out.ok).toBe(false);
     expect((out as any).fallbackUrl).toContain('https://github.com/itsdestin/youcoded/issues/new');
     expect((out as any).fallbackUrl).toContain('labels=bug');
   });
 
-  it('returns a fallback URL when gh issue create fails after auth check', async () => {
-    vi.mocked(execFile).mockImplementation(((_c: string, args: string[], _o: any, cb: any) => {
-      if (args[0] === 'auth') cb(null, 'Logged in', '');
-      else cb(new Error('rate limited'), '', '');
-      return {} as any;
-    }) as any);
+  it('returns a fallback URL when no client singleton is registered at all', async () => {
+    setGithubClient(null);
+    const out = await submitIssue(SUBMIT_BUG);
+    expect(out.ok).toBe(false);
+    expect((out as any).fallbackUrl).toContain('labels=bug');
+  });
+
+  it('returns a fallback URL when the REST create fails', async () => {
+    const { client } = fakeGithubClient({ apiThrows: true });
+    setGithubClient(client);
     const out = await submitIssue(SUBMIT_FEATURE);
     expect(out.ok).toBe(false);
     expect((out as any).fallbackUrl).toContain('labels=enhancement');
   });
 
   it('builds the issue body in main using buildIssueBody (not navigator.userAgent)', async () => {
-    // Verify the body written to the tmp file contains the canonical Environment
-    // line format produced by buildIssueBody, not a raw user-agent string.
-    let writtenBody = '';
-    const fs = await import('fs');
-    vi.mocked(fs.promises.writeFile).mockImplementation(async (_p: any, content: any) => {
-      writtenBody = String(content);
-    });
-    vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], _o: any, cb: any) => {
-      if (args[0] === 'auth') cb(null, 'Logged in', '');
-      else cb(null, 'https://github.com/itsdestin/youcoded/issues/99\n', '');
-      return {} as any;
-    }) as any);
+    const { client, apiCalls } = fakeGithubClient({});
+    setGithubClient(client);
     await submitIssue(SUBMIT_BUG);
     // Body must contain the canonical "YouCoded vX.Y.Z · desktop · ..." format.
+    const writtenBody = String(apiCalls[0].body.body);
     expect(writtenBody).toContain('**Environment:** YouCoded v');
     expect(writtenBody).toContain('desktop');
     // Must NOT contain the raw navigator.userAgent substring that the old renderer
     // build-body helper would have included.
     expect(writtenBody).not.toContain('navigator');
   });
+
+  // The singleton outlives this describe — clear it so later suites (and other
+  // files sharing the worker) never see a stale fake client.
+  afterEach(() => setGithubClient(null));
 });
 
 import { installWorkspace, _resetInstallGuard } from '../src/main/dev-tools';

--- a/desktop/tests/github-client.test.ts
+++ b/desktop/tests/github-client.test.ts
@@ -247,3 +247,52 @@ describe('combinedGithubStatus', () => {
     expect(s).toMatchObject({ installed: false, authed: false, source: null });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3: generic api() + fetchAuthedLogin (the gh-CLI conversion surface)
+// ---------------------------------------------------------------------------
+
+describe('github-client api()', () => {
+  it('sends the token in the Authorization header only; caller interprets statuses', async () => {
+    const { fn, calls } = fakeFetch([['POST', '/repos/o/r/forks', { status: 202, json: { ok: true } }]]);
+    const c = createGithubClient({ storageDir: tmp, safeStorage: fakeSafeStorage(), execFn: ghExec(null), fetchFn: fn });
+    await c.setToken(SECRET);
+    const out = await c.api('POST', '/repos/o/r/forks');
+    expect(out.status).toBe(202);
+    expect(calls[0].url).not.toContain(SECRET);
+  });
+
+  it('no token → coded not-connected error, UNLESS anonymous is allowed', async () => {
+    const { fn } = fakeFetch([['GET', '/search/issues', { status: 200, json: { items: [] } }]]);
+    const c = createGithubClient({ storageDir: tmp, safeStorage: fakeSafeStorage(), execFn: ghExec(null), fetchFn: fn });
+    await expect(c.api('GET', '/search/issues')).rejects.toMatchObject({ syncErrorCode: GITHUB_AUTH_ERROR_CODE });
+    const anon = await c.api('GET', '/search/issues', undefined, { anonymous: true });
+    expect(anon.status).toBe(200);
+  });
+
+  it('401 with a token → coded sign-in-expired error (centralized for every consumer)', async () => {
+    const { fn } = fakeFetch([['GET', '/user', { status: 401, json: { message: 'Bad credentials' } }]]);
+    const c = createGithubClient({ storageDir: tmp, safeStorage: fakeSafeStorage(), execFn: ghExec(null), fetchFn: fn });
+    await c.setToken(SECRET);
+    const err = await c.api('GET', '/user').catch((e) => e);
+    expect(err.syncErrorCode).toBe(GITHUB_AUTH_ERROR_CODE);
+    expect(String(err.message)).toContain('GitHub sign-in expired');
+    expect(String(err.message)).not.toContain(SECRET);
+  });
+});
+
+describe('github-client fetchAuthedLogin', () => {
+  it('returns the login (replaces `gh api user --jq .login`)', async () => {
+    const { fn } = fakeFetch([['GET', '/user', { status: 200, json: { login: 'octocat' } }]]);
+    const c = createGithubClient({ storageDir: tmp, safeStorage: fakeSafeStorage(), execFn: ghExec(null), fetchFn: fn });
+    await c.setToken(SECRET);
+    await expect(c.fetchAuthedLogin()).resolves.toBe('octocat');
+  });
+
+  it('login missing from the response → named error without inventing a cause', async () => {
+    const { fn } = fakeFetch([['GET', '/user', { status: 500, json: {} }]]);
+    const c = createGithubClient({ storageDir: tmp, safeStorage: fakeSafeStorage(), execFn: ghExec(null), fetchFn: fn });
+    await c.setToken(SECRET);
+    await expect(c.fetchAuthedLogin()).rejects.toThrow('HTTP 500');
+  });
+});

--- a/desktop/tests/github-fork-publish.test.ts
+++ b/desktop/tests/github-fork-publish.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { forkPublish, extractPRNumber, type ForkPublishArgs } from '../src/main/github-fork-publish';
+
+// ---------------------------------------------------------------------------
+// The pipeline is driven entirely through a FAKE GithubClient — no gh, no
+// network, no token in sight (the client owns token handling; this module
+// never sees it, which is the hygiene-by-construction property).
+// ---------------------------------------------------------------------------
+
+type Call = { method: string; path: string; body?: any };
+
+/** Scripted fake client: route(method, path) → response; records every call. */
+function fakeClient(route: (method: string, path: string, call: number) => { status: number; json?: any }) {
+  const calls: Call[] = [];
+  let n = 0;
+  return {
+    calls,
+    client: {
+      fetchAuthedLogin: async () => 'octocat',
+      api: async (method: string, path: string, body?: any) => {
+        calls.push({ method, path, body });
+        const res = route(method, path, n++);
+        return { status: res.status, json: res.json ?? {} };
+      },
+    } as any,
+  };
+}
+
+const FILES = [{ repoPath: 'themes/sunset/manifest.json', contentBase64: 'eyJ9' }];
+
+function baseArgs(client: any, extra: Partial<ForkPublishArgs> = {}): ForkPublishArgs {
+  return {
+    upstreamRepo: 'itsdestin/wecoded-themes',
+    branchName: 'theme/sunset',
+    files: FILES,
+    prTitle: '[Theme] Sunset',
+    prBody: (username) => `by ${username}`,
+    client,
+    sleepFn: async () => {},
+    ...extra,
+  };
+}
+
+/** Happy-path router: fork 202, ref 200, branch 201, PUT 201, PR 201. */
+function happyRoute(method: string, path: string): { status: number; json?: any } {
+  if (method === 'POST' && path.endsWith('/forks')) return { status: 202 };
+  if (method === 'GET' && path.includes('/git/ref/')) return { status: 200, json: { object: { sha: 'abc123' } } };
+  if (method === 'POST' && path.endsWith('/git/refs')) return { status: 201 };
+  if (method === 'PUT' && path.includes('/contents/')) return { status: 201 };
+  if (method === 'POST' && path.endsWith('/pulls')) return { status: 201, json: { html_url: 'https://github.com/itsdestin/wecoded-themes/pull/9', number: 9 } };
+  return { status: 500 };
+}
+
+describe('forkPublish', () => {
+  it('happy path: fork → branch from upstream head → upload → PR, body built with the authed login', async () => {
+    const { client, calls } = fakeClient(happyRoute);
+    const result = await forkPublish(baseArgs(client));
+    expect(result).toEqual({ prUrl: 'https://github.com/itsdestin/wecoded-themes/pull/9', prNumber: 9, username: 'octocat' });
+
+    // Fork is created on upstream; branch + contents land on the FORK; the PR
+    // goes back to upstream with the cross-repo head.
+    expect(calls.find(c => c.path === '/repos/itsdestin/wecoded-themes/forks')).toBeTruthy();
+    const refCreate = calls.find(c => c.method === 'POST' && c.path.endsWith('/git/refs'))!;
+    expect(refCreate.path).toContain('/repos/octocat/wecoded-themes/');
+    expect(refCreate.body).toEqual({ ref: 'refs/heads/theme/sunset', sha: 'abc123' });
+    const put = calls.find(c => c.method === 'PUT')!;
+    expect(put.path).toBe('/repos/octocat/wecoded-themes/contents/themes/sunset/manifest.json');
+    expect(put.body.branch).toBe('theme/sunset');
+    const pr = calls.find(c => c.method === 'POST' && c.path.endsWith('/pulls'))!;
+    expect(pr.body.head).toBe('octocat:theme/sunset');
+    expect(pr.body.base).toBe('main');
+    expect(pr.body.body).toBe('by octocat');
+  });
+
+  it('FORK-MATERIALIZING PIN: 404 on branch creation retries until the fork exists', async () => {
+    let refAttempts = 0;
+    const { client } = fakeClient((method, path) => {
+      if (method === 'POST' && path.endsWith('/git/refs')) {
+        refAttempts++;
+        return refAttempts < 3 ? { status: 404 } : { status: 201 };
+      }
+      return happyRoute(method, path);
+    });
+    const result = await forkPublish(baseArgs(client));
+    expect(refAttempts).toBe(3);
+    expect(result.prNumber).toBe(9);
+  });
+
+  it('branch already exists (422) → force-reset to upstream head, publish continues', async () => {
+    const { client, calls } = fakeClient((method, path) => {
+      if (method === 'POST' && path.endsWith('/git/refs')) return { status: 422 };
+      if (method === 'PATCH') return { status: 200 };
+      return happyRoute(method, path);
+    });
+    await forkPublish(baseArgs(client));
+    const patch = calls.find(c => c.method === 'PATCH')!;
+    expect(patch.path).toBe('/repos/octocat/wecoded-themes/git/refs/heads/theme/sunset');
+    expect(patch.body).toEqual({ sha: 'abc123', force: true });
+  });
+
+  it('file already on the branch → sha lookup then update PUT', async () => {
+    let puts = 0;
+    const { client, calls } = fakeClient((method, path) => {
+      if (method === 'PUT') { puts++; return puts === 1 ? { status: 422 } : { status: 200 }; }
+      if (method === 'GET' && path.includes('/contents/')) return { status: 200, json: { sha: 'oldsha' } };
+      return happyRoute(method, path);
+    });
+    await forkPublish(baseArgs(client));
+    const secondPut = calls.filter(c => c.method === 'PUT')[1];
+    expect(secondPut.body.sha).toBe('oldsha');
+  });
+
+  it('PR already open (422) → returns the existing PR (success, not failure)', async () => {
+    const { client } = fakeClient((method, path) => {
+      if (method === 'POST' && path.endsWith('/pulls')) return { status: 422, json: { message: 'A pull request already exists' } };
+      if (method === 'GET' && path.includes('/pulls?head=')) {
+        return { status: 200, json: [{ html_url: 'https://github.com/itsdestin/wecoded-themes/pull/7', number: 7 }] };
+      }
+      return happyRoute(method, path);
+    });
+    const result = await forkPublish(baseArgs(client));
+    expect(result.prUrl).toContain('/pull/7');
+    expect(result.prNumber).toBe(7);
+  });
+
+  it('exhausted fork-readiness retries → plain-language "fork still being created" error', async () => {
+    const { client } = fakeClient((method, path) => {
+      if (method === 'POST' && path.endsWith('/git/refs')) return { status: 404 };
+      return happyRoute(method, path);
+    });
+    await expect(forkPublish(baseArgs(client))).rejects.toThrow('still being created');
+  });
+
+  it('no client registered → plain-language "Not connected to GitHub" error', async () => {
+    await expect(forkPublish(baseArgs(null))).rejects.toThrow('Not connected to GitHub');
+  });
+
+  it('upstream unreadable → error names the repo and suggests checking the connection', async () => {
+    const { client } = fakeClient((method, path) => {
+      if (method === 'GET' && path.includes('/git/ref/')) return { status: 404, json: {} };
+      return happyRoute(method, path);
+    });
+    await expect(forkPublish(baseArgs(client))).rejects.toThrow('Could not read itsdestin/wecoded-themes');
+  });
+});
+
+describe('extractPRNumber', () => {
+  it('parses /pull/<n> and degrades to 0 on junk', () => {
+    expect(extractPRNumber('https://github.com/a/b/pull/123')).toBe(123);
+    expect(extractPRNumber('nonsense')).toBe(0);
+  });
+});

--- a/desktop/tests/theme-pr-lookup.test.ts
+++ b/desktop/tests/theme-pr-lookup.test.ts
@@ -1,34 +1,50 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ThemePRLookup } from '../src/main/theme-pr-lookup';
 
+// Phase 3 (2026-07-22): ThemePRLookup runs on the GitHub SEARCH API (was a
+// `gh pr list` wrapper). Fakes inject fetch + token source — no gh, no network.
+
 describe('ThemePRLookup', () => {
-  let calls: string[][];
-  let stubResults: Record<string, string>;
+  let calls: string[];
+  let stubItems: Record<string, any[]>; // url-substring → search items
   let lookup: ThemePRLookup;
+  let token: string | null;
 
   beforeEach(() => {
     calls = [];
-    stubResults = {};
-    const fakeExec = async (_bin: string, args: string[]) => {
-      calls.push(args);
-      const key = args.join(' ');
-      return { stdout: stubResults[key] ?? '[]' };
+    stubItems = {};
+    token = 'gho_token';
+    const fakeFetch = async (url: string, _init?: any) => {
+      calls.push(url);
+      const hit = Object.entries(stubItems).find(([part]) => url.includes(part));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: hit ? hit[1] : [] }),
+      };
     };
-    lookup = new ThemePRLookup({ execFile: fakeExec as any, ttlMs: 60_000, now: () => 1_000 });
+    lookup = new ThemePRLookup({
+      fetchFn: fakeFetch as any,
+      getToken: async () => token,
+      ttlMs: 60_000,
+      now: () => 1_000,
+    });
   });
 
-  it('returns null when gh returns empty list', async () => {
+  it('returns null when the search returns no items', async () => {
     const result = await lookup.findOpenPR('sunset', 'alice');
     expect(result).toBeNull();
   });
 
-  it('returns first matching PR', async () => {
-    const args = ['pr', 'list', '--repo', 'itsdestin/wecoded-themes',
-      '--author', 'alice', '--state', 'open', '--search', 'sunset',
-      '--json', 'number,url'];
-    stubResults[args.join(' ')] = JSON.stringify([{ number: 42, url: 'https://x/42' }]);
+  it('returns the first matching PR and scopes the query to repo/author/state', async () => {
+    stubItems['state%3Aopen'] = [{ number: 42, html_url: 'https://x/pull/42' }];
     const result = await lookup.findOpenPR('sunset', 'alice');
-    expect(result).toEqual({ number: 42, url: 'https://x/42' });
+    expect(result).toEqual({ number: 42, url: 'https://x/pull/42' });
+    const q = decodeURIComponent(calls[0]);
+    expect(q).toContain('repo:itsdestin/wecoded-themes');
+    expect(q).toContain('author:alice');
+    expect(q).toContain('state:open');
+    expect(q).toContain('sunset');
   });
 
   it('caches results within the TTL window', async () => {
@@ -44,19 +60,25 @@ describe('ThemePRLookup', () => {
     expect(calls.length).toBe(2);
   });
 
-  it('searches recently merged PRs (5 minute window)', async () => {
+  it('searches recently merged PRs with the 5-minute merged:>= window', async () => {
     await lookup.findRecentlyMergedPR('sunset', 'alice');
-    expect(calls[0]).toContain('--state');
-    expect(calls[0]).toContain('merged');
-    // Search includes a merged:>= filter; just confirm it's present
-    const search = calls[0][calls[0].indexOf('--search') + 1];
-    expect(search).toContain('sunset');
-    expect(search).toMatch(/merged:>=/);
+    const q = decodeURIComponent(calls[0]);
+    expect(q).toContain('is:merged');
+    expect(q).toContain('sunset');
+    expect(q).toMatch(/merged:>=/);
   });
 
-  it('falls back to null on gh failure', async () => {
+  it('works ANONYMOUSLY when no token exists (the old gh path just failed here)', async () => {
+    token = null;
+    stubItems['state%3Aopen'] = [{ number: 7, html_url: 'https://x/pull/7' }];
+    const result = await lookup.findOpenPR('sunset', 'alice');
+    expect(result).toEqual({ number: 7, url: 'https://x/pull/7' });
+  });
+
+  it('falls back to null on fetch failure', async () => {
     const failing = new ThemePRLookup({
-      execFile: (async () => { throw new Error('gh not found'); }) as any,
+      fetchFn: (async () => { throw new Error('network down'); }) as any,
+      getToken: async () => null,
       ttlMs: 60_000, now: () => 1_000,
     });
     const result = await failing.findOpenPR('sunset', 'alice');


### PR DESCRIPTION
## Summary

Phase 3 (part 1) of the sync-setup overhaul (`youcoded-dev/docs/active/plans/2026-07-22-sync-setup-overhaul.md`): the remaining gh-CLI consumers ride the shared REST client from #201, so **marketplace publishing, theme publishing, bug reports, and publish-state lookups all work with no gh installed**.

- **New `github-fork-publish.ts`** — the fork → branch → upload → PR pipeline both publishers previously duplicated as gh exec sequences. Handles fresh-fork materialization (404 retry), leftover branches (422 → force-reset), and already-open PRs (adopted as success). Never touches the token — the client owns auth entirely.
- **Windows publish fix for free**: the skill path passed file content as `gh api -f content=<base64>` argv, silently breaking on Windows's ~32 KB command-line limit for any file past a few KB. REST bodies have no argv.
- **`dev-tools.submitIssue`** → one REST POST with labels; browser-prefill fallback stays as the guaranteed no-credential exit.
- **`theme-pr-lookup`** → GitHub search API: authed rate limits (60/hr → 5,000/hr) when a token exists, and anonymous lookups still work where the old gh path returned null unconditionally.
- **`github-client`** grows `api()` (caller-interpreted statuses, centralized coded 401, anonymous option) and `fetchAuthedLogin()`.

No IPC shape changes — `dev:submit-issue` payload/result and all publish signatures are unchanged (parity-safe).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full suite green locally: 264 files / 2906 tests
- [x] New pins: forkPublish pipeline (happy path, fork-materializing retry, branch force-reset, sha-update, existing-PR adoption, plain-language errors), search-based PR lookup (incl. the anonymous-works pin), submitIssue REST + fallback matrix
- [ ] CI green on all platforms

Part 2 (Connected accounts UI + `repo`-scope sentence in the connect modal) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)