### PR TITLE
cleanup(desktop): remove verified dead code + tighten export surface

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -55,7 +55,6 @@
         "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/diff": "^7.0.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/ws": "^8.18.1",
@@ -2969,13 +2968,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -62,7 +62,6 @@
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/diff": "^7.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",

--- a/desktop/src/main/announcement-service.ts
+++ b/desktop/src/main/announcement-service.ts
@@ -69,7 +69,7 @@ function parseAnnouncement(text: string): { message: string; expires?: string } 
  * or all-expired remote file writes a cleared cache so the status bar
  * pill disappears within the refresh interval.
  */
-export async function fetchAnnouncement(): Promise<void> {
+async function fetchAnnouncement(): Promise<void> {
   let response: Response;
   try {
     response = await fetch(ANNOUNCEMENTS_URL);
@@ -125,7 +125,7 @@ export function startAnnouncementService(): void {
   refreshTimer.unref?.();
 }
 
-export function stopAnnouncementService(): void {
+function stopAnnouncementService(): void {
   if (refreshTimer) {
     clearInterval(refreshTimer);
     refreshTimer = null;

--- a/desktop/src/main/artifacts/artifact-store.ts
+++ b/desktop/src/main/artifacts/artifact-store.ts
@@ -5,7 +5,7 @@ import { newArtifactId, newVersionId } from '../../shared/artifacts/ulid';
 import { SIDECAR_SCHEMA_VERSION } from '../../shared/artifacts/types';
 import { casWrite } from './cas-write';
 
-export const SIDECAR_RELATIVE = '.youcoded/artifacts.json';
+const SIDECAR_RELATIVE = '.youcoded/artifacts.json';
 
 export type ReadResult = ProjectSidecar | null | { corrupted: true };
 

--- a/desktop/src/main/artifacts/central-index.ts
+++ b/desktop/src/main/artifacts/central-index.ts
@@ -5,7 +5,7 @@ import {
 } from '../../shared/artifacts/types';
 import { mutateFileUnderLock } from './cas-write';
 
-export const INDEX_FILE = 'youcoded-projects-index.json';
+const INDEX_FILE = 'youcoded-projects-index.json';
 
 const MAX_RETRIES = 5;
 

--- a/desktop/src/main/artifacts/project-watcher.ts
+++ b/desktop/src/main/artifacts/project-watcher.ts
@@ -42,7 +42,7 @@ export const WATCH_SKIP_DIRS = new Set([
 
 // Matches discovery MAX_DEPTH so a broad root (the seeded Home folder) cannot
 // point chokidar at an unbounded tree (plan ADDED 2026-07-22 — depth cap).
-export const WATCH_DEPTH = 6;
+const WATCH_DEPTH = 6;
 
 // How long a path written by the app itself stays suppressed. Must exceed
 // chokidar awaitWriteFinish stabilityThreshold (500ms) with margin, or every

--- a/desktop/src/main/buddy-bar-geometry.ts
+++ b/desktop/src/main/buddy-bar-geometry.ts
@@ -34,8 +34,8 @@ export const CHAT_SIZE: Size = { width: 320, height: 480 };
  * (Destin 2026-07-17: "the mascot/buttons should be slightly closer to the chat
  * window when below it").
  */
-export const MASCOT_INK_TOP_INSET = 5 / 30;
-export const MASCOT_INK_BOTTOM_INSET = 2 / 30;
+const MASCOT_INK_TOP_INSET = 5 / 30;
+const MASCOT_INK_BOTTOM_INSET = 2 / 30;
 
 /**
  * Gap between the chat panel and the mascot's ARTWORK — NOT his window edge.
@@ -71,10 +71,10 @@ export function mascotInkRect(mascotBounds: Rect): Rect {
  * below the mascot's midline. Destin wants the action bar's row lined up with
  * the hands rather than the midline (2026-07-17).
  */
-export const HANDS_CENTER_FRACTION = 0.583;
+const HANDS_CENTER_FRACTION = 0.583;
 
 /** Chat's horizontal nudge off the group's true centre — Destin's eye, 2026-07-16. */
-export const CHAT_NUDGE_X = 10;
+const CHAT_NUDGE_X = 10;
 
 /**
  * The VISIBLE button row's rect — ALWAYS to the mascot's right, vertically

--- a/desktop/src/main/claude-code-registry.ts
+++ b/desktop/src/main/claude-code-registry.ts
@@ -39,8 +39,8 @@ import os from 'os';
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const PLUGIN_CACHE_DIR = path.join(CLAUDE_DIR, 'plugins'); // tW() in the CLI
 
-export const YOUCODED_MARKETPLACE_ID = 'youcoded';
-export const YOUCODED_MARKETPLACE_ROOT = path.join(PLUGIN_CACHE_DIR, 'marketplaces', YOUCODED_MARKETPLACE_ID);
+const YOUCODED_MARKETPLACE_ID = 'youcoded';
+const YOUCODED_MARKETPLACE_ROOT = path.join(PLUGIN_CACHE_DIR, 'marketplaces', YOUCODED_MARKETPLACE_ID);
 export const YOUCODED_PLUGINS_DIR = path.join(YOUCODED_MARKETPLACE_ROOT, 'plugins');
 
 /**
@@ -95,7 +95,7 @@ const SETTINGS = path.join(CLAUDE_DIR, 'settings.json');
 // --- Key helpers ---
 
 /** The @-qualified key Claude Code uses in enabledPlugins & installed_plugins.json. */
-export function pluginKey(id: string): string {
+function pluginKey(id: string): string {
   return `${id}@${YOUCODED_MARKETPLACE_ID}`;
 }
 

--- a/desktop/src/main/conversations/service.ts
+++ b/desktop/src/main/conversations/service.ts
@@ -152,6 +152,8 @@ export function noteSessionStarted(claudeSessionId: string, cwd: string): void {
  * Idempotent (a second run finds nothing) and best-effort — a failure here must
  * never block store startup.
  */
+// Exported for tests (conversations-service.test.ts imports the module namespace
+// and calls this directly); production callers use the in-scope reference above.
 export async function pruneNativePhantomRecords(opts?: { nativeHomeRoot?: string }): Promise<number> {
   const s = store;
   if (!s) return 0;

--- a/desktop/src/main/conversations/tag-registry-service.ts
+++ b/desktop/src/main/conversations/tag-registry-service.ts
@@ -19,6 +19,6 @@ export function startTagRegistry(opts?: { tagsRoot?: string }): void {
   registry = createTagRegistry(root);
 }
 
-export function stopTagRegistry(): void {
+function stopTagRegistry(): void {
   registry = null;
 }

--- a/desktop/src/main/engine/engine-acquisition.ts
+++ b/desktop/src/main/engine/engine-acquisition.ts
@@ -197,7 +197,7 @@ export class EngineAcquisition {
 }
 
 /** Streaming SHA-256 — engine archives are tens of MB; never buffer whole. */
-export function sha256File(file: string): Promise<string> {
+function sha256File(file: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash('sha256');
     fs.createReadStream(file)

--- a/desktop/src/main/harness/search/search-chain.ts
+++ b/desktop/src/main/harness/search/search-chain.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 
 export type SearchBackendId = 'exa' | 'ddg' | 'tavily';
 export interface SearchChainEntry { backend: SearchBackendId; requiresKey: boolean }
-export const SEARCH_CHAIN_SCHEMA_VERSION = 1;
+const SEARCH_CHAIN_SCHEMA_VERSION = 1;
 // Order rationale (plan decision 7): a user who added a Tavily key wants it
 // used; keyless users skip it (requiresKey) and land on Exa keyless, then DDG.
 export const SHIPPED_SEARCH_CHAIN: SearchChainEntry[] = [

--- a/desktop/src/main/harness/tools/bash.ts
+++ b/desktop/src/main/harness/tools/bash.ts
@@ -133,7 +133,7 @@ function withCwdProbe(command: string): string {
 /** Split the sentinel back off the combined stdout+stderr. Returns the text the
  *  model should see and the reported cwd (null when the command exited early,
  *  timed out, or was killed — all cases where cwd simply doesn't change). */
-export function extractCwd(out: string): { text: string; cwd: string | null } {
+function extractCwd(out: string): { text: string; cwd: string | null } {
   const at = out.lastIndexOf(`\n${CWD_SENTINEL}`);
   if (at === -1) return { text: out, cwd: null };
   const after = out.slice(at + 1 + CWD_SENTINEL.length);
@@ -173,7 +173,7 @@ function isInside(root: string, candidate: string): boolean {
 /** Built per-read so it reflects the LAZILY resolved shell (see getShell). A
  *  module-level string would bake in whatever was detected at import — i.e.
  *  "PowerShell" for a user whose git arrived during first-run. */
-export function bashDescription(): string {
+function bashDescription(): string {
   const s = getShell();
   return (
     `Run a shell command (${s.label} on this machine). ` +

--- a/desktop/src/main/harness/tools/edit.ts
+++ b/desktop/src/main/harness/tools/edit.ts
@@ -17,7 +17,7 @@ export function toHunks(oldText: string, newText: string, filePath: string): Str
 }
 
 /** Detect and preserve line endings + BOM (Windows repos — spec §2.3). */
-export function preserveFormat(original: string, edited: string): string {
+function preserveFormat(original: string, edited: string): string {
   const hasBom = original.charCodeAt(0) === 0xfeff;
   const crlf = original.includes('\r\n');
   let out = edited;

--- a/desktop/src/main/harness/tools/index.ts
+++ b/desktop/src/main/harness/tools/index.ts
@@ -14,4 +14,3 @@ import { AskUserQuestionTool } from './ask-user-question';
  *  every preset/mode — see permission-types.rulesForMode); AskUserQuestion
  *  (interactive, driver-routed) comes last. */
 export const CORE_TOOLS: NativeTool[] = [ReadTool, WriteTool, EditTool, BashTool, GlobTool, GrepTool, TodoWriteTool, WebFetchTool, WebSearchTool, AskUserQuestionTool];
-export const toolByName = new Map(CORE_TOOLS.map((t) => [t.name, t]));

--- a/desktop/src/main/models/gpu-detector.ts
+++ b/desktop/src/main/models/gpu-detector.ts
@@ -192,8 +192,3 @@ export async function detectGpu(): Promise<GpuInfo> {
   }
   return cached;
 }
-
-/** Test-only: clear the module-level cache so platform behavior can be re-probed. */
-export function __resetGpuCacheForTests(): void {
-  cached = undefined;
-}

--- a/desktop/src/main/plugin-installer.ts
+++ b/desktop/src/main/plugin-installer.ts
@@ -53,7 +53,7 @@ function isContainedIn(child: string, parent: string): boolean {
  * YouCoded/YouCoded local entries live in the itsdestin/wecoded-marketplace
  * repo, while Anthropic upstream entries live in anthropics/claude-plugins-official.
  */
-export function getMarketplaceRepo(sourceMarketplace?: string): string {
+function getMarketplaceRepo(sourceMarketplace?: string): string {
   if (sourceMarketplace === 'youcoded' || sourceMarketplace === 'youcoded-core') {
     return 'https://github.com/itsdestin/wecoded-marketplace.git';
   }
@@ -164,7 +164,7 @@ function copyDirSync(src: string, dest: string): void {
  * Claude Code's plugin cache dir (`tW()` in the CLI) is `~/.claude/plugins/`,
  * so `installed_plugins.json` lives there — not at `~/.claude/`. Skip keys
  * ending in `@youcoded` since those are ours, not a foreign conflict. */
-export function hasConflict(id: string): boolean {
+function hasConflict(id: string): boolean {
   try {
     const installedPath = path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json');
     if (!fs.existsSync(installedPath)) return false;

--- a/desktop/src/main/prerequisite-installer.ts
+++ b/desktop/src/main/prerequisite-installer.ts
@@ -110,7 +110,7 @@ function youcodedDataDir(): string {
 }
 
 /** Where we extract Node's tarball (macOS + Linux). */
-export function userLocalNodeDir(): string {
+function userLocalNodeDir(): string {
   return path.join(youcodedDataDir(), 'node');
 }
 
@@ -120,12 +120,12 @@ export function userLocalNodeDir(): string {
  * tarball extraction, which uses `--strip-components=1` into `userLocalNodeDir()`
  * and would clobber anything else living there on a Node reinstall.
  */
-export function userLocalToolsBinDir(): string {
+function userLocalToolsBinDir(): string {
   return path.join(youcodedDataDir(), 'bin');
 }
 
 /** Node's bin dir (contains node, npm, npx — and later, claude from `npm i -g`). */
-export function userLocalNodeBinDir(): string {
+function userLocalNodeBinDir(): string {
   return path.join(userLocalNodeDir(), 'bin');
 }
 
@@ -299,7 +299,7 @@ function cleanStaleClaudeDownloads(): void {
  * is interpolated. This is intentional; execFile cannot run reg queries that
  * need shell parsing of the output format.
  */
-export function refreshPath(): void {
+function refreshPath(): void {
   if (process.platform !== 'win32') return;
 
   try {
@@ -352,7 +352,7 @@ export function resolveCommand(cmd: string): string {
  * Download a file via HTTPS, following 301/302 redirects.
  * Returns a Promise that resolves when writing is complete.
  */
-export function downloadFile(url: string, dest: string): Promise<void> {
+function downloadFile(url: string, dest: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const request = (targetUrl: string) => {
       https.get(targetUrl, (res) => {

--- a/desktop/src/main/retention-default.ts
+++ b/desktop/src/main/retention-default.ts
@@ -16,7 +16,7 @@ import os from 'os';
 // CC-coupled: `cleanupPeriodDays` is a Claude Code settings contract. See
 // youcoded/docs/cc-dependencies.md → "Transcript retention (cleanupPeriodDays)".
 
-export const DEFAULT_CLEANUP_PERIOD_DAYS = 365;
+const DEFAULT_CLEANUP_PERIOD_DAYS = 365;
 
 export interface SeedRetentionResult {
   /** True iff settings.json was rewritten (key was absent). */

--- a/desktop/src/main/saved-folders.ts
+++ b/desktop/src/main/saved-folders.ts
@@ -13,7 +13,7 @@ export interface SavedFolder {
   addedAt: number;
 }
 
-export function foldersFilePath(): string {
+function foldersFilePath(): string {
   return path.join(os.homedir(), '.claude', 'youcoded-folders.json');
 }
 

--- a/desktop/src/main/sync-spaces/project-registry.ts
+++ b/desktop/src/main/sync-spaces/project-registry.ts
@@ -84,7 +84,7 @@ export function mergeProjectEntries(a: ProjectRegistryEntry, b: ProjectRegistryE
   };
 }
 
-export function foldProjectEntries(entries: ProjectRegistryEntry[]): ProjectRegistryEntry {
+function foldProjectEntries(entries: ProjectRegistryEntry[]): ProjectRegistryEntry {
   return entries.reduce((acc, e) => mergeProjectEntries(acc, e));
 }
 

--- a/desktop/src/main/sync-spaces/service.ts
+++ b/desktop/src/main/sync-spaces/service.ts
@@ -1,7 +1,7 @@
 // desktop/src/main/sync-spaces/service.ts
 // Composition root: owns the singleton ManagedRoots/SpaceManager/Engine and
 // exposes the functions IPC + remote-server call. Mirrors the sync-state.ts
-// singleton pattern (setSyncService/getSyncService).
+// singleton pattern (setSyncService).
 import os from 'os';
 import { BrowserWindow } from 'electron';
 import { ManagedRoots } from './managed-roots';

--- a/desktop/src/main/sync-state.ts
+++ b/desktop/src/main/sync-state.ts
@@ -36,12 +36,6 @@ export function setSyncService(service: SyncService | null): void {
   syncServiceInstance = service;
 }
 
-/** Exposed so IPC handlers can read/write the conversation index without
- *  importing the SyncService module directly. */
-export function getSyncService(): SyncService | null {
-  return syncServiceInstance;
-}
-
 // --- V2 Types: Multi-instance backend model ---
 
 /** The three cloud service types the sync system supports. */

--- a/desktop/src/main/sync-state.ts
+++ b/desktop/src/main/sync-state.ts
@@ -219,7 +219,7 @@ async function atomicWrite(target: string, content: string): Promise<void> {
  * Generate a URL-safe slug from a backend type and user-assigned label.
  * Used as the stable ID for a backend instance.
  */
-export function generateBackendId(type: string, label: string): string {
+function generateBackendId(type: string, label: string): string {
   const slug = label
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')   // Replace non-alphanumeric with dashes

--- a/desktop/src/renderer/components/AssistantTurnBubble.tsx
+++ b/desktop/src/renderer/components/AssistantTurnBubble.tsx
@@ -108,7 +108,7 @@ function TurnMetadataStrip({ turn }: { turn: AssistantTurn }) {
 /** Renders a collapsed summary for 2+ tools in a group. Exported so the dev
  * sandbox at /tool-sandbox can render fixtures with the same grouping
  * treatment real chat uses (single visual unit + shared bg-inset on cards). */
-export function CollapsedToolGroup({ tools, sessionId }: { tools: ToolCallState[]; sessionId: string }) {
+function CollapsedToolGroup({ tools, sessionId }: { tools: ToolCallState[]; sessionId: string }) {
   const [expanded, setExpanded] = useState(() => getInitialExpanded());
   useExpandAllToggle(() => setExpanded(true), () => setExpanded(false));
 

--- a/desktop/src/renderer/components/ConnectedAccounts.tsx
+++ b/desktop/src/renderer/components/ConnectedAccounts.tsx
@@ -23,7 +23,7 @@ export interface GithubStatus {
 
 // Same octocat path AccountSection / SignInPromptModal use, so the GitHub
 // affordance reads consistently across the app.
-export function GitHubMarkIcon({ className = 'w-4 h-4 text-fg-muted' }: { className?: string }) {
+function GitHubMarkIcon({ className = 'w-4 h-4 text-fg-muted' }: { className?: string }) {
   return (
     <svg className={className} width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
       <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />

--- a/desktop/src/renderer/components/FlowingKeywords.tsx
+++ b/desktop/src/renderer/components/FlowingKeywords.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 // input and in user bubbles. Longer alternatives come first so "ultraplan"
 // wins over "plan" at the same position. \b ensures we only match whole
 // words — "planner" and "subplan" are left alone.
-export const FLOWING_KEYWORD_RE = /\b(ultrathink|ultraplan|brainstorm|plan)\b/gi;
+const FLOWING_KEYWORD_RE = /\b(ultrathink|ultraplan|brainstorm|plan)\b/gi;
 
 export interface FlowingSegment {
   text: string;

--- a/desktop/src/renderer/components/QuickChips.tsx
+++ b/desktop/src/renderer/components/QuickChips.tsx
@@ -37,7 +37,7 @@ export interface QuickChip {
 }
 
 // Fallback defaults if no config exists yet
-export const defaultChips: QuickChip[] = [
+const defaultChips: QuickChip[] = [
   { label: 'Journal', prompt: "let's journal" },
   { label: 'Inbox', prompt: 'check my inbox' },
   { label: 'Git Status', prompt: "run git status and summarize what's changed" },

--- a/desktop/src/renderer/components/RuntimeBinding.tsx
+++ b/desktop/src/renderer/components/RuntimeBinding.tsx
@@ -10,7 +10,7 @@ export type PresetId = 'assistant' | 'coder';
 
 /** Spec §3.4 heuristic: a project folder set at form-open → Coder, else Assistant.
  *  Both new-session forms seed the preset from this until the user picks one. */
-export function defaultPresetFor(cwd: string): PresetId { return cwd.trim() ? 'coder' : 'assistant'; }
+function defaultPresetFor(cwd: string): PresetId { return cwd.trim() ? 'coder' : 'assistant'; }
 
 // Preset lifecycle (spec §3.4): follow the folder heuristic (folder set → Coder,
 // empty → Assistant) UNTIL the user explicitly picks a card, then latch. Lifted
@@ -98,7 +98,7 @@ export function persistLastBinding(binding: Binding): void {
 
 // Native runtime is desktop-only AND gated on the capability flag — with a single
 // runtime there's nothing to select, so the whole selector hides.
-export function isNativeSupported(): boolean {
+function isNativeSupported(): boolean {
   return !isAndroid() && !isRemoteMode() && (window as any).claude?.native?.supported === true;
 }
 

--- a/desktop/src/renderer/components/artifact-views/BinaryContent.tsx
+++ b/desktop/src/renderer/components/artifact-views/BinaryContent.tsx
@@ -12,7 +12,7 @@ import { useArtifactBytes } from './useArtifactBytes';
 // switches files — no stale-content flash from the previous document.
 
 /** Map the read-binary error codes to a human message. */
-export function describeBytesError(error: string, noun: string): string {
+function describeBytesError(error: string, noun: string): string {
   switch (error) {
     case 'orphan':
       return `This ${noun} no longer exists on disk.`;

--- a/desktop/src/renderer/components/artifact-views/UnsavedChangesDialog.tsx
+++ b/desktop/src/renderer/components/artifact-views/UnsavedChangesDialog.tsx
@@ -7,7 +7,7 @@ import type { ActiveArtifactHandle } from './ActiveArtifactView';
 import { registerDirtyEditorGuard, unregisterDirtyEditorGuard } from './dirty-editor-guard';
 import { Button } from '../ui';
 
-export function UnsavedChangesDialog({
+function UnsavedChangesDialog({
   fileName,
   onSave,
   onDiscard,

--- a/desktop/src/renderer/components/artifact-views/cm/syntax-colors.ts
+++ b/desktop/src/renderer/components/artifact-views/cm/syntax-colors.ts
@@ -75,7 +75,7 @@ export const SYNTAX_MIN_CONTRAST = 4.5;
 /** Walk `color` toward `towards` (normally fg, which passes by construction)
  * until it clears the contrast floor against `bg`. 10% steps: coarse enough to
  * terminate fast, fine enough to keep the hue's character. */
-export function ensureContrast(color: string, bg: string, towards: string): string {
+function ensureContrast(color: string, bg: string, towards: string): string {
   let out = color;
   for (let i = 0; i < 10 && contrastRatio(out, bg) < SYNTAX_MIN_CONTRAST; i++) {
     out = mix(out, towards, 0.1 * (i + 1));

--- a/desktop/src/renderer/components/artifact-views/exceljs-cell.ts
+++ b/desktop/src/renderer/components/artifact-views/exceljs-cell.ts
@@ -19,7 +19,7 @@ export function colLetter(n: number): string {
 // a CSS color. Theme/indexed colors aren't resolved here (no palette) — they
 // return undefined so the cell keeps the default look. openpyxl-generated files
 // (the common agent case) use explicit ARGB, so this covers them well.
-export function argbToCss(color: any): string | undefined {
+function argbToCss(color: any): string | undefined {
   const argb: string | undefined = color?.argb;
   if (!argb || typeof argb !== 'string' || argb.length < 6) return undefined;
   const hex = argb.length === 8 ? argb.slice(2) : argb;

--- a/desktop/src/renderer/components/artifact-views/xlsx-formula.ts
+++ b/desktop/src/renderer/components/artifact-views/xlsx-formula.ts
@@ -4,7 +4,7 @@
 // without this a Total column would render blank. This is NOT a full engine;
 // anything unsupported throws FormulaError and the caller falls back gracefully.
 
-export class FormulaError extends Error {}
+class FormulaError extends Error {}
 
 export type CellValue = number | string | boolean | null;
 // Resolve a single cell reference (e.g. "B4") to its value.

--- a/desktop/src/renderer/components/diff/UnifiedDiff.tsx
+++ b/desktop/src/renderer/components/diff/UnifiedDiff.tsx
@@ -19,8 +19,8 @@ import { diffLines as jsdiffLines } from 'diff';
 import type { StructuredPatchHunk } from '../../../shared/types';
 import { useExpandAllToggle, getInitialExpanded } from '../../hooks/useExpandAllToggle';
 
-export const DIFF_ROW_PX = 20;
-export const DIFF_PREVIEW_LINES = 15;
+const DIFF_ROW_PX = 20;
+const DIFF_PREVIEW_LINES = 15;
 
 // Unified-diff row: del = removed line (old side only), add = inserted line
 // (new side only), ctx = unchanged (shown on both sides, dimmed). Line numbers

--- a/desktop/src/renderer/components/project-view/icons.tsx
+++ b/desktop/src/renderer/components/project-view/icons.tsx
@@ -125,11 +125,3 @@ export function CogIcon({ size = 15, strokeWidth = 2 }: IconProps) {
     </svg>
   );
 }
-
-export function CloseIcon({ size = 14, strokeWidth = 2 }: IconProps) {
-  return (
-    <svg {...base(size, strokeWidth)}>
-      <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-    </svg>
-  );
-}

--- a/desktop/src/renderer/components/tags/NoteEditor.tsx
+++ b/desktop/src/renderer/components/tags/NoteEditor.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Textarea } from '../ui';
 
-export const NOTE_MAX = 8000;
+const NOTE_MAX = 8000;
 
 // Freeform per-session note. maxLength hard-caps at 8000 chars (design); a
 // remaining-count appears near the limit. Saves on blur (only when changed),

--- a/desktop/src/renderer/components/ui/AnchorTip.tsx
+++ b/desktop/src/renderer/components/ui/AnchorTip.tsx
@@ -173,5 +173,3 @@ export function AnchorTip({
     </>
   );
 }
-
-export default AnchorTip;

--- a/desktop/src/renderer/components/ui/Button.tsx
+++ b/desktop/src/renderer/components/ui/Button.tsx
@@ -34,7 +34,7 @@ export const FOCUS_RING =
  *  packs, since --radius-lg is a theme token). Rejected: sm, md, full-everywhere.
  *  Pills survive only as a documented exception (first-run hero CTAs), via
  *  className override. */
-export const BUTTON_BASE =
+const BUTTON_BASE =
   'inline-flex items-center justify-center gap-1.5 font-medium rounded-lg transition-colors ' +
   'disabled:opacity-50 disabled:cursor-not-allowed ' +
   FOCUS_RING;
@@ -53,7 +53,7 @@ export const BUTTON_BASE =
  *  panel as a fill, the label has to be readable text on that panel. On dark
  *  themes --destructive is too dark to read as text — no single red satisfies
  *  both roles at AA across our themes, which is why the token is split. */
-export const BUTTON_VARIANT: Record<ButtonVariant, string> = {
+const BUTTON_VARIANT: Record<ButtonVariant, string> = {
   primary: 'bg-accent text-on-accent hover:bg-accent/90',
   secondary: 'border border-edge-dim text-fg-2 hover:bg-inset',
   ghost: 'text-fg-dim hover:text-fg hover:bg-inset',
@@ -65,7 +65,7 @@ export const BUTTON_VARIANT: Record<ButtonVariant, string> = {
  *  md  — forms, popup footers, most actions
  *  lg  — page-level CTAs (sign-in, marketplace hero)
  *  icon— icon-only square; aria-label is required by the type signature */
-export const BUTTON_SIZE: Record<ButtonSize, string> = {
+const BUTTON_SIZE: Record<ButtonSize, string> = {
   sm: 'text-2xs px-2.5 py-1',
   md: 'text-xs px-3 py-1.5',
   lg: 'text-sm px-4 py-2',

--- a/desktop/src/renderer/components/ui/Button.tsx
+++ b/desktop/src/renderer/components/ui/Button.tsx
@@ -195,5 +195,3 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
     />
   );
 });
-
-export default Button;

--- a/desktop/src/renderer/components/ui/Checkbox.tsx
+++ b/desktop/src/renderer/components/ui/Checkbox.tsx
@@ -60,5 +60,3 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(funct
     </button>
   );
 });
-
-export default Checkbox;

--- a/desktop/src/renderer/components/ui/CloseButton.tsx
+++ b/desktop/src/renderer/components/ui/CloseButton.tsx
@@ -38,5 +38,3 @@ export const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>
     );
   },
 );
-
-export default CloseButton;

--- a/desktop/src/renderer/components/ui/InputGroup.tsx
+++ b/desktop/src/renderer/components/ui/InputGroup.tsx
@@ -109,5 +109,3 @@ const InputGroupField = React.forwardRef<HTMLInputElement, InputGroupFieldProps>
 );
 
 export const InputGroup = Object.assign(InputGroupRoot, { Field: InputGroupField });
-
-export default InputGroup;

--- a/desktop/src/renderer/components/ui/ProgressBar.tsx
+++ b/desktop/src/renderer/components/ui/ProgressBar.tsx
@@ -52,5 +52,3 @@ export function ProgressBar({
     </div>
   );
 }
-
-export default ProgressBar;

--- a/desktop/src/renderer/components/ui/Radio.tsx
+++ b/desktop/src/renderer/components/ui/Radio.tsx
@@ -88,5 +88,3 @@ export function RadioGroup({
     </div>
   );
 }
-
-export default Radio;

--- a/desktop/src/renderer/components/ui/SegmentedTabs.tsx
+++ b/desktop/src/renderer/components/ui/SegmentedTabs.tsx
@@ -89,5 +89,3 @@ export function SegmentedTabs({
     </div>
   );
 }
-
-export default SegmentedTabs;

--- a/desktop/src/renderer/components/ui/Select.tsx
+++ b/desktop/src/renderer/components/ui/Select.tsx
@@ -302,5 +302,3 @@ export function Select({
     </>
   );
 }
-
-export default Select;

--- a/desktop/src/renderer/components/ui/TextInput.tsx
+++ b/desktop/src/renderer/components/ui/TextInput.tsx
@@ -21,5 +21,3 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(func
 ) {
   return <input ref={ref} type={type} className={fieldClasses(size, className)} {...rest} />;
 });
-
-export default TextInput;

--- a/desktop/src/renderer/components/ui/Textarea.tsx
+++ b/desktop/src/renderer/components/ui/Textarea.tsx
@@ -32,5 +32,3 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(fun
     />
   );
 });
-
-export default Textarea;

--- a/desktop/src/renderer/components/ui/Toast.tsx
+++ b/desktop/src/renderer/components/ui/Toast.tsx
@@ -70,5 +70,3 @@ export function Toast({
     </OverlayPanel>
   );
 }
-
-export default Toast;

--- a/desktop/src/renderer/components/ui/Toggle.tsx
+++ b/desktop/src/renderer/components/ui/Toggle.tsx
@@ -88,5 +88,3 @@ export const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(function 
     </button>
   );
 });
-
-export default Toggle;

--- a/desktop/src/renderer/components/ui/index.ts
+++ b/desktop/src/renderer/components/ui/index.ts
@@ -10,7 +10,7 @@
  * docs/active/specs/2026-07-16-ui-consistency-design-spec.md
  */
 
-export { Button, buttonClasses, BUTTON_BASE, BUTTON_VARIANT, BUTTON_SIZE, FOCUS_RING } from './Button';
+export { Button, buttonClasses, FOCUS_RING } from './Button';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
 
 export { CloseButton } from './CloseButton';

--- a/desktop/src/renderer/game/connect-four.ts
+++ b/desktop/src/renderer/game/connect-four.ts
@@ -3,8 +3,8 @@
 // the TypeScript rootDir (src/), so we copy the essential exports here.
 // The server is authoritative for game state; these are used for optimistic UI.
 
-export const ROWS = 6;
-export const COLS = 7;
+const ROWS = 6;
+const COLS = 7;
 
 export type Board = number[][];
 
@@ -17,7 +17,7 @@ export function createBoard(): Board {
   return Array.from({ length: COLS }, () => Array(ROWS).fill(0));
 }
 
-export function cloneBoard(board: Board): Board {
+function cloneBoard(board: Board): Board {
   return board.map((col) => [...col]);
 }
 

--- a/desktop/src/renderer/game/party-client.ts
+++ b/desktop/src/renderer/game/party-client.ts
@@ -3,7 +3,7 @@ import PartySocket from "partysocket";
 // Injected by Vite's `define` config when VITE_PARTYKIT_HOST is set;
 // falls back to the production URL at build time.
 declare const __PARTYKIT_HOST__: string | undefined;
-export const PARTYKIT_HOST =
+const PARTYKIT_HOST =
   (typeof __PARTYKIT_HOST__ !== 'undefined' ? __PARTYKIT_HOST__ : null)
   ?? "youcoded-games.itsdestin.partykit.dev";
 

--- a/desktop/src/renderer/platform.ts
+++ b/desktop/src/renderer/platform.ts
@@ -19,10 +19,6 @@ export type ConnectionMode = 'local' | 'remote'
 let _connectionMode: ConnectionMode = 'local';
 let _connectionModeListeners: ((mode: ConnectionMode) => void)[] = [];
 
-export function getConnectionMode(): ConnectionMode {
-  return _connectionMode;
-}
-
 export function isRemoteMode(): boolean {
   return _connectionMode === 'remote';
 }

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -566,7 +566,7 @@ export function retryLocalBridge(): void {
   }, delay);
 }
 
-export function disconnect(): void {
+function disconnect(): void {
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
   if (ws) { ws.close(); ws = null; }
   setConnectionState('disconnected');

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -57,10 +57,6 @@ function setConnectionState(state: RemoteConnectionState) {
   stateChangeCallback?.(state);
 }
 
-export function getConnectionState(): RemoteConnectionState {
-  return connectionState;
-}
-
 export function onConnectionStateChange(cb: (state: RemoteConnectionState) => void) {
   stateChangeCallback = cb;
 }

--- a/desktop/src/renderer/state/drawer-width.ts
+++ b/desktop/src/renderer/state/drawer-width.ts
@@ -12,7 +12,7 @@
 export const DRAWER_WIDTH_KEY = 'youcoded-drawer-width';
 export const DEFAULT_DRAWER_WIDTH = 480; // matches the pre-resize fixed width
 export const MIN_DRAWER_WIDTH = 320;     // thinner is unreadable
-export const MAX_DRAWER_FRACTION = 0.6;  // leave the chat pane usable
+const MAX_DRAWER_FRACTION = 0.6;  // leave the chat pane usable
 
 /** Clamp a candidate width to [320, 60% of window], defaulting to 480 for
  *  non-finite input (e.g. corrupt localStorage). Always returns an integer. */

--- a/desktop/src/renderer/state/theme-context.tsx
+++ b/desktop/src/renderer/state/theme-context.tsx
@@ -24,7 +24,7 @@ const BUILTIN_THEMES: LoadedTheme[] = [
   { ...(cremeJson as unknown as ThemeDefinition), source: 'youcoded-core' },
 ];
 
-export const DEFAULT_FONT_FAMILY = "'Cascadia Mono', 'Cascadia Code', 'Fira Code', monospace";
+const DEFAULT_FONT_FAMILY = "'Cascadia Mono', 'Cascadia Code', 'Fira Code', monospace";
 
 const STORAGE_KEY = 'youcoded-theme';
 const CYCLE_KEY = 'youcoded-theme-cycle';

--- a/desktop/src/renderer/themes/theme-validator.ts
+++ b/desktop/src/renderer/themes/theme-validator.ts
@@ -27,7 +27,7 @@ export function computeOnAccent(accentHex: string): '#FFFFFF' | '#000000' {
  *  The old body::before/::after wallpaper+pattern template prescribed z-index: 0,
  *  which stopped being correct when the terminal switched to container-opacity
  *  (Apr 8, youcoded commit e3cc7ce2). Negative z-index is the right value now. */
-export function lintCustomCss(css: string | undefined, slug: string): void {
+function lintCustomCss(css: string | undefined, slug: string): void {
   if (!css) return;
   // Match rule blocks with position:fixed|absolute AND z-index: 0 or positive integer.
   // Deliberately loose — this is a console warn, not a reject.

--- a/desktop/src/renderer/utils/sounds.ts
+++ b/desktop/src/renderer/utils/sounds.ts
@@ -16,12 +16,12 @@
 
 export const SOUND_MUTED_KEY     = 'youcoded-sound-muted';
 export const SOUND_VOLUME_KEY    = 'youcoded-sound-volume';
-export const SOUND_ATTENTION_KEY = 'youcoded-sound-attention';    // red status preset
-export const SOUND_READY_KEY     = 'youcoded-sound-ready';        // blue status preset
-export const SOUND_ATTENTION_ENABLED_KEY = 'youcoded-sound-attention-enabled';
-export const SOUND_READY_ENABLED_KEY     = 'youcoded-sound-ready-enabled';
+const SOUND_ATTENTION_KEY = 'youcoded-sound-attention';    // red status preset
+const SOUND_READY_KEY     = 'youcoded-sound-ready';        // blue status preset
+const SOUND_ATTENTION_ENABLED_KEY = 'youcoded-sound-attention-enabled';
+const SOUND_READY_ENABLED_KEY     = 'youcoded-sound-ready-enabled';
 // Custom sound file paths per category
-export const SOUND_CUSTOM_PATH_PREFIX = 'youcoded-sound-custom-path-'; // + category
+const SOUND_CUSTOM_PATH_PREFIX = 'youcoded-sound-custom-path-'; // + category
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -372,11 +372,11 @@ export function setSelectedPresetId(cat: SoundCategory, id: string) {
 
 // ── Global getters ───────────────────────────────────────────────────────────
 
-export function isSoundMuted(): boolean {
+function isSoundMuted(): boolean {
   try { return localStorage.getItem(SOUND_MUTED_KEY) === '1'; } catch { return false; }
 }
 
-export function getSoundVolume(): number {
+function getSoundVolume(): number {
   try {
     const v = parseFloat(localStorage.getItem(SOUND_VOLUME_KEY) || '0.3');
     return isNaN(v) ? 0.3 : Math.max(0, Math.min(1, v));

--- a/desktop/src/shared/ports.ts
+++ b/desktop/src/shared/ports.ts
@@ -5,7 +5,7 @@
 const env = typeof process !== 'undefined' && process.env ? process.env : ({} as Record<string, string | undefined>);
 const raw = Number(env.YOUCODED_PORT_OFFSET ?? 0);
 
-export const PORT_OFFSET = Number.isFinite(raw) ? raw : 0;
+const PORT_OFFSET = Number.isFinite(raw) ? raw : 0;
 export const VITE_DEV_PORT = 5173 + PORT_OFFSET;
 export const REMOTE_SERVER_DEFAULT_PORT = 9900 + PORT_OFFSET;
 // llama-server (native local engine, Plan B). 9920 built / 9970 dev — clear of


### PR DESCRIPTION
Items 5 + 9 of the dead/duplicative-code review. Two commits.

## Commit 1 — remove verified dead exports (item 5)
All confirmed unused by repo-wide trace (incl. the Android Kotlin mirror, which can't import TS):
- **6 fully-dead functions/consts:** `toolByName` (harness/tools/index.ts), `__resetGpuCacheForTests` (gpu-detector.ts, not even tests call it), `getSyncService` (sync-state.ts), `getConnectionMode` (platform.ts), `getConnectionState` (remote-shim.ts), `CloseIcon` (project-view/icons.tsx — superseded by the shared `<CloseButton/>`).
- **13 redundant `export default`** removed from every `ui/` primitive — all consumers use the named export; zero default-import sites exist.
- **`@types/diff` devDependency** removed (`diff` v9 ships its own types) — from both `package.json` and `package-lock.json`.

## Commit 2 — tighten export surface (item 9)
- **63 `export const/function/class`** across 40 files → module-private (`export` keyword dropped). Each was verified referenced only inside its own module.
- `ui/index.ts`: removed the dead `BUTTON_BASE/BUTTON_VARIANT/BUTTON_SIZE` re-export (nothing imported them from the barrel).
- **One correction during verification:** `pruneNativePhantomRecords` is imported as a module namespace by `conversations-service.test.ts`, so it stays exported (with a comment) — the full test suite caught this; tsc alone did not.

## Verification
- `tsc --noEmit`: **0 errors**
- Full `vitest run`: **3021 passed**, 39 skipped, 0 failed

## Not included (pending your decision)
The 9 unadopted `ui/` primitive *files* (Checkbox, Radio, SegmentedTabs, AnchorTip, Toast, ProgressBar, states.tsx — ~724 LOC) are the design-system decision (review item 1), left for you to adopt-or-prune. Their files still compile; only their redundant default exports were touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)