### PR TITLE
fix(social): close presence socket on OS suspend, reconnect on wake

### DIFF
--- a/desktop/src/main/presence-socket.ts
+++ b/desktop/src/main/presence-socket.ts
@@ -21,6 +21,10 @@ export type WebSocketCtor = ReconnectingWebSocketCtor;
 
 export interface PresenceSocket {
   setDesired(want: boolean): void;
+  // System sleep gate (powerMonitor suspend/resume). Kept SEPARATE from
+  // setDesired: desired is the RENDERER's intent (sign-in/incognito/leader)
+  // and must survive a sleep/wake cycle unchanged.
+  setSuspended(asleep: boolean): void;
   send(message: Record<string, unknown>): void;
   isConnected(): boolean;
   destroy(): void;
@@ -91,8 +95,25 @@ export function createPresenceSocket(opts: {
     onTeardown: () => { lastPresence = null; },
   });
 
+  // Suspend gate (2026-07-22, "closed MacBook stays Online" follow-up to the
+  // ghost-socket fix): the engine's effective desire is rendererDesired AND
+  // awake. On OS suspend we close NOW, while the network is still up, so the
+  // close frame reaches the server and friends see "Last seen just now"
+  // immediately — instead of a silently-dead socket riding the server's
+  // staleness timeout. macOS dark wakes never fire powerMonitor 'resume', so a
+  // lid-closed laptop can't blip back online from a maintenance wake; a real
+  // wake restores whatever the renderer wanted.
+  let rendererDesired = false;
+  let suspended = false;
+  const applyDesire = () => engine.setDesired(rendererDesired && !suspended);
+
   return {
-    setDesired(want) { engine.setDesired(want); },
+    setDesired(want) { rendererDesired = want; applyDesire(); },
+    setSuspended(asleep) {
+      if (suspended === asleep) return;
+      suspended = asleep;
+      applyDesire();
+    },
     send(message) { engine.send(JSON.stringify(message)); },
     // True only when a socket exists AND finished its handshake — lets the
     // presence-send handler return an honest failure instead of silently

--- a/desktop/src/main/social-handlers.ts
+++ b/desktop/src/main/social-handlers.ts
@@ -4,7 +4,7 @@
 // every call needs the bearer token, so all logic lives in the main process —
 // the token never crosses the contextBridge into the renderer bundle.
 
-import { ipcMain, webContents } from "electron";
+import { ipcMain, webContents, powerMonitor } from "electron";
 import type { MarketplaceAuthStore } from "./marketplace-auth-store";
 import { createMarketplaceApiClient, MARKETPLACE_API_HOST } from "../renderer/state/marketplace-api-client";
 import type {
@@ -29,6 +29,12 @@ import type { RemoteServer } from "./remote-server";
 // app-quit teardown can destroy it — without threading the instance through the
 // account module. Only the most recent registration's socket is retained.
 let presenceSocket: PresenceSocket | null = null;
+
+// Named refs so hot-reload re-registration swaps the powerMonitor listeners
+// instead of stacking a new pair per reload (a stale pair would setSuspended
+// on a destroyed socket and could resurrect it via the engine).
+let onSuspend: (() => void) | null = null;
+let onResume: (() => void) | null = null;
 
 // ── Channel list for double-registration guard ───────────────────────────────
 // Byte-identical to the strings in preload.ts (IPC.SOCIAL_*), remote-shim.ts,
@@ -95,6 +101,20 @@ export function registerSocialHandlers(
     onEvent: broadcastPresenceEvent,
   });
   presenceSocket = presence;
+
+  // Sleep gate (see presence-socket.ts): close the presence socket the moment
+  // the OS suspends — the close frame gets out while the network is still up,
+  // so friends see "Last seen just now" instead of a ghost riding the server's
+  // staleness timeout — and reconnect on real wake. macOS dark wakes don't fire
+  // 'resume', so a lid-closed MacBook can't blip back online from maintenance
+  // wakes. Renderer intent (sign-in/incognito/leader) is preserved across the
+  // sleep cycle by the setDesired/setSuspended split.
+  if (onSuspend) powerMonitor.removeListener("suspend", onSuspend);
+  if (onResume) powerMonitor.removeListener("resume", onResume);
+  onSuspend = () => presence.setSuspended(true);
+  onResume = () => presence.setSuspended(false);
+  powerMonitor.on("suspend", onSuspend);
+  powerMonitor.on("resume", onResume);
 
   // One client instance shared across all handlers. getToken() is read lazily
   // per-request so sign-out takes effect immediately.

--- a/desktop/tests/presence-socket.test.ts
+++ b/desktop/tests/presence-socket.test.ts
@@ -205,6 +205,59 @@ describe('presence-socket state machine', () => {
     sock.destroy();
   });
 
+  it('system suspend closes the socket cleanly and resume reconnects (renderer intent preserved)', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+    expect(sock.isConnected()).toBe(true);
+
+    // Lid close / OS sleep → powerMonitor 'suspend'. The close frame must go
+    // out NOW (while the network is still up) so friends see "Last seen just
+    // now" immediately instead of waiting out the server's staleness timeout.
+    sock.setSuspended(true);
+    expect(inst.closeCalls).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: 'disconnected', reason: 'local' });
+    expect(sock.isConnected()).toBe(false);
+
+    // macOS dark wake: the process may briefly run while still "asleep" —
+    // no reconnect and no pings may fire ('resume' never fired).
+    vi.advanceTimersByTime(300_000);
+    expect(FakeSocket.instances).toHaveLength(1);
+    expect(inst.sent).toEqual([]);
+
+    // Real wake → powerMonitor 'resume': reconnect because the renderer still
+    // wants presence on.
+    sock.setSuspended(false);
+    expect(FakeSocket.instances).toHaveLength(2);
+    sock.destroy();
+  });
+
+  it('suspend respects renderer intent: off stays off across resume, and intent changes made while asleep win', () => {
+    const { sock } = makeSocket(() => 'tok');
+    // Renderer never asked for presence (signed out / incognito): suspend and
+    // resume must not conjure a connection.
+    sock.setSuspended(true);
+    sock.setSuspended(false);
+    expect(FakeSocket.instances).toHaveLength(0);
+
+    // Renderer turns presence ON while suspended (e.g. sign-in completes just
+    // as the lid closes): remembered, but no socket until resume.
+    sock.setSuspended(true);
+    sock.setDesired(true);
+    expect(FakeSocket.instances).toHaveLength(0);
+    sock.setSuspended(false);
+    expect(FakeSocket.instances).toHaveLength(1);
+
+    // Renderer turns presence OFF while suspended (incognito toggle mid-sleep):
+    // resume must NOT reconnect.
+    sock.setSuspended(true);
+    sock.setDesired(false);
+    sock.setSuspended(false);
+    expect(FakeSocket.instances).toHaveLength(1); // no new socket
+    sock.destroy();
+  });
+
   it('send is a silent no-op when disconnected; isConnected gates the honest handler receipt', () => {
     const { sock } = makeSocket(() => 'tok');
     // The manager itself no-ops; the HANDLER (social-handlers.ts) consults


### PR DESCRIPTION
Follow-up to #209 / the stuck-"Online" investigation, at Destin's direction: **a sleeping computer should not count as online.**

## Why the OS hook (not an in-app check)

During true sleep the process is frozen — it already can't ping. The two actual problems:
- **No goodbye at lid-close**: the socket died silently, so friends waited out the server's 10-min staleness timeout (and before tonight's server fix, forever).
- **macOS dark wakes**: maintenance wakes briefly run the process, enough to reconnect/ping and blip "Online" from inside a backpack.

`powerMonitor.on('suspend')` closes the socket **immediately, while the network is still up**, so the close frame reaches the server and friends see "Last seen just now". `'resume'` reconnects. Dark wakes never fire `'resume'`, so a lid-closed MacBook stays silent until a real wake. Works on Windows/Linux suspend too.

## Design

New `setSuspended()` on the presence manager, composed with `setDesired()` — renderer intent (sign-in / incognito / leader) is a separate axis and survives the sleep cycle, including intent changes made *while* asleep (sign-out mid-sleep → resume stays off). Hot-reload swaps the powerMonitor listener pair instead of stacking stale ones (a stale pair could resurrect a destroyed socket).

Android note: no equivalent needed there for now — Doze freezing the ping timer + server-side eviction covers the phone-asleep case once #209's ping ships; the deeper "service-alive vs user-present" question stays a design item.

## Verification

Two new state-machine tests (suspend/resume lifecycle; intent preservation), written first, watched fail. 3093 desktop tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)