### PR TITLE
refactor(desktop): share one reconnecting-WebSocket engine (presence + sync)

### DIFF
--- a/desktop/src/main/presence-socket.ts
+++ b/desktop/src/main/presence-socket.ts
@@ -1,25 +1,23 @@
 // Platform-owned presence socket (spec §6): Electron main holds the account
 // session token and the WebSocket; the renderer only ever sees relayed events.
-import WebSocket from 'ws';
+// The reconnect/backoff/ping/supersede-guard mechanics live in the shared
+// reconnecting-ws engine (mirrored with sync-hub-socket.ts); this module only
+// supplies the presence-specific URL, message caching, and the renderer-reload
+// re-hydration hook. No-token policy is 'wait' — the renderer (usePresence,
+// Task 7) re-invokes presence-connect when sign-in completes.
+import {
+  createReconnectingWs,
+  type ReconnectingWebSocketLike,
+  type ReconnectingWebSocketCtor,
+} from './reconnecting-ws';
 
 const PRESENCE_URL = 'wss://wecoded-marketplace-api.destinj101.workers.dev/social/presence';
-const PING_INTERVAL_MS = 30_000;
-const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000]; // capped exponential
 
-// Injectable constructor so the state-machine test (tests/presence-socket.test.ts)
-// can substitute a fake socket without touching the network. Production always
-// uses the real 'ws' default. Structurally typed to the surface we consume
-// (on/send/close/readyState) rather than the full ws class.
-export interface PresenceWebSocketLike {
-  on(event: string, listener: (...args: any[]) => void): unknown;
-  send(data: string): void;
-  close(code?: number, reason?: string): void;
-  readyState: number;
-}
-export type WebSocketCtor = new (
-  url: string,
-  opts: { headers: Record<string, string> },
-) => PresenceWebSocketLike;
+// Structural socket surface + injectable constructor. Kept as named exports so
+// the state-machine test (tests/presence-socket.test.ts) can substitute a fake
+// socket. Both alias the shared engine's types (identical shape).
+export type PresenceWebSocketLike = ReconnectingWebSocketLike;
+export type WebSocketCtor = ReconnectingWebSocketCtor;
 
 export interface PresenceSocket {
   setDesired(want: boolean): void;
@@ -33,12 +31,6 @@ export function createPresenceSocket(opts: {
   onEvent: (ev: Record<string, unknown>) => void; // relayed as social:presence-event
   WebSocketCtor?: WebSocketCtor;
 }): PresenceSocket {
-  const Ctor: WebSocketCtor = opts.WebSocketCtor ?? (WebSocket as unknown as WebSocketCtor);
-  let desired = false;
-  let ws: PresenceWebSocketLike | null = null;
-  let attempts = 0;
-  let pingTimer: NodeJS.Timeout | null = null;
-  let retryTimer: NodeJS.Timeout | null = null;
   // Last full presence snapshot seen on the live socket. Kept so a RELOADED
   // renderer (dev HMR / Ctrl+R resets the reducer while main keeps the socket)
   // can be re-hydrated: setDesired(true) on an already-open socket replays
@@ -46,27 +38,13 @@ export function createPresenceSocket(opts: {
   // the fresh renderer never leaves "Connecting…".
   let lastPresence: Record<string, unknown> | null = null;
 
-  function clearTimers() {
-    if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
-    if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
-  }
-
-  function connect() {
-    const token = opts.getToken();
-    // No token: stay quiet. The renderer (usePresence, Task 7) re-invokes
-    // presence-connect when sign-in completes; do NOT turn this bail into an
-    // error — no-token is the normal pre-sign-in state.
-    if (!desired || ws || !token) return;
-    const sock = new Ctor(PRESENCE_URL, { headers: { Authorization: `Bearer ${token}` } });
-    ws = sock;
-    sock.on('open', () => {
-      if (ws !== sock) return; // superseded before handshake completed — don't start a ping timer on a dead socket
-      attempts = 0;
-      opts.onEvent({ type: 'connected' });
-      // Liveness ping — the DO answers pong; also keeps intermediaries from idling us out.
-      pingTimer = setInterval(() => { try { sock.send(JSON.stringify({ type: 'ping' })); } catch { /* mid-close */ } }, PING_INTERVAL_MS);
-    });
-    sock.on('message', (data) => {
+  const engine = createReconnectingWs({
+    Ctor: opts.WebSocketCtor,
+    getUrl: () => PRESENCE_URL,
+    getToken: opts.getToken,
+    noToken: 'wait',
+    closeReason: 'incognito or sign-out',
+    onMessage: (data) => {
       try {
         const ev = JSON.parse(String(data));
         // Cache the latest full presence snapshot for renderer-reload replay
@@ -74,76 +52,34 @@ export function createPresenceSocket(opts: {
         if (ev && ev.type === 'presence') lastPresence = ev;
         opts.onEvent(ev);
       } catch { /* non-JSON frame: ignore */ }
-    });
-    sock.on('close', (code, reason) => {
-      if (ws !== sock) return; // superseded socket — its lifecycle no longer drives state
-      handleDown({ type: 'disconnected', code, reason: String(reason) });
-    });
-    sock.on('error', (err: Error) => {
-      opts.onEvent({ type: 'error', message: err.message });
-      try { sock.close(); } catch { /* already closing */ } // 'close' fires next and schedules the retry
-    });
-  }
-
-  function handleDown(ev: Record<string, unknown>) {
-    clearTimers();
-    ws = null;
-    lastPresence = null; // snapshot belongs to the dead socket — never replay it stale
-    opts.onEvent(ev);
-    if (desired) {
-      // Reconnect with capped backoff — a Worker deploy or network blip must
-      // not silently end presence for the rest of the app session.
-      // A dead-token loop (persistent handshake reject) is bounded by Task 2's
-      // focus/15-min revalidation: dead token → 401 on any account call →
-      // signOut → notifySignedOut drops `desired`. Revisit a close-code-based
-      // stop here once the worker's close-code contract is pinned.
-      const delay = BACKOFF_MS[Math.min(attempts, BACKOFF_MS.length - 1)];
-      attempts += 1;
-      retryTimer = setTimeout(connect, delay);
-    }
-  }
+    },
+    onConnected: () => opts.onEvent({ type: 'connected' }),
+    onDisconnected: (info) => {
+      // reason:'local' marks an INTENTIONAL disconnect — Task 7 uses it to
+      // suppress "reconnecting" UI. A dropped/failed socket forwards the ws
+      // close code/reason instead.
+      if (info.intentional) opts.onEvent({ type: 'disconnected', code: 1000, reason: 'local' });
+      else opts.onEvent({ type: 'disconnected', code: info.code, reason: info.reason });
+    },
+    // The 'error' handler surfaces an error event; the engine then closes the
+    // socket so its 'close' schedules the retry.
+    onError: (err) => opts.onEvent({ type: 'error', message: err.message }),
+    onReplay: () => {
+      opts.onEvent({ type: 'connected' });
+      if (lastPresence) opts.onEvent(lastPresence);
+    },
+    // The cached snapshot belongs to the socket that just went down — never
+    // replay it stale onto the next connection.
+    onTeardown: () => { lastPresence = null; },
+  });
 
   return {
-    setDesired(want) {
-      // Idempotent by intent. Return early only when the request matches the
-      // current state AND there's nothing to do: either we already want-off, or
-      // we want-on WITH a live socket. The one case we must NOT short-circuit is
-      // want===true while desired-but-disconnected (e.g. the token finally
-      // appeared after sign-in) — that has to fall through and trigger connect().
-      if (want === desired && (!want || ws !== null)) {
-        // Renderer-reload replay: dev HMR / Ctrl+R resets the renderer's reducer
-        // while main keeps the socket open, so the fresh renderer's connect
-        // request lands here with nothing to do — and without a replay it never
-        // sees 'connected' and sticks on "Connecting…" forever. Re-emit the
-        // synthetic connected + the cached presence snapshot so the reducer
-        // re-hydrates. Skip while still CONNECTING — the real open event fires.
-        if (want && ws && ws.readyState === WebSocket.OPEN) {
-          opts.onEvent({ type: 'connected' });
-          if (lastPresence) opts.onEvent(lastPresence);
-        }
-        return;
-      }
-      desired = want;
-      if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
-      if (want) { connect(); return; }
-      const s = ws;
-      ws = null;
-      lastPresence = null; // intentional teardown — drop the snapshot with the socket
-      clearTimers();
-      if (s) {
-        try { s.close(1000, 'incognito or sign-out'); } catch { /* already closed */ }
-        // reason:'local' marks an INTENTIONAL disconnect — Task 7 uses it to
-        // suppress "reconnecting" UI. Emitted synchronously; the socket's own
-        // async close event is ignored via the supersede guard (ws was nulled
-        // above, so `ws !== sock` in the close handler).
-        opts.onEvent({ type: 'disconnected', code: 1000, reason: 'local' });
-      }
-    },
-    send(message) { try { ws?.send(JSON.stringify(message)); } catch { /* mid-close */ } },
+    setDesired(want) { engine.setDesired(want); },
+    send(message) { engine.send(JSON.stringify(message)); },
     // True only when a socket exists AND finished its handshake — lets the
     // presence-send handler return an honest failure instead of silently
     // dropping a frame with a success receipt.
-    isConnected() { return ws !== null && ws.readyState === WebSocket.OPEN; },
-    destroy() { desired = false; clearTimers(); try { ws?.close(); } catch { /* noop */ } ws = null; lastPresence = null; },
+    isConnected() { return engine.isOpen(); },
+    destroy() { engine.destroy(); },
   };
 }

--- a/desktop/src/main/reconnecting-ws.ts
+++ b/desktop/src/main/reconnecting-ws.ts
@@ -1,0 +1,165 @@
+// Shared reconnecting-WebSocket engine for the two Electron-MAIN-held sockets:
+// presence-socket.ts and sync-hub-socket.ts. Both need the identical mechanics —
+// a node `ws` client with capped-backoff reconnect (a Worker deploy or network
+// blip must never silently end the connection for the rest of the app session),
+// a 30s liveness ping, and a "supersede guard" so a socket replaced mid-handshake
+// never drives state. Before this module those mechanics were copy-pasted; a bug
+// fixed in one had to be mirrored by hand into the other.
+//
+// The two callers DIVERGE only in the bits injected as hooks below: the URL, the
+// per-frame message parsing, the no-token policy, whether errors surface as
+// events, and the teardown extras (sync fails its in-flight lease requests;
+// presence drops its cached snapshot). Everything else lives here, once.
+import WebSocket from 'ws';
+
+// Structural surface both call sites consume (on/send/close/readyState) — lets
+// the state-machine tests inject a fake socket without touching the network.
+export interface ReconnectingWebSocketLike {
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  readyState: number;
+}
+export type ReconnectingWebSocketCtor = new (
+  url: string,
+  opts: { headers: Record<string, string> },
+) => ReconnectingWebSocketLike;
+
+const PING_INTERVAL_MS = 30_000;
+const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000]; // capped exponential
+
+export interface ReconnectingWsHooks {
+  Ctor?: ReconnectingWebSocketCtor; // defaults to the real node `ws`; tests inject a fake
+  getUrl: () => string;
+  getToken: () => string | null;
+  // No-token policy. 'wait': stay quiet — a renderer re-invokes on sign-in
+  // (presence). 'poll': there is no renderer to wait for, so re-check at the max
+  // backoff so a mid-session sign-in connects on the next tick (sync).
+  noToken: 'wait' | 'poll';
+  // ws close-frame reason sent on an INTENTIONAL teardown (setDesired(false)).
+  closeReason: string;
+  onMessage: (data: unknown) => void;             // per-socket frame parsing
+  onConnected: () => void;                         // handshake completed
+  // A disconnect surfaced to the consumer. `intentional` marks a caller-driven
+  // teardown (vs a dropped/failed socket); code/reason ride from the ws close.
+  onDisconnected: (info: { code?: number; reason?: string; intentional?: boolean }) => void;
+  onError?: (err: Error) => void;                  // presence surfaces; sync omits (engine still closes → retry)
+  onReplay?: () => void;                           // setDesired(true) on an already-open socket (presence re-hydration)
+  onTeardown?: () => void;                         // runs on every down/teardown/destroy (failAllPending / drop snapshot)
+}
+
+export interface ReconnectingWs {
+  setDesired(want: boolean): void;
+  send(data: string): boolean;   // true only when written on an OPEN socket
+  isOpen(): boolean;             // socket exists AND finished its handshake
+  destroy(): void;
+}
+
+export function createReconnectingWs(hooks: ReconnectingWsHooks): ReconnectingWs {
+  const Ctor: ReconnectingWebSocketCtor = hooks.Ctor ?? (WebSocket as unknown as ReconnectingWebSocketCtor);
+  let desired = false;
+  let ws: ReconnectingWebSocketLike | null = null;
+  let attempts = 0;
+  let pingTimer: NodeJS.Timeout | null = null;
+  let retryTimer: NodeJS.Timeout | null = null;
+
+  function clearTimers() {
+    if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+    if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+  }
+
+  function connect() {
+    if (!desired || ws) return;
+    const token = hooks.getToken();
+    if (!token) {
+      // No token yet. 'wait' stays quiet (the renderer re-invokes on sign-in);
+      // 'poll' re-checks at the max backoff so a mid-session sign-in connects on
+      // the next tick without an app restart. Clear-then-reschedule (not a
+      // `!retryTimer` guard): when THIS callback is itself the fired retry, the
+      // timer variable still holds the elapsed id, so a guard would stop the poll
+      // dead after one attempt. clearTimeout on an already-fired timer is a no-op.
+      if (hooks.noToken === 'poll') {
+        if (retryTimer) clearTimeout(retryTimer);
+        retryTimer = setTimeout(connect, BACKOFF_MS[BACKOFF_MS.length - 1]);
+      }
+      return;
+    }
+    const sock = new Ctor(hooks.getUrl(), { headers: { Authorization: `Bearer ${token}` } });
+    ws = sock;
+    sock.on('open', () => {
+      if (ws !== sock) return; // superseded before handshake completed — don't start a ping timer on a dead socket
+      attempts = 0;
+      hooks.onConnected();
+      // Liveness ping — the DO answers pong; also keeps intermediaries from idling us out.
+      pingTimer = setInterval(() => { try { sock.send(JSON.stringify({ type: 'ping' })); } catch { /* mid-close */ } }, PING_INTERVAL_MS);
+    });
+    sock.on('message', (data) => { hooks.onMessage(data); });
+    sock.on('close', (code, reason) => {
+      if (ws !== sock) return; // superseded socket — its lifecycle no longer drives state
+      handleDown({ code, reason: reason === undefined ? undefined : String(reason) });
+    });
+    sock.on('error', (err: Error) => {
+      hooks.onError?.(err);
+      try { sock.close(); } catch { /* already closing */ } // 'close' fires next and schedules the retry
+    });
+  }
+
+  function handleDown(info: { code?: number; reason?: string }) {
+    clearTimers();
+    hooks.onTeardown?.(); // socket died — resolve any in-flight work before the reconnect (sync); drop stale snapshot (presence)
+    ws = null;
+    hooks.onDisconnected(info);
+    if (desired) {
+      // Reconnect with capped backoff. A dead-token loop (persistent handshake
+      // reject) is bounded upstream by the consumer dropping `desired` on
+      // sign-out; revisit a close-code-based stop once the worker's close-code
+      // contract is pinned.
+      const delay = BACKOFF_MS[Math.min(attempts, BACKOFF_MS.length - 1)];
+      attempts += 1;
+      retryTimer = setTimeout(connect, delay);
+    }
+  }
+
+  return {
+    setDesired(want) {
+      // Idempotent by intent. Short-circuit only when the request matches the
+      // current state AND there's nothing to do: either we already want-off, or
+      // we want-on WITH a live socket. The one case we must NOT short-circuit is
+      // want===true while desired-but-disconnected (the token finally appeared
+      // after sign-in, or a retry is pending) — that has to fall through to connect().
+      if (want === desired && (!want || ws !== null)) {
+        // Already want-on with a socket: give the consumer a chance to re-hydrate
+        // a reloaded renderer (presence) — but only once the handshake is done;
+        // while CONNECTING the real open event will fire onConnected anyway.
+        if (want && ws !== null && ws.readyState === WebSocket.OPEN) hooks.onReplay?.();
+        return;
+      }
+      desired = want;
+      if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+      if (want) { connect(); return; }
+      hooks.onTeardown?.(); // intentional teardown — clear in-flight work before closing
+      const s = ws;
+      ws = null;
+      clearTimers();
+      if (s) {
+        try { s.close(1000, hooks.closeReason); } catch { /* already closed */ }
+        // Emit synchronously; the socket's own async close event is ignored via
+        // the supersede guard (ws was nulled above → `ws !== sock` in the close
+        // handler) — that's what prevents a reconnect after an INTENTIONAL teardown.
+        hooks.onDisconnected({ code: 1000, intentional: true });
+      }
+    },
+    send(data) {
+      if (ws === null || ws.readyState !== WebSocket.OPEN) return false;
+      try { ws.send(data); return true; } catch { return false; }
+    },
+    isOpen() { return ws !== null && ws.readyState === WebSocket.OPEN; },
+    destroy() {
+      desired = false;
+      clearTimers();
+      hooks.onTeardown?.();
+      try { ws?.close(); } catch { /* noop */ }
+      ws = null;
+    },
+  };
+}

--- a/desktop/src/main/sync-hub-socket.ts
+++ b/desktop/src/main/sync-hub-socket.ts
@@ -1,37 +1,30 @@
-// SyncHub client (spec §6, Plan 1b). Mirrors presence-socket.ts: a node `ws`
-// client held by the Electron MAIN process with capped-backoff reconnect, so a
-// Worker deploy or network blip never silently ends cross-device signalling for
-// the rest of the app session.
+// SyncHub client (spec §6, Plan 1b). Shares the reconnect/backoff/ping/supersede
+// engine with presence-socket.ts (see reconnecting-ws.ts) — a node `ws` client
+// held by the Electron MAIN process, so a Worker deploy or network blip never
+// silently ends cross-device signalling for the rest of the app session.
 //
-// Differences from presence-socket.ts (all deliberate):
+// Differences from presence-socket.ts (all deliberate, expressed as engine hooks):
 //   (1) Owned by the sync-spaces SERVICE, not renderer-driven — sync must work
-//       with zero windows open, so there is no renderer to re-invoke us.
-//   (2) No-token is retried on a timer (presence waits for the renderer to
-//       reconnect after sign-in; we have no renderer to wait for, so we poll at
-//       the max backoff and connect the moment a token appears — no restart).
+//       with zero windows open, so no-token policy is 'poll' (presence 'wait'):
+//       we re-check at the max backoff and connect the moment a token appears.
+//   (2) In-flight lease requests are failed (resolved null) on every teardown so
+//       a request never hangs across a reconnect — the onTeardown hook.
 //   (3) hello.replay entries are flattened into ordinary signal events — the
 //       engine's single-flight syncSpace makes duplicate signals free, so the
 //       consumer never has to distinguish replay from live.
-import WebSocket from 'ws';
+import {
+  createReconnectingWs,
+  type ReconnectingWebSocketLike,
+  type ReconnectingWebSocketCtor,
+} from './reconnecting-ws';
 
 const SYNC_HUB_URL = 'wss://wecoded-marketplace-api.destinj101.workers.dev/sync/hub';
-const PING_INTERVAL_MS = 30_000;
-const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000]; // capped exponential
 
-// Injectable constructor so the state-machine test (tests/sync-hub-socket.test.ts)
-// can substitute a fake socket without touching the network. Production always
-// uses the real 'ws' default. Structurally typed to the surface we consume
-// (on/send/close/readyState) rather than the full ws class.
-export interface SyncHubWebSocketLike {
-  on(event: string, listener: (...args: any[]) => void): unknown;
-  send(data: string): void;
-  close(code?: number, reason?: string): void;
-  readyState: number;
-}
-export type WebSocketCtor = new (
-  url: string,
-  opts: { headers: Record<string, string> },
-) => SyncHubWebSocketLike;
+// Structural socket surface + injectable constructor. Named exports so the
+// state-machine test (tests/sync-hub-socket.test.ts) can substitute a fake
+// socket. Both alias the shared engine's types (identical shape).
+export type SyncHubWebSocketLike = ReconnectingWebSocketLike;
+export type WebSocketCtor = ReconnectingWebSocketCtor;
 
 // Who currently holds a session lease (returned on lease-result, and carried in
 // takeover-request events as `from`). expiresAt is an epoch-ms deadline.
@@ -81,7 +74,6 @@ export interface SyncHubSocket {
 }
 
 export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
-  const Ctor: WebSocketCtor = opts.WebSocketCtor ?? (WebSocket as unknown as WebSocketCtor);
   // device= identifies this client to the room so the server can fan a signal
   // out to the account's OTHER devices (never echo it back to the sender).
   // deviceId= (when present) is the durable machineId the DO records into its
@@ -90,59 +82,31 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
   const url = `${SYNC_HUB_URL}?device=${encodeURIComponent(opts.deviceName)}`
     + (opts.deviceId ? `&deviceId=${encodeURIComponent(opts.deviceId)}` : '');
 
-  let desired = false;
-  let ws: SyncHubWebSocketLike | null = null;
-  let attempts = 0;
-  let pingTimer: NodeJS.Timeout | null = null;
-  let retryTimer: NodeJS.Timeout | null = null;
-
   // In-flight lease requests, keyed by the client-generated reqId. A matching
   // server `lease-result` (or the 5s timeout) removes the entry and resolves it.
   let reqCounter = 0;
   const pending = new Map<string, { resolve: (r: LeaseResult | null) => void; timer: NodeJS.Timeout }>();
 
   // Resolve EVERY in-flight request to null and clear the map. Called from all
-  // teardown paths (handleDown / setDesired(false) / destroy) so a request that
-  // was awaiting a reply when the socket died never hangs forever across a
-  // reconnect — the never-block guarantee. The caller sees null (treat as "no
-  // answer"), same as a timeout.
+  // teardown paths (engine handleDown / setDesired(false) / destroy, via the
+  // onTeardown hook) so a request that was awaiting a reply when the socket died
+  // never hangs forever across a reconnect — the never-block guarantee. The
+  // caller sees null (treat as "no answer"), same as a timeout.
   function failAllPending() {
     for (const [, p] of pending) { clearTimeout(p.timer); p.resolve(null); }
     pending.clear();
   }
 
-  function clearTimers() {
-    if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
-    if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
-  }
-
-  function connect() {
-    if (!desired || ws) return;
-    const token = opts.getToken();
-    if (!token) {
-      // No token yet (not signed in). Unlike presence — which relies on the
-      // renderer to re-invoke on sign-in — the sync service has no renderer to
-      // wait for, so poll at the max backoff so a mid-session sign-in connects
-      // on the next tick without an app restart. Clear-then-reschedule (not a
-      // `!retryTimer` guard): when THIS callback is itself the fired retry, the
-      // timer variable still holds the elapsed id, so `!retryTimer` would be
-      // false and the poll would stop dead after one attempt. clearTimeout on an
-      // already-fired timer is a harmless no-op, and it guarantees exactly one
-      // pending no-token retry.
-      if (retryTimer) clearTimeout(retryTimer);
-      retryTimer = setTimeout(connect, BACKOFF_MS[BACKOFF_MS.length - 1]);
-      return;
-    }
-    const sock = new Ctor(url, { headers: { Authorization: `Bearer ${token}` } });
-    ws = sock;
-    sock.on('open', () => {
-      if (ws !== sock) return; // superseded before handshake completed — don't start a ping timer on a dead socket
-      attempts = 0;
-      opts.onEvent({ type: 'connected' });
-      // Liveness ping — the DO answers pong; also keeps intermediaries from idling us out.
-      pingTimer = setInterval(() => { try { sock.send(JSON.stringify({ type: 'ping' })); } catch { /* mid-close */ } }, PING_INTERVAL_MS);
-    });
-    sock.on('message', (data) => {
+  const engine = createReconnectingWs({
+    Ctor: opts.WebSocketCtor,
+    getUrl: () => url,
+    getToken: opts.getToken,
+    noToken: 'poll',
+    closeReason: 'sync disabled or sign-out',
+    onConnected: () => opts.onEvent({ type: 'connected' }),
+    onDisconnected: () => opts.onEvent({ type: 'disconnected' }),
+    onTeardown: failAllPending,
+    onMessage: (data) => {
       try {
         const msg = JSON.parse(String(data));
         if (msg && msg.type === 'hello') {
@@ -185,68 +149,16 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
         }
         // pong (or any other frame): ignore — pings are fire-and-forget liveness.
       } catch { /* non-JSON frame: ignore */ }
-    });
-    sock.on('close', () => {
-      if (ws !== sock) return; // superseded socket — its lifecycle no longer drives state
-      handleDown();
-    });
-    sock.on('error', () => {
-      // Don't surface errors as events — the consumer only cares about
-      // connected/disconnected/signal. Close to let 'close' schedule the retry.
-      try { sock.close(); } catch { /* already closing */ }
-    });
-  }
-
-  function handleDown() {
-    clearTimers();
-    failAllPending(); // socket died — a request awaiting a reply must resolve null, not hang across the reconnect
-    ws = null;
-    opts.onEvent({ type: 'disconnected' });
-    if (desired) {
-      // Reconnect with capped backoff. A dead-token loop (persistent handshake
-      // reject) is bounded upstream by the service dropping `desired` on
-      // sign-out; revisit a close-code-based stop once the worker's close-code
-      // contract is pinned.
-      const delay = BACKOFF_MS[Math.min(attempts, BACKOFF_MS.length - 1)];
-      attempts += 1;
-      retryTimer = setTimeout(connect, delay);
-    }
-  }
+    },
+  });
 
   return {
-    setDesired(want) {
-      // Idempotent by intent. Short-circuit only when the request matches the
-      // current state AND there's nothing to do: either we already want-off, or
-      // we want-on WITH a live socket. The case we must NOT short-circuit is
-      // want===true while desired-but-disconnected (e.g. the token finally
-      // appeared after sign-in, or a retry is pending) — that has to fall
-      // through and (re)trigger connect().
-      if (want === desired && (!want || ws !== null)) return;
-      desired = want;
-      if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
-      if (want) { connect(); return; }
-      failAllPending(); // intentional teardown — resolve any in-flight request to null so the caller never blocks on a socket we're closing
-      const s = ws;
-      ws = null;
-      clearTimers();
-      if (s) {
-        try { s.close(1000, 'sync disabled or sign-out'); } catch { /* already closed */ }
-        // Emit the disconnect synchronously; the socket's own async close event
-        // is ignored via the supersede guard (ws was nulled above, so
-        // `ws !== sock` in the close handler) — that's what prevents a reconnect
-        // after an INTENTIONAL teardown.
-        opts.onEvent({ type: 'disconnected' });
-      }
-    },
+    setDesired(want) { engine.setDesired(want); },
     // Send a change signal to the room. Returns true only when actually written
     // on an OPEN socket; a closed/connecting socket is a silent no-op (the 120s
     // poll fallback covers the miss — no queueing, YAGNI).
     sendSignal(kind, spaceKey) {
-      if (ws !== null && ws.readyState === WebSocket.OPEN) {
-        try { ws.send(JSON.stringify({ type: 'signal', kind, spaceKey })); return true; }
-        catch { return false; }
-      }
-      return false;
+      return engine.send(JSON.stringify({ type: 'signal', kind, spaceKey }));
     },
     // Request/response lease op. Sends a {type:'lease', op, sessionId, deviceId,
     // reqId} frame and resolves the matching server `lease-result` by reqId.
@@ -254,18 +166,19 @@ export function createSyncHubSocket(opts: SyncHubSocketOpts): SyncHubSocket {
     // 5s timeout, if the send throws, or if the socket goes down mid-flight
     // (failAllPending). The consumer treats null as "no answer / fall back".
     request(op, sessionId, deviceId) {
-      if (ws === null || ws.readyState !== WebSocket.OPEN) return Promise.resolve(null); // never-block
+      if (!engine.isOpen()) return Promise.resolve(null); // never-block
       const reqId = `r${++reqCounter}`;
       return new Promise<LeaseResult | null>((resolve) => {
         const timer = setTimeout(() => { pending.delete(reqId); resolve(null); }, 5_000);
         timer.unref?.(); // don't keep the Electron main process alive just for a lease timeout
         pending.set(reqId, { resolve, timer });
-        try { ws!.send(JSON.stringify({ type: 'lease', op, sessionId, deviceId, reqId })); }
-        catch { pending.delete(reqId); clearTimeout(timer); resolve(null); }
+        if (!engine.send(JSON.stringify({ type: 'lease', op, sessionId, deviceId, reqId }))) {
+          pending.delete(reqId); clearTimeout(timer); resolve(null);
+        }
       });
     },
     // True only when a socket exists AND finished its handshake.
-    isConnected() { return ws !== null && ws.readyState === WebSocket.OPEN; },
-    destroy() { desired = false; clearTimers(); failAllPending(); try { ws?.close(); } catch { /* noop */ } ws = null; },
+    isConnected() { return engine.isOpen(); },
+    destroy() { engine.destroy(); },
   };
 }


### PR DESCRIPTION
Item 8 of the dead/duplicative-code review.

## Problem
`presence-socket.ts` and `sync-hub-socket.ts` each hand-rolled the **same** reconnecting-WebSocket state machine — capped-backoff reconnect, 30s liveness ping, the `ws !== sock` supersede guard, `clearTimers`, and the injectable-`Ctor` test seam. `sync-hub-socket`'s header literally said *"Mirrors presence-socket.ts"*. A reconnect bug fixed in one had to be hand-copied to the other.

## Change
Extracted that machine into **`reconnecting-ws.ts`** (`createReconnectingWs`). Each caller now supplies only its genuine differences as hooks:

| Hook | presence | sync |
|---|---|---|
| `noToken` | `'wait'` (renderer re-invokes on sign-in) | `'poll'` (no renderer → re-check at max backoff) |
| `onMessage` | cache snapshot + relay | hello/replay/signal/lease parsing |
| `onError` | surfaces an error event | omitted (engine still closes → retry) |
| `onReplay` | renderer-reload re-hydration | — |
| `onTeardown` | drop cached snapshot | `failAllPending` (never-block lease requests) |

## Safety
- **Public API byte-for-byte unchanged** — `createPresenceSocket`, `createSyncHubSocket`, all exported types (`LeaseResult`, `SyncHubEvent`, `*WebSocketLike`). The 4 external importers and **both test suites are untouched**.
- **All 33 state-machine tests pass** (8 presence + 25 sync), tsc clean, full suite green.

This is de-duplication, not line-golf: total LOC is ~flat (+14) because the shared engine adds a documented hooks interface, but the reconnect/backoff/ping/supersede logic now lives in exactly one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)