### PR TITLE
fix(social): presence client liveness — Android app-level ping + delta-updated replay cache

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/social/PresenceClient.kt
+++ b/app/src/main/kotlin/com/youcoded/app/social/PresenceClient.kt
@@ -25,6 +25,10 @@ class PresenceClient(
     private var desired = false
     private var attempts = 0
     private val backoffMs = longArrayOf(1_000, 2_000, 5_000, 10_000, 30_000)
+    // Desktop parity: reconnecting-ws.ts PING_INTERVAL_MS — the app-level ping
+    // both platforms must send (see schedulePing below for why OkHttp's
+    // protocol-level ping is not enough).
+    private val pingIntervalMs = 30_000L
     private val handler = android.os.Handler(android.os.Looper.getMainLooper())
 
     // Read by isConnected() from the SessionService bridge thread (the honest
@@ -80,6 +84,7 @@ class PresenceClient(
                     attempts = 0
                     connected = true
                     onEvent(JSONObject().put("type", "connected"))
+                    schedulePing(webSocket)
                 }
             }
             override fun onMessage(webSocket: WebSocket, text: String) {
@@ -97,6 +102,27 @@ class PresenceClient(
                 handler.post { retry(webSocket, 1006, t.message ?: "failure") }
             }
         })
+    }
+
+    // App-level liveness ping — REQUIRED, not redundant with OkHttp's
+    // pingInterval. OkHttp sends WebSocket *protocol* pings, which Cloudflare's
+    // edge answers without the presence room ever observing them; the server's
+    // liveness model (PresenceRoom stale-socket eviction, 2026-07-22) counts
+    // only application frames and its auto-response JSON ping pair. Without
+    // this loop, every Android socket looks permanently silent server-side and
+    // gets evicted on the staleness timer. The string must stay byte-exact:
+    // the server's WebSocketRequestResponsePair matches {"type":"ping"}
+    // (identical to desktop's JSON.stringify({type:'ping'})).
+    // OkHttp's protocol ping stays enabled too — it is what detects a dead
+    // connection CLIENT-side and triggers the reconnect backoff.
+    private fun schedulePing(socket: WebSocket) {
+        handler.postDelayed({
+            // Superseded or torn down — stop silently; a new socket's onOpen
+            // starts its own loop. Same identity guard as retry().
+            if (ws !== socket) return@postDelayed
+            socket.send("""{"type":"ping"}""")
+            schedulePing(socket)
+        }, pingIntervalMs)
     }
 
     private fun retry(source: WebSocket, code: Int, reason: String) {

--- a/desktop/src/main/presence-socket.ts
+++ b/desktop/src/main/presence-socket.ts
@@ -49,7 +49,25 @@ export function createPresenceSocket(opts: {
         const ev = JSON.parse(String(data));
         // Cache the latest full presence snapshot for renderer-reload replay
         // (see lastPresence above).
-        if (ev && ev.type === 'presence') lastPresence = ev;
+        if (ev && ev.type === 'presence') {
+          lastPresence = ev;
+        } else if (lastPresence) {
+          // Fold the roster deltas into the cached snapshot (same semantics as
+          // the game-reducer's USER_JOINED/LEFT/STATUS). Without this, a
+          // renderer reload replayed the CONNECT-TIME roster and resurrected
+          // friends who had since left — the client-side twin of the server's
+          // ghost-socket stuck-"Online" bug (2026-07-22 investigation).
+          // A delta arriving before any snapshot is skipped: a roster can't be
+          // synthesized from deltas, and the server always snapshots first.
+          const users = Array.isArray(lastPresence.users) ? (lastPresence.users as Array<{ id: string }>) : [];
+          if (ev?.type === 'user-joined' && ev.user) {
+            lastPresence = { ...lastPresence, users: [...users.filter((u) => u.id !== ev.user.id), ev.user] };
+          } else if (ev?.type === 'user-left') {
+            lastPresence = { ...lastPresence, users: users.filter((u) => u.id !== ev.id) };
+          } else if (ev?.type === 'user-status') {
+            lastPresence = { ...lastPresence, users: users.map((u) => (u.id === ev.id ? { ...u, status: ev.status } : u)) };
+          }
+        }
         opts.onEvent(ev);
       } catch { /* non-JSON frame: ignore */ }
     },

--- a/desktop/tests/presence-socket.test.ts
+++ b/desktop/tests/presence-socket.test.ts
@@ -170,6 +170,31 @@ describe('presence-socket state machine', () => {
     sock.destroy();
   });
 
+  it('renderer-reload replay folds deltas into the cached snapshot — departed friends are not resurrected', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+    const bob = { id: 'github:2', display_name: 'Bob', handle: 'bob', status: 'idle' };
+    inst.emit('message', JSON.stringify({ type: 'presence', users: [bob] }));
+
+    // Live deltas after the snapshot: Carol joins and goes in-game; Bob leaves.
+    const carol = { id: 'github:3', display_name: 'Carol', handle: 'carol', status: 'idle' };
+    inst.emit('message', JSON.stringify({ type: 'user-joined', user: carol }));
+    inst.emit('message', JSON.stringify({ type: 'user-status', id: 'github:3', status: 'in-game' }));
+    inst.emit('message', JSON.stringify({ type: 'user-left', id: 'github:2' }));
+
+    // A renderer reload must see the CURRENT roster, not the connect-time one —
+    // replaying stale users is the client-side twin of the server ghost bug
+    // (a departed friend pinned "Online" until the next full snapshot).
+    const before = events.length;
+    sock.setDesired(true);
+    const replayed = events.slice(before);
+    expect(types(replayed)).toEqual(['connected', 'presence']);
+    expect((replayed[1] as any).users).toEqual([{ ...carol, status: 'in-game' }]);
+    sock.destroy();
+  });
+
   it('renderer-reload replay does NOT fire while the handshake is still in flight', () => {
     const { sock, events } = makeSocket(() => 'tok');
     sock.setDesired(true); // socket exists, still CONNECTING


### PR DESCRIPTION
Pairs with [wecoded-marketplace #54](https://github.com/itsdestin/wecoded-marketplace/pull/54) (heartbeat-based presence liveness — the stuck-"Online" fix). Investigation: `youcoded-dev/docs/active/investigations/2026-07-22-presence-stuck-online.md`.

## Android — app-level ping (required, not redundant)

`PresenceClient` now sends `{"type":"ping"}` every 30s, mirroring desktop's `reconnecting-ws` loop. OkHttp's `pingInterval` sends WebSocket **protocol** pings, which Cloudflare's edge answers without the presence room ever observing them — under the server's new liveness model an Android socket would look permanently silent and be evicted on the staleness timer. The string is byte-exact to match the server's `WebSocketRequestResponsePair`. The protocol ping stays enabled too: it's what detects a dead connection *client*-side and triggers the reconnect backoff. The loop is bound to the socket instance (same identity guard as `retry()`), so supersede/teardown self-cancels it.

## Desktop — replay cache folds deltas

`presence-socket`'s cached snapshot (replayed to a reloaded renderer) previously held the **connect-time** roster and ignored `user-joined`/`user-left`/`user-status` deltas — a renderer reload resurrected friends who had since left (the client-side twin of the server ghost bug). The cache now applies deltas with the same semantics as the game-reducer. A delta arriving before any snapshot is skipped (a roster can't be synthesized from deltas; the server always snapshots first, and this guards the connect-window race).

## Verification

- New state-machine test: *renderer-reload replay folds deltas — departed friends are not resurrected* (written first, watched fail on the old code)
- Desktop: 3087 passed / 39 skipped, `tsc --noEmit` clean
- **Android: not locally compiled** — this machine has no Android SDK (pre-existing; main checkout fails identically), so CI is the compile check. `PresenceClient` has no JVM test harness (main-looper bound, no Robolectric in the deps) — the 30s loop behavior is pinned indirectly by the worker-side "a socket that keeps pinging is never evicted" test; a Robolectric harness would be a separate, larger change.

## Merge order

Either order is safe, but this PR reaching users is what lets the Worker threshold tighten later — the Worker ships with a generous 60-min default until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)