### PR TITLE
cleanup(android): dedupe fork-publish + remove dead members/flows + forEachKey

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/marketplace/MarketplaceApiClient.kt
+++ b/app/src/main/kotlin/com/youcoded/app/marketplace/MarketplaceApiClient.kt
@@ -153,12 +153,6 @@ class MarketplaceApiClient(
 
     // ── Public API (mirrors TS client method by method) ──────────────────────
 
-    /** GET /stats — no auth required */
-    suspend fun getStats(): ApiResult<JSONObject> {
-        val (code, body) = request("/stats")
-        return if (code == 200) ApiResult.Ok(body) else errFromResponse(code, body)
-    }
-
     /** POST /auth/github/start — initiates device-code OAuth flow */
     suspend fun authStart(): ApiResult<JSONObject> {
         val (code, body) = request("/auth/github/start", method = "POST")

--- a/app/src/main/kotlin/com/youcoded/app/runtime/ManagedSession.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/ManagedSession.kt
@@ -29,7 +29,6 @@ import java.util.UUID
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 
 // --- Permission override classification ---
@@ -98,16 +97,6 @@ class ManagedSession(
 
     /** Draft text in the input bar — shared across Chat/Terminal/Shell modes */
     var inputDraft by mutableStateOf(TextFieldValue())
-
-    /** Set draft text with cursor at end */
-    fun setDraftText(text: String) {
-        inputDraft = TextFieldValue(text, TextRange(text.length))
-    }
-
-    /** Clear draft */
-    fun clearDraft() {
-        inputDraft = TextFieldValue()
-    }
 
     val isRunning: Boolean get() = ptyBridge?.isRunning ?: directShellBridge?.isRunning ?: false
     fun getTerminalSession(): com.termux.terminal.TerminalSession? =
@@ -660,11 +649,6 @@ class ManagedSession(
         // so cleanup never matched anything. Socket closure is now handled by
         // EventBridge.monitorSocketClosure() which detects when the relay
         // process exits and emits PermissionExpired to clear the React UI.
-    }
-
-    /** Mark a prompt as completed so the detector won't re-create it. */
-    fun markPromptCompleted(promptId: String) {
-        completedPromptIds.add(promptId)
     }
 
     // ─── Transcript watcher integration ─────────────────────────

--- a/app/src/main/kotlin/com/youcoded/app/runtime/PtyBridge.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/PtyBridge.kt
@@ -28,9 +28,6 @@ class PtyBridge(
     val socketPath: String get() = socketName
     val homeDir: File get() = bootstrap.homeDir
 
-    private val _outputFlow = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 1000)
-    val outputFlow: SharedFlow<String> = _outputFlow
-
     private val _screenVersion = MutableStateFlow(0)
     val screenVersion: StateFlow<Int> = _screenVersion
 
@@ -80,7 +77,6 @@ class PtyBridge(
                 if (_rawBuffer.length > RAW_BUFFER_MAX) {
                     _rawBuffer.delete(0, _rawBuffer.length - RAW_BUFFER_MAX)
                 }
-                _outputFlow.tryEmit(delta)
             } else if (transcript.length < lastTranscriptLength) {
                 lastTranscriptLength = transcript.length
             }
@@ -291,18 +287,6 @@ class PtyBridge(
             } catch (_: Exception) { continue }
         }
         return sb.toString()
-    }
-
-    /** Check whether the current PTY screen contains an "always allow" option.
-     *  Reads the live screen buffer to detect 3-option vs 2-option prompts. */
-    fun hasAlwaysAllowOption(): Boolean {
-        val screenText = readScreenText().lowercase()
-        val result = "always" in screenText || "ask again" in screenText
-        return result
-    }
-
-    fun sendBtw(message: String) {
-        writeInput("/btw $message\r")
     }
 
     fun getSession(): TerminalSession? = session

--- a/app/src/main/kotlin/com/youcoded/app/runtime/ServiceBinder.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/ServiceBinder.kt
@@ -55,11 +55,6 @@ class ServiceBinder(private val context: Context) {
         }
     }
 
-    fun stopService() {
-        service?.destroyAllSessions()
-        _state.value = SessionState.Disconnected
-    }
-
     fun unbind() {
         try {
             context.unbindService(connection)

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionBrowser.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionBrowser.kt
@@ -128,15 +128,13 @@ object SessionBrowser {
 
     data class HistoryResult(
         val messages: List<HistoryMessage>,
-        val hasMore: Boolean,
     )
 
     /**
      * Load the last N conversational messages from a session's JSONL file.
      * Only includes user prompts (with promptId, not isMeta) and assistant
      * end_turn messages (text blocks only, no tool calls).
-     * Returns messages + whether more exist (single parse, no double read).
-     * Mirrors the desktop's loadHistory().
+     * Single parse, no double read. Mirrors the desktop's loadHistory().
      */
     fun loadHistory(
         projectsDir: File,
@@ -147,17 +145,17 @@ object SessionBrowser {
     ): HistoryResult {
         if (!SAFE_ID_RE.matches(projectSlug) || !SAFE_ID_RE.matches(sessionId)) {
             Log.w(TAG, "Invalid slug or sessionId")
-            return HistoryResult(emptyList(), false)
+            return HistoryResult(emptyList())
         }
 
         val jsonlFile = File(projectsDir, "$projectSlug/$sessionId.jsonl")
-        if (!jsonlFile.exists()) return HistoryResult(emptyList(), false)
+        if (!jsonlFile.exists()) return HistoryResult(emptyList())
 
         val allMessages = parseConversationalMessages(jsonlFile)
         return if (all) {
-            HistoryResult(allMessages, false)
+            HistoryResult(allMessages)
         } else {
-            HistoryResult(allMessages.takeLast(count), allMessages.size > count)
+            HistoryResult(allMessages.takeLast(count))
         }
     }
 

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionRegistry.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionRegistry.kt
@@ -17,7 +17,6 @@ class SessionRegistry {
     val sessions: StateFlow<Map<String, ManagedSession>> = _sessions
 
     private val _currentSessionId = MutableStateFlow<String?>(null)
-    val currentSessionId: StateFlow<String?> = _currentSessionId
 
     fun getCurrentSession(): ManagedSession? {
         val id = _currentSessionId.value ?: return null
@@ -116,21 +115,6 @@ class SessionRegistry {
         _currentSessionId.value = null
     }
 
-    fun relaunchSession(
-        sessionId: String,
-        bootstrap: Bootstrap,
-        apiKey: String?,
-        titlesDir: File,
-    ): ManagedSession? {
-        val old = _sessions.value[sessionId] ?: return null
-        destroySession(sessionId)
-        return if (old.shellMode) {
-            createShellSession(bootstrap, titlesDir)
-        } else {
-            createSession(bootstrap, old.cwd, old.dangerousMode, apiKey, titlesDir)
-        }
-    }
-
     /** Create a managed shell session (appears in session switcher). */
     fun createShellSession(bootstrap: Bootstrap, titlesDir: File): ManagedSession {
         val sessionId = java.util.UUID.randomUUID().toString()
@@ -154,38 +138,6 @@ class SessionRegistry {
 
         _sessions.update { it + (sessionId to session) }
         _currentSessionId.value = sessionId
-
-        return session
-    }
-
-    /**
-     * Resume a past session. Creates a new Claude Code PTY with --resume flag
-     * in the session's original project directory, then loads history.
-     * Mirrors the desktop's handleResumeSession() in App.tsx.
-     */
-    fun resumeSession(
-        pastSession: SessionBrowser.PastSession,
-        bootstrap: Bootstrap,
-        apiKey: String?,
-        titlesDir: File,
-        model: String? = null,
-    ): ManagedSession {
-        // Derive CWD from the project slug — fall back to homeDir if path doesn't exist
-        val cwd = SessionBrowser.slugToCwd(pastSession.projectSlug, bootstrap.homeDir)
-
-        // Create session with --resume CLI flag (NOT /resume stdin)
-        val session = createSession(
-            bootstrap = bootstrap,
-            cwd = cwd,
-            dangerousMode = false,
-            apiKey = apiKey,
-            titlesDir = titlesDir,
-            resumeSessionId = pastSession.sessionId,
-            model = model,
-        )
-
-        // History for resumed sessions is now handled entirely by the React UI
-        // via TranscriptWatcher forwarding — no need to load it here.
 
         return session
     }

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -92,12 +92,6 @@ class SessionService : Service() {
     }
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    /** View mode requested by React UI — ChatScreen observes this.
-     *  SharedFlow (not StateFlow) because these are events, not state:
-     *  "switch to terminal" must fire even if the last request was also "terminal". */
-    private val _viewModeRequest = kotlinx.coroutines.flow.MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val viewModeRequest: kotlinx.coroutines.flow.SharedFlow<String> = _viewModeRequest
-
     /** Layout insets reported by React UI (header and bottom bar pixel heights). */
     data class LayoutInsets(val headerPx: Int, val bottomPx: Int)
     private val _layoutInsets = kotlinx.coroutines.flow.MutableSharedFlow<LayoutInsets>(replay = 1)
@@ -1564,11 +1558,13 @@ class SessionService : Service() {
             }
             "ui:action" -> {
                 val action = msg.payload.optString("action", "")
+                // No "switch-view" branch on purpose: since Tier 2 the React UI owns
+                // chat↔terminal switching entirely (xterm.js in the WebView is the only
+                // terminal renderer — see ChatScreen.kt). The old native viewModeRequest
+                // flow existed solely to drive the deleted Compose TerminalView block, and
+                // desktop's relay of this action only exists to fan it out to OTHER remote
+                // clients, which Android doesn't host. So switch-view needs no native work.
                 when (action) {
-                    "switch-view" -> {
-                        val mode = msg.payload.optString("mode", "chat")
-                        _viewModeRequest.tryEmit(mode)
-                    }
                     "layout-update" -> {
                         val headerPx = msg.payload.optInt("headerHeight", 0)
                         val bottomPx = msg.payload.optInt("bottomHeight", 0)

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -41,6 +41,7 @@ import com.youcoded.app.artifacts.*
 import com.youcoded.app.skills.BundledPlugins
 import com.youcoded.app.skills.LocalSkillProvider
 import com.youcoded.app.skills.PluginInstaller
+import com.youcoded.app.util.forEachKey
 import com.youcoded.app.social.PresenceClient
 
 class SessionService : Service() {
@@ -96,11 +97,6 @@ class SessionService : Service() {
      *  "switch to terminal" must fire even if the last request was also "terminal". */
     private val _viewModeRequest = kotlinx.coroutines.flow.MutableSharedFlow<String>(extraBufferCapacity = 1)
     val viewModeRequest: kotlinx.coroutines.flow.SharedFlow<String> = _viewModeRequest
-
-    /** Emit a view mode change from native code. */
-    fun requestViewMode(mode: String) {
-        _viewModeRequest.tryEmit(mode)
-    }
 
     /** Layout insets reported by React UI (header and bottom bar pixel heights). */
     data class LayoutInsets(val headerPx: Int, val bottomPx: Int)
@@ -624,22 +620,6 @@ class SessionService : Service() {
     }
 
     val titlesDir: File get() = File(bootstrap?.homeDir ?: File("/"), ".claude-mobile/titles")
-
-    // Legacy single-session API — used by ServiceBinder until full migration
-    fun startSession(bs: Bootstrap, apiKey: String? = null) {
-        initBootstrap(bs)
-        val session = createSession(bs.homeDir, dangerousMode = false, apiKey = apiKey)
-        ptyBridge = session.ptyBridge
-        startForeground(NOTIFICATION_ID, buildSessionNotification())
-    }
-
-    fun stopSession() {
-        sessionRegistry.destroyAll()
-        ptyBridge = null
-        releaseWakeLock()
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        stopSelf()
-    }
 
     fun createSession(cwd: File, dangerousMode: Boolean, apiKey: String?, model: String? = null): ManagedSession {
         val bs = bootstrap ?: throw IllegalStateException("Bootstrap not initialized")
@@ -1728,9 +1708,7 @@ class SessionService : Service() {
                     val existing = try {
                         org.json.JSONObject(prefFile.readText())
                     } catch (_: Exception) { org.json.JSONObject() }
-                    val keys = msg.payload.keys()
-                    while (keys.hasNext()) {
-                        val key = keys.next()
+                    msg.payload.forEachKey { key ->
                         existing.put(key, msg.payload.get(key))
                     }
                     prefFile.parentFile?.mkdirs()

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3771,17 +3771,29 @@ class SessionService : Service() {
      * Runs gh commands using the Termux runtime environment (linker64 routing).
      * Mirrors the desktop publish flow: verify auth, fork, branch, upload, PR.
      */
-    private suspend fun publishPluginViaGh(pluginId: String): JSONObject = withContext(Dispatchers.IO) {
+    /**
+     * Shared fork-and-PR publisher for community submissions (plugins →
+     * wecoded-marketplace, themes → wecoded-themes). Extracted from the former
+     * publishPluginViaGh/publishThemeViaGh, which were ~110 lines of byte-identical
+     * fork → create-branch → recursive-upload → open-PR logic. Desktop already factored
+     * the equivalent into github-fork-publish.ts (forkPublish); this brings Android to
+     * the same single-helper shape (dead/duplicative-code review, 2026-07-22).
+     *
+     * gh routes through /system/bin/linker64 for SELinux (see android-runtime.md).
+     * `noun` is the capitalized kind ("Plugin"/"Theme"); branch prefix, repo subdir, and
+     * PR text all derive from it. `resolveDir` runs on the IO dispatcher and returns the
+     * local directory to upload (letting each caller do its own existence check inline).
+     */
+    private suspend fun forkPublishViaGh(
+        upstreamRepo: String,
+        noun: String,
+        id: String,
+        resolveDir: () -> File,
+    ): JSONObject = withContext(Dispatchers.IO) {
         val bs = bootstrap ?: throw IllegalStateException("Bootstrap not initialized")
         val env = bs.buildRuntimeEnv().toMutableMap()
-        // Look for the plugin in both the legacy toolkit root and the
-        // marketplace subtree — match whichever directory actually exists.
-        val pluginDir = com.youcoded.app.skills.ClaudeCodeRegistry
-            .listInstalledPluginDirs(bs.homeDir)
-            .firstOrNull { it.name == pluginId }
-            ?: throw IllegalStateException("Plugin directory not found: $pluginId")
-
         val ghBin = File(bs.usrDir, "bin/gh").absolutePath
+        val sourceDir = resolveDir()
 
         // Helper: run a gh command and return stdout
         fun runGh(vararg args: String): String {
@@ -3797,18 +3809,18 @@ class SessionService : Service() {
             return stdout.trim()
         }
 
-        // 1. Get GitHub username
         val username = runGh("api", "user", "--jq", ".login")
         if (username.isBlank()) throw IllegalStateException("GitHub CLI not authenticated")
 
-        val upstreamRepo = "itsdestin/wecoded-marketplace"
-        val forkRepo = "$username/wecoded-marketplace"
-        val branchName = "plugin/$pluginId"
+        val branchPrefix = noun.lowercase()          // "plugin" / "theme"
+        val repoSubdir = "${branchPrefix}s"          // "plugins" / "themes"
+        val forkRepo = "$username/${upstreamRepo.substringAfter('/')}"
+        val branchName = "$branchPrefix/$id"
 
-        // 2. Fork (idempotent)
+        // Fork (idempotent)
         try { runGh("repo", "fork", upstreamRepo, "--clone=false") } catch (_: Exception) {}
 
-        // 3. Get base SHA and create branch
+        // Get base SHA and create branch from upstream main
         val baseSha = runGh("api", "repos/$upstreamRepo/git/ref/heads/main", "--jq", ".object.sha")
         try {
             runGh("api", "repos/$forkRepo/git/refs", "-X", "POST",
@@ -3818,7 +3830,9 @@ class SessionService : Service() {
                 "-f", "sha=$baseSha", "-f", "force=true")
         }
 
-        // 4. Upload plugin files (skip sensitive files, .git, node_modules)
+        // Upload files (skip sensitive files, .git, node_modules). Superset of the two
+        // former lists — the plugin path already blocked credentials.json/secrets.*; a
+        // theme never contains those, so applying the same list to both is purely safer.
         val sensitivePatterns = listOf(
             Regex("\\.env$", RegexOption.IGNORE_CASE),
             Regex("\\.env\\..*", RegexOption.IGNORE_CASE),
@@ -3839,7 +3853,7 @@ class SessionService : Service() {
                     }
                 } else {
                     if (sensitivePatterns.any { it.containsMatchIn(relPath) }) return@forEach
-                    val repoPath = "plugins/$pluginId/$relPath"
+                    val repoPath = "$repoSubdir/$id/$relPath"
                     val content = android.util.Base64.encodeToString(file.readBytes(), android.util.Base64.NO_WRAP)
                     try {
                         runGh("api", "repos/$forkRepo/contents/$repoPath", "-X", "PUT",
@@ -3857,13 +3871,13 @@ class SessionService : Service() {
                 }
             }
         }
-        uploadRecursive(pluginDir, "")
+        uploadRecursive(sourceDir, "")
 
         if (uploadedFiles.isEmpty()) throw IllegalStateException("No files to upload")
 
-        // 5. Create PR
-        val prTitle = "[Plugin] $pluginId"
-        val prBody = "## New Plugin: $pluginId\n\nSubmitted via YouCoded (Android)\n\n" +
+        // Create PR
+        val prTitle = "[$noun] $id"
+        val prBody = "## New $noun: $id\n\nSubmitted via YouCoded (Android)\n\n" +
             "### Files\n" + uploadedFiles.joinToString("\n") { "- `$it`" }
 
         val prUrl = try {
@@ -3880,109 +3894,24 @@ class SessionService : Service() {
         JSONObject().put("prUrl", prUrl)
     }
 
-    /**
-     * Phase 5b: Publish a user-created theme to wecoded-themes registry via `gh` CLI.
-     * Mirrors publishPluginViaGh but targets the theme registry repo.
-     */
-    private suspend fun publishThemeViaGh(slug: String): JSONObject = withContext(Dispatchers.IO) {
-        val bs = bootstrap ?: throw IllegalStateException("Bootstrap not initialized")
-        val env = bs.buildRuntimeEnv().toMutableMap()
-        val themeDir = File(themesDir, slug)
-        if (!themeDir.exists()) throw IllegalStateException("Theme directory not found: $slug")
-
-        val ghBin = File(bs.usrDir, "bin/gh").absolutePath
-
-        // Helper: run a gh command and return stdout (routes through linker64 for SELinux)
-        fun runGh(vararg args: String): String {
-            val envArray = env.map { "${it.key}=${it.value}" }.toTypedArray()
-            val cmd = arrayOf("/system/bin/linker64", ghBin, *args)
-            val process = Runtime.getRuntime().exec(cmd, envArray, bs.homeDir)
-            val stdout = process.inputStream.bufferedReader().readText()
-            val stderr = process.errorStream.bufferedReader().readText()
-            val exitCode = process.waitFor()
-            if (exitCode != 0 && !stderr.contains("already exists")) {
-                throw RuntimeException("gh ${args.firstOrNull()} failed: $stderr")
-            }
-            return stdout.trim()
+    private suspend fun publishPluginViaGh(pluginId: String): JSONObject =
+        forkPublishViaGh("itsdestin/wecoded-marketplace", "Plugin", pluginId) {
+            val bs = bootstrap ?: throw IllegalStateException("Bootstrap not initialized")
+            // Look for the plugin in both the legacy toolkit root and the
+            // marketplace subtree — match whichever directory actually exists.
+            com.youcoded.app.skills.ClaudeCodeRegistry
+                .listInstalledPluginDirs(bs.homeDir)
+                .firstOrNull { it.name == pluginId }
+                ?: throw IllegalStateException("Plugin directory not found: $pluginId")
         }
 
-        val username = runGh("api", "user", "--jq", ".login")
-        if (username.isBlank()) throw IllegalStateException("GitHub CLI not authenticated")
-
-        val upstreamRepo = "itsdestin/wecoded-themes"
-        val forkRepo = "$username/wecoded-themes"
-        val branchName = "theme/$slug"
-
-        // Fork (idempotent)
-        try { runGh("repo", "fork", upstreamRepo, "--clone=false") } catch (_: Exception) {}
-
-        // Create branch from upstream main
-        val baseSha = runGh("api", "repos/$upstreamRepo/git/ref/heads/main", "--jq", ".object.sha")
-        try {
-            runGh("api", "repos/$forkRepo/git/refs", "-X", "POST",
-                "-f", "ref=refs/heads/$branchName", "-f", "sha=$baseSha")
-        } catch (_: Exception) {
-            runGh("api", "repos/$forkRepo/git/refs/heads/$branchName", "-X", "PATCH",
-                "-f", "sha=$baseSha", "-f", "force=true")
-        }
-
-        // Upload theme files (skip sensitive files, .git, node_modules)
-        val sensitivePatterns = listOf(
-            Regex("\\.env$", RegexOption.IGNORE_CASE),
-            Regex("\\.env\\..*", RegexOption.IGNORE_CASE),
-            Regex("\\.pem$", RegexOption.IGNORE_CASE),
-            Regex("\\.key$", RegexOption.IGNORE_CASE),
-            Regex("tokens?\\.(json|txt)$", RegexOption.IGNORE_CASE),
-        )
-        val uploadedFiles = mutableListOf<String>()
-
-        fun uploadRecursive(dir: File, prefix: String) {
-            dir.listFiles()?.sortedBy { it.name }?.forEach { file ->
-                val relPath = if (prefix.isEmpty()) file.name else "$prefix/${file.name}"
-                if (file.isDirectory) {
-                    if (file.name != ".git" && file.name != "node_modules") {
-                        uploadRecursive(file, relPath)
-                    }
-                } else {
-                    if (sensitivePatterns.any { it.containsMatchIn(relPath) }) return@forEach
-                    val repoPath = "themes/$slug/$relPath"
-                    val content = android.util.Base64.encodeToString(file.readBytes(), android.util.Base64.NO_WRAP)
-                    try {
-                        runGh("api", "repos/$forkRepo/contents/$repoPath", "-X", "PUT",
-                            "-f", "message=Add $repoPath", "-f", "content=$content", "-f", "branch=$branchName")
-                    } catch (_: Exception) {
-                        val sha = runGh("api", "repos/$forkRepo/contents/$repoPath",
-                            "-q", ".sha", "-H", "Accept: application/vnd.github.v3+json",
-                            "--method", "GET", "-f", "ref=$branchName")
-                        runGh("api", "repos/$forkRepo/contents/$repoPath", "-X", "PUT",
-                            "-f", "message=Update $repoPath", "-f", "content=$content",
-                            "-f", "sha=$sha", "-f", "branch=$branchName")
-                    }
-                    uploadedFiles.add(repoPath)
-                }
+    /** Phase 5b: Publish a user-created theme to the wecoded-themes registry. */
+    private suspend fun publishThemeViaGh(slug: String): JSONObject =
+        forkPublishViaGh("itsdestin/wecoded-themes", "Theme", slug) {
+            File(themesDir, slug).also {
+                if (!it.exists()) throw IllegalStateException("Theme directory not found: $slug")
             }
         }
-        uploadRecursive(themeDir, "")
-
-        if (uploadedFiles.isEmpty()) throw IllegalStateException("No files to upload")
-
-        // Create PR
-        val prTitle = "[Theme] $slug"
-        val prBody = "## New Theme: $slug\n\nSubmitted via YouCoded (Android)\n\n" +
-            "### Files\n" + uploadedFiles.joinToString("\n") { "- `$it`" }
-
-        val prUrl = try {
-            runGh("pr", "create", "--repo", upstreamRepo,
-                "--head", "$username:$branchName", "--title", prTitle, "--body", prBody)
-        } catch (e: Exception) {
-            val existing = runGh("pr", "list", "--repo", upstreamRepo,
-                "--head", "$username:$branchName", "--json", "url", "--jq", ".[0].url")
-            if (existing.isNotBlank()) existing
-            else throw RuntimeException("Failed to create PR: ${e.message}")
-        }
-
-        JSONObject().put("prUrl", prUrl)
-    }
 
     // ── Phase 5a: Theme marketplace helpers ────────────────────────
     // Registry URL matches desktop's theme-marketplace-provider.ts REGISTRY_URL

--- a/app/src/main/kotlin/com/youcoded/app/runtime/SyncService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SyncService.kt
@@ -39,7 +39,6 @@ class SyncService(
     private val configPath = File(claudeDir, "toolkit-state/config.json")
     private val localConfigPath = File(claudeDir, "toolkit-state/config.local.json")
     private val syncMarkerPath = File(claudeDir, "toolkit-state/.sync-marker")
-    private val pullMarkerPath = File(claudeDir, "toolkit-state/.session-sync-marker")
     private val lockDir = File(claudeDir, "toolkit-state/.sync-lock")
     private val backupLogPath = File(claudeDir, "backup.log")
     private val appSyncMarkerPath = File(claudeDir, "toolkit-state/.app-sync-active")
@@ -50,10 +49,8 @@ class SyncService(
     companion object {
         private const val PUSH_INTERVAL_MS = 15 * 60 * 1000L   // 15 minutes
         private const val PUSH_DEBOUNCE_MIN = 15
-        private const val PULL_DEBOUNCE_MIN = 10
         private const val INDEX_PRUNE_DAYS = 30
         private const val PROCESS_TIMEOUT_S = 60L
-        private const val SESSION_PUSH_TIMEOUT_S = 15L
         // Recent-conversations strategy: foreground pull only fetches the N most-
         // recently-active sessions (sorted by lastActive in conversation-index.json).
         // The remainder is scheduled as a background pull. Without this, a fresh

--- a/app/src/main/kotlin/com/youcoded/app/skills/BundledPlugins.kt
+++ b/app/src/main/kotlin/com/youcoded/app/skills/BundledPlugins.kt
@@ -14,8 +14,5 @@ object BundledPlugins {
         "wecoded-marketplace-publisher",
     )
 
-    const val REASON =
-        "Bundled with YouCoded — required for theme customization and publishing."
-
     fun isBundled(id: String): Boolean = IDS.contains(id)
 }

--- a/app/src/main/kotlin/com/youcoded/app/skills/ClaudeCodeRegistry.kt
+++ b/app/src/main/kotlin/com/youcoded/app/skills/ClaudeCodeRegistry.kt
@@ -39,10 +39,6 @@ object ClaudeCodeRegistry {
     fun youcodedPluginsDir(homeDir: File): File =
         File(youcodedMarketplaceRoot(homeDir), "plugins")
 
-    /** Absolute install dir for a plugin under the YouCoded marketplace. */
-    fun pluginInstallDir(homeDir: File, id: String): File =
-        File(youcodedPluginsDir(homeDir), id)
-
     /** The @-qualified key Claude Code uses in enabledPlugins and installed_plugins.json. */
     fun pluginKey(id: String): String = "$id@$YOUCODED_MARKETPLACE_ID"
 
@@ -279,12 +275,5 @@ object ClaudeCodeRegistry {
         removePluginFromManifest(homeDir, id)
         removeInstalledPlugin(homeDir, id)
         disablePluginInSettings(homeDir, id)
-    }
-
-    /** Is this plugin already present in installed_plugins.json? */
-    fun isPluginRegistered(homeDir: File, id: String): Boolean {
-        val db = readInstalledPlugins(homeDir)
-        val plugins = db.optJSONObject("plugins") ?: return false
-        return plugins.has(pluginKey(id))
     }
 }

--- a/app/src/main/kotlin/com/youcoded/app/skills/LocalSkillProvider.kt
+++ b/app/src/main/kotlin/com/youcoded/app/skills/LocalSkillProvider.kt
@@ -2,6 +2,7 @@ package com.youcoded.app.skills
 
 import android.content.Context
 import android.util.Log
+import com.youcoded.app.util.forEachKey
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -136,8 +137,7 @@ class LocalSkillProvider(private val homeDir: File, private val context: Context
             val skill = JSONObject(cache.getJSONObject(i).toString())
             val o = overrides.optJSONObject(skill.optString("id"))
             if (o != null) {
-                val keys = o.keys()
-                while (keys.hasNext()) { val key = keys.next(); skill.put(key, o.get(key)) }
+                o.forEachKey { key -> skill.put(key, o.get(key)) }
             }
             result.put(skill)
         }
@@ -246,8 +246,7 @@ class LocalSkillProvider(private val homeDir: File, private val context: Context
 
         val override = configStore.getOverride(id)
         if (override != null) {
-            val keys = override.keys()
-            while (keys.hasNext()) { val key = keys.next(); result.put(key, override.get(key)) }
+            override.forEachKey { key -> result.put(key, override.get(key)) }
         }
         return result
     }
@@ -411,9 +410,7 @@ class LocalSkillProvider(private val homeDir: File, private val context: Context
         pluginDirs.forEach { pluginDir ->
             val manifest = readPluginManifest(pluginDir) ?: return@forEach
             val provides = manifest.optJSONObject("provides") ?: return@forEach
-            val keys = provides.keys()
-            while (keys.hasNext()) {
-                val cap = keys.next()
+            provides.forEachKey { cap ->
                 providerMap.putIfAbsent(cap, manifest.optString("name"))
             }
         }
@@ -616,8 +613,7 @@ class LocalSkillProvider(private val homeDir: File, private val context: Context
             val json = input.bufferedReader().use { it.readText() }
             val registry = JSONObject(json)
             val result = JSONArray()
-            val keys = registry.keys()
-            while (keys.hasNext()) result.put(keys.next())
+            registry.forEachKey { result.put(it) }
             result
         } catch (_: Exception) {
             JSONArray()
@@ -631,9 +627,7 @@ class LocalSkillProvider(private val homeDir: File, private val context: Context
             val json = input.bufferedReader().use { it.readText() }
             val registry = JSONObject(json)
             val result = JSONArray()
-            val keys = registry.keys()
-            while (keys.hasNext()) {
-                val id = keys.next()
+            registry.forEachKey { id ->
                 val meta = registry.getJSONObject(id)
                 val entry = JSONObject(meta.toString())
                 entry.put("id", id)

--- a/app/src/main/kotlin/com/youcoded/app/skills/SkillConfigStore.kt
+++ b/app/src/main/kotlin/com/youcoded/app/skills/SkillConfigStore.kt
@@ -374,41 +374,6 @@ class SkillConfigStore(private val homeDir: File) {
     fun getPackages(): JSONObject =
         config.optJSONObject("packages") ?: JSONObject()
 
-    fun getPackage(id: String): JSONObject? =
-        getPackages().optJSONObject(id)
-
-    /**
-     * Decomposition v3 §9.8: return packages with status computed from disk
-     * presence. After cross-device sync, Android may have a desktop-installed
-     * package in config but no files on disk yet — surface that as "pending"
-     * so the UI can show an Install CTA.
-     */
-    fun getPackagesWithStatus(): JSONObject {
-        val packages = getPackages()
-        val result = JSONObject()
-        val keys = packages.keys()
-        while (keys.hasNext()) {
-            val id = keys.next()
-            val pkg = packages.optJSONObject(id) ?: continue
-            val components = pkg.optJSONArray("components")
-            var onDisk = true
-            if (components != null) {
-                for (i in 0 until components.length()) {
-                    val c = components.optJSONObject(i) ?: continue
-                    if (c.optString("type") == "plugin") {
-                        onDisk = java.io.File(c.optString("path")).exists()
-                        break
-                    }
-                }
-            }
-            // Clone + annotate without mutating the stored object
-            val copy = JSONObject(pkg.toString())
-            copy.put("status", if (onDisk) "installed" else "pending")
-            result.put(id, copy)
-        }
-        return result
-    }
-
     fun recordPackageInstall(id: String, pkg: JSONObject) {
         val packages = getPackages()
         packages.put(id, pkg)
@@ -478,22 +443,6 @@ class SkillConfigStore(private val homeDir: File) {
             }
         }
         return result
-    }
-
-    fun recordPluginInstall(id: String, meta: JSONObject) {
-        // Bridge to packages API
-        val pluginsDir = File(homeDir, ".claude/plugins/$id")
-        val pkg = JSONObject().apply {
-            put("version", "1.0.0")
-            put("source", "marketplace")
-            put("installedAt", meta.optString("installedAt", ""))
-            put("removable", true)
-            put("components", JSONArray().put(JSONObject().apply {
-                put("type", "plugin")
-                put("path", meta.optString("installPath", pluginsDir.absolutePath))
-            }))
-        }
-        recordPackageInstall(id, pkg)
     }
 
     fun removePluginInstall(id: String) {

--- a/app/src/main/kotlin/com/youcoded/app/ui/ChatScreen.kt
+++ b/app/src/main/kotlin/com/youcoded/app/ui/ChatScreen.kt
@@ -14,10 +14,13 @@ import com.youcoded.app.runtime.SessionService
 // layoutInsets / screenMode plumbing they fed. xterm.js inside the React
 // WebView is the sole terminal renderer now (see TerminalView.tsx). The
 // React side toggles chat↔terminal entirely via viewModes; Compose only
-// hosts the WebView. screenMode + viewModeRequest collector were removed
+// hosts the WebView. screenMode + the viewModeRequest collector were removed
 // because their only consumer was the deleted render block. shellMode auto-
 // switch is also gone for the same reason — if shell auto-switch needs to
 // drive the React UI later, it should fire a viewMode message instead.
+// 2026-07-22: the viewModeRequest SharedFlow itself (and the switch-view
+// branch that fed it in SessionService) is now gone too — it had sat here
+// emitting into nothing since this Tier 2 change removed its only collector.
 
 @Composable
 fun ChatScreen(service: SessionService) {

--- a/app/src/main/kotlin/com/youcoded/app/util/JsonExt.kt
+++ b/app/src/main/kotlin/com/youcoded/app/util/JsonExt.kt
@@ -1,0 +1,9 @@
+package com.youcoded.app.util
+
+import org.json.JSONObject
+
+/** Iterate a JSONObject's keys without the manual keys()/hasNext()/next() dance. */
+inline fun JSONObject.forEachKey(action: (String) -> Unit) {
+    val it = keys()
+    while (it.hasNext()) action(it.next())
+}


### PR DESCRIPTION
Items 2, 3, 7, and 10-kotlin of the dead/duplicative-code review. 3 commits.
No local Android SDK on this host — **relying on this PR's android-ci** (unit tests + `assembleDebug` + R8 `assembleReleaseTest`). Every deletion verified by repo-wide trace; composite post-sweep finds zero dangling references.

## Commit 1 — extract `forkPublishViaGh` (item 2)
`publishPluginViaGh` and `publishThemeViaGh` were ~110 lines of byte-identical fork → branch → recursive-upload → PR logic. Desktop already factored this into `github-fork-publish.ts`; Android had two hand-copied copies. Now one helper + two thin wrappers. The unified sensitive-file list is the **superset** of the two former lists (the theme copy lacked `credentials.json`/`secrets.*`). Behavior-preserving.

## Commit 2 — 24 dead members + `forEachKey` (items 3 + 10)
Removed 24 confirmed-dead members (net −202 lines) whose stale "legacy"/"parity" docstrings misled readers into thinking they were live. Notable: `MarketplaceApiClient.getStats` (parity mirror never invoked), `PtyBridge.outputFlow` (no collector), public `SessionRegistry.currentSessionId` (never observed), `HistoryResult.hasMore` (never read).

New `util/JsonExt.kt` `JSONObject.forEachKey { }` replaces the manual `keys()/hasNext()/next()` dance at **6 mechanically-safe sites**. Sites whose body uses `continue`/early-return were intentionally left alone (a lambda can't `continue`).

## Commit 3 — dead `viewModeRequest` flow (item 7)
**Investigated first: switch-view is NOT broken on Android.** `ChatScreen.kt` records that Tier 2 deleted the native Termux `TerminalView` Compose block, and the React UI has owned chat↔terminal switching entirely since (xterm.js in the WebView is the sole terminal renderer). `viewModeRequest` existed *only* to drive that deleted block, so it has been emitting into nothing. Desktop's relay of `ui:action` exists to fan the action out to **other remote clients**, which Android doesn't host — so there's genuinely no native work for switch-view.

Removed the flow + its `"switch-view"` branch, with a WHY comment so the absence reads as intentional. The `"ui:action"` case is **deliberately kept** for `layout-update` — dropping it would fall through to the unknown-message branch, which logs a warning and returns an error to the WebView on every layout report.

## Separate finding, NOT actioned
`layoutInsets`/`LayoutInsets` is the **same vestigial pattern** from the same Tier 2 deletion (emitted, never collected — `ChatScreen.kt:14` even names it as removed plumbing). Left in place pending a call, since planned Android soft-keyboard/inset work may want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)