### PR TITLE
Files tab: project-wide content search (unified ranked list)

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3659,6 +3659,11 @@ class SessionService : Service() {
             // Electron main — see desktop project-watcher.ts). Stub cases keep the
             // type strings in parity; the renderer hook tolerates ok:false by
             // degrading to "no live refresh".
+            // Content search is desktop-only: no ripgrep binary on Android (D2).
+            "artifacts:search-content" -> {
+                msg.id?.let { bridgeServer.respond(ws, msg.type, it,
+                    org.json.JSONObject().put("ok", false).put("error", "not-implemented-on-mobile")) }
+            }
             "artifacts:watch-project", "artifacts:unwatch-project" -> {
                 msg.id?.let { bridgeServer.respond(ws, msg.type, it,
                     org.json.JSONObject().put("ok", false).put("error", "not-implemented-on-mobile")) }

--- a/desktop/src/main/artifacts/content-search.ts
+++ b/desktop/src/main/artifacts/content-search.ts
@@ -1,0 +1,146 @@
+// Project-wide CONTENT search for the Files tab (roadmap follow-up to the
+// Tier 1 code editor; design decision 2026-07-22: no name/contents toggle —
+// the renderer ranks name matches above these content hits in ONE list).
+//
+// Engine: the bundled @vscode/ripgrep the agent's Grep tool already uses.
+// This module spawns it with --json for STRUCTURED results (grep.ts returns
+// raw stdout because its consumer is a model; a UI needs line numbers and
+// snippets it can render). The hard-won spawn defenses carry over from
+// grep.ts: explicit cwd (never inherit Electron's ambient cwd), resolveRgPath
+// (an inside-asar binary path throws spawn ENOTDIR synchronously), and the
+// synchronous try/catch around spawn itself.
+//
+// The QUERY IS LITERAL TEXT (-F), case-insensitive: this is a user typing
+// words they remember into a search box, not a regex surface. Desktop-only —
+// Android has no ripgrep binary (D2), the Kotlin side is a stub.
+import { spawn } from 'child_process';
+import { resolveRgPath } from '../harness/tools/grep';
+
+export interface ContentHit {
+  /** Project-relative path, forward slashes. */
+  path: string;
+  /** 1-indexed line number of the match. */
+  line: number;
+  /** The matching line, trimmed and capped for display. */
+  text: string;
+}
+
+export interface ContentSearchResult {
+  ok: boolean;
+  hits: ContentHit[];
+  /** True when a cap cut the result set — the UI should say "showing first N". */
+  truncated: boolean;
+  error?: string;
+}
+
+/** Total hits returned to the renderer — a search box, not an audit tool. */
+export const MAX_HITS = 200;
+/** Per-file cap so one giant log file cannot eat the whole result budget. */
+const MAX_PER_FILE = 20;
+/** Stdout accumulation gate (the grep.ts 200KB lesson, scaled for --json
+ * verbosity) — kill the process rather than buffer unboundedly. */
+const MAX_STDOUT_BYTES = 1_000_000;
+/** Wall-clock kill switch; rg is fast, a hung mount should not hang the UI. */
+const TIMEOUT_MS = 5000;
+const SNIPPET_MAX_CHARS = 200;
+
+/** Parse one line of `rg --json` output into a hit, or null for the other
+ * event types (begin/end/summary) and malformed lines. Pure — unit-pinned. */
+export function parseRgJsonLine(line: string): ContentHit | null {
+  if (!line) return null;
+  let evt: any;
+  try {
+    evt = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (evt?.type !== 'match') return null;
+  const path = evt.data?.path?.text;
+  const lineNumber = evt.data?.line_number;
+  const text = evt.data?.lines?.text;
+  if (typeof path !== 'string' || typeof lineNumber !== 'number' || typeof text !== 'string') return null;
+  return {
+    // rg reports "./x" for a "." search root — strip it so paths line up with
+    // the artifact records the renderer compares against.
+    path: path.replace(/\\/g, '/').replace(/^\.\//, ''),
+    line: lineNumber,
+    text: text.trim().slice(0, SNIPPET_MAX_CHARS),
+  };
+}
+
+export function searchProjectContent(projectRoot: string, query: string): Promise<ContentSearchResult> {
+  const q = query.trim();
+  if (!q) return Promise.resolve({ ok: true, hits: [], truncated: false });
+
+  const rgArgs = [
+    '--no-config', '--hidden', '--json',
+    '-F', '-i',                          // literal, case-insensitive
+    '--max-count', String(MAX_PER_FILE),
+    // rg respects .gitignore in git projects; these keep non-git projects from
+    // drowning in dependency/bookkeeping noise and match the discovery pass.
+    '--glob', '!.git', '--glob', '!.youcoded', '--glob', '!node_modules',
+    '--', q, '.',
+  ];
+
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(resolveRgPath(), rgArgs, { cwd: projectRoot, windowsHide: true });
+    } catch (e: any) {
+      // Surface the REAL failure (error-message-standards) — the renderer
+      // shows res.error verbatim when it is present.
+      resolve({ ok: false, hits: [], truncated: false, error: `could not start ripgrep (${e?.message ?? e})` });
+      return;
+    }
+
+    const hits: ContentHit[] = [];
+    let truncated = false;
+    let bytes = 0;
+    let buffer = '';
+    let settled = false;
+
+    const finish = (error?: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(error ? { ok: false, hits, truncated, error } : { ok: true, hits, truncated });
+    };
+    const timer = setTimeout(() => {
+      truncated = true;
+      child.kill('SIGKILL');
+      finish();
+    }, TIMEOUT_MS);
+
+    child.stdout.on('data', (d: Buffer) => {
+      bytes += d.length;
+      buffer += d.toString('utf8');
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        const hit = parseRgJsonLine(buffer.slice(0, nl));
+        buffer = buffer.slice(nl + 1);
+        if (hit) {
+          if (hits.length >= MAX_HITS) {
+            truncated = true;
+            child.kill('SIGKILL');
+            finish();
+            return;
+          }
+          hits.push(hit);
+        }
+      }
+      if (bytes > MAX_STDOUT_BYTES) {
+        truncated = true;
+        child.kill('SIGKILL');
+        finish();
+      }
+    });
+    child.on('error', (e: any) => finish(`ripgrep failed to run (${e?.message ?? e})`));
+    child.on('close', (code) => {
+      // Exit 1 = no matches (not an error); null = we killed it (caps/timeout).
+      const tail = parseRgJsonLine(buffer);
+      if (tail && hits.length < MAX_HITS) hits.push(tail);
+      if (code !== null && code !== 0 && code !== 1) finish(`ripgrep exited with code ${code}`);
+      else finish();
+    });
+  });
+}

--- a/desktop/src/main/artifacts/ipc-channels.ts
+++ b/desktop/src/main/artifacts/ipc-channels.ts
@@ -47,6 +47,9 @@ export const ARTIFACT_IPC = {
   // by external, meaning changed on disk by something other than this app.
   WATCH_PROJECT: 'artifacts:watch-project',
   UNWATCH_PROJECT: 'artifacts:unwatch-project',
+  // Project-wide content search over bundled ripgrep (desktop-only; the Files
+  // tab ranks these hits BELOW filename matches in one unified list).
+  SEARCH_CONTENT: 'artifacts:search-content',
 } as const;
 
 export type ArtifactIpcChannel = typeof ARTIFACT_IPC[keyof typeof ARTIFACT_IPC];

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -86,6 +86,7 @@ import { ensureProject, applyGitTreatment } from './artifacts/project-manager';
 import { canonicalize } from '../shared/artifacts/canonicalize';
 import { evaluateBinaryRead } from './artifacts/read-binary-access';
 import { initProjectWatchers, watchProject, unwatchProject, dropSubscriber, noteOwnWrite, invalidateSidecarIdCache } from './artifacts/project-watcher';
+import { searchProjectContent } from './artifacts/content-search';
 import { looksBinary, EDIT_MAX_BYTES } from '../shared/artifacts/editable-path-policy';
 import { authorizeArtifactRead, authorizeArtifactWrite } from './artifacts/write-authorization';
 import { trackedArtifacts } from './artifacts/visible-artifacts';
@@ -3248,6 +3249,12 @@ export function registerIpcHandlers(
     if (typeof projectRoot !== 'string' || projectRoot.length === 0) return { ok: false };
     unwatchProject(projectRoot, e.sender.id);
     return { ok: true };
+  });
+  ipcMain.handle(ARTIFACT_IPC.SEARCH_CONTENT, async (_e, projectRoot: string, query: string) => {
+    if (typeof projectRoot !== 'string' || projectRoot.length === 0 || typeof query !== 'string') {
+      return { ok: false, hits: [], truncated: false, error: 'projectRoot and query are required' };
+    }
+    return searchProjectContent(projectRoot, query);
   });
 
   // Normalize an include/exclude entry to a canonical ABSOLUTE path. FilesTab

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -1265,6 +1265,9 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.invoke('artifacts:watch-project', projectRoot),
     unwatchProject: (projectRoot: string) =>
       ipcRenderer.invoke('artifacts:unwatch-project', projectRoot),
+    // Project-wide content search (ripgrep in main; desktop-only).
+    searchContent: (projectRoot: string, query: string) =>
+      ipcRenderer.invoke('artifacts:search-content', projectRoot, query),
     onChanged: (cb: (event: any) => void) => {
       const handler = (_e: any, payload: any) => cb(payload);
       ipcRenderer.on('artifacts:changed', handler);

--- a/desktop/src/renderer/components/artifact-views/ActiveArtifactView.tsx
+++ b/desktop/src/renderer/components/artifact-views/ActiveArtifactView.tsx
@@ -8,7 +8,7 @@ import type { ArtifactRecord } from '../../../shared/artifacts/types';
 import { editTier } from '../../../shared/artifacts/editable-path-policy';
 import { canonicalize } from '../../../shared/artifacts/canonicalize';
 import { UnifiedDiff } from '../diff/UnifiedDiff';
-import { openEditorSearch } from './cm/editor-registry';
+import { openEditorSearch, revealLineIn } from './cm/editor-registry';
 import { draftKey, stashDraft, takeDraft, clearDraft } from './draft-store';
 
 // Confirm-tier wording (D5): name the actual consequence, per path family.
@@ -55,6 +55,10 @@ export interface ActiveArtifactHandle {
    * viewer is CM6 (its DOM is virtualized — ContentFindBar would silently
    * miss off-viewport matches). Returns true when handled. */
   openFind(): boolean;
+  /** Scroll the code editor to a 1-indexed line (search jump-to-hit).
+   * Retries briefly — the lazy CM6 chunk may still be mounting when a search
+   * result opens a file. No-op for non-code viewers. */
+  revealLine(line: number): void;
 }
 
 /** Metadata from the artifacts:get response that content alone cannot carry —
@@ -311,6 +315,17 @@ export const ActiveArtifactView = forwardRef<ActiveArtifactHandle, ActiveArtifac
     saveEdit: () => handleSave(),
     cancelEdit: handleCancel,
     openFind: () => openEditorSearch(rootRef.current),
+    revealLine: (line: number) => {
+      // Retry across a few frames: the editor is a lazy chunk and mounts in an
+      // effect, so it may not be registered yet when the host calls this right
+      // after opening the file.
+      let attempts = 0;
+      const tryReveal = () => {
+        if (revealLineIn(rootRef.current, line)) return;
+        if (attempts++ < 20) setTimeout(tryReveal, 50);
+      };
+      tryReveal();
+    },
   }), [isEditable, editing, dirty, handleStartEdit, handleSave, handleCancel]);
 
   // Desktop app-quit / window-close guard while dirty (D3). Android never

--- a/desktop/src/renderer/components/artifact-views/cm/editor-registry.ts
+++ b/desktop/src/renderer/components/artifact-views/cm/editor-registry.ts
@@ -36,6 +36,24 @@ export function editorViewWithin(root: Element | null): EditorView | null {
 }
 
 /**
+ * Scroll the editor under `root` to a 1-indexed line, select it, and focus.
+ * The jump-to-hit primitive for cross-file search (and anything later that
+ * needs "open at line N" — imperative on purpose: a line stored in state
+ * would re-fire on stale re-selections, see the archived plan §12.10).
+ * Returns false when no editor is mounted under root (markdown viewer,
+ * binary fallback) — callers just open the file without the jump.
+ */
+export function revealLineIn(root: Element | null, line: number): boolean {
+  const view = editorViewWithin(root);
+  if (!view) return false;
+  const clamped = Math.max(1, Math.min(line, view.state.doc.lines));
+  const pos = view.state.doc.line(clamped).from;
+  view.dispatch({ selection: { anchor: pos }, scrollIntoView: true });
+  view.focus();
+  return true;
+}
+
+/**
  * Route Ctrl+F to CodeMirror's own search panel when a CM6 editor is mounted
  * under `root`. Returns true when handled. WHY not ContentFindBar: it walks
  * rendered DOM text nodes, and CM6 virtualizes — it would silently find only

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -13,7 +13,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useArtifact } from '../../../state/ArtifactContext';
 import { useProjectWatch } from '../../../hooks/useProjectWatch';
-import { dedupeContentHits, groupContentHits, MAX_CONTENT_ROWS, type RankableHit } from '../../../utils/content-search-ranking';
+import { dedupeContentHits, groupContentHits, capGroups, MAX_CONTENT_ROWS, type RankableHit } from '../../../utils/content-search-ranking';
 import { useTheme } from '../../../state/theme-context';
 import type { CentralIndexProject, ArtifactRecord } from '../../../../shared/artifacts/types';
 import { ActiveArtifactView } from '../../artifact-views/ActiveArtifactView';
@@ -494,13 +494,14 @@ export function FilesTab({
               {searching && (() => {
                 const namePaths = new Set(flatResults.map((a) => a.path.replace(/\\/g, '/')));
                 const rows = dedupeContentHits(contentHits, namePaths);
-                const shownRows = rows.slice(0, MAX_CONTENT_ROWS);
-                const groups = groupContentHits(shownRows);
-                const capped = contentTruncated || rows.length > shownRows.length;
+                // Group + sort BEFORE capping, so the biggest groups survive the cut.
+                const all = groupContentHits(rows);
+                const { groups, shownRows, capped: displayCapped } = capGroups(all, MAX_CONTENT_ROWS);
+                const capped = contentTruncated || displayCapped;
                 return (
                   <div className="col-span-full min-w-0">
                     <div className="text-[10.5px] uppercase tracking-wider text-fg-faint mt-2 mb-1.5 px-0.5">
-                      Matches by file contents ({shownRows.length}{capped ? '+' : ''})
+                      Matches by file contents ({shownRows}{capped ? '+' : ''})
                     </div>
                     <div className="flex flex-col gap-2">
                       {groups.map((group) => {

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -121,6 +121,7 @@ function listDir(artifacts: ArtifactRecord[], dir: string, sortBy: FileSortKey):
 // Aliased: detail-tool-icons also exports a (different) FolderIcon used by the
 // Reveal button above.
 import { FolderIcon as FolderCardIcon, DocIcon, ImageIcon, SheetIcon, CodeGlyphIcon } from '../icons';
+import { ChevronIcon } from '../../Icons';
 import { Button } from '../../ui';
 
 // Tiny per-type glyph for the folder-card filename list — one icon per
@@ -280,6 +281,16 @@ export function FilesTab({
   // an empty hit list and the search stays names-only there).
   const [contentHits, setContentHits] = useState<RankableHit[]>([]);
   const [contentTruncated, setContentTruncated] = useState(false);
+  // Groups are collapsed by default (Destin, 2026-07-22) — a fresh query
+  // collapses everything again so results always start as a scannable summary.
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set());
+  useEffect(() => { setExpandedGroups(new Set()); }, [search]);
+  const toggleGroup = (path: string) => setExpandedGroups((prev) => {
+    const next = new Set(prev);
+    if (next.has(path)) next.delete(path);
+    else next.add(path);
+    return next;
+  });
   // Search-result jump: which file+line to reveal once the overlay opens.
   const [pendingReveal, setPendingReveal] = useState<{ id: string; line: number } | null>(null);
   // A content hit on a file outside the loaded list (untracked in artifacts
@@ -490,27 +501,29 @@ export function FilesTab({
                       {groups.map((group) => {
                         const filename = group.path.split('/').pop() ?? group.path;
                         const dir = group.path.slice(0, group.path.length - filename.length);
+                        const expanded = expandedGroups.has(group.path);
                         return (
                           <div key={group.path} className="rounded-md border border-edge-dim overflow-hidden">
-                            {/* Group header — the file. Clicking opens at the FIRST hit. */}
+                            {/* Group header toggles the hit list (collapsed by default). */}
                             <button
                               type="button"
-                              onClick={() => openContentHit(group.hits[0])}
-                              className="w-full flex items-baseline gap-2 px-2.5 py-1.5 text-left min-w-0 bg-well/60 hover:bg-well transition-colors border-b border-edge-dim"
+                              onClick={() => toggleGroup(group.path)}
+                              className={`w-full flex items-center gap-2 px-2.5 py-1.5 text-left min-w-0 bg-well/60 hover:bg-well transition-colors ${expanded ? 'border-b border-edge-dim' : ''}`}
                               title={group.path}
                             >
+                              <ChevronIcon className="w-3 h-3 shrink-0" expanded={expanded} />
                               <span className="text-[12px] font-mono font-medium text-fg-2 shrink-0">{filename}</span>
                               {dir && <span className="text-[11px] font-mono text-fg-faint truncate min-w-0">{dir}</span>}
                               <span className="text-[11px] text-fg-muted shrink-0 ml-auto">
                                 {group.hits.length} {group.hits.length === 1 ? 'match' : 'matches'}
                               </span>
                             </button>
-                            {group.hits.map((hit, i) => (
+                            {expanded && group.hits.map((hit, i) => (
                               <button
                                 key={`${hit.line}:${i}`}
                                 type="button"
                                 onClick={() => openContentHit(hit)}
-                                className="w-full flex items-baseline gap-2 pl-5 pr-2.5 py-1 text-left min-w-0 hover:bg-well transition-colors"
+                                className="w-full flex items-baseline gap-2 pl-7 pr-2.5 py-1 text-left min-w-0 hover:bg-well transition-colors"
                                 title={`${group.path}:${hit.line}`}
                               >
                                 <span className="text-[11px] font-mono text-fg-muted shrink-0 w-8 text-right">{hit.line}</span>

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -13,7 +13,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useArtifact } from '../../../state/ArtifactContext';
 import { useProjectWatch } from '../../../hooks/useProjectWatch';
-import { dedupeContentHits, MAX_CONTENT_ROWS, type RankableHit } from '../../../utils/content-search-ranking';
+import { dedupeContentHits, groupContentHits, MAX_CONTENT_ROWS, type RankableHit } from '../../../utils/content-search-ranking';
 import { useTheme } from '../../../state/theme-context';
 import type { CentralIndexProject, ArtifactRecord } from '../../../../shared/artifacts/types';
 import { ActiveArtifactView } from '../../artifact-views/ActiveArtifactView';
@@ -478,29 +478,46 @@ export function FilesTab({
                 const namePaths = new Set(flatResults.map((a) => a.path.replace(/\\/g, '/')));
                 const rows = dedupeContentHits(contentHits, namePaths);
                 if (rows.length === 0) return null;
-                const shown = rows.slice(0, MAX_CONTENT_ROWS);
+                const shownRows = rows.slice(0, MAX_CONTENT_ROWS);
+                const groups = groupContentHits(shownRows);
+                const capped = contentTruncated || rows.length > shownRows.length;
                 return (
                   <div className="col-span-full min-w-0">
                     <div className="text-[10.5px] uppercase tracking-wider text-fg-faint mt-2 mb-1.5 px-0.5">
-                      Matches in file contents{contentTruncated || rows.length > shown.length ? ` — first ${shown.length}` : ` (${rows.length})`}
+                      Matches in file contents{capped ? ` — first ${shownRows.length}` : ` (${rows.length})`}
                     </div>
-                    <div className="flex flex-col rounded-md border border-edge-dim overflow-hidden">
-                      {shown.map((hit, i) => {
-                        const filename = hit.path.split('/').pop() ?? hit.path;
-                        const dir = hit.path.slice(0, hit.path.length - filename.length);
+                    <div className="flex flex-col gap-2">
+                      {groups.map((group) => {
+                        const filename = group.path.split('/').pop() ?? group.path;
+                        const dir = group.path.slice(0, group.path.length - filename.length);
                         return (
-                          <button
-                            key={`${hit.path}:${hit.line}:${i}`}
-                            type="button"
-                            onClick={() => openContentHit(hit)}
-                            className="flex items-baseline gap-2 px-2.5 py-1.5 text-left min-w-0 hover:bg-well transition-colors border-b border-edge-dim last:border-b-0"
-                            title={`${hit.path}:${hit.line}`}
-                          >
-                            <span className="text-[12px] font-mono text-fg-2 shrink-0">{filename}</span>
-                            {dir && <span className="text-[11px] font-mono text-fg-faint truncate shrink min-w-0 max-w-[30%]">{dir}</span>}
-                            <span className="text-[11px] font-mono text-fg-muted shrink-0">:{hit.line}</span>
-                            <span className="text-[11.5px] font-mono text-fg-dim truncate min-w-0 flex-1">{hit.text}</span>
-                          </button>
+                          <div key={group.path} className="rounded-md border border-edge-dim overflow-hidden">
+                            {/* Group header — the file. Clicking opens at the FIRST hit. */}
+                            <button
+                              type="button"
+                              onClick={() => openContentHit(group.hits[0])}
+                              className="w-full flex items-baseline gap-2 px-2.5 py-1.5 text-left min-w-0 bg-well/60 hover:bg-well transition-colors border-b border-edge-dim"
+                              title={group.path}
+                            >
+                              <span className="text-[12px] font-mono font-medium text-fg-2 shrink-0">{filename}</span>
+                              {dir && <span className="text-[11px] font-mono text-fg-faint truncate min-w-0">{dir}</span>}
+                              <span className="text-[11px] text-fg-muted shrink-0 ml-auto">
+                                {group.hits.length} {group.hits.length === 1 ? 'match' : 'matches'}
+                              </span>
+                            </button>
+                            {group.hits.map((hit, i) => (
+                              <button
+                                key={`${hit.line}:${i}`}
+                                type="button"
+                                onClick={() => openContentHit(hit)}
+                                className="w-full flex items-baseline gap-2 pl-5 pr-2.5 py-1 text-left min-w-0 hover:bg-well transition-colors"
+                                title={`${group.path}:${hit.line}`}
+                              >
+                                <span className="text-[11px] font-mono text-fg-muted shrink-0 w-8 text-right">{hit.line}</span>
+                                <span className="text-[11.5px] font-mono text-fg-dim truncate min-w-0 flex-1">{hit.text}</span>
+                              </button>
+                            ))}
+                          </div>
                         );
                       })}
                     </div>

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -452,10 +452,11 @@ export function FilesTab({
           </Button>
         </div>
       )}
-      {!loading && !gated && flat && flatResults.length === 0 && (
-        <p className="text-sm text-fg-muted">
-          {searching ? `No ${noun} match your search.` : 'Nothing matches the current filters.'}
-        </p>
+      {/* Search mode has NO prose empty state — the "(0)" in the section
+          headers below carries it (Destin, 2026-07-22). The line remains for
+          the type-filter flatten, which has no headers. */}
+      {!loading && !gated && flat && !searching && flatResults.length === 0 && (
+        <p className="text-sm text-fg-muted">Nothing matches the current filters.</p>
       )}
       {!loading && !gated && emptyHere && (
         <p className="text-sm text-fg-muted">
@@ -484,18 +485,22 @@ export function FilesTab({
         {flat
           ? (
             <>
+              {searching && (
+                <div className="col-span-full text-[10.5px] uppercase tracking-wider text-fg-faint mb-0.5 px-0.5">
+                  Matches by file name ({flatResults.length})
+                </div>
+              )}
               {flatResults.map(renderFileCard)}
               {searching && (() => {
                 const namePaths = new Set(flatResults.map((a) => a.path.replace(/\\/g, '/')));
                 const rows = dedupeContentHits(contentHits, namePaths);
-                if (rows.length === 0) return null;
                 const shownRows = rows.slice(0, MAX_CONTENT_ROWS);
                 const groups = groupContentHits(shownRows);
                 const capped = contentTruncated || rows.length > shownRows.length;
                 return (
                   <div className="col-span-full min-w-0">
                     <div className="text-[10.5px] uppercase tracking-wider text-fg-faint mt-2 mb-1.5 px-0.5">
-                      Matches in file contents{capped ? ` — first ${shownRows.length}` : ` (${rows.length})`}
+                      Matches by file contents ({shownRows.length}{capped ? '+' : ''})
                     </div>
                     <div className="flex flex-col gap-2">
                       {groups.map((group) => {

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -13,6 +13,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useArtifact } from '../../../state/ArtifactContext';
 import { useProjectWatch } from '../../../hooks/useProjectWatch';
+import { dedupeContentHits, MAX_CONTENT_ROWS, type RankableHit } from '../../../utils/content-search-ranking';
 import { useTheme } from '../../../state/theme-context';
 import type { CentralIndexProject, ArtifactRecord } from '../../../../shared/artifacts/types';
 import { ActiveArtifactView } from '../../artifact-views/ActiveArtifactView';
@@ -273,7 +274,52 @@ export function FilesTab({
     };
   }, [project.path]);
 
-  const activeArtifact = pvActiveId ? artifacts.find((a) => a.id === pvActiveId) : undefined;
+  // ── Project-wide CONTENT search (unified list, Destin 2026-07-22: no
+  // toggle — name matches rank above these). Debounced; desktop-only (the
+  // Kotlin side is a stub and remote rejects as unsupported — both settle to
+  // an empty hit list and the search stays names-only there).
+  const [contentHits, setContentHits] = useState<RankableHit[]>([]);
+  const [contentTruncated, setContentTruncated] = useState(false);
+  // Search-result jump: which file+line to reveal once the overlay opens.
+  const [pendingReveal, setPendingReveal] = useState<{ id: string; line: number } | null>(null);
+  // A content hit on a file outside the loaded list (untracked in artifacts
+  // mode, cap-truncated in allfiles) still opens via the id-as-path GET
+  // contract — this synthetic record lets the overlay render it.
+  const [syntheticHit, setSyntheticHit] = useState<ArtifactRecord | null>(null);
+  useEffect(() => {
+    const q = search.trim();
+    if (!q || q.length < 2 || getPlatform() !== 'electron') {
+      setContentHits([]);
+      setContentTruncated(false);
+      return;
+    }
+    let cancelled = false;
+    const t = setTimeout(() => {
+      Promise.resolve((window.claude as any).artifacts.searchContent?.(project.path, q))
+        .then((res: any) => {
+          if (cancelled) return;
+          setContentHits(res?.ok ? (res.hits ?? []) : []);
+          setContentTruncated(!!res?.truncated);
+        })
+        .catch(() => { if (!cancelled) { setContentHits([]); setContentTruncated(false); } });
+    }, 300);
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [search, project.path]);
+
+  const openContentHit = (hit: RankableHit) => {
+    const rec = artifacts.find((a) => a.path.replace(/\\/g, '/') === hit.path);
+    const id = rec?.id ?? hit.path;
+    if (!rec) {
+      setSyntheticHit({ id, path: hit.path, kind: 'internal', discovered: true } as any);
+    }
+    setPendingReveal({ id, line: hit.line });
+    dispatch({ type: 'ACTIVE_ARTIFACT_SET', sessionId: PV_SESSION, artifactId: id });
+  };
+
+  const activeArtifact = pvActiveId
+    ? (artifacts.find((a) => a.id === pvActiveId)
+      ?? (syntheticHit && syntheticHit.id === pvActiveId ? syntheticHit : undefined))
+    : undefined;
 
   // Searching OR an active type filter flattens the tree to matching FILES only
   // — no folder cards. When you're looking for something, folders are noise;
@@ -425,7 +471,44 @@ export function FilesTab({
           columns read correctly on a phone. */}
       <div className="flex-1 overflow-auto max-sm:overflow-visible grid grid-cols-2 sm:grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-3 content-start p-2 -m-2">
         {flat
-          ? flatResults.map(renderFileCard)
+          ? (
+            <>
+              {flatResults.map(renderFileCard)}
+              {searching && (() => {
+                const namePaths = new Set(flatResults.map((a) => a.path.replace(/\\/g, '/')));
+                const rows = dedupeContentHits(contentHits, namePaths);
+                if (rows.length === 0) return null;
+                const shown = rows.slice(0, MAX_CONTENT_ROWS);
+                return (
+                  <div className="col-span-full min-w-0">
+                    <div className="text-[10.5px] uppercase tracking-wider text-fg-faint mt-2 mb-1.5 px-0.5">
+                      Matches in file contents{contentTruncated || rows.length > shown.length ? ` — first ${shown.length}` : ` (${rows.length})`}
+                    </div>
+                    <div className="flex flex-col rounded-md border border-edge-dim overflow-hidden">
+                      {shown.map((hit, i) => {
+                        const filename = hit.path.split('/').pop() ?? hit.path;
+                        const dir = hit.path.slice(0, hit.path.length - filename.length);
+                        return (
+                          <button
+                            key={`${hit.path}:${hit.line}:${i}`}
+                            type="button"
+                            onClick={() => openContentHit(hit)}
+                            className="flex items-baseline gap-2 px-2.5 py-1.5 text-left min-w-0 hover:bg-well transition-colors border-b border-edge-dim last:border-b-0"
+                            title={`${hit.path}:${hit.line}`}
+                          >
+                            <span className="text-[12px] font-mono text-fg-2 shrink-0">{filename}</span>
+                            {dir && <span className="text-[11px] font-mono text-fg-faint truncate shrink min-w-0 max-w-[30%]">{dir}</span>}
+                            <span className="text-[11px] font-mono text-fg-muted shrink-0">:{hit.line}</span>
+                            <span className="text-[11.5px] font-mono text-fg-dim truncate min-w-0 flex-1">{hit.text}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })()}
+            </>
+          )
           : (
             <>
               {/* Files directly in this folder FIRST, then subfolders (per request:
@@ -523,6 +606,8 @@ export function FilesTab({
           artifact={activeArtifact}
           project={project}
           onRefreshArtifacts={() => { refreshArtifacts(); onMutated?.(); }}
+          initialLine={pendingReveal?.id === activeArtifact.id ? pendingReveal.line : undefined}
+          onInitialLineConsumed={() => setPendingReveal(null)}
         />
       )}
     </div>
@@ -539,9 +624,14 @@ interface DetailProps {
   artifact: ArtifactRecord;
   project: CentralIndexProject;
   onRefreshArtifacts: () => void;
+  /** Search jump-to-hit: reveal this 1-indexed line once content loads.
+   * Consumed exactly once (onInitialLineConsumed) so reopening the same file
+   * later does not re-jump to a stale line. */
+  initialLine?: number;
+  onInitialLineConsumed?: () => void;
 }
 
-function ArtifactDetail({ artifact, project, onRefreshArtifacts }: DetailProps) {
+function ArtifactDetail({ artifact, project, onRefreshArtifacts, initialLine, onInitialLineConsumed }: DetailProps) {
   const { dispatch } = useArtifact();
   const [content, setContent] = useState<string | null>(null);
   // Drive the viewer's edit lifecycle from the overlay header (controlsInHeader).
@@ -576,6 +666,18 @@ function ArtifactDetail({ artifact, project, onRefreshArtifacts }: DetailProps) 
     });
     return () => { cancelled = true; };
   }, [artifact.id, project.path]);
+
+  // Search jump-to-hit: fire once, only after content resolved (the editor
+  // mounts then; revealLine itself retries across the lazy-chunk window).
+  const revealedRef = useRef(false);
+  useEffect(() => { revealedRef.current = false; }, [artifact.id]);
+  useEffect(() => {
+    if (revealedRef.current || initialLine == null || content === null) return;
+    revealedRef.current = true;
+    viewRef.current?.revealLine(initialLine);
+    onInitialLineConsumed?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content, initialLine, artifact.id]);
 
   const handleExclude = async () => {
     // Use absolutePath for external artifacts, relative path (internal) gets

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1240,6 +1240,8 @@ export function installShim(): void {
         invoke('artifacts:watch-project', { projectRoot }),
       unwatchProject: (projectRoot: string) =>
         invoke('artifacts:unwatch-project', { projectRoot }),
+      searchContent: (projectRoot: string, query: string) =>
+        invoke('artifacts:search-content', { projectRoot, query }),
       onChanged: (cb: (event: any) => void) => {
         const handler: Callback = (evt: any) => cb(evt);
         addListener('artifacts:changed', handler);

--- a/desktop/src/renderer/utils/content-search-ranking.ts
+++ b/desktop/src/renderer/utils/content-search-ranking.ts
@@ -1,0 +1,18 @@
+// Ranking rule for the unified Files search (Destin, 2026-07-22): ONE list,
+// no name/contents toggle — filename matches render first (the existing card
+// grid), content hits below. A file that already name-matched is dropped from
+// the content section: its card is right above, and repeating it as snippet
+// rows would read as more results than there are.
+export interface RankableHit {
+  path: string;   // project-relative, forward slashes
+  line: number;
+  text: string;
+}
+
+export function dedupeContentHits(hits: RankableHit[], nameMatchedPaths: Set<string>): RankableHit[] {
+  return hits.filter((h) => !nameMatchedPaths.has(h.path));
+}
+
+/** Cap the rendered rows — the IPC already caps at 200 hits, but 200 DOM rows
+ * under the grid drowns the cards the ranking says matter more. */
+export const MAX_CONTENT_ROWS = 60;

--- a/desktop/src/renderer/utils/content-search-ranking.ts
+++ b/desktop/src/renderer/utils/content-search-ranking.ts
@@ -16,3 +16,25 @@ export function dedupeContentHits(hits: RankableHit[], nameMatchedPaths: Set<str
 /** Cap the rendered rows — the IPC already caps at 200 hits, but 200 DOM rows
  * under the grid drowns the cards the ranking says matter more. */
 export const MAX_CONTENT_ROWS = 60;
+
+export interface HitGroup {
+  path: string;
+  hits: RankableHit[];
+}
+
+/** Group hits by file, first-seen order (Destin, 2026-07-22: content results
+ * grouped per file — "N results in CLAUDE.md" — instead of one flat list).
+ * rg usually emits a file's matches contiguously, but its parallel workers can
+ * interleave files, so group via a map rather than trusting adjacency. */
+export function groupContentHits(hits: RankableHit[]): HitGroup[] {
+  const byPath = new Map<string, HitGroup>();
+  for (const hit of hits) {
+    let group = byPath.get(hit.path);
+    if (!group) {
+      group = { path: hit.path, hits: [] };
+      byPath.set(hit.path, group);
+    }
+    group.hits.push(hit);
+  }
+  return [...byPath.values()];
+}

--- a/desktop/src/renderer/utils/content-search-ranking.ts
+++ b/desktop/src/renderer/utils/content-search-ranking.ts
@@ -36,5 +36,27 @@ export function groupContentHits(hits: RankableHit[]): HitGroup[] {
     }
     group.hits.push(hit);
   }
-  return [...byPath.values()];
+  // Most matches first (Destin, 2026-07-22) — the file that mentions the query
+  // ten times is a better bet than ten files that mention it once. Sort is
+  // stable, so equal counts keep first-seen order.
+  return [...byPath.values()].sort((a, b) => b.hits.length - a.hits.length);
+}
+
+/** Apply the display cap by WHOLE groups after sorting, so the cap never
+ * splits a file's matches in half — except the first group, which is always
+ * shown and clipped to the budget if it alone exceeds it. */
+export function capGroups(groups: HitGroup[], maxRows: number): { groups: HitGroup[]; shownRows: number; capped: boolean } {
+  const out: HitGroup[] = [];
+  let rows = 0;
+  for (const group of groups) {
+    if (out.length === 0 && group.hits.length > maxRows) {
+      out.push({ path: group.path, hits: group.hits.slice(0, maxRows) });
+      rows = maxRows;
+      break;
+    }
+    if (rows + group.hits.length > maxRows) break;
+    out.push(group);
+    rows += group.hits.length;
+  }
+  return { groups: out, shownRows: rows, capped: out.length < groups.length || groups.some((g, i) => i === 0 && out[0] && out[0].hits.length < g.hits.length) };
 }

--- a/desktop/tests/artifacts/content-search.test.ts
+++ b/desktop/tests/artifacts/content-search.test.ts
@@ -1,0 +1,83 @@
+// Pins the content-search module: the rg --json parser contract and a REAL
+// end-to-end search over a temp directory using the bundled ripgrep binary —
+// the same binary ships in the app, so if this passes, the packaged feature
+// has no parsing surprises left (spawn-path pitfalls are grep.ts's
+// resolveRgPath, reused verbatim).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseRgJsonLine, searchProjectContent, MAX_HITS } from '../../src/main/artifacts/content-search';
+
+describe('parseRgJsonLine', () => {
+  it('parses a match event into path/line/snippet', () => {
+    const line = JSON.stringify({
+      type: 'match',
+      data: { path: { text: 'src\\app.ts' }, line_number: 42, lines: { text: '  const port = 5223;\n' } },
+    });
+    expect(parseRgJsonLine(line)).toEqual({ path: 'src/app.ts', line: 42, text: 'const port = 5223;' });
+  });
+  it('ignores begin/end/summary events, blanks, and garbage', () => {
+    expect(parseRgJsonLine(JSON.stringify({ type: 'begin', data: {} }))).toBeNull();
+    expect(parseRgJsonLine(JSON.stringify({ type: 'summary', data: {} }))).toBeNull();
+    expect(parseRgJsonLine('')).toBeNull();
+    expect(parseRgJsonLine('not json at all')).toBeNull();
+  });
+  it('caps runaway snippets', () => {
+    const line = JSON.stringify({
+      type: 'match',
+      data: { path: { text: 'a.txt' }, line_number: 1, lines: { text: 'x'.repeat(5000) } },
+    });
+    expect(parseRgJsonLine(line)!.text.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('searchProjectContent (real ripgrep)', () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-search-'));
+    await fs.promises.mkdir(path.join(root, 'src'), { recursive: true });
+    await fs.promises.writeFile(path.join(root, 'src/app.ts'), 'const port = 5223;\nconst other = 1;\n');
+    await fs.promises.writeFile(path.join(root, 'notes.md'), 'remember: PORT 5223 is the dev vite port\n');
+    await fs.promises.mkdir(path.join(root, 'node_modules/dep'), { recursive: true });
+    await fs.promises.writeFile(path.join(root, 'node_modules/dep/x.js'), 'port 5223 in a dependency\n');
+    await fs.promises.mkdir(path.join(root, '.youcoded'), { recursive: true });
+    await fs.promises.writeFile(path.join(root, '.youcoded/artifacts.json'), '{"note":"port 5223"}\n');
+  });
+  afterEach(async () => {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  });
+
+  it('finds matches with 1-indexed lines, case-insensitively, skipping node_modules and .youcoded', async () => {
+    const res = await searchProjectContent(root, 'port 5223');
+    expect(res.ok).toBe(true);
+    const byPath = Object.fromEntries(res.hits.map((h) => [h.path, h]));
+    expect(byPath['src/app.ts']).toBeUndefined(); // "port = 5223" is not a literal match
+    expect(byPath['notes.md']).toMatchObject({ line: 1 }); // case-insensitive "PORT 5223"
+    expect(res.hits.some((h) => h.path.includes('node_modules'))).toBe(false);
+    expect(res.hits.some((h) => h.path.includes('.youcoded'))).toBe(false);
+  });
+
+  it('treats the query as LITERAL text, not a regex', async () => {
+    await fs.promises.writeFile(path.join(root, 'regex.txt'), 'a literal a.c string\nabc should not match\n');
+    const res = await searchProjectContent(root, 'a.c');
+    expect(res.hits.map((h) => `${h.path}:${h.line}`)).toEqual(['regex.txt:1']);
+  });
+
+  it('empty query returns cleanly; no matches is ok:true with zero hits', async () => {
+    expect(await searchProjectContent(root, '   ')).toEqual({ ok: true, hits: [], truncated: false });
+    const res = await searchProjectContent(root, 'zzz-not-in-any-file-zzz');
+    expect(res).toMatchObject({ ok: true, hits: [], truncated: false });
+  });
+
+  it('caps total hits and reports truncation', async () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `needle line ${i}`).join('\n');
+    for (let f = 0; f < 20; f++) {
+      await fs.promises.writeFile(path.join(root, `many-${f}.txt`), lines);
+    }
+    const res = await searchProjectContent(root, 'needle');
+    expect(res.ok).toBe(true);
+    expect(res.hits.length).toBeLessThanOrEqual(MAX_HITS);
+    expect(res.truncated).toBe(true);
+  }, 15000);
+});

--- a/desktop/tests/content-search-ranking.test.ts
+++ b/desktop/tests/content-search-ranking.test.ts
@@ -2,7 +2,7 @@
 // matches render first, and a file that already name-matched never repeats in
 // the content section.
 import { describe, it, expect } from 'vitest';
-import { dedupeContentHits } from '../src/renderer/utils/content-search-ranking';
+import { dedupeContentHits, groupContentHits } from '../src/renderer/utils/content-search-ranking';
 
 describe('dedupeContentHits', () => {
   it('drops hits for files already shown as name matches', () => {
@@ -13,5 +13,18 @@ describe('dedupeContentHits', () => {
     expect(dedupeContentHits(hits, new Set(['src/timeout.ts']))).toEqual([
       { path: 'src/server.ts', line: 9, text: 'y' },
     ]);
+  });
+});
+
+describe('groupContentHits', () => {
+  it('groups by file in first-seen order, tolerating interleaved input', () => {
+    const groups = groupContentHits([
+      { path: 'CLAUDE.md', line: 3, text: 'a' },
+      { path: 'ROADMAP.md', line: 8, text: 'b' },
+      { path: 'CLAUDE.md', line: 12, text: 'c' },
+    ]);
+    expect(groups.map((g) => g.path)).toEqual(['CLAUDE.md', 'ROADMAP.md']);
+    expect(groups[0].hits.map((h) => h.line)).toEqual([3, 12]);
+    expect(groups[1].hits).toHaveLength(1);
   });
 });

--- a/desktop/tests/content-search-ranking.test.ts
+++ b/desktop/tests/content-search-ranking.test.ts
@@ -2,7 +2,7 @@
 // matches render first, and a file that already name-matched never repeats in
 // the content section.
 import { describe, it, expect } from 'vitest';
-import { dedupeContentHits, groupContentHits } from '../src/renderer/utils/content-search-ranking';
+import { dedupeContentHits, groupContentHits, capGroups } from '../src/renderer/utils/content-search-ranking';
 
 describe('dedupeContentHits', () => {
   it('drops hits for files already shown as name matches', () => {
@@ -17,14 +17,35 @@ describe('dedupeContentHits', () => {
 });
 
 describe('groupContentHits', () => {
-  it('groups by file in first-seen order, tolerating interleaved input', () => {
+  it('groups by file and sorts by match count, most first; ties keep first-seen order', () => {
     const groups = groupContentHits([
-      { path: 'CLAUDE.md', line: 3, text: 'a' },
       { path: 'ROADMAP.md', line: 8, text: 'b' },
+      { path: 'CLAUDE.md', line: 3, text: 'a' },
       { path: 'CLAUDE.md', line: 12, text: 'c' },
+      { path: 'notes.md', line: 1, text: 'd' },
     ]);
-    expect(groups.map((g) => g.path)).toEqual(['CLAUDE.md', 'ROADMAP.md']);
+    expect(groups.map((g) => g.path)).toEqual(['CLAUDE.md', 'ROADMAP.md', 'notes.md']);
     expect(groups[0].hits.map((h) => h.line)).toEqual([3, 12]);
-    expect(groups[1].hits).toHaveLength(1);
+  });
+});
+
+describe('capGroups', () => {
+  const mk = (path: string, n: number) => ({ path, hits: Array.from({ length: n }, (_, i) => ({ path, line: i + 1, text: 'x' })) });
+  it('keeps whole groups within the budget and reports the cut', () => {
+    const { groups, shownRows, capped } = capGroups([mk('a', 3), mk('b', 3), mk('c', 3)], 7);
+    expect(groups.map((g) => g.path)).toEqual(['a', 'b']);
+    expect(shownRows).toBe(6);
+    expect(capped).toBe(true);
+  });
+  it('always shows the first group, clipped, when it alone exceeds the budget', () => {
+    const { groups, shownRows, capped } = capGroups([mk('big', 100), mk('b', 2)], 10);
+    expect(groups[0].hits).toHaveLength(10);
+    expect(shownRows).toBe(10);
+    expect(capped).toBe(true);
+  });
+  it('no cap when everything fits', () => {
+    const { shownRows, capped } = capGroups([mk('a', 2), mk('b', 2)], 60);
+    expect(shownRows).toBe(4);
+    expect(capped).toBe(false);
   });
 });

--- a/desktop/tests/content-search-ranking.test.ts
+++ b/desktop/tests/content-search-ranking.test.ts
@@ -1,0 +1,17 @@
+// Pins the unified-search ranking rule (Destin, 2026-07-22): no toggle — name
+// matches render first, and a file that already name-matched never repeats in
+// the content section.
+import { describe, it, expect } from 'vitest';
+import { dedupeContentHits } from '../src/renderer/utils/content-search-ranking';
+
+describe('dedupeContentHits', () => {
+  it('drops hits for files already shown as name matches', () => {
+    const hits = [
+      { path: 'src/timeout.ts', line: 3, text: 'x' },
+      { path: 'src/server.ts', line: 9, text: 'y' },
+    ];
+    expect(dedupeContentHits(hits, new Set(['src/timeout.ts']))).toEqual([
+      { path: 'src/server.ts', line: 9, text: 'y' },
+    ]);
+  });
+});

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -452,6 +452,7 @@ describe('artifact IPC parity', () => {
     // External-change watcher subscribe/unsubscribe (project-watcher.ts).
     WATCH_PROJECT: 'artifacts:watch-project',
     UNWATCH_PROJECT: 'artifacts:unwatch-project',
+    SEARCH_CONTENT: 'artifacts:search-content',
   }).reduce<Record<string, string>>((acc, [name, value]) => {
     acc[value] = `ARTIFACT_IPC.${name}`;
     return acc;


### PR DESCRIPTION
The cross-file search follow-up cut from #200 (spec: archived plan step 6, `youcoded-dev/docs/archive/plans/2026-07-22-artifact-pane-code-editor-implementation.md`).

**Design (Destin, 2026-07-22):** no name/contents toggle — one search box, one ranked list. Filename matches render first as the existing cards; content hits appear below as `file:line — snippet` rows; a name-matched file never repeats as a content row. Clicking a hit opens the file **scrolled to that line** (new `revealLine` primitive on the editor — reusable by the future git surface).

**Engine:** the bundled ripgrep the agent's Grep tool already uses, spawned with `--json` for structured results and `-F -i` (literal, case-insensitive — it's a search box, not a regex surface). Caps: 20 hits/file, 200 total, 1MB stdout, 5s kill, truncation surfaced as "first N". Reuses `resolveRgPath` + the grep.ts spawn defenses (asar-unpacked binary, explicit cwd, sync spawn try/catch).

**Platforms:** desktop-only per D2 — Kotlin stub + remote unsupported both settle to names-only search.

**Tests:** rg-json parser contract; a REAL end-to-end ripgrep run over a temp tree pinning literal-not-regex, case-insensitivity, `node_modules`/`.youcoded` exclusion, and truncation; ranking dedupe. Suite green (3016), `tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)