### PR TITLE
feat(git): in-app git surface — per-file review, stage, commit, discard in the SessionDrawer

### DIFF
--- a/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
+++ b/app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt
@@ -3644,6 +3644,14 @@ class SessionService : Service() {
             }
             // artifacts:changed is a server-push event only — no inbound handler needed.
 
+            "git:file-status", "git:file-review", "git:commit-file-diff", "git:stage",
+            "git:unstage", "git:commit", "git:discard", "git:watch", "git:unwatch" -> {
+                // Git surface is desktop-only for now (spec 2026-07-22); the shared
+                // renderer hides the footer entry when these reject.
+                msg.id?.let { bridgeServer.respond(ws, msg.type, it,
+                    org.json.JSONObject().put("ok", false).put("error", "not-implemented-on-mobile")) }
+            }
+
             // Project View hub (conversations, repo, context) is desktop-only in v1
             // (see docs/superpowers/specs/2026-06-14-project-view-redesign-design.md).
             // Reply not-implemented so the shared React UI can degrade to an

--- a/desktop/src/main/git/git-exec.ts
+++ b/desktop/src/main/git/git-exec.ts
@@ -18,13 +18,29 @@ export interface GitExecResult {
 
 export async function execGit(cwd: string, args: string[]): Promise<GitExecResult> {
   try {
-    const { stdout, stderr } = await execFileP('git', args, {
+    // WHY: an app launched from a shell/hook that exports GIT_DIR, GIT_WORK_TREE
+    // or GIT_INDEX_FILE would have every git call below silently retarget at
+    // whatever repo/index those point to, instead of `cwd`. Strip them so this
+    // runner always operates on the repo it was actually asked about.
+    const env: NodeJS.ProcessEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
+    delete env.GIT_DIR;
+    delete env.GIT_WORK_TREE;
+    delete env.GIT_INDEX_FILE;
+    const { stdout, stderr } = await execFileP('git', [
+      // WHY: with the default core.quotepath=true, git C-quotes any filename
+      // with non-ASCII bytes in porcelain/numstat/log output (e.g. "café.md"
+      // becomes "caf\303\251.md"). That never matches the plain `rel` string
+      // this service compares paths against, so accented filenames silently
+      // fall out of status/diff/stage matching. Force it off on every call.
+      '-c', 'core.quotepath=false',
+      ...args,
+    ], {
       cwd,
       timeout: GIT_TIMEOUT_MS,
       maxBuffer: MAX_BUFFER,
       // Never let git prompt — a hung credential prompt would wedge the handler.
       // MVP operations are all local, so no credentials are ever needed.
-      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      env,
     });
     return { code: 0, stdout: String(stdout), stderr: String(stderr) };
   } catch (err: unknown) {

--- a/desktop/src/main/git/git-exec.ts
+++ b/desktop/src/main/git/git-exec.ts
@@ -1,0 +1,57 @@
+// Thin runner for the user's real repo. Deliberately NOT GitTransport
+// (sync-spaces/git-transport.ts): that class pins GIT_DIR to the hidden
+// .youcoded/sync.git and must never touch the user's own .git. Here we run
+// plain `git` with cwd only — the repo is whatever the user's project is.
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileP = promisify(execFile);
+
+const GIT_TIMEOUT_MS = 60_000;
+const MAX_BUFFER = 16 * 1024 * 1024; // large diffs; UnifiedDiff paginates client-side
+
+export interface GitExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export async function execGit(cwd: string, args: string[]): Promise<GitExecResult> {
+  try {
+    const { stdout, stderr } = await execFileP('git', args, {
+      cwd,
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: MAX_BUFFER,
+      // Never let git prompt — a hung credential prompt would wedge the handler.
+      // MVP operations are all local, so no credentials are ever needed.
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    return { code: 0, stdout: String(stdout), stderr: String(stderr) };
+  } catch (err: unknown) {
+    const e = err as { code?: number | string; stdout?: string; stderr?: string; message?: string };
+    if (typeof e.code === 'number') {
+      // git ran and exited nonzero — pass its real stderr through untouched
+      return { code: e.code, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+    }
+    // spawn failure (git not installed, ENOENT) or timeout kill
+    return { code: -1, stdout: '', stderr: e.stderr || e.message || String(err) };
+  }
+}
+
+// dir -> repo toplevel (or null). Cached: the footer asks on every artifact
+// switch and status refresh; rev-parse per keystroke would be wasteful.
+// Invalidated wholesale on git:changed (Task 5) — repos appear/vanish rarely.
+const rootCache = new Map<string, string | null>();
+
+export async function resolveRepoRoot(dir: string): Promise<string | null> {
+  const hit = rootCache.get(dir);
+  if (hit !== undefined) return hit;
+  const r = await execGit(dir, ['rev-parse', '--show-toplevel']);
+  const root = r.code === 0 ? r.stdout.trim() : null;
+  rootCache.set(dir, root);
+  return root;
+}
+
+export function invalidateRepoRootCache(): void {
+  rootCache.clear();
+}

--- a/desktop/src/main/git/git-service.ts
+++ b/desktop/src/main/git/git-service.ts
@@ -17,14 +17,21 @@ import type {
 export const LOG_PAGE = 20;
 const MAX_UNTRACKED_BYTES = 1024 * 1024; // beyond this, show as binary-style stub
 
-// %H = sha, %s = subject, %aI = author date ISO; 0x1f/0x1e separators survive
-// any subject content (newlines in subjects are impossible for %s).
-const LOG_FORMAT = '%H%x1f%s%x1f%aI%x1e';
+// %H = sha, %s = subject, %aI = author date ISO; 0x1f separates header fields,
+// LEADING 0x1e separates commits — rides with `--name-status` in the actual
+// `git log` call so each chunk also carries the file's historical path
+// (parseLogRecords reads it). Newlines in subjects are impossible for %s.
+const LOG_FORMAT = '%x1e%H%x1f%s%x1f%aI';
 
 interface Located {
   repoRoot: string;
   abs: string;
   rel: string; // repo-relative, posix separators
+  // Canonicalized project root (see the realpath WHY comment in locate()) —
+  // exposed so gitFileReview can convert each log entry's repo-relative
+  // pathAtCommit/renamedFrom into the project-root-relative form the
+  // renderer already works in, the same way `rel` does for the current path.
+  realProject: string;
 }
 
 function fail<T extends { ok: boolean; error?: string }>(base: Omit<T, 'ok' | 'error'>, error: string): T {
@@ -56,7 +63,7 @@ async function locate(projectRoot: string, relPath: string): Promise<Located | '
   const repoRoot = await resolveRepoRoot(realProject);
   if (!repoRoot) return null;
   const rel = path.relative(repoRoot, abs).split(path.sep).join('/');
-  return { repoRoot, abs, rel };
+  return { repoRoot, abs, rel, realProject };
 }
 
 const NOT_REPO: Omit<GitFileStatusResult, 'ok' | 'error'> = {
@@ -124,7 +131,7 @@ export async function gitFileReview(
   const loc = await locate(projectRoot, relPath);
   if (loc === 'outside') return fail<GitFileReviewResult>(base, 'path-outside-project');
   if (!loc) return { ok: true, ...base };
-  const { repoRoot, abs, rel } = loc;
+  const { repoRoot, abs, rel, realProject } = loc;
 
   // Whole-repo status: branch + this file's entry + the repo-wide staged count
   // (the commit button label counts everything a commit would include).
@@ -165,12 +172,26 @@ export async function gitFileReview(
 
   const skip = opts?.logSkip ?? 0;
   // Ask for one extra record purely to learn whether a next page exists.
+  // --name-status rides with the pathspec-limited log so parseLogRecords can
+  // read each commit's historical name for this file (see LOG_FORMAT WHY).
   const log = await execGit(repoRoot, [
     'log', '--follow', `--max-count=${LOG_PAGE + 1}`, `--skip=${skip}`,
-    `--pretty=format:${LOG_FORMAT}`, '--', rel,
+    `--pretty=format:${LOG_FORMAT}`, '--name-status', '--', rel,
   ]);
   // git log exits 0 with empty output for a path with no commits (e.g. untracked)
-  const entries = log.code === 0 ? parseLogRecords(log.stdout) : [];
+  const rawEntries = log.code === 0 ? parseLogRecords(log.stdout) : [];
+  // pathAtCommit/renamedFrom come back REPO-relative (git's own coordinate
+  // system); convert to project-root-relative so the renderer's calls stay
+  // consistent with `relPath`/`rel` everywhere else. No pathAtCommit (rare —
+  // a chunk with no name-status line) falls back to the file's current
+  // project-relative path. Deliberately NOT filtered for escaping the
+  // project root — see WHY at the fetch-time escape check in gitCommitFileDiff.
+  const toProjectRel = (p: string) => path.relative(realProject, path.resolve(repoRoot, p)).split(path.sep).join('/');
+  const entries = rawEntries.map((e) => ({
+    ...e,
+    pathAtCommit: e.pathAtCommit !== undefined ? toProjectRel(e.pathAtCommit) : relPath,
+    renamedFrom: e.renamedFrom !== undefined ? toProjectRel(e.renamedFrom) : undefined,
+  }));
   const hasMore = entries.length > LOG_PAGE;
 
   return {
@@ -180,7 +201,7 @@ export async function gitFileReview(
 }
 
 export async function gitCommitFileDiff(
-  projectRoot: string, sha: string, relPath: string,
+  projectRoot: string, sha: string, relPath: string, prevPath?: string,
 ): Promise<GitCommitFileDiffResult> {
   const loc = await locate(projectRoot, relPath);
   // 'outside' (path escaped the project root) and null (no repo found here) are
@@ -189,8 +210,26 @@ export async function gitCommitFileDiff(
   if (loc === 'outside') return { ok: false, error: 'path-outside-project', hunks: [], binary: false };
   if (!loc) return { ok: false, error: 'not-a-git-repository', hunks: [], binary: false };
   if (!/^[0-9a-f]{4,40}$/i.test(sha)) return { ok: false, error: 'invalid-sha', hunks: [], binary: false };
+  const args = ['show', sha, '--format='];
+  // WHY -M + the old pathspec: without pairing, `git show` on the commit that
+  // renamed/moved the file only shows the ADD side of the rename — the whole
+  // file rendered as a `+` wall, which reads like a rewrite. Passing both the
+  // old and new (repo-relative) paths with -M lets git detect the rename and
+  // answer with an honest rename-only diff (empty hunks when content didn't
+  // also change). If prevPath doesn't locate cleanly (escaped the project
+  // root, or resolves to no repo), degrade to the plain add-side view instead
+  // of erroring — pairing is a nicety, never a hard requirement to fetch.
+  let paired = false;
+  if (prevPath !== undefined) {
+    const prevLoc = await locate(projectRoot, prevPath);
+    if (prevLoc !== 'outside' && prevLoc !== null) {
+      args.push('-M', '--', loc.rel, prevLoc.rel);
+      paired = true;
+    }
+  }
   // --format= suppresses the commit header so output is pure diff.
-  const r = await execGit(loc.repoRoot, ['show', sha, '--format=', '--', loc.rel]);
+  if (!paired) args.push('--', loc.rel);
+  const r = await execGit(loc.repoRoot, args);
   if (r.code !== 0) return { ok: false, error: errText(r), hunks: [], binary: false };
   const { hunks, binary } = parseUnifiedDiff(r.stdout);
   // Empty hunks is a real state (merge commit / rename-only) — the card body

--- a/desktop/src/main/git/git-service.ts
+++ b/desktop/src/main/git/git-service.ts
@@ -36,12 +36,24 @@ function errText(r: { code: number; stderr: string }): string {
 }
 
 async function locate(projectRoot: string, relPath: string): Promise<Located | 'outside' | null> {
-  const abs = path.resolve(projectRoot, relPath);
-  const inProject = path.relative(projectRoot, abs);
+  // WHY realpath: `git rev-parse --show-toplevel` (via resolveRepoRoot below)
+  // always answers with the CANONICAL physical path. If the caller's
+  // projectRoot is a non-canonical alias of the same directory — macOS's
+  // os.tmpdir() is a /var -> /private/var symlink, Windows CI runners hand
+  // out 8.3 short names like C:\Users\RUNNER~1\... — then `path.relative`
+  // between the alias and the canonical repoRoot produces a garbage
+  // `../../...` path and every downstream git call fails as "outside
+  // repository". Canonicalize first so all path math agrees with git's own
+  // notion of the root. `.catch` falls through to the raw projectRoot for a
+  // path that doesn't exist (yet) — resolveRepoRoot then gives git's own
+  // honest "not a repository" answer instead of an ENOENT here.
+  const realProject = await fs.promises.realpath(projectRoot).catch(() => projectRoot);
+  const abs = path.resolve(realProject, relPath);
+  const inProject = path.relative(realProject, abs);
   // Defense in depth under the IPC known-root gate: an artifact path may never
   // escape its project root.
   if (inProject.startsWith('..') || path.isAbsolute(inProject)) return 'outside';
-  const repoRoot = await resolveRepoRoot(projectRoot);
+  const repoRoot = await resolveRepoRoot(realProject);
   if (!repoRoot) return null;
   const rel = path.relative(repoRoot, abs).split(path.sep).join('/');
   return { repoRoot, abs, rel };

--- a/desktop/src/main/git/git-service.ts
+++ b/desktop/src/main/git/git-service.ts
@@ -160,7 +160,11 @@ export async function gitCommitFileDiff(
   projectRoot: string, sha: string, relPath: string,
 ): Promise<GitCommitFileDiffResult> {
   const loc = await locate(projectRoot, relPath);
-  if (loc === 'outside' || !loc) return { ok: false, error: 'path-outside-project', hunks: [], binary: false };
+  // 'outside' (path escaped the project root) and null (no repo found here) are
+  // distinct, real states — collapsing them into one error would misreport a
+  // plain non-repo dir as a path-safety violation.
+  if (loc === 'outside') return { ok: false, error: 'path-outside-project', hunks: [], binary: false };
+  if (!loc) return { ok: false, error: 'not-a-git-repository', hunks: [], binary: false };
   if (!/^[0-9a-f]{4,40}$/i.test(sha)) return { ok: false, error: 'invalid-sha', hunks: [], binary: false };
   // --format= suppresses the commit header so output is pure diff.
   const r = await execGit(loc.repoRoot, ['show', sha, '--format=', '--', loc.rel]);
@@ -173,7 +177,11 @@ export async function gitCommitFileDiff(
 
 async function simpleOp(projectRoot: string, relPath: string, args: (rel: string) => string[]): Promise<GitOpResult> {
   const loc = await locate(projectRoot, relPath);
-  if (loc === 'outside' || !loc) return { ok: false, error: 'path-outside-project' };
+  // 'outside' (path escaped the project root) and null (no repo found here) are
+  // distinct, real states — collapsing them into one error would misreport a
+  // plain non-repo dir as a path-safety violation.
+  if (loc === 'outside') return { ok: false, error: 'path-outside-project' };
+  if (!loc) return { ok: false, error: 'not-a-git-repository' };
   const r = await execGit(loc.repoRoot, args(loc.rel));
   return r.code === 0 ? { ok: true } : { ok: false, error: errText(r) };
 }
@@ -210,7 +218,11 @@ export async function gitCommit(projectRoot: string, message: string): Promise<G
 
 export async function gitDiscard(projectRoot: string, relPath: string): Promise<GitOpResult> {
   const loc = await locate(projectRoot, relPath);
-  if (loc === 'outside' || !loc) return { ok: false, error: 'path-outside-project' };
+  // 'outside' (path escaped the project root) and null (no repo found here) are
+  // distinct, real states — collapsing them into one error would misreport a
+  // plain non-repo dir as a path-safety violation.
+  if (loc === 'outside') return { ok: false, error: 'path-outside-project' };
+  if (!loc) return { ok: false, error: 'not-a-git-repository' };
   const status = await execGit(loc.repoRoot, ['status', '--porcelain=v2', '--untracked-files=all', '--', loc.rel]);
   if (status.code !== 0) return { ok: false, error: errText(status) };
   const entry = parsePorcelainV2(status.stdout).files.find((f) => f.path === loc.rel);

--- a/desktop/src/main/git/git-service.ts
+++ b/desktop/src/main/git/git-service.ts
@@ -18,9 +18,10 @@ export const LOG_PAGE = 20;
 const MAX_UNTRACKED_BYTES = 1024 * 1024; // beyond this, show as binary-style stub
 
 // %H = sha, %s = subject, %aI = author date ISO; 0x1f separates header fields,
-// LEADING 0x1e separates commits — rides with `--name-status` in the actual
-// `git log` call so each chunk also carries the file's historical path
-// (parseLogRecords reads it). Newlines in subjects are impossible for %s.
+// LEADING 0x1e separates commits — rides with `--numstat` in the actual
+// `git log` call so each chunk also carries the file's historical path AND
+// its per-commit +/- counts (parseLogRecords reads both). Newlines in
+// subjects are impossible for %s.
 const LOG_FORMAT = '%x1e%H%x1f%s%x1f%aI';
 
 interface Located {
@@ -172,11 +173,12 @@ export async function gitFileReview(
 
   const skip = opts?.logSkip ?? 0;
   // Ask for one extra record purely to learn whether a next page exists.
-  // --name-status rides with the pathspec-limited log so parseLogRecords can
-  // read each commit's historical name for this file (see LOG_FORMAT WHY).
+  // --numstat rides with the pathspec-limited log so parseLogRecords can read
+  // each commit's historical name AND +/- counts for this file (see
+  // LOG_FORMAT WHY).
   const log = await execGit(repoRoot, [
     'log', '--follow', `--max-count=${LOG_PAGE + 1}`, `--skip=${skip}`,
-    `--pretty=format:${LOG_FORMAT}`, '--name-status', '--', rel,
+    `--pretty=format:${LOG_FORMAT}`, '--numstat', '--', rel,
   ]);
   // git log exits 0 with empty output for a path with no commits (e.g. untracked)
   const rawEntries = log.code === 0 ? parseLogRecords(log.stdout) : [];

--- a/desktop/src/main/git/git-service.ts
+++ b/desktop/src/main/git/git-service.ts
@@ -1,0 +1,236 @@
+// Git operations for the user's real repo (spec section 3). Every function is
+// projectRoot-scoped and answers with plain serializable objects; the IPC
+// handlers in ipc-handlers.ts add the known-root gate and broadcasting.
+import fs from 'fs';
+import path from 'path';
+import { shell } from 'electron';
+import { execGit, resolveRepoRoot } from './git-exec';
+import {
+  parsePorcelainV2, parseNumstat, parseLogRecords, parseUnifiedDiff,
+  countsFromHunks, synthesizeAddHunk,
+} from './porcelain';
+import type {
+  GitFileStatusResult, GitFileReviewResult, GitCommitFileDiffResult,
+  GitOpResult, GitUncommitted, GitFileCounts,
+} from '../../shared/git-types';
+
+export const LOG_PAGE = 20;
+const MAX_UNTRACKED_BYTES = 1024 * 1024; // beyond this, show as binary-style stub
+
+// %H = sha, %s = subject, %aI = author date ISO; 0x1f/0x1e separators survive
+// any subject content (newlines in subjects are impossible for %s).
+const LOG_FORMAT = '%H%x1f%s%x1f%aI%x1e';
+
+interface Located {
+  repoRoot: string;
+  abs: string;
+  rel: string; // repo-relative, posix separators
+}
+
+function fail<T extends { ok: boolean; error?: string }>(base: Omit<T, 'ok' | 'error'>, error: string): T {
+  return { ...(base as object), ok: false, error } as T;
+}
+
+function errText(r: { code: number; stderr: string }): string {
+  return r.stderr.trim() || `git exited with code ${r.code}`;
+}
+
+async function locate(projectRoot: string, relPath: string): Promise<Located | 'outside' | null> {
+  const abs = path.resolve(projectRoot, relPath);
+  const inProject = path.relative(projectRoot, abs);
+  // Defense in depth under the IPC known-root gate: an artifact path may never
+  // escape its project root.
+  if (inProject.startsWith('..') || path.isAbsolute(inProject)) return 'outside';
+  const repoRoot = await resolveRepoRoot(projectRoot);
+  if (!repoRoot) return null;
+  const rel = path.relative(repoRoot, abs).split(path.sep).join('/');
+  return { repoRoot, abs, rel };
+}
+
+const NOT_REPO: Omit<GitFileStatusResult, 'ok' | 'error'> = {
+  isRepo: false, branch: null, counts: null, hasHistory: false, staged: false,
+};
+
+// Counts for a file HEAD has no copy of (untracked / staged-new / unborn
+// HEAD): its whole content is the addition. Oversized or unreadable -> 0/0.
+async function worktreeAddCounts(abs: string): Promise<GitFileCounts> {
+  try {
+    const stat = await fs.promises.stat(abs);
+    if (stat.size > MAX_UNTRACKED_BYTES) return { added: 0, removed: 0 };
+    return countsFromHunks([synthesizeAddHunk(await fs.promises.readFile(abs, 'utf8'))]);
+  } catch { return { added: 0, removed: 0 }; }
+}
+
+export async function gitFileStatus(projectRoot: string, relPath: string): Promise<GitFileStatusResult> {
+  const loc = await locate(projectRoot, relPath);
+  if (loc === 'outside') return { ok: false, error: 'path-outside-project', ...NOT_REPO };
+  if (!loc) return { ok: true, ...NOT_REPO };
+  const { repoRoot, abs, rel } = loc;
+
+  const status = await execGit(repoRoot, ['status', '--porcelain=v2', '--branch', '--untracked-files=all', '--', rel]);
+  if (status.code !== 0) return { ok: false, error: errText(status), ...NOT_REPO };
+  const parsed = parsePorcelainV2(status.stdout);
+  const entry = parsed.files.find((f) => f.path === rel) ?? null;
+
+  let counts: GitFileStatusResult['counts'] = null;
+  if (entry?.untracked) {
+    counts = await worktreeAddCounts(abs);
+  } else if (entry) {
+    const num = await execGit(repoRoot, ['diff', '--numstat', 'HEAD', '--', rel]);
+    if (num.code === 0) {
+      const m = parseNumstat(num.stdout).get(rel);
+      counts = m ? { added: m.added, removed: m.removed } : { added: 0, removed: 0 };
+    } else {
+      // HEAD may be unborn (fresh git init, nothing committed yet) — the file
+      // is effectively all-new, so count its content as additions.
+      counts = await worktreeAddCounts(abs);
+    }
+  }
+
+  // Any commit touching this path? --max-count=1 keeps it O(first hit).
+  const hist = await execGit(repoRoot, ['rev-list', '--max-count=1', 'HEAD', '--', rel]);
+  const hasHistory = hist.code === 0 && hist.stdout.trim().length > 0;
+
+  return {
+    ok: true, isRepo: true, branch: parsed.branch, counts,
+    hasHistory, staged: entry?.staged ?? false,
+  };
+}
+
+export async function gitFileReview(
+  projectRoot: string, relPath: string, opts?: { logSkip?: number },
+): Promise<GitFileReviewResult> {
+  const base: Omit<GitFileReviewResult, 'ok' | 'error'> = {
+    isRepo: false, branch: null, uncommitted: null, log: [], hasMore: false, stagedCount: 0,
+  };
+  const loc = await locate(projectRoot, relPath);
+  if (loc === 'outside') return fail<GitFileReviewResult>(base, 'path-outside-project');
+  if (!loc) return { ok: true, ...base };
+  const { repoRoot, abs, rel } = loc;
+
+  // Whole-repo status: branch + this file's entry + the repo-wide staged count
+  // (the commit button label counts everything a commit would include).
+  const status = await execGit(repoRoot, ['status', '--porcelain=v2', '--branch', '--untracked-files=all']);
+  if (status.code !== 0) return fail<GitFileReviewResult>(base, errText(status));
+  const parsed = parsePorcelainV2(status.stdout);
+  const entry = parsed.files.find((f) => f.path === rel) ?? null;
+  const stagedCount = parsed.files.filter((f) => f.staged).length;
+
+  let uncommitted: GitUncommitted | null = null;
+  if (entry) {
+    // cat-file -e answers "does HEAD have a copy of this file?" — false for
+    // untracked, staged-new AND unborn-HEAD repos, which all render as pure
+    // additions (there is nothing to diff against).
+    const inHead = !entry.untracked
+      && (await execGit(repoRoot, ['cat-file', '-e', `HEAD:${rel}`])).code === 0;
+    if (!inHead) {
+      let hunks = [] as GitUncommitted['hunks'];
+      let binary = false;
+      try {
+        const stat = await fs.promises.stat(abs);
+        if (stat.size <= MAX_UNTRACKED_BYTES) hunks = [synthesizeAddHunk(await fs.promises.readFile(abs, 'utf8'))];
+        else binary = true;
+      } catch { binary = true; }
+      uncommitted = { hunks, counts: countsFromHunks(hunks), staged: entry.staged, untracked: entry.untracked, inHead: false, binary };
+    } else {
+      const diff = await execGit(repoRoot, ['diff', 'HEAD', '--', rel]);
+      if (diff.code !== 0) return fail<GitFileReviewResult>(base, errText(diff));
+      const { hunks, binary } = parseUnifiedDiff(diff.stdout);
+      uncommitted = { hunks, counts: countsFromHunks(hunks), staged: entry.staged, untracked: false, inHead: true, binary };
+    }
+  }
+
+  const skip = opts?.logSkip ?? 0;
+  // Ask for one extra record purely to learn whether a next page exists.
+  const log = await execGit(repoRoot, [
+    'log', '--follow', `--max-count=${LOG_PAGE + 1}`, `--skip=${skip}`,
+    `--pretty=format:${LOG_FORMAT}`, '--', rel,
+  ]);
+  // git log exits 0 with empty output for a path with no commits (e.g. untracked)
+  const entries = log.code === 0 ? parseLogRecords(log.stdout) : [];
+  const hasMore = entries.length > LOG_PAGE;
+
+  return {
+    ok: true, isRepo: true, branch: parsed.branch,
+    uncommitted, log: entries.slice(0, LOG_PAGE), hasMore, stagedCount,
+  };
+}
+
+export async function gitCommitFileDiff(
+  projectRoot: string, sha: string, relPath: string,
+): Promise<GitCommitFileDiffResult> {
+  const loc = await locate(projectRoot, relPath);
+  if (loc === 'outside' || !loc) return { ok: false, error: 'path-outside-project', hunks: [], binary: false };
+  if (!/^[0-9a-f]{4,40}$/i.test(sha)) return { ok: false, error: 'invalid-sha', hunks: [], binary: false };
+  // --format= suppresses the commit header so output is pure diff.
+  const r = await execGit(loc.repoRoot, ['show', sha, '--format=', '--', loc.rel]);
+  if (r.code !== 0) return { ok: false, error: errText(r), hunks: [], binary: false };
+  const { hunks, binary } = parseUnifiedDiff(r.stdout);
+  // Empty hunks is a real state (merge commit / rename-only) — the card body
+  // renders the "no direct changes" line, not an error.
+  return { ok: true, hunks, binary };
+}
+
+async function simpleOp(projectRoot: string, relPath: string, args: (rel: string) => string[]): Promise<GitOpResult> {
+  const loc = await locate(projectRoot, relPath);
+  if (loc === 'outside' || !loc) return { ok: false, error: 'path-outside-project' };
+  const r = await execGit(loc.repoRoot, args(loc.rel));
+  return r.code === 0 ? { ok: true } : { ok: false, error: errText(r) };
+}
+
+export function gitStage(projectRoot: string, relPath: string): Promise<GitOpResult> {
+  return simpleOp(projectRoot, relPath, (rel) => ['add', '--', rel]);
+}
+
+export async function gitUnstage(projectRoot: string, relPath: string): Promise<GitOpResult> {
+  const first = await simpleOp(projectRoot, relPath, (rel) => ['restore', '--staged', '--', rel]);
+  if (first.ok) return first;
+  // Unborn HEAD (repo with no commits): restore --staged cannot resolve HEAD.
+  // The equivalent unstage there is rm --cached, which leaves the worktree
+  // file untouched. Only fall back when HEAD verifiably does not resolve —
+  // any other failure keeps its real stderr.
+  const loc = await locate(projectRoot, relPath);
+  if (loc && loc !== 'outside') {
+    const head = await execGit(loc.repoRoot, ['rev-parse', '--verify', '--quiet', 'HEAD']);
+    if (head.code !== 0) {
+      const rm = await execGit(loc.repoRoot, ['rm', '--cached', '--force', '--', loc.rel]);
+      if (rm.code === 0) return { ok: true };
+    }
+  }
+  return first;
+}
+
+export async function gitCommit(projectRoot: string, message: string): Promise<GitOpResult> {
+  if (!message.trim()) return { ok: false, error: 'empty-commit-message' };
+  const repoRoot = await resolveRepoRoot(projectRoot);
+  if (!repoRoot) return { ok: false, error: 'not-a-git-repository' };
+  const r = await execGit(repoRoot, ['commit', '-m', message]);
+  return r.code === 0 ? { ok: true } : { ok: false, error: r.stderr.trim() || r.stdout.trim() || `git exited with code ${r.code}` };
+}
+
+export async function gitDiscard(projectRoot: string, relPath: string): Promise<GitOpResult> {
+  const loc = await locate(projectRoot, relPath);
+  if (loc === 'outside' || !loc) return { ok: false, error: 'path-outside-project' };
+  const status = await execGit(loc.repoRoot, ['status', '--porcelain=v2', '--untracked-files=all', '--', loc.rel]);
+  if (status.code !== 0) return { ok: false, error: errText(status) };
+  const entry = parsePorcelainV2(status.stdout).files.find((f) => f.path === loc.rel);
+  if (!entry) return { ok: true }; // nothing to discard — already clean
+  const trash = async (): Promise<GitOpResult> => {
+    // Recoverable OS-trash delete, never `git clean` (spec section 5).
+    try { await shell.trashItem(loc.abs); return { ok: true }; }
+    catch (e) { return { ok: false, error: e instanceof Error ? e.message : String(e) }; }
+  };
+  if (entry.untracked) return trash();
+  const inHead = (await execGit(loc.repoRoot, ['cat-file', '-e', `HEAD:${loc.rel}`])).code === 0;
+  if (!inHead) {
+    // Staged-new (or unborn HEAD): there is no committed copy to restore, and
+    // `checkout HEAD` would fail with a pathspec error. Unstage with
+    // rm --cached (works before the first commit too), then trash.
+    const rm = await execGit(loc.repoRoot, ['rm', '--cached', '--force', '--', loc.rel]);
+    if (rm.code !== 0) return { ok: false, error: errText(rm) };
+    return trash();
+  }
+  // Tracked with a HEAD copy: restore BOTH index and worktree copy to HEAD.
+  const r = await execGit(loc.repoRoot, ['checkout', 'HEAD', '--', loc.rel]);
+  return r.code === 0 ? { ok: true } : { ok: false, error: errText(r) };
+}

--- a/desktop/src/main/git/git-service.ts
+++ b/desktop/src/main/git/git-service.ts
@@ -55,8 +55,14 @@ const NOT_REPO: Omit<GitFileStatusResult, 'ok' | 'error'> = {
 // HEAD): its whole content is the addition. Oversized or unreadable -> 0/0.
 async function worktreeAddCounts(abs: string): Promise<GitFileCounts> {
   try {
-    const stat = await fs.promises.stat(abs);
-    if (stat.size > MAX_UNTRACKED_BYTES) return { added: 0, removed: 0 };
+    // WHY lstat not stat: stat follows symlinks, so an untracked symlink
+    // pointing outside the repo root (e.g. at /etc/passwd) would have its
+    // TARGET's content read and counted, bypassing the realpath enforcement
+    // the rest of the artifact-read surface relies on (see
+    // write-authorization.ts's symlink-following threat model). Treat any
+    // non-regular-file entry as the existing binary-stub shape.
+    const stat = await fs.promises.lstat(abs);
+    if (!stat.isFile() || stat.size > MAX_UNTRACKED_BYTES) return { added: 0, removed: 0 };
     return countsFromHunks([synthesizeAddHunk(await fs.promises.readFile(abs, 'utf8'))]);
   } catch { return { added: 0, removed: 0 }; }
 }
@@ -127,8 +133,13 @@ export async function gitFileReview(
       let hunks = [] as GitUncommitted['hunks'];
       let binary = false;
       try {
-        const stat = await fs.promises.stat(abs);
-        if (stat.size <= MAX_UNTRACKED_BYTES) hunks = [synthesizeAddHunk(await fs.promises.readFile(abs, 'utf8'))];
+        // WHY lstat not stat: see worktreeAddCounts above — following a
+        // symlink here would read and diff its TARGET's content (possibly
+        // outside the repo), not the symlink itself. Non-regular files render
+        // as the existing binary stub, same as an oversized file.
+        const stat = await fs.promises.lstat(abs);
+        if (!stat.isFile()) binary = true;
+        else if (stat.size <= MAX_UNTRACKED_BYTES) hunks = [synthesizeAddHunk(await fs.promises.readFile(abs, 'utf8'))];
         else binary = true;
       } catch { binary = true; }
       uncommitted = { hunks, counts: countsFromHunks(hunks), staged: entry.staged, untracked: entry.untracked, inHead: false, binary };

--- a/desktop/src/main/git/git-watcher.ts
+++ b/desktop/src/main/git/git-watcher.ts
@@ -42,11 +42,27 @@ export function watchGit(repoRoot: string, subscriberId: number): { ok: boolean 
         emit?.({ repoRoot });
       }, DEBOUNCE_MS);
     };
+    // WHY: fs.watch's FSWatcher is an EventEmitter, and it emits 'error' (not
+    // just throw) when its watched target vanishes out from under it — repo
+    // deleted, `git worktree remove`, or anything else that surgeries .git
+    // while we're subscribed. An EventEmitter with zero 'error' listeners
+    // throws an uncaught exception that crashes the whole Electron main
+    // process. Tear this root's entry down the same way unwatch/drop do, so
+    // the app self-heals: the next watchGit() for this root goes back
+    // through the existsSync check above and correctly reports {ok:false}.
+    const onWatcherError = () => {
+      // Guard against a stale watcher's error arriving after this entry was
+      // already replaced (e.g. a fresh watchGit() re-created it) — only tear
+      // down if we're still the current entry for this root.
+      if (entries.get(repoRoot) === created) closeEntry(repoRoot, created);
+    };
     // Watching the DIRECTORIES catches create/replace of direct children —
     // git rewrites HEAD/index atomically via rename, which a file-watch loses.
     for (const target of [gitDir, path.join(gitDir, 'refs', 'heads')]) {
       try {
-        created.watchers.push(fs.watch(target, fire));
+        const watcher = fs.watch(target, fire);
+        watcher.on('error', onWatcherError);
+        created.watchers.push(watcher);
       } catch {
         // refs/heads may not exist yet in a repo with no commits — HEAD watch
         // still covers the state change when the first commit creates it.

--- a/desktop/src/main/git/git-watcher.ts
+++ b/desktop/src/main/git/git-watcher.ts
@@ -1,0 +1,86 @@
+// WHY this exists: the chokidar project watcher (artifacts/project-watcher.ts)
+// deliberately ignores dot-directories, so commits, checkouts and staging —
+// which only touch .git/ — are invisible to it. This tiny fs.watch on the
+// .git dir (HEAD + index live there) and .git/refs/heads keeps the git
+// surface honest when the agent or a terminal moves git state underneath it.
+// Same refcount model as project-watcher: N renderers x M roots.
+import fs from 'fs';
+import path from 'path';
+
+export interface GitWatchEvent {
+  repoRoot: string;
+}
+
+type Emit = (evt: GitWatchEvent) => void;
+
+const DEBOUNCE_MS = 300;
+
+interface Entry {
+  watchers: fs.FSWatcher[];
+  refs: Map<number, number>; // subscriberId -> refcount
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+let emit: Emit | null = null;
+const entries = new Map<string, Entry>();
+
+export function initGitWatchers(cb: Emit): void {
+  emit = cb;
+}
+
+export function watchGit(repoRoot: string, subscriberId: number): { ok: boolean } {
+  let entry = entries.get(repoRoot);
+  if (!entry) {
+    const gitDir = path.join(repoRoot, '.git');
+    if (!fs.existsSync(gitDir)) return { ok: false };
+    const created: Entry = { watchers: [], refs: new Map(), timer: null };
+    const fire = () => {
+      // Debounce: one commit touches index, HEAD and a ref within milliseconds.
+      if (created.timer) clearTimeout(created.timer);
+      created.timer = setTimeout(() => {
+        created.timer = null;
+        emit?.({ repoRoot });
+      }, DEBOUNCE_MS);
+    };
+    // Watching the DIRECTORIES catches create/replace of direct children —
+    // git rewrites HEAD/index atomically via rename, which a file-watch loses.
+    for (const target of [gitDir, path.join(gitDir, 'refs', 'heads')]) {
+      try {
+        created.watchers.push(fs.watch(target, fire));
+      } catch {
+        // refs/heads may not exist yet in a repo with no commits — HEAD watch
+        // still covers the state change when the first commit creates it.
+      }
+    }
+    if (created.watchers.length === 0) return { ok: false };
+    entries.set(repoRoot, created);
+    entry = created;
+  }
+  entry.refs.set(subscriberId, (entry.refs.get(subscriberId) ?? 0) + 1);
+  return { ok: true };
+}
+
+function closeEntry(repoRoot: string, entry: Entry): void {
+  if (entry.timer) clearTimeout(entry.timer);
+  for (const w of entry.watchers) w.close();
+  entries.delete(repoRoot);
+}
+
+export function unwatchGit(repoRoot: string, subscriberId: number): void {
+  const entry = entries.get(repoRoot);
+  if (!entry) return;
+  const n = (entry.refs.get(subscriberId) ?? 0) - 1;
+  if (n > 0) entry.refs.set(subscriberId, n);
+  else entry.refs.delete(subscriberId);
+  if (entry.refs.size === 0) closeEntry(repoRoot, entry);
+}
+
+export function dropGitSubscriber(subscriberId: number): void {
+  for (const [root, entry] of entries) {
+    if (entry.refs.delete(subscriberId) && entry.refs.size === 0) closeEntry(root, entry);
+  }
+}
+
+export function closeAllGitWatchers(): void {
+  for (const [root, entry] of entries) closeEntry(root, entry);
+}

--- a/desktop/src/main/git/git-watcher.ts
+++ b/desktop/src/main/git/git-watcher.ts
@@ -28,11 +28,46 @@ export function initGitWatchers(cb: Emit): void {
   emit = cb;
 }
 
+// WHY: for a LINKED worktree (`git worktree add`), <repoRoot>/.git is not a
+// directory — it's a file containing a single line `gitdir: <path>` pointing
+// at <main-repo>/.git/worktrees/<name>/. HEAD and the index for that
+// worktree live under THAT directory, not under <repoRoot>/.git itself, and
+// refs/heads is shared and lives under the main repo's real .git (found via
+// that dir's `commondir` file, which may itself be a relative path). Without
+// this resolution, fs.watch would watch the plain gitdir FILE (never fires
+// for a commit) and the refs/heads watch would throw on a path that doesn't
+// exist there, leaving watchGit lying with {ok:true} on a dead watcher.
+function resolveGitDirs(repoRoot: string): { gitDir: string; refsHeadsDir: string } | null {
+  const dotGit = path.join(repoRoot, '.git');
+  let stat: fs.Stats;
+  try { stat = fs.statSync(dotGit); } catch { return null; }
+  if (stat.isDirectory()) {
+    return { gitDir: dotGit, refsHeadsDir: path.join(dotGit, 'refs', 'heads') };
+  }
+  if (!stat.isFile()) return null;
+  let contents: string;
+  try { contents = fs.readFileSync(dotGit, 'utf8'); } catch { return null; }
+  const m = /^gitdir:\s*(.+?)\s*$/m.exec(contents);
+  if (!m) return null;
+  const gitDir = path.isAbsolute(m[1]) ? m[1] : path.resolve(repoRoot, m[1]);
+  if (!fs.existsSync(gitDir)) return null;
+  // commondir holds the path (often relative, resolved against gitDir) to the
+  // real .git that refs/heads lives under — shared across all linked worktrees.
+  const commondirFile = path.join(gitDir, 'commondir');
+  let commonDir = gitDir;
+  try {
+    const raw = fs.readFileSync(commondirFile, 'utf8').trim();
+    commonDir = path.isAbsolute(raw) ? raw : path.resolve(gitDir, raw);
+  } catch { /* no commondir -> this IS the main repo's gitdir (shouldn't happen for a file .git, but degrade gracefully) */ }
+  return { gitDir, refsHeadsDir: path.join(commonDir, 'refs', 'heads') };
+}
+
 export function watchGit(repoRoot: string, subscriberId: number): { ok: boolean } {
   let entry = entries.get(repoRoot);
   if (!entry) {
-    const gitDir = path.join(repoRoot, '.git');
-    if (!fs.existsSync(gitDir)) return { ok: false };
+    const dirs = resolveGitDirs(repoRoot);
+    if (!dirs) return { ok: false };
+    const { gitDir, refsHeadsDir } = dirs;
     const created: Entry = { watchers: [], refs: new Map(), timer: null };
     const fire = () => {
       // Debounce: one commit touches index, HEAD and a ref within milliseconds.
@@ -49,7 +84,7 @@ export function watchGit(repoRoot: string, subscriberId: number): { ok: boolean 
     // throws an uncaught exception that crashes the whole Electron main
     // process. Tear this root's entry down the same way unwatch/drop do, so
     // the app self-heals: the next watchGit() for this root goes back
-    // through the existsSync check above and correctly reports {ok:false}.
+    // through resolveGitDirs above and correctly reports {ok:false}.
     const onWatcherError = () => {
       // Guard against a stale watcher's error arriving after this entry was
       // already replaced (e.g. a fresh watchGit() re-created it) — only tear
@@ -58,7 +93,9 @@ export function watchGit(repoRoot: string, subscriberId: number): { ok: boolean 
     };
     // Watching the DIRECTORIES catches create/replace of direct children —
     // git rewrites HEAD/index atomically via rename, which a file-watch loses.
-    for (const target of [gitDir, path.join(gitDir, 'refs', 'heads')]) {
+    // gitDir (HEAD + index) and refsHeadsDir (branch ref updates) may be two
+    // different directories for a linked worktree — see resolveGitDirs above.
+    for (const target of [gitDir, refsHeadsDir]) {
       try {
         const watcher = fs.watch(target, fire);
         watcher.on('error', onWatcherError);

--- a/desktop/src/main/git/ipc-channels.ts
+++ b/desktop/src/main/git/ipc-channels.ts
@@ -1,0 +1,17 @@
+// IPC channel constants for the git surface (spec 2026-07-22).
+// Comment rule: never put a single-quoted string inside a comment in this
+// file family — parity tests harvest every quoted token as a channel name.
+export const GIT_IPC = {
+  FILE_STATUS: 'git:file-status',
+  FILE_REVIEW: 'git:file-review',
+  COMMIT_FILE_DIFF: 'git:commit-file-diff',
+  STAGE: 'git:stage',
+  UNSTAGE: 'git:unstage',
+  COMMIT: 'git:commit',
+  DISCARD: 'git:discard',
+  WATCH: 'git:watch',
+  UNWATCH: 'git:unwatch',
+  CHANGED: 'git:changed',
+} as const;
+
+export type GitIpcChannel = typeof GIT_IPC[keyof typeof GIT_IPC];

--- a/desktop/src/main/git/porcelain.ts
+++ b/desktop/src/main/git/porcelain.ts
@@ -1,0 +1,124 @@
+// Pure parsers for git plumbing output. No I/O, no electron imports — every
+// function takes strings so the whole module unit-tests with fixtures.
+// Spec: docs/active/specs/2026-07-22-git-surface.md section 3.
+import type { StructuredPatchHunk } from '../../shared/types';
+import type { GitFileCounts, GitLogEntry } from '../../shared/git-types';
+
+export interface PorcelainEntry {
+  path: string;
+  staged: boolean;
+  unstaged: boolean;
+  untracked: boolean;
+  kind: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked';
+}
+
+// git status --porcelain=v2 --branch. Line shapes we consume:
+//   # branch.head <name>          (name is "(detached)" when detached)
+//   1 XY ... <path>               (ordinary change; X=index, Y=worktree, "." = unchanged)
+//   2 XY ... <path>\t<origPath>   (rename/copy)
+//   ? <path>                      (untracked)
+export function parsePorcelainV2(text: string): { branch: string | null; files: PorcelainEntry[] } {
+  let branch: string | null = null;
+  const files: PorcelainEntry[] = [];
+  for (const line of text.split('\n')) {
+    if (line.startsWith('# branch.head ')) {
+      const name = line.slice('# branch.head '.length).trim();
+      branch = name === '(detached)' ? null : name;
+    } else if (line.startsWith('1 ') || line.startsWith('2 ')) {
+      const xy = line.slice(2, 4);
+      // Fields are space-separated; the path is everything after the 8th field
+      // (v2 format is fixed-width up to the path). Renames append "\t<orig>".
+      const fieldCount = line.startsWith('2 ') ? 9 : 8;
+      const parts = line.split(' ');
+      const rawPath = parts.slice(fieldCount).join(' ');
+      const p = rawPath.split('\t')[0];
+      const staged = xy[0] !== '.';
+      const unstaged = xy[1] !== '.';
+      const kind =
+        xy.includes('R') ? 'renamed'
+        : xy.includes('A') ? 'added'
+        : xy.includes('D') ? 'deleted'
+        : 'modified';
+      files.push({ path: p, staged, unstaged, untracked: false, kind });
+    } else if (line.startsWith('? ')) {
+      files.push({ path: line.slice(2), staged: false, unstaged: true, untracked: true, kind: 'untracked' });
+    }
+  }
+  return { branch, files };
+}
+
+// git diff --numstat: "<added>\t<removed>\t<path>"; binary files show "-\t-".
+export function parseNumstat(text: string): Map<string, { added: number; removed: number; binary: boolean }> {
+  const out = new Map<string, { added: number; removed: number; binary: boolean }>();
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    const [a, r, ...rest] = line.split('\t');
+    const p = rest.join('\t');
+    if (!p) continue;
+    if (a === '-' || r === '-') out.set(p, { added: 0, removed: 0, binary: true });
+    else out.set(p, { added: parseInt(a, 10) || 0, removed: parseInt(r, 10) || 0, binary: false });
+  }
+  return out;
+}
+
+// git log --pretty=format:%H%x1f%s%x1f%aI%x1e — unit sep 0x1f, record sep 0x1e.
+// Chosen over newline parsing so commit subjects can contain anything.
+export function parseLogRecords(text: string): GitLogEntry[] {
+  return text
+    .split('\x1e')
+    .map((rec) => rec.replace(/^\n/, ''))
+    .filter((rec) => rec.trim().length > 0)
+    .map((rec) => {
+      const [sha, subject, authorDate] = rec.split('\x1f');
+      return { sha, shortSha: sha.slice(0, 7), subject: subject ?? '', authorDate: authorDate ?? '' };
+    });
+}
+
+// Unified diff -> StructuredPatchHunk[] (absolute file line numbers, the shape
+// UnifiedDiff.tsx already renders for tool cards). "@@ -a[,b] +c[,d] @@".
+const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export function parseUnifiedDiff(text: string): { hunks: StructuredPatchHunk[]; binary: boolean } {
+  const hunks: StructuredPatchHunk[] = [];
+  let binary = false;
+  let current: StructuredPatchHunk | null = null;
+  for (const line of text.split('\n')) {
+    const m = HUNK_RE.exec(line);
+    if (m) {
+      current = {
+        oldStart: parseInt(m[1], 10),
+        oldLines: m[2] !== undefined ? parseInt(m[2], 10) : 1,
+        newStart: parseInt(m[3], 10),
+        newLines: m[4] !== undefined ? parseInt(m[4], 10) : 1,
+        lines: [],
+      };
+      hunks.push(current);
+      continue;
+    }
+    if (/^Binary files .* differ$/.test(line)) { binary = true; continue; }
+    if (current && (line.startsWith(' ') || line.startsWith('+') || line.startsWith('-'))) {
+      // "\ No newline at end of file" starts with backslash and is skipped.
+      current.lines.push(line);
+    } else if (line.startsWith('diff ') || line.startsWith('--- ') || line.startsWith('+++ ')) {
+      current = null; // next file section header — stop appending to the old hunk
+    }
+  }
+  return { hunks, binary };
+}
+
+export function countsFromHunks(hunks: StructuredPatchHunk[]): GitFileCounts {
+  let added = 0;
+  let removed = 0;
+  for (const h of hunks) for (const l of h.lines) {
+    if (l.startsWith('+')) added++;
+    else if (l.startsWith('-')) removed++;
+  }
+  return { added, removed };
+}
+
+// An untracked file has no diff vs HEAD; render it as one all-additions hunk.
+export function synthesizeAddHunk(content: string): StructuredPatchHunk {
+  const lines = content.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop(); // trailing terminator, not a line
+  return { oldStart: 0, oldLines: 0, newStart: 1, newLines: lines.length, lines: lines.map((l) => '+' + l) };
+}

--- a/desktop/src/main/git/porcelain.ts
+++ b/desktop/src/main/git/porcelain.ts
@@ -61,16 +61,42 @@ export function parseNumstat(text: string): Map<string, { added: number; removed
   return out;
 }
 
-// git log --pretty=format:%H%x1f%s%x1f%aI%x1e — unit sep 0x1f, record sep 0x1e.
+// git log --pretty=format:%x1e%H%x1f%s%x1f%aI --name-status — unit sep 0x1f
+// between header fields, LEADING record sep 0x1e before each commit (so
+// splitting on it always drops an empty first chunk, never a trailing one).
 // Chosen over newline parsing so commit subjects can contain anything.
+// `--name-status` rides along, pathspec-limited to the followed file, so each
+// chunk after the header line carries at most one status line for it — that's
+// how per-commit diffs learn the file's HISTORICAL path (see GitLogEntry).
 export function parseLogRecords(text: string): GitLogEntry[] {
   return text
     .split('\x1e')
-    .map((rec) => rec.replace(/^\n/, ''))
     .filter((rec) => rec.trim().length > 0)
     .map((rec) => {
-      const [sha, subject, authorDate] = rec.split('\x1f');
-      return { sha, shortSha: sha.slice(0, 7), subject: subject ?? '', authorDate: authorDate ?? '' };
+      const lines = rec.split('\n');
+      const [sha, subject, authorDate] = lines[0].split('\x1f');
+      let pathAtCommit: string | undefined;
+      let renamedFrom: string | undefined;
+      // First non-blank line after the header is the name-status entry for
+      // the followed file (pathspec-limited to one file, so there's at most
+      // one). No such line at all (e.g. a surfaced merge commit) -> both
+      // stay undefined, and the caller falls back to the file's current path.
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim()) continue;
+        const fields = line.split('\t');
+        // Last tab field is always the path as of this commit: for M/A/D
+        // that's fields[1]; for R<score>/C<score> (old\tnew) it's the new
+        // name, which for THIS commit is correct — that's the name the file
+        // was renamed/copied TO.
+        pathAtCommit = fields[fields.length - 1];
+        if (fields[0][0] === 'R' || fields[0][0] === 'C') renamedFrom = fields[1];
+        break;
+      }
+      return {
+        sha, shortSha: sha.slice(0, 7), subject: subject ?? '', authorDate: authorDate ?? '',
+        pathAtCommit, renamedFrom,
+      };
     });
 }
 

--- a/desktop/src/main/git/porcelain.ts
+++ b/desktop/src/main/git/porcelain.ts
@@ -71,6 +71,13 @@ export function parseNumstat(text: string): Map<string, { added: number; removed
 //     collapse it back to one.
 //   - plain form, when there's no common affix: "old.md => new.md".
 // Extracted as its own pure function so each shape unit-tests directly.
+//
+// ACCEPTED LIMITATION: a real filename containing a literal " => " is
+// indistinguishable from a rename in git's human-readable numstat output and
+// will be misread as one. Consequence is display-only; the misread path still
+// passes the full path gate at fetch time. Proper fix is the planned
+// `--numstat -z` migration where rename paths arrive as separate
+// NUL-delimited fields.
 export function parseRenamePath(field: string): { path: string; renamedFrom?: string } {
   const brace = /^(.*?)\{(.*) => (.*)\}(.*)$/.exec(field);
   if (brace) {

--- a/desktop/src/main/git/porcelain.ts
+++ b/desktop/src/main/git/porcelain.ts
@@ -61,13 +61,41 @@ export function parseNumstat(text: string): Map<string, { added: number; removed
   return out;
 }
 
-// git log --pretty=format:%x1e%H%x1f%s%x1f%aI --name-status — unit sep 0x1f
+// A `--numstat` pathfield for a renamed/moved file comes in one of two
+// shapes (plain paths with no " => " at all just pass through unchanged):
+//   - brace form, when old and new share a common prefix/suffix:
+//     "docs/{superpowers => archive}/plans/x.md" -> old "docs/superpowers/…",
+//     new "docs/archive/…". Either side of the brace may be empty (a segment
+//     was purely inserted/removed, e.g. "dir/{ => sub}/f.md") — concatenating
+//     prefix+mid+suffix then leaves a doubled '/' where the empty mid sat;
+//     collapse it back to one.
+//   - plain form, when there's no common affix: "old.md => new.md".
+// Extracted as its own pure function so each shape unit-tests directly.
+export function parseRenamePath(field: string): { path: string; renamedFrom?: string } {
+  const brace = /^(.*?)\{(.*) => (.*)\}(.*)$/.exec(field);
+  if (brace) {
+    const [, prefix, oldMid, newMid, suffix] = brace;
+    const collapse = (s: string) => s.replace(/\/{2,}/g, '/');
+    return {
+      path: collapse(prefix + newMid + suffix),
+      renamedFrom: collapse(prefix + oldMid + suffix),
+    };
+  }
+  const arrow = field.indexOf(' => ');
+  if (arrow !== -1) {
+    return { path: field.slice(arrow + 4), renamedFrom: field.slice(0, arrow) };
+  }
+  return { path: field };
+}
+
+// git log --pretty=format:%x1e%H%x1f%s%x1f%aI --numstat — unit sep 0x1f
 // between header fields, LEADING record sep 0x1e before each commit (so
 // splitting on it always drops an empty first chunk, never a trailing one).
 // Chosen over newline parsing so commit subjects can contain anything.
-// `--name-status` rides along, pathspec-limited to the followed file, so each
-// chunk after the header line carries at most one status line for it — that's
-// how per-commit diffs learn the file's HISTORICAL path (see GitLogEntry).
+// `--numstat` rides along, pathspec-limited to the followed file, so each
+// chunk after the header line carries at most one numstat line for it —
+// that's how per-commit diffs learn the file's HISTORICAL path (see
+// GitLogEntry) AND how the card headers learn this commit's +/- counts.
 export function parseLogRecords(text: string): GitLogEntry[] {
   return text
     .split('\x1e')
@@ -77,25 +105,28 @@ export function parseLogRecords(text: string): GitLogEntry[] {
       const [sha, subject, authorDate] = lines[0].split('\x1f');
       let pathAtCommit: string | undefined;
       let renamedFrom: string | undefined;
-      // First non-blank line after the header is the name-status entry for
-      // the followed file (pathspec-limited to one file, so there's at most
-      // one). No such line at all (e.g. a surfaced merge commit) -> both
-      // stay undefined, and the caller falls back to the file's current path.
+      let counts: GitFileCounts | null = null;
+      // First non-blank line after the header is the numstat entry for the
+      // followed file (pathspec-limited to one file, so there's at most
+      // one). No such line at all (e.g. a surfaced merge commit) -> path
+      // fields stay undefined and counts stays null; the caller falls back
+      // to the file's current path.
       for (let i = 1; i < lines.length; i++) {
         const line = lines[i];
         if (!line.trim()) continue;
-        const fields = line.split('\t');
-        // Last tab field is always the path as of this commit: for M/A/D
-        // that's fields[1]; for R<score>/C<score> (old\tnew) it's the new
-        // name, which for THIS commit is correct — that's the name the file
-        // was renamed/copied TO.
-        pathAtCommit = fields[fields.length - 1];
-        if (fields[0][0] === 'R' || fields[0][0] === 'C') renamedFrom = fields[1];
+        const [addedStr, removedStr, ...rest] = line.split('\t');
+        const parsed = parseRenamePath(rest.join('\t'));
+        pathAtCommit = parsed.path;
+        renamedFrom = parsed.renamedFrom;
+        // Binary numstat rows are "-\t-\t<path>" — no line counts to show.
+        counts = addedStr === '-' || removedStr === '-'
+          ? null
+          : { added: parseInt(addedStr, 10) || 0, removed: parseInt(removedStr, 10) || 0 };
         break;
       }
       return {
         sha, shortSha: sha.slice(0, 7), subject: subject ?? '', authorDate: authorDate ?? '',
-        pathAtCommit, renamedFrom,
+        pathAtCommit, renamedFrom, counts,
       };
     });
 }

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -90,6 +90,13 @@ import { searchProjectContent } from './artifacts/content-search';
 import { looksBinary, EDIT_MAX_BYTES } from '../shared/artifacts/editable-path-policy';
 import { authorizeArtifactRead, authorizeArtifactWrite } from './artifacts/write-authorization';
 import { trackedArtifacts } from './artifacts/visible-artifacts';
+import { GIT_IPC } from './git/ipc-channels';
+import {
+  gitFileStatus, gitFileReview, gitCommitFileDiff,
+  gitStage, gitUnstage, gitCommit, gitDiscard,
+} from './git/git-service';
+import { initGitWatchers, watchGit, unwatchGit, dropGitSubscriber } from './git/git-watcher';
+import { resolveRepoRoot, invalidateRepoRootCache } from './git/git-exec';
 import { PROJECT_IPC } from './project/ipc-channels';
 import { listProjectConversations, projectConversationHistory, ccProjectSlug } from './project-conversations';
 // Conversation Store (Phase 2a): live intake of transcript activity, session
@@ -3255,6 +3262,84 @@ export function registerIpcHandlers(
     unwatchProject(projectRoot, e.sender.id);
     return { ok: true };
   });
+
+  // ── Git surface (spec docs/active/specs/2026-07-22-git-surface.md) ──
+  // Known-roots gate: a git operation may only target a saved folder or an
+  // indexed project root — same allow-list the read-binary guard builds.
+  const knownGitRoot = async (projectRoot: unknown): Promise<boolean> => {
+    if (typeof projectRoot !== 'string' || projectRoot.length === 0) return false;
+    const canon = canonicalize(projectRoot, null);
+    const roots = [
+      ...readFolders().map((f) => canonicalize(f.path, null)),
+      ...(await listProjects(CLAUDE_DIR)).map((p) => canonicalize(p.path, null)),
+    ];
+    return roots.includes(canon);
+  };
+  const gitGate = async <T extends object>(projectRoot: unknown, blocked: T, run: () => Promise<T>): Promise<T> => {
+    if (!(await knownGitRoot(projectRoot))) return blocked;
+    return run();
+  };
+  const broadcastGitChanged = (repoRoot: string) => {
+    // Commits and checkouts can create or retarget repos — drop the cache so
+    // the next footer query re-resolves.
+    invalidateRepoRootCache();
+    webContents.getAllWebContents().forEach((wc) => wc.send(GIT_IPC.CHANGED, { repoRoot }));
+  };
+
+  initGitWatchers((evt) => broadcastGitChanged(evt.repoRoot));
+
+  ipcMain.handle(GIT_IPC.FILE_STATUS, (_e, projectRoot: string, relPath: string) =>
+    gitGate(projectRoot, { ok: false, error: 'unknown-project-root', isRepo: false, branch: null, counts: null, hasHistory: false, staged: false },
+      () => gitFileStatus(projectRoot, relPath)));
+
+  ipcMain.handle(GIT_IPC.FILE_REVIEW, (_e, projectRoot: string, relPath: string, opts?: { logSkip?: number }) =>
+    gitGate(projectRoot, { ok: false, error: 'unknown-project-root', isRepo: false, branch: null, uncommitted: null, log: [], hasMore: false, stagedCount: 0 },
+      () => gitFileReview(projectRoot, relPath, opts)));
+
+  ipcMain.handle(GIT_IPC.COMMIT_FILE_DIFF, (_e, projectRoot: string, sha: string, relPath: string) =>
+    gitGate(projectRoot, { ok: false, error: 'unknown-project-root', hunks: [], binary: false },
+      () => gitCommitFileDiff(projectRoot, sha, relPath)));
+
+  const mutating = async (projectRoot: string, run: () => Promise<{ ok: boolean; error?: string }>) =>
+    gitGate(projectRoot, { ok: false, error: 'unknown-project-root' }, async () => {
+      const result = await run();
+      if (result.ok) {
+        const repoRoot = await resolveRepoRoot(projectRoot);
+        if (repoRoot) broadcastGitChanged(repoRoot);
+      }
+      return result;
+    });
+
+  ipcMain.handle(GIT_IPC.STAGE, (_e, projectRoot: string, relPath: string) =>
+    mutating(projectRoot, () => gitStage(projectRoot, relPath)));
+  ipcMain.handle(GIT_IPC.UNSTAGE, (_e, projectRoot: string, relPath: string) =>
+    mutating(projectRoot, () => gitUnstage(projectRoot, relPath)));
+  ipcMain.handle(GIT_IPC.COMMIT, (_e, projectRoot: string, message: string) =>
+    mutating(projectRoot, () => gitCommit(projectRoot, message)));
+  ipcMain.handle(GIT_IPC.DISCARD, (_e, projectRoot: string, relPath: string) =>
+    mutating(projectRoot, () => gitDiscard(projectRoot, relPath)));
+
+  const gitWatchedSenders = new Set<number>();
+  ipcMain.handle(GIT_IPC.WATCH, (e, projectRoot: string) =>
+    gitGate(projectRoot, { ok: false }, async () => {
+      const repoRoot = await resolveRepoRoot(projectRoot);
+      if (!repoRoot) return { ok: false };
+      const senderId = e.sender.id;
+      if (!gitWatchedSenders.has(senderId)) {
+        gitWatchedSenders.add(senderId);
+        e.sender.once('destroyed', () => { gitWatchedSenders.delete(senderId); dropGitSubscriber(senderId); });
+      }
+      return watchGit(repoRoot, senderId);
+    }));
+  // Gated like every other git channel — unwatch shells rev-parse, and the
+  // known-roots gate should be uniform even for read-only paths.
+  ipcMain.handle(GIT_IPC.UNWATCH, (e, projectRoot: string) =>
+    gitGate(projectRoot, { ok: false }, async () => {
+      const repoRoot = await resolveRepoRoot(projectRoot);
+      if (repoRoot) unwatchGit(repoRoot, e.sender.id);
+      return { ok: true };
+    }));
+
   ipcMain.handle(ARTIFACT_IPC.SEARCH_CONTENT, async (_e, projectRoot: string, query: string) => {
     if (typeof projectRoot !== 'string' || projectRoot.length === 0 || typeof query !== 'string') {
       return { ok: false, hits: [], truncated: false, error: 'projectRoot and query are required' };

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -3296,9 +3296,9 @@ export function registerIpcHandlers(
     gitGate(projectRoot, { ok: false, error: 'unknown-project-root', isRepo: false, branch: null, uncommitted: null, log: [], hasMore: false, stagedCount: 0 },
       () => gitFileReview(projectRoot, relPath, opts)));
 
-  ipcMain.handle(GIT_IPC.COMMIT_FILE_DIFF, (_e, projectRoot: string, sha: string, relPath: string) =>
+  ipcMain.handle(GIT_IPC.COMMIT_FILE_DIFF, (_e, projectRoot: string, sha: string, relPath: string, prevPath?: string) =>
     gitGate(projectRoot, { ok: false, error: 'unknown-project-root', hunks: [], binary: false },
-      () => gitCommitFileDiff(projectRoot, sha, relPath)));
+      () => gitCommitFileDiff(projectRoot, sha, relPath, prevPath)));
 
   const mutating = async (projectRoot: string, run: () => Promise<{ ok: boolean; error?: string }>) =>
     gitGate(projectRoot, { ok: false, error: 'unknown-project-root' }, async () => {

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -1281,6 +1281,29 @@ contextBridge.exposeInMainWorld('claude', {
       return () => ipcRenderer.removeListener('artifacts:changed', handler);
     },
   },
+  git: {
+    fileStatus: (projectRoot: string, relPath: string) =>
+      ipcRenderer.invoke('git:file-status', projectRoot, relPath),
+    fileReview: (projectRoot: string, relPath: string, opts?: { logSkip?: number }) =>
+      ipcRenderer.invoke('git:file-review', projectRoot, relPath, opts),
+    commitFileDiff: (projectRoot: string, sha: string, relPath: string) =>
+      ipcRenderer.invoke('git:commit-file-diff', projectRoot, sha, relPath),
+    stage: (projectRoot: string, relPath: string) =>
+      ipcRenderer.invoke('git:stage', projectRoot, relPath),
+    unstage: (projectRoot: string, relPath: string) =>
+      ipcRenderer.invoke('git:unstage', projectRoot, relPath),
+    commit: (projectRoot: string, message: string) =>
+      ipcRenderer.invoke('git:commit', projectRoot, message),
+    discard: (projectRoot: string, relPath: string) =>
+      ipcRenderer.invoke('git:discard', projectRoot, relPath),
+    watch: (projectRoot: string) => ipcRenderer.invoke('git:watch', projectRoot),
+    unwatch: (projectRoot: string) => ipcRenderer.invoke('git:unwatch', projectRoot),
+    onChanged: (cb: (event: any) => void) => {
+      const handler = (_e: any, payload: any) => cb(payload);
+      ipcRenderer.on('git:changed', handler);
+      return () => ipcRenderer.removeListener('git:changed', handler);
+    },
+  },
   // Project View IPC — sibling to artifacts. Backs the project overlay's
   // conversations / repo / context tabs.
   project: {

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -1286,8 +1286,11 @@ contextBridge.exposeInMainWorld('claude', {
       ipcRenderer.invoke('git:file-status', projectRoot, relPath),
     fileReview: (projectRoot: string, relPath: string, opts?: { logSkip?: number }) =>
       ipcRenderer.invoke('git:file-review', projectRoot, relPath, opts),
-    commitFileDiff: (projectRoot: string, sha: string, relPath: string) =>
-      ipcRenderer.invoke('git:commit-file-diff', projectRoot, sha, relPath),
+    // prevPath (project-root-relative old name) is passed for the rename
+    // commit itself so the main-process handler can pair the rename with -M
+    // instead of rendering the add-side full-file wall.
+    commitFileDiff: (projectRoot: string, sha: string, relPath: string, prevPath?: string) =>
+      ipcRenderer.invoke('git:commit-file-diff', projectRoot, sha, relPath, prevPath),
     stage: (projectRoot: string, relPath: string) =>
       ipcRenderer.invoke('git:stage', projectRoot, relPath),
     unstage: (projectRoot: string, relPath: string) =>

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -17,6 +17,7 @@ import { gitFooterState } from '../utils/git-footer';
 import { ActiveArtifactView, type ActiveArtifactHandle, type ArtifactContentInfo } from './artifact-views/ActiveArtifactView';
 import { useUnsavedGuard } from './artifact-views/UnsavedChangesDialog';
 import { ContentFindBar } from './ContentFindBar';
+import { GitReviewView } from './git/GitReviewView';
 import type { ArtifactRecord } from '../../shared/artifacts/types';
 import { categorizeArtifact } from '../../shared/artifacts/categorization';
 import { getPlatform } from '../platform';
@@ -624,11 +625,24 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
             the find bar (a sibling) isn't itself walked by the search. */}
         <div className="drawer-content flex-1 min-w-0 overflow-hidden relative flex flex-col">
           {gitReviewOpen && active ? (
-            // Task 8 replaces this placeholder with <GitReviewView …/>. Standard
-            // top bar (above) stays; find bar, content, edit cluster, and the
-            // metadata strip below are all swapped out while review is open
+            // Standard top bar (above) stays; find bar, content, edit cluster, and
+            // the metadata strip below are all swapped out while review is open
             // (locked decision, ledger 10).
-            <div data-testid="git-review-view" className="flex-1 min-h-0" />
+            <GitReviewView
+              projectRoot={projectRoot}
+              relPath={active.path}
+              fileName={fileName}
+              onBack={() => dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId })}
+              onOpenAtLine={(line) => {
+                // Close review, then land the editor on the line. revealLine
+                // internally retries while the lazy CM6 chunk mounts, but the
+                // handle itself is null until ActiveArtifactView remounts —
+                // defer one frame so the ref is populated.
+                dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId });
+                requestAnimationFrame(() => editRef.current?.revealLine(line));
+              }}
+              onRequestDiscard={() => { /* wired in Task 9 */ }}
+            />
           ) : (
             <>
               {findOpen && (

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -656,14 +656,6 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
               relPath={active.path}
               fileName={fileName}
               onBack={closeGitReview}
-              onOpenAtLine={(line) => {
-                // Close review, then land the editor on the line. revealLine
-                // internally retries while the lazy CM6 chunk mounts, but the
-                // handle itself is null until ActiveArtifactView remounts —
-                // defer one frame so the ref is populated.
-                closeGitReview();
-                requestAnimationFrame(() => editRef.current?.revealLine(line));
-              }}
               onRequestDiscard={(willTrash) => setDiscardAsk({ willTrash })}
               externalError={discardError}
               onExternalErrorClear={() => setDiscardError(null)}

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -18,6 +18,7 @@ import { ActiveArtifactView, type ActiveArtifactHandle, type ArtifactContentInfo
 import { useUnsavedGuard } from './artifact-views/UnsavedChangesDialog';
 import { ContentFindBar } from './ContentFindBar';
 import { GitReviewView } from './git/GitReviewView';
+import { DiscardConfirmDialog } from './git/DiscardConfirmDialog';
 import type { ArtifactRecord } from '../../shared/artifacts/types';
 import { categorizeArtifact } from '../../shared/artifacts/categorization';
 import { getPlatform } from '../platform';
@@ -225,6 +226,16 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
   // Footer git status only for the open file, only while the drawer is visible.
   const gitStatus = useGitFileStatus(projectRoot, active && isElectron ? active.path : null, drawerOpen);
   const gitFooter = gitFooterState(gitStatus);
+  // L3 discard confirm (Task 9). discardError is the ONE error surface for the
+  // review view — rendered via GitReviewView's externalError prop, cleared (a)
+  // whenever a new git op runs inside the view and (b) whenever review closes,
+  // so a stale discard failure can never linger into a reopened review.
+  const [discardAsk, setDiscardAsk] = useState<{ willTrash: boolean } | null>(null);
+  const [discardError, setDiscardError] = useState<string | null>(null);
+  const closeGitReview = useCallback(() => {
+    setDiscardError(null);
+    dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId });
+  }, [dispatch, sessionId]);
 
   // No selection → force the list visible so the user can pick something.
   const showList = !active ? true : listOpen;
@@ -377,11 +388,11 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
     if (findOpen) { setFindOpen(false); return; }
     if (editState.editing) { guardUnsaved(() => editRef.current?.cancelEdit()); return; }
     if (expanded) { dispatch({ type: 'DRAWER_EXPAND_TOGGLED' }); return; }
-    if (gitReviewOpen) { dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId }); return; }
+    if (gitReviewOpen) { closeGitReview(); return; }
     if (listOpen) { setListOpen(false); return; }
     if (activeArtifactId) { dispatch({ type: 'ACTIVE_ARTIFACT_CLEARED', sessionId }); return; }
     dispatch({ type: 'DRAWER_CLOSED', sessionId });
-  }, [findOpen, editState.editing, expanded, gitReviewOpen, listOpen, activeArtifactId, dispatch, cancelRename, sessionId, guardUnsaved]);
+  }, [findOpen, editState.editing, expanded, gitReviewOpen, listOpen, activeArtifactId, dispatch, cancelRename, sessionId, guardUnsaved, closeGitReview]);
 
   useEscClose(drawerOpen, handleBack);
 
@@ -558,6 +569,20 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
     <aside ref={asideRef} className={asideClass}>
       {resizeHandle}
       {unsavedDialog}
+      {discardAsk && active && (
+        <DiscardConfirmDialog
+          fileName={fileName}
+          willTrash={discardAsk.willTrash}
+          onConfirm={async () => {
+            setDiscardAsk(null);
+            const r = await (window as any).claude?.git?.discard?.(projectRoot, active.path).catch(
+              (e: unknown) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }));
+            // Real stderr or nothing — the review view refreshes itself via git:changed.
+            setDiscardError(r?.ok ? null : (r?.error ?? 'git discard failed'));
+          }}
+          onCancel={() => setDiscardAsk(null)}
+        />
+      )}
       {/* top bar */}
       <div className="flex items-center gap-1 px-2 py-1.5 border-b border-edge shrink-0">
         <IconBtn name="list" title={listOpen ? 'Hide list' : 'Show list'} active={listOpen} onClick={() => setListOpen((v) => !v)} />
@@ -632,16 +657,18 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
               projectRoot={projectRoot}
               relPath={active.path}
               fileName={fileName}
-              onBack={() => dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId })}
+              onBack={closeGitReview}
               onOpenAtLine={(line) => {
                 // Close review, then land the editor on the line. revealLine
                 // internally retries while the lazy CM6 chunk mounts, but the
                 // handle itself is null until ActiveArtifactView remounts —
                 // defer one frame so the ref is populated.
-                dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId });
+                closeGitReview();
                 requestAnimationFrame(() => editRef.current?.revealLine(line));
               }}
-              onRequestDiscard={() => { /* wired in Task 9 */ }}
+              onRequestDiscard={(willTrash) => setDiscardAsk({ willTrash })}
+              externalError={discardError}
+              onExternalErrorClear={() => setDiscardError(null)}
             />
           ) : (
             <>

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -12,6 +12,8 @@ import { useTheme } from '../state/theme-context';
 import { clampDrawerWidth, applyDrawerWidthVar } from '../state/drawer-width';
 import { useEscClose } from '../hooks/use-esc-close';
 import { useProjectWatch } from '../hooks/useProjectWatch';
+import { useGitFileStatus } from '../hooks/useGitFileStatus';
+import { gitFooterState } from '../utils/git-footer';
 import { ActiveArtifactView, type ActiveArtifactHandle, type ArtifactContentInfo } from './artifact-views/ActiveArtifactView';
 import { useUnsavedGuard } from './artifact-views/UnsavedChangesDialog';
 import { ContentFindBar } from './ContentFindBar';
@@ -62,6 +64,9 @@ const PATHS: Record<string, string> = {
   editdoc: 'M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z',
   check: 'M20 6 9 17l-5-5',
   close: 'M18 6 6 18M6 6l12 12',
+  back: 'M19 12H5M11 18l-6-6 6-6',
+  forward: 'M5 12h14M13 6l6 6-6 6',
+  gitbranch: 'M6 8.5v7M18 10.5c0 3-4 3.5-7 3.5M6 8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5M6 20.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5M18 10.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5',
 };
 function Ic({ name, size = 15 }: { name: keyof typeof PATHS | string; size?: number }) {
   return (
@@ -215,6 +220,10 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
   const [searchQuery, setSearchQuery] = useState('');  // filter the artifact list
   const [sortBy, setSortBy] = useState<SortKey>('recent');
   const isElectron = getPlatform() === 'electron';
+  const gitReviewOpen = state.gitReviewBySession?.[sessionId] ?? false;
+  // Footer git status only for the open file, only while the drawer is visible.
+  const gitStatus = useGitFileStatus(projectRoot, active && isElectron ? active.path : null, drawerOpen);
+  const gitFooter = gitFooterState(gitStatus);
 
   // No selection → force the list visible so the user can pick something.
   const showList = !active ? true : listOpen;
@@ -367,10 +376,11 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
     if (findOpen) { setFindOpen(false); return; }
     if (editState.editing) { guardUnsaved(() => editRef.current?.cancelEdit()); return; }
     if (expanded) { dispatch({ type: 'DRAWER_EXPAND_TOGGLED' }); return; }
+    if (gitReviewOpen) { dispatch({ type: 'GIT_REVIEW_CLOSED', sessionId }); return; }
     if (listOpen) { setListOpen(false); return; }
     if (activeArtifactId) { dispatch({ type: 'ACTIVE_ARTIFACT_CLEARED', sessionId }); return; }
     dispatch({ type: 'DRAWER_CLOSED', sessionId });
-  }, [findOpen, editState.editing, expanded, listOpen, activeArtifactId, dispatch, cancelRename, sessionId, guardUnsaved]);
+  }, [findOpen, editState.editing, expanded, gitReviewOpen, listOpen, activeArtifactId, dispatch, cancelRename, sessionId, guardUnsaved]);
 
   useEscClose(drawerOpen, handleBack);
 
@@ -613,85 +623,132 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
         {/* Positioning parent for the find bar. contentRef is the INNER div so
             the find bar (a sibling) isn't itself walked by the search. */}
         <div className="drawer-content flex-1 min-w-0 overflow-hidden relative flex flex-col">
-          {findOpen && (
-            <ContentFindBar
-              containerRef={contentRef}
-              resetKey={active.id}
-              onClose={() => setFindOpen(false)}
-            />
-          )}
-          <div ref={contentRef} className="flex-1 min-h-0 overflow-hidden artifact-content-pane">
-            <ActiveArtifactView
-              ref={editRef}
-              artifact={active}
-              content={content}
-              contentInfo={contentInfo}
-              projectRoot={projectRoot}
-              projectId={projectId}
-              projectName={projectName}
-              sessionId={sessionId}
-              onContentChange={setContent}
-              controlsInHeader
-              onEditStateChange={setEditState}
-            />
-          </div>
-          {/* Floating Edit ↔ Save cluster, bottom-right of the doc pane.
-              Pops IN when the artifact list collapses (doc goes full-width)
-              and back OUT when the list reopens — kept mounted so both
-              directions animate. While EDITING it stays visible regardless,
-              so Save can never be hidden by opening the list. */}
-          {active && (editState.editing || editState.isEditable) && (
-            <div
-              className={`absolute bottom-9 right-4 z-20 flex items-center gap-2 transition-all duration-200 ${
-                editState.editing || !showList
-                  ? 'opacity-100 scale-100'
-                  : 'opacity-0 scale-90 pointer-events-none'
-              }`}
-            >
-              {editState.editing ? (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => editRef.current?.cancelEdit()}
-                    className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold bg-panel text-fg-2 border border-edge shadow-lg hover:text-fg hover:bg-well transition-colors"
-                  >
-                    <Ic name="close" size={15} />
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => editRef.current?.saveEdit()}
-                    className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold bg-accent text-on-accent shadow-lg hover:opacity-90 transition-opacity"
-                  >
-                    <Ic name="check" size={15} />
-                    Save
-                  </button>
-                </>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => { editRef.current?.startEdit(); setListOpen(false); }}
-                  className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold bg-accent text-on-accent shadow-lg hover:opacity-90 transition-opacity"
-                >
-                  <Ic name="editdoc" size={15} />
-                  Edit
-                </button>
+          {gitReviewOpen && active ? (
+            // Task 8 replaces this placeholder with <GitReviewView …/>. Standard
+            // top bar (above) stays; find bar, content, edit cluster, and the
+            // metadata strip below are all swapped out while review is open
+            // (locked decision, ledger 10).
+            <div data-testid="git-review-view" className="flex-1 min-h-0" />
+          ) : (
+            <>
+              {findOpen && (
+                <ContentFindBar
+                  containerRef={contentRef}
+                  resetKey={active.id}
+                  onClose={() => setFindOpen(false)}
+                />
               )}
-            </div>
+              <div ref={contentRef} className="flex-1 min-h-0 overflow-hidden artifact-content-pane">
+                <ActiveArtifactView
+                  ref={editRef}
+                  artifact={active}
+                  content={content}
+                  contentInfo={contentInfo}
+                  projectRoot={projectRoot}
+                  projectId={projectId}
+                  projectName={projectName}
+                  sessionId={sessionId}
+                  onContentChange={setContent}
+                  controlsInHeader
+                  onEditStateChange={setEditState}
+                />
+              </div>
+              {/* Floating Edit ↔ Save cluster, bottom-right of the doc pane.
+                  Pops IN when the artifact list collapses (doc goes full-width)
+                  and back OUT when the list reopens — kept mounted so both
+                  directions animate. While EDITING it stays visible regardless,
+                  so Save can never be hidden by opening the list. */}
+              {active && (editState.editing || editState.isEditable) && (
+                <div
+                  className={`absolute bottom-9 right-4 z-20 flex items-center gap-2 transition-all duration-200 ${
+                    editState.editing || !showList
+                      ? 'opacity-100 scale-100'
+                      : 'opacity-0 scale-90 pointer-events-none'
+                  }`}
+                >
+                  {editState.editing ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => editRef.current?.cancelEdit()}
+                        className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold bg-panel text-fg-2 border border-edge shadow-lg hover:text-fg hover:bg-well transition-colors"
+                      >
+                        <Ic name="close" size={15} />
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => editRef.current?.saveEdit()}
+                        className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold bg-accent text-on-accent shadow-lg hover:opacity-90 transition-opacity"
+                      >
+                        <Ic name="check" size={15} />
+                        Save
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { editRef.current?.startEdit(); setListOpen(false); }}
+                      className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold bg-accent text-on-accent shadow-lg hover:opacity-90 transition-opacity"
+                    >
+                      <Ic name="editdoc" size={15} />
+                      Edit
+                    </button>
+                  )}
+                </div>
+              )}
+              {/* metadata strip — bottom of the DOC column (not a full-width row up
+                  top), so it shares the document's width and expands/shrinks with
+                  the artifact list (Destin, 2026-07-22). */}
+              <div className="flex items-center gap-2 px-3.5 py-1 text-[11px] text-fg-muted border-t border-edge-dim bg-well shrink-0">
+                {/* WHY: status shown as a word, not a ●◐○ glyph (user-disliked — see dislikes-status-glyphs memory). */}
+                <span>{statusWord}</span>
+                <span className="text-fg-faint">·</span>
+                <span>{formatRelativeTime(active.lastModified)}</span>
+                {content !== null && <><span className="text-fg-faint">·</span><span>{formatSize(content)}</span></>}
+                <div className="flex-1" />
+                <GitFooterEntry
+                  counts={gitFooter.counts}
+                  show={gitFooter.show}
+                  onOpenReview={() => dispatch({ type: 'GIT_REVIEW_OPENED', sessionId })}
+                />
+              </div>
+            </>
           )}
-          {/* metadata strip — bottom of the DOC column (not a full-width row up
-              top), so it shares the document's width and expands/shrinks with
-              the artifact list (Destin, 2026-07-22). */}
-          <div className="flex items-center gap-2 px-3.5 py-1 text-[11px] text-fg-muted border-t border-edge-dim bg-well shrink-0">
-            {/* WHY: status shown as a word, not a ●◐○ glyph (user-disliked — see dislikes-status-glyphs memory). */}
-            <span>{statusWord}</span>
-            <span className="text-fg-faint">·</span>
-            <span>{formatRelativeTime(active.lastModified)}</span>
-            {content !== null && <><span className="text-fg-faint">·</span><span>{formatSize(content)}</span></>}
-          </div>
         </div>
       </div>
     </aside>
+  );
+}
+
+// Footer entry for the git surface (mockup ledger 9). Rendered inside the
+// metadata strip; absent entirely when show=false so the strip reads exactly
+// as it did before the git surface existed.
+export function GitFooterEntry({
+  counts, show, onOpenReview,
+}: {
+  counts: { added: number; removed: number } | null;
+  show: boolean;
+  onOpenReview: () => void;
+}) {
+  if (!show) return null;
+  return (
+    <>
+      {counts && (
+        <>
+          <span className="font-mono text-green-400">+{counts.added}</span>
+          <span className="font-mono text-red-400">−{counts.removed}</span>
+        </>
+      )}
+      <button
+        type="button"
+        onClick={onOpenReview}
+        title="Review this file's changes"
+        className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] text-fg-dim hover:text-fg hover:bg-inset transition-colors"
+      >
+        Review Changes <Ic name="forward" size={11} />
+      </button>
+    </>
   );
 }
 

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -66,9 +66,7 @@ const PATHS: Record<string, string> = {
   editdoc: 'M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z',
   check: 'M20 6 9 17l-5-5',
   close: 'M18 6 6 18M6 6l12 12',
-  back: 'M19 12H5M11 18l-6-6 6-6',
   forward: 'M5 12h14M13 6l6 6-6 6',
-  gitbranch: 'M6 8.5v7M18 10.5c0 3-4 3.5-7 3.5M6 8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5M6 20.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5M18 10.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5',
 };
 function Ic({ name, size = 15 }: { name: keyof typeof PATHS | string; size?: number }) {
   return (
@@ -382,7 +380,7 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
     }
   }, [projectRoot, sessionId, activeArtifactId, dispatch]);
 
-  // ── ESC / back: rename → find → edit → expand → list → active → drawer ──
+  // ── ESC / back: rename → find → edit → expand → gitReview → list → active → drawer ──
   const handleBack = useCallback(() => {
     if (renameActiveRef.current) { cancelRename(); return; }
     if (findOpen) { setFindOpen(false); return; }

--- a/desktop/src/renderer/components/SessionDrawerGitFooter.test.tsx
+++ b/desktop/src/renderer/components/SessionDrawerGitFooter.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { GitFooterEntry } from './SessionDrawer';
+
+describe('GitFooterEntry', () => {
+  beforeEach(() => {
+    (window as any).claude = { git: {} };
+  });
+  afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+  it('renders counts and the Review Changes button when there are changes', () => {
+    const onOpen = vi.fn();
+    render(<GitFooterEntry counts={{ added: 41, removed: 12 }} show onOpenReview={onOpen} />);
+    expect(screen.getByText('+41')).toBeInTheDocument();
+    expect(screen.getByText('−12')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Review Changes' }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the button without counts for clean-with-history', () => {
+    render(<GitFooterEntry counts={null} show onOpenReview={() => {}} />);
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review Changes' })).toBeInTheDocument();
+  });
+
+  it('renders nothing when show is false', () => {
+    const { container } = render(<GitFooterEntry counts={null} show={false} onOpenReview={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/desktop/src/renderer/components/diff/UnifiedDiff.tsx
+++ b/desktop/src/renderer/components/diff/UnifiedDiff.tsx
@@ -86,10 +86,18 @@ export function UnifiedDiff({
   oldStr,
   newStr,
   structuredPatch,
+  fill,
 }: {
   oldStr: string;
   newStr: string;
   structuredPatch?: StructuredPatchHunk[];
+  /** When a host wraps this diff in its own scroll container (the git review
+   *  timeline caps each diff at 45vh), the internal 15-line preview cap and its
+   *  "Expand" button are redundant — they stack a second scrollbar inside the
+   *  host's and the "Expand" click barely moves anything. `fill` renders every
+   *  row at full height and drops the button so the HOST is the sole scroll
+   *  surface for the diff text. */
+  fill?: boolean;
 }) {
   // Prefer Claude Code's pre-computed hunks (absolute file line numbers).
   // Fall back to a jsdiff line diff when no structured result exists yet.
@@ -117,7 +125,8 @@ export function UnifiedDiff({
   const total = rows.length;
   const [open, setOpen] = useState(() => getInitialExpanded());
   useExpandAllToggle(() => setOpen(true), () => setOpen(false));
-  const overflow = total > DIFF_PREVIEW_LINES;
+  // `fill` hands height control to the host wrapper: no internal cap, no button.
+  const overflow = !fill && total > DIFF_PREVIEW_LINES;
   const containerStyle = open || !overflow
     ? undefined
     : { maxHeight: `${DIFF_PREVIEW_LINES * DIFF_ROW_PX}px` };

--- a/desktop/src/renderer/components/git/DiscardConfirmDialog.test.tsx
+++ b/desktop/src/renderer/components/git/DiscardConfirmDialog.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { DiscardConfirmDialog } from './DiscardConfirmDialog';
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+describe('DiscardConfirmDialog', () => {
+  it('tracked copy states exactly what is restored and confirm fires', () => {
+    const onConfirm = vi.fn();
+    render(<DiscardConfirmDialog fileName="f.ts" willTrash={false} onConfirm={onConfirm} onCancel={() => {}} />);
+    expect(screen.getByText(/Restore “f.ts” to its last committed state\?/)).toBeInTheDocument();
+    expect(screen.getByText(/uncommitted edits to this file will be lost/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('never-committed copy says trash, not restore', () => {
+    render(<DiscardConfirmDialog fileName="new.ts" willTrash onConfirm={() => {}} onCancel={() => {}} />);
+    expect(screen.getByText(/Move “new.ts” to the system trash\?/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete file' })).toBeInTheDocument();
+  });
+
+  it('cancel and Escape both close without confirming', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(<DiscardConfirmDialog fileName="f.ts" willTrash={false} onConfirm={onConfirm} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/renderer/components/git/DiscardConfirmDialog.test.tsx
+++ b/desktop/src/renderer/components/git/DiscardConfirmDialog.test.tsx
@@ -41,14 +41,14 @@ describe('DiscardConfirmDialog', () => {
     renderDialog({ onConfirm });
     expect(screen.getByText(/Restore “f.ts” to its last committed state\?/)).toBeInTheDocument();
     expect(screen.getByText(/uncommitted edits to this file will be lost/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Revert Changes' }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
   it('never-committed copy says trash, not restore', () => {
     renderDialog({ fileName: 'new.ts', willTrash: true });
     expect(screen.getByText(/Move “new.ts” to the system trash\?/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete file' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Move to Trash' })).toBeInTheDocument();
   });
 
   it('cancel and Escape both close without confirming', () => {

--- a/desktop/src/renderer/components/git/DiscardConfirmDialog.test.tsx
+++ b/desktop/src/renderer/components/git/DiscardConfirmDialog.test.tsx
@@ -2,15 +2,43 @@
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { DiscardConfirmDialog } from './DiscardConfirmDialog';
+import { EscCloseProvider, useEscClose } from '../../hooks/use-esc-close';
 
 afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+// Dialog now joins the shared useEscClose LIFO stack (see WHY comment in
+// DiscardConfirmDialog.tsx), so it needs the provider mounted to receive ESC
+// at all — matches how the real app always wraps everything in one
+// EscCloseProvider at the App root.
+function renderDialog(props: Partial<React.ComponentProps<typeof DiscardConfirmDialog>> = {}) {
+  const onConfirm = props.onConfirm ?? vi.fn();
+  const onCancel = props.onCancel ?? vi.fn();
+  const utils = render(
+    <EscCloseProvider>
+      <DiscardConfirmDialog
+        fileName="f.ts"
+        willTrash={false}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        {...props}
+      />
+    </EscCloseProvider>,
+  );
+  return { ...utils, onConfirm, onCancel };
+}
+
+function pressEsc() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+  });
+}
 
 describe('DiscardConfirmDialog', () => {
   it('tracked copy states exactly what is restored and confirm fires', () => {
     const onConfirm = vi.fn();
-    render(<DiscardConfirmDialog fileName="f.ts" willTrash={false} onConfirm={onConfirm} onCancel={() => {}} />);
+    renderDialog({ onConfirm });
     expect(screen.getByText(/Restore “f.ts” to its last committed state\?/)).toBeInTheDocument();
     expect(screen.getByText(/uncommitted edits to this file will be lost/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
@@ -18,18 +46,44 @@ describe('DiscardConfirmDialog', () => {
   });
 
   it('never-committed copy says trash, not restore', () => {
-    render(<DiscardConfirmDialog fileName="new.ts" willTrash onConfirm={() => {}} onCancel={() => {}} />);
+    renderDialog({ fileName: 'new.ts', willTrash: true });
     expect(screen.getByText(/Move “new.ts” to the system trash\?/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Delete file' })).toBeInTheDocument();
   });
 
   it('cancel and Escape both close without confirming', () => {
-    const onConfirm = vi.fn();
-    const onCancel = vi.fn();
-    render(<DiscardConfirmDialog fileName="f.ts" willTrash={false} onConfirm={onConfirm} onCancel={onCancel} />);
+    const { onConfirm, onCancel } = renderDialog();
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    fireEvent.keyDown(window, { key: 'Escape' });
+    pressEsc();
     expect(onCancel).toHaveBeenCalled();
     expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  // Regression for the Critical review finding (Task 9): a dialog-local
+  // capture-phase `stopPropagation()` listener does NOT stop the app's other
+  // capture-phase window listener (EscCloseProvider) from also firing — only
+  // stopImmediatePropagation would, and even that depends on registration
+  // order, which favors the provider since it mounts once at App root before
+  // any dialog exists. Concretely: pressing Escape while this dialog is open
+  // used to ALSO fire SessionDrawer's useEscClose(drawerOpen, handleBack),
+  // collapsing the whole git review underneath the dialog. This test stands
+  // in a registered ESC consumer (simulating the drawer) beneath the dialog
+  // and asserts only the dialog's onCancel fires on a single Escape press.
+  it('does not let an underlying useEscClose consumer fire — the dialog is top of stack', () => {
+    const onCancel = vi.fn();
+    const underlyingClose = vi.fn(); // stands in for SessionDrawer's handleBack
+    function UnderlyingConsumer() {
+      useEscClose(true, underlyingClose);
+      return null;
+    }
+    render(
+      <EscCloseProvider>
+        <UnderlyingConsumer />
+        <DiscardConfirmDialog fileName="f.ts" willTrash={false} onConfirm={() => {}} onCancel={onCancel} />
+      </EscCloseProvider>,
+    );
+    pressEsc();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(underlyingClose).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/renderer/components/git/DiscardConfirmDialog.tsx
+++ b/desktop/src/renderer/components/git/DiscardConfirmDialog.tsx
@@ -1,0 +1,55 @@
+// L3 destructive confirm for the git surface (spec section 5). Uses the shared
+// overlay primitives — never a hand-rolled bg-black/40 (react-renderer rule).
+// The copy states EXACTLY what happens; the failure path (surfaced by the
+// caller) carries real git stderr.
+import React, { useEffect } from 'react';
+import { Scrim, OverlayPanel } from '../overlays/Overlay';
+import { Button } from '../ui';
+
+export interface DiscardConfirmDialogProps {
+  fileName: string;
+  /** true = HEAD has no committed copy (untracked OR staged-new) — the file
+   *  goes to the OS trash instead of being restored from HEAD */
+  willTrash: boolean;
+  onConfirm: () => void;  // caller runs git.discard and closes
+  onCancel: () => void;
+}
+
+export function DiscardConfirmDialog({ fileName, willTrash, onConfirm, onCancel }: DiscardConfirmDialogProps) {
+  // Capture-phase Escape = cancel, same pattern as UnsavedChangesDialog — the
+  // drawer's own ESC cascade must not fire underneath an open dialog.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onCancel(); }
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [onCancel]);
+
+  return (
+    <Scrim layer={3} onClick={onCancel} className="flex items-center justify-center">
+      <OverlayPanel
+        layer={3}
+        destructive
+        role="alertdialog"
+        aria-modal
+        aria-label={willTrash ? 'Delete file' : 'Discard changes'}
+        className="p-4 max-w-sm w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-sm font-medium text-fg mb-1">
+          {willTrash ? `Move “${fileName}” to the system trash?` : `Restore “${fileName}” to its last committed state?`}
+        </div>
+        <div className="text-sm text-fg-2 mb-4 break-all">
+          {willTrash
+            ? 'Git has no committed copy of this file. It goes to the trash, not permanent deletion.'
+            : 'Your uncommitted edits to this file will be lost. Staged and unstaged changes are both restored from HEAD.'}
+        </div>
+        <div className="flex gap-2 justify-end">
+          <Button variant="secondary" onClick={onCancel}>Cancel</Button>
+          <Button variant="danger" onClick={onConfirm}>{willTrash ? 'Delete file' : 'Discard changes'}</Button>
+        </div>
+      </OverlayPanel>
+    </Scrim>
+  );
+}

--- a/desktop/src/renderer/components/git/DiscardConfirmDialog.tsx
+++ b/desktop/src/renderer/components/git/DiscardConfirmDialog.tsx
@@ -38,7 +38,7 @@ export function DiscardConfirmDialog({ fileName, willTrash, onConfirm, onCancel 
         destructive
         role="alertdialog"
         aria-modal
-        aria-label={willTrash ? 'Delete file' : 'Discard changes'}
+        aria-label={willTrash ? 'Move file to trash' : 'Revert changes'}
         className="p-4 max-w-sm w-full mx-4"
         onClick={(e) => e.stopPropagation()}
       >
@@ -52,7 +52,7 @@ export function DiscardConfirmDialog({ fileName, willTrash, onConfirm, onCancel 
         </div>
         <div className="flex gap-2 justify-end">
           <Button variant="secondary" onClick={onCancel}>Cancel</Button>
-          <Button variant="danger" onClick={onConfirm}>{willTrash ? 'Delete file' : 'Discard changes'}</Button>
+          <Button variant="danger" onClick={onConfirm}>{willTrash ? 'Move to Trash' : 'Revert Changes'}</Button>
         </div>
       </OverlayPanel>
     </Scrim>

--- a/desktop/src/renderer/components/git/DiscardConfirmDialog.tsx
+++ b/desktop/src/renderer/components/git/DiscardConfirmDialog.tsx
@@ -2,9 +2,10 @@
 // overlay primitives — never a hand-rolled bg-black/40 (react-renderer rule).
 // The copy states EXACTLY what happens; the failure path (surfaced by the
 // caller) carries real git stderr.
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Scrim, OverlayPanel } from '../overlays/Overlay';
 import { Button } from '../ui';
+import { useEscClose } from '../../hooks/use-esc-close';
 
 export interface DiscardConfirmDialogProps {
   fileName: string;
@@ -16,15 +17,19 @@ export interface DiscardConfirmDialogProps {
 }
 
 export function DiscardConfirmDialog({ fileName, willTrash, onConfirm, onCancel }: DiscardConfirmDialogProps) {
-  // Capture-phase Escape = cancel, same pattern as UnsavedChangesDialog — the
-  // drawer's own ESC cascade must not fire underneath an open dialog.
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onCancel(); }
-    };
-    window.addEventListener('keydown', handler, true);
-    return () => window.removeEventListener('keydown', handler, true);
-  }, [onCancel]);
+  // Escape = cancel, routed through the shared useEscClose LIFO stack (same
+  // pattern as CloseSessionPrompt). A dialog-local capture-phase listener
+  // does NOT work here: EscCloseProvider's own capture-phase window listener
+  // fires in registration order (it mounts once at App root, before this
+  // dialog ever exists), so it always runs FIRST and pops whatever is
+  // beneath us on the stack — e.g. SessionDrawer's handleBack — even if this
+  // dialog also calls stopPropagation() in its own listener. stopPropagation
+  // only stops propagation to ancestor/descendant nodes; it does nothing to
+  // sibling listeners already registered on the same window. Joining the
+  // stack via useEscClose(true, onCancel) instead pushes THIS dialog on top,
+  // so EscCloseProvider pops us first and the drawer's entry underneath
+  // never fires.
+  useEscClose(true, onCancel);
 
   return (
     <Scrim layer={3} onClick={onCancel} className="flex items-center justify-center">

--- a/desktop/src/renderer/components/git/GitReviewCard.tsx
+++ b/desktop/src/renderer/components/git/GitReviewCard.tsx
@@ -1,0 +1,31 @@
+// One expandable card in the review timeline (mockup ledger 11/12): the
+// uncommitted card and every commit card share this shell so the two states
+// cannot drift apart visually.
+import React from 'react';
+
+export function GitReviewCard({
+  accent, expanded, onToggle, headerLeft, headerRight, children,
+}: {
+  /** accent border marks the pinned Uncommitted card */
+  accent?: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  headerLeft: React.ReactNode;
+  headerRight?: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className={`rounded-lg border ${accent ? 'border-accent' : 'border-edge'} bg-well overflow-hidden`}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-inset transition-colors"
+      >
+        <span className={`text-fg-muted text-[10px] transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
+        {headerLeft}
+        {headerRight}
+      </button>
+      {expanded && <div className="px-3 pb-3">{children}</div>}
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/git/GitReviewCard.tsx
+++ b/desktop/src/renderer/components/git/GitReviewCard.tsx
@@ -15,7 +15,14 @@ export function GitReviewCard({
   children?: React.ReactNode;
 }) {
   return (
-    <div className={`rounded-lg border ${accent ? 'border-accent' : 'border-edge'} bg-well overflow-hidden`}>
+    // shrink-0 is load-bearing: the timeline is a `flex flex-col` scroll
+    // container, so without it these cards (default flex-shrink:1) COMPRESS to
+    // fit the panel instead of overflowing. That squeezed the diff (clipped by
+    // this card's overflow-hidden) AND left the timeline with nothing to scroll
+    // — scrollHeight collapsed to clientHeight. Holding natural height lets the
+    // diff show fully (or hit its own 45vh inner scroll) and lets the timeline
+    // overflow and scroll.
+    <div className={`shrink-0 rounded-lg border ${accent ? 'border-accent' : 'border-edge'} bg-well overflow-hidden`}>
       <button
         type="button"
         onClick={onToggle}

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { GitReviewView } from './GitReviewView';
+import type { GitFileReviewResult } from '../../../shared/git-types';
+
+// Typed against the real IPC result shape (not inferred from the literal) so
+// `Partial<typeof review>` allows `uncommitted: null` in the "clean file"
+// test below — `uncommitted` is `GitUncommitted | null` on the real type,
+// but a bare object-literal inference would narrow it to non-null only.
+const review: GitFileReviewResult = {
+  ok: true, isRepo: true, branch: 'master',
+  uncommitted: {
+    hunks: [{ oldStart: 142, oldLines: 1, newStart: 142, newLines: 2, lines: ['-old line', '+new line', '+added line'] }],
+    counts: { added: 2, removed: 1 }, staged: false, untracked: false, inHead: true, binary: false,
+  },
+  log: [
+    { sha: 'a'.repeat(40), shortSha: 'aaaaaaa', subject: 'fix: first', authorDate: '2026-07-22T10:00:00Z' },
+    { sha: 'b'.repeat(40), shortSha: 'bbbbbbb', subject: 'feat: second', authorDate: '2026-07-21T10:00:00Z' },
+  ],
+  hasMore: false, stagedCount: 0,
+};
+
+function mountWith(overrides: Partial<typeof review> = {}, props: Partial<React.ComponentProps<typeof GitReviewView>> = {}) {
+  (window as any).claude = {
+    git: {
+      fileReview: vi.fn(async () => ({ ...review, ...overrides })),
+      commitFileDiff: vi.fn(async () => ({ ok: true, hunks: [], binary: false })),
+      stage: vi.fn(async () => ({ ok: true })),
+      unstage: vi.fn(async () => ({ ok: true })),
+      commit: vi.fn(async () => ({ ok: true })),
+      onChanged: vi.fn(() => () => {}),
+    },
+  };
+  render(
+    <GitReviewView
+      projectRoot="/proj" relPath="src/f.ts" fileName="f.ts"
+      onBack={() => {}} onOpenAtLine={() => {}} onRequestDiscard={() => {}}
+      {...props}
+    />,
+  );
+  return (window as any).claude.git;
+}
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+describe('GitReviewView', () => {
+  it('renders sub-header title, branch chip, uncommitted card first and expanded', async () => {
+    mountWith();
+    await waitFor(() => expect(screen.getByText('Uncommitted changes')).toBeInTheDocument());
+    expect(screen.getByText(/Reviewing changes for/)).toBeInTheDocument();
+    expect(screen.getByText('master')).toBeInTheDocument();
+    // expanded by default: its diff rows are visible
+    expect(screen.getByText('-old line'.slice(1))).toBeInTheDocument(); // "old line" text cell
+    // commit cards listed, collapsed
+    expect(screen.getByText('fix: first')).toBeInTheDocument();
+    expect(screen.getByText('feat: second')).toBeInTheDocument();
+  });
+
+  it('no uncommitted card when the file is clean', async () => {
+    mountWith({ uncommitted: null });
+    await waitFor(() => expect(screen.getByText('fix: first')).toBeInTheDocument());
+    expect(screen.queryByText('Uncommitted changes')).not.toBeInTheDocument();
+  });
+
+  it('expanding a commit card lazily fetches its diff', async () => {
+    const git = mountWith();
+    await waitFor(() => screen.getByText('fix: first'));
+    fireEvent.click(screen.getByText('fix: first'));
+    await waitFor(() =>
+      expect(git.commitFileDiff).toHaveBeenCalledWith('/proj', 'a'.repeat(40), 'src/f.ts'));
+  });
+
+  it('Show more appears when hasMore and fetches the next page', async () => {
+    const git = mountWith({ hasMore: true });
+    await waitFor(() => screen.getByRole('button', { name: /Show more/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Show more/ }));
+    await waitFor(() =>
+      expect(git.fileReview).toHaveBeenCalledWith('/proj', 'src/f.ts', { logSkip: 2 }));
+  });
+
+  it('composer: disabled until a message exists AND stagedCount > 0', async () => {
+    mountWith({ stagedCount: 0 });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    const btn = screen.getByRole('button', { name: /Commit/ }) as HTMLButtonElement;
+    expect(btn).toBeDisabled(); // no staged files
+    fireEvent.change(screen.getByPlaceholderText('Commit message'), { target: { value: 'msg' } });
+    expect(btn).toBeDisabled(); // still no staged files
+  });
+
+  it('composer: commit fires git.commit with the message and clears it', async () => {
+    const git = mountWith({ stagedCount: 2 });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    const area = screen.getByPlaceholderText('Commit message');
+    fireEvent.change(area, { target: { value: 'feat: from drawer' } });
+    const btn = screen.getByRole('button', { name: 'Commit 2 staged files' });
+    expect(btn).toBeEnabled();
+    fireEvent.click(btn);
+    await waitFor(() => expect(git.commit).toHaveBeenCalledWith('/proj', 'feat: from drawer'));
+    await waitFor(() => expect((area as HTMLTextAreaElement).value).toBe(''));
+  });
+
+  it('staged checkbox row stages/unstages the file', async () => {
+    const git = mountWith();
+    await waitFor(() => screen.getByText('Staged for commit'));
+    fireEvent.click(screen.getByText('Staged for commit'));
+    await waitFor(() => expect(git.stage).toHaveBeenCalledWith('/proj', 'src/f.ts'));
+  });
+
+  it('surfaces a failed operation error verbatim', async () => {
+    const git = mountWith({ stagedCount: 1 });
+    git.commit.mockResolvedValueOnce({ ok: false, error: 'nothing added to commit' });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    fireEvent.change(screen.getByPlaceholderText('Commit message'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Commit 1 staged file' }));
+    await waitFor(() => expect(screen.getByText('nothing added to commit')).toBeInTheDocument());
+  });
+});

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -41,7 +41,7 @@ function mountWith(overrides: Partial<typeof review> = {}, props: Partial<React.
   render(
     <GitReviewView
       projectRoot="/proj" relPath="src/f.ts" fileName="f.ts"
-      onBack={() => {}} onOpenAtLine={() => {}} onRequestDiscard={() => {}}
+      onBack={() => {}} onRequestDiscard={() => {}}
       {...props}
     />,
   );
@@ -83,7 +83,7 @@ describe('GitReviewView', () => {
     expect(scrollContainer).not.toBeNull();
     expect(scrollContainer?.className).toContain('max-h-[45vh]');
     // The action row (staged checkbox) must NOT be inside that scroll cap.
-    const actionRow = screen.getByText('Staged for commit');
+    const actionRow = screen.getByText('Include in commit');
     expect(scrollContainer?.contains(actionRow)).toBe(false);
   });
 
@@ -151,9 +151,67 @@ describe('GitReviewView', () => {
 
   it('staged checkbox row stages/unstages the file', async () => {
     const git = mountWith();
-    await waitFor(() => screen.getByText('Staged for commit'));
-    fireEvent.click(screen.getByText('Staged for commit'));
+    await waitFor(() => screen.getByText('Include in commit'));
+    fireEvent.click(screen.getByText('Include in commit'));
     await waitFor(() => expect(git.stage).toHaveBeenCalledWith('/proj', 'src/f.ts'));
+  });
+
+  // Legible mirror (owner decision 2026-07-23): the checkbox used to hide
+  // behind `!uncommitted.untracked`, so brand-new files had no way to be
+  // included in a commit from this view at all. It must render for
+  // untracked files too, and clicking it must still call git.stage — the
+  // backend already handles staging an untracked file as a plain `git add`.
+  it('shows the Include in commit checkbox for an untracked file and stages it on click', async () => {
+    const git = mountWith({
+      uncommitted: {
+        hunks: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 1, lines: ['+new file'] }],
+        counts: { added: 1, removed: 0 }, staged: false, untracked: true, inHead: false, binary: false,
+      },
+    });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    const checkbox = screen.getByText('Include in commit');
+    expect(checkbox).toBeInTheDocument();
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(git.stage).toHaveBeenCalledWith('/proj', 'src/f.ts'));
+  });
+
+  // Composer empty-cart hint (owner decision 2026-07-23): nothing explains
+  // WHY the commit button is disabled when the message field is empty of
+  // staged files — the hint only needs to appear when nothing is staged.
+  it('shows the empty-cart hint when stagedCount is 0 and hides it once something is staged', async () => {
+    mountWith({ stagedCount: 0 });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    expect(screen.getByText('Tick “Include in commit” on a change above to choose what gets committed.')).toBeInTheDocument();
+
+    cleanup();
+    mountWith({ stagedCount: 2 });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    expect(screen.queryByText('Tick “Include in commit” on a change above to choose what gets committed.')).not.toBeInTheDocument();
+  });
+
+  // Revert-button rename (owner decision 2026-07-23): "Delete file…" read as
+  // deleting the underlying file even though it only moves it to the OS
+  // trash (or restores from HEAD) — same label for both tracked and
+  // untracked files now, behavior (onRequestDiscard(!inHead)) unchanged.
+  it('revert button reads "Revert Changes…" for a tracked file and calls onRequestDiscard(false)', async () => {
+    const onRequestDiscard = vi.fn();
+    mountWith({}, { onRequestDiscard });
+    const btn = await waitFor(() => screen.getByRole('button', { name: 'Revert Changes…' }));
+    fireEvent.click(btn);
+    expect(onRequestDiscard).toHaveBeenCalledWith(false);
+  });
+
+  it('revert button also reads "Revert Changes…" for an untracked file and calls onRequestDiscard(true)', async () => {
+    const onRequestDiscard = vi.fn();
+    mountWith({
+      uncommitted: {
+        hunks: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 1, lines: ['+new file'] }],
+        counts: { added: 1, removed: 0 }, staged: false, untracked: true, inHead: false, binary: false,
+      },
+    }, { onRequestDiscard });
+    const btn = await waitFor(() => screen.getByRole('button', { name: 'Revert Changes…' }));
+    fireEvent.click(btn);
+    expect(onRequestDiscard).toHaveBeenCalledWith(true);
   });
 
   it('surfaces a failed operation error verbatim', async () => {
@@ -183,8 +241,8 @@ describe('GitReviewView', () => {
   it('calls onExternalErrorClear at the top of a new run() (stage/unstage)', async () => {
     const onExternalErrorClear = vi.fn();
     const git = mountWith({}, { onExternalErrorClear });
-    await waitFor(() => screen.getByText('Staged for commit'));
-    fireEvent.click(screen.getByText('Staged for commit'));
+    await waitFor(() => screen.getByText('Include in commit'));
+    fireEvent.click(screen.getByText('Include in commit'));
     await waitFor(() => expect(git.stage).toHaveBeenCalledWith('/proj', 'src/f.ts'));
     expect(onExternalErrorClear).toHaveBeenCalledTimes(1);
   });
@@ -192,10 +250,10 @@ describe('GitReviewView', () => {
   it('a blocked run() (busy guard) does not call onExternalErrorClear', async () => {
     const onExternalErrorClear = vi.fn();
     const git = mountWith({}, { onExternalErrorClear });
-    await waitFor(() => screen.getByText('Staged for commit'));
+    await waitFor(() => screen.getByText('Include in commit'));
     let resolveStage: (v: { ok: boolean }) => void = () => {};
     git.stage.mockReturnValueOnce(new Promise((resolve) => { resolveStage = resolve; }));
-    const btn = screen.getByText('Staged for commit');
+    const btn = screen.getByText('Include in commit');
     fireEvent.click(btn); // first call clears
     fireEvent.click(btn); // second call is blocked by the busy guard — no additional clear
     expect(onExternalErrorClear).toHaveBeenCalledTimes(1);
@@ -205,10 +263,10 @@ describe('GitReviewView', () => {
 
   it('serializes overlapping stage/unstage clicks through run()', async () => {
     const git = mountWith();
-    await waitFor(() => screen.getByText('Staged for commit'));
+    await waitFor(() => screen.getByText('Include in commit'));
     let resolveStage: (v: { ok: boolean }) => void = () => {};
     git.stage.mockReturnValueOnce(new Promise((resolve) => { resolveStage = resolve; }));
-    const btn = screen.getByText('Staged for commit');
+    const btn = screen.getByText('Include in commit');
     fireEvent.click(btn);
     fireEvent.click(btn); // second click while the first op is still in-flight
     expect(git.stage).toHaveBeenCalledTimes(1);

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -117,4 +117,26 @@ describe('GitReviewView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Commit 1 staged file' }));
     await waitFor(() => expect(screen.getByText('nothing added to commit')).toBeInTheDocument());
   });
+
+  it('surfaces a commit-diff fetch error instead of collapsing to "No direct changes"', async () => {
+    const git = mountWith();
+    git.commitFileDiff.mockResolvedValueOnce({ ok: false, error: 'fatal: bad object', hunks: [], binary: false });
+    await waitFor(() => screen.getByText('fix: first'));
+    fireEvent.click(screen.getByText('fix: first'));
+    await waitFor(() => expect(screen.getByText('fatal: bad object')).toBeInTheDocument());
+    expect(screen.queryByText('No direct changes to this file in this commit.')).not.toBeInTheDocument();
+  });
+
+  it('serializes overlapping stage/unstage clicks through run()', async () => {
+    const git = mountWith();
+    await waitFor(() => screen.getByText('Staged for commit'));
+    let resolveStage: (v: { ok: boolean }) => void = () => {};
+    git.stage.mockReturnValueOnce(new Promise((resolve) => { resolveStage = resolve; }));
+    const btn = screen.getByText('Staged for commit');
+    fireEvent.click(btn);
+    fireEvent.click(btn); // second click while the first op is still in-flight
+    expect(git.stage).toHaveBeenCalledTimes(1);
+    resolveStage({ ok: true });
+    await waitFor(() => expect(git.stage).toHaveBeenCalledTimes(1));
+  });
 });

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -93,6 +93,14 @@ describe('GitReviewView', () => {
     expect(screen.queryByText('Uncommitted changes')).not.toBeInTheDocument();
   });
 
+  it('no composer block when the file is clean (uncommitted is null)', async () => {
+    mountWith({ uncommitted: null });
+    await waitFor(() => expect(screen.getByText('fix: first')).toBeInTheDocument());
+    // Entire composer should be hidden: no message textarea, no commit button
+    expect(screen.queryByPlaceholderText('Commit message')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Commit/ })).not.toBeInTheDocument();
+  });
+
   it('expanding a commit card lazily fetches its diff using the HISTORICAL path, not the current path', async () => {
     const git = mountWith();
     await waitFor(() => screen.getByText('fix: first'));

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -17,8 +17,10 @@ const review: GitFileReviewResult = {
     counts: { added: 2, removed: 1 }, staged: false, untracked: false, inHead: true, binary: false,
   },
   log: [
-    { sha: 'a'.repeat(40), shortSha: 'aaaaaaa', subject: 'fix: first', authorDate: '2026-07-22T10:00:00Z' },
-    { sha: 'b'.repeat(40), shortSha: 'bbbbbbb', subject: 'feat: second', authorDate: '2026-07-21T10:00:00Z' },
+    // pathAtCommit deliberately differs from relPath ('src/f.ts') so the
+    // "historical path, not current path" assertion below is meaningful.
+    { sha: 'a'.repeat(40), shortSha: 'aaaaaaa', subject: 'fix: first', authorDate: '2026-07-22T10:00:00Z', pathAtCommit: 'old-name.ts' },
+    { sha: 'b'.repeat(40), shortSha: 'bbbbbbb', subject: 'feat: second', authorDate: '2026-07-21T10:00:00Z', pathAtCommit: 'src/f.ts' },
   ],
   hasMore: false, stagedCount: 0,
 };
@@ -65,12 +67,30 @@ describe('GitReviewView', () => {
     expect(screen.queryByText('Uncommitted changes')).not.toBeInTheDocument();
   });
 
-  it('expanding a commit card lazily fetches its diff', async () => {
+  it('expanding a commit card lazily fetches its diff using the HISTORICAL path, not the current path', async () => {
     const git = mountWith();
     await waitFor(() => screen.getByText('fix: first'));
     fireEvent.click(screen.getByText('fix: first'));
     await waitFor(() =>
-      expect(git.commitFileDiff).toHaveBeenCalledWith('/proj', 'a'.repeat(40), 'src/f.ts'));
+      expect(git.commitFileDiff).toHaveBeenCalledWith('/proj', 'a'.repeat(40), 'old-name.ts', undefined));
+  });
+
+  it('renders "Moved from" copy instead of the generic empty state for a renamedFrom commit with no content changes', async () => {
+    const git = mountWith({
+      log: [
+        {
+          sha: 'c'.repeat(40), shortSha: 'ccccccc', subject: 'chore: move file',
+          authorDate: '2026-07-20T10:00:00Z', pathAtCommit: 'src/f.ts', renamedFrom: 'old-name.ts',
+        },
+      ],
+    });
+    await waitFor(() => screen.getByText('chore: move file'));
+    fireEvent.click(screen.getByText('chore: move file'));
+    await waitFor(() =>
+      expect(git.commitFileDiff).toHaveBeenCalledWith('/proj', 'c'.repeat(40), 'src/f.ts', 'old-name.ts'));
+    await waitFor(() =>
+      expect(screen.getByText('Moved from “old-name.ts” — no content changes in this commit.')).toBeInTheDocument());
+    expect(screen.queryByText('No direct changes to this file in this commit.')).not.toBeInTheDocument();
   });
 
   it('Show more appears when hasMore and fetches the next page', async () => {

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -127,6 +127,35 @@ describe('GitReviewView', () => {
     expect(screen.queryByText('No direct changes to this file in this commit.')).not.toBeInTheDocument();
   });
 
+  it('renders externalError in the same slot as opError when there is no opError', async () => {
+    mountWith({}, { externalError: 'fatal: could not restore f.ts' });
+    await waitFor(() => screen.getByText('Uncommitted changes'));
+    expect(screen.getByText('fatal: could not restore f.ts')).toBeInTheDocument();
+  });
+
+  it('calls onExternalErrorClear at the top of a new run() (stage/unstage)', async () => {
+    const onExternalErrorClear = vi.fn();
+    const git = mountWith({}, { onExternalErrorClear });
+    await waitFor(() => screen.getByText('Staged for commit'));
+    fireEvent.click(screen.getByText('Staged for commit'));
+    await waitFor(() => expect(git.stage).toHaveBeenCalledWith('/proj', 'src/f.ts'));
+    expect(onExternalErrorClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('a blocked run() (busy guard) does not call onExternalErrorClear', async () => {
+    const onExternalErrorClear = vi.fn();
+    const git = mountWith({}, { onExternalErrorClear });
+    await waitFor(() => screen.getByText('Staged for commit'));
+    let resolveStage: (v: { ok: boolean }) => void = () => {};
+    git.stage.mockReturnValueOnce(new Promise((resolve) => { resolveStage = resolve; }));
+    const btn = screen.getByText('Staged for commit');
+    fireEvent.click(btn); // first call clears
+    fireEvent.click(btn); // second call is blocked by the busy guard — no additional clear
+    expect(onExternalErrorClear).toHaveBeenCalledTimes(1);
+    resolveStage({ ok: true });
+    await waitFor(() => expect(git.stage).toHaveBeenCalledTimes(1));
+  });
+
   it('serializes overlapping stage/unstage clicks through run()', async () => {
     const git = mountWith();
     await waitFor(() => screen.getByText('Staged for commit'));

--- a/desktop/src/renderer/components/git/GitReviewView.test.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.test.tsx
@@ -2,7 +2,7 @@
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
 import { GitReviewView } from './GitReviewView';
 import type { GitFileReviewResult } from '../../../shared/git-types';
 
@@ -19,8 +19,10 @@ const review: GitFileReviewResult = {
   log: [
     // pathAtCommit deliberately differs from relPath ('src/f.ts') so the
     // "historical path, not current path" assertion below is meaningful.
-    { sha: 'a'.repeat(40), shortSha: 'aaaaaaa', subject: 'fix: first', authorDate: '2026-07-22T10:00:00Z', pathAtCommit: 'old-name.ts' },
-    { sha: 'b'.repeat(40), shortSha: 'bbbbbbb', subject: 'feat: second', authorDate: '2026-07-21T10:00:00Z', pathAtCommit: 'src/f.ts' },
+    // counts differ (a real value vs null) so the header-counts test below
+    // can assert both the "shows +/-" and "shows nothing" cases.
+    { sha: 'a'.repeat(40), shortSha: 'aaaaaaa', subject: 'fix: first', authorDate: '2026-07-22T10:00:00Z', pathAtCommit: 'old-name.ts', counts: { added: 3, removed: 1 } },
+    { sha: 'b'.repeat(40), shortSha: 'bbbbbbb', subject: 'feat: second', authorDate: '2026-07-21T10:00:00Z', pathAtCommit: 'src/f.ts', counts: null },
   ],
   hasMore: false, stagedCount: 0,
 };
@@ -61,6 +63,30 @@ describe('GitReviewView', () => {
     expect(screen.getByText('feat: second')).toBeInTheDocument();
   });
 
+  it('commit card header shows the same +/- counts as the uncommitted card; null counts show no count text', async () => {
+    mountWith();
+    // Scope to the specific commit card so the assertion isn't ambiguous
+    // with the uncommitted card's own +2/−1 counts.
+    const firstCard = (await waitFor(() => screen.getByText('fix: first'))).closest('button')!;
+    expect(within(firstCard).getByText('+3')).toBeInTheDocument();
+    expect(within(firstCard).getByText('−1')).toBeInTheDocument(); // U+2212 minus, same glyph as the uncommitted card
+    // 'feat: second' has counts: null -> no +/- text for it at all
+    const secondCard = screen.getByText('feat: second').closest('button')!;
+    expect(within(secondCard).queryByText('+', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('the expanded diff sits in a height-capped scroll container, separate from the uncommitted card action row', async () => {
+    mountWith();
+    await waitFor(() => expect(screen.getByText('Uncommitted changes')).toBeInTheDocument());
+    const diffText = screen.getByText('old line');
+    const scrollContainer = diffText.closest('.overflow-y-auto');
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer?.className).toContain('max-h-[45vh]');
+    // The action row (staged checkbox) must NOT be inside that scroll cap.
+    const actionRow = screen.getByText('Staged for commit');
+    expect(scrollContainer?.contains(actionRow)).toBe(false);
+  });
+
   it('no uncommitted card when the file is clean', async () => {
     mountWith({ uncommitted: null });
     await waitFor(() => expect(screen.getByText('fix: first')).toBeInTheDocument());
@@ -81,6 +107,7 @@ describe('GitReviewView', () => {
         {
           sha: 'c'.repeat(40), shortSha: 'ccccccc', subject: 'chore: move file',
           authorDate: '2026-07-20T10:00:00Z', pathAtCommit: 'src/f.ts', renamedFrom: 'old-name.ts',
+          counts: { added: 0, removed: 0 },
         },
       ],
     });

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -1,0 +1,251 @@
+// The pushed review sub-view (mockup ledger 10-13, spec section 2). Mirror,
+// not gate: everything shown here is a live read of git state; staging is the
+// real index; refresh rides git:changed. The standard drawer top bar stays in
+// the host — this component starts at the sub-header row.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { UnifiedDiff } from '../diff/UnifiedDiff';
+import { formatRelativeTime } from '../../utils/format-time';
+import { Button, Textarea } from '../ui';
+import { GitReviewCard } from './GitReviewCard';
+import type { GitFileReviewResult, GitLogEntry } from '../../../shared/git-types';
+import type { StructuredPatchHunk } from '../../../shared/types';
+
+export interface GitReviewViewProps {
+  projectRoot: string;
+  /** project-root-relative path of the file under review (artifact.path) */
+  relPath: string;
+  fileName: string;
+  onBack: () => void;
+  /** jump into the editor at a 1-indexed line (Task 7 host wires revealLine) */
+  onOpenAtLine: (line: number) => void;
+  /** open the L3 discard confirm; willTrash = HEAD has no copy, so discard
+   *  trashes the file instead of restoring (Task 9 wires the dialog) */
+  onRequestDiscard: (willTrash: boolean) => void;
+}
+
+function gitApi(): any {
+  return (window as any).claude?.git;
+}
+
+export function GitReviewView({
+  projectRoot, relPath, fileName, onBack, onOpenAtLine, onRequestDiscard,
+}: GitReviewViewProps) {
+  const [review, setReview] = useState<GitFileReviewResult | null>(null);
+  const [extraLog, setExtraLog] = useState<GitLogEntry[]>([]);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(['uncommitted']));
+  const [commitDiffs, setCommitDiffs] = useState<Map<string, StructuredPatchHunk[] | 'loading' | 'empty'>>(new Map());
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [opError, setOpError] = useState<string | null>(null);
+  const aliveRef = useRef(true);
+
+  const refresh = useCallback(() => {
+    gitApi()?.fileReview?.(projectRoot, relPath)
+      .then((r: GitFileReviewResult) => { if (aliveRef.current && r?.ok) { setReview(r); } })
+      .catch(() => {});
+  }, [projectRoot, relPath]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    refresh();
+    const off = gitApi()?.onChanged?.(() => refresh()) ?? (() => {});
+    return () => { aliveRef.current = false; off(); };
+  }, [refresh]);
+
+  const toggle = (key: string) => setExpanded((prev) => {
+    const next = new Set(prev);
+    if (next.has(key)) next.delete(key); else next.add(key);
+    return next;
+  });
+
+  const expandCommit = (sha: string) => {
+    toggle(sha);
+    if (!commitDiffs.has(sha)) {
+      setCommitDiffs((m) => new Map(m).set(sha, 'loading'));
+      gitApi()?.commitFileDiff?.(projectRoot, sha, relPath)
+        .then((d: { ok: boolean; hunks: StructuredPatchHunk[] }) => {
+          if (!aliveRef.current) return;
+          setCommitDiffs((m) => new Map(m).set(sha, d.ok && d.hunks.length > 0 ? d.hunks : 'empty'));
+        })
+        .catch(() => { if (aliveRef.current) setCommitDiffs((m) => new Map(m).set(sha, 'empty')); });
+    }
+  };
+
+  const showMore = () => {
+    const skip = (review?.log.length ?? 0) + extraLog.length;
+    gitApi()?.fileReview?.(projectRoot, relPath, { logSkip: skip })
+      .then((r: GitFileReviewResult) => {
+        if (aliveRef.current && r?.ok) {
+          setExtraLog((prev) => [...prev, ...r.log]);
+          setReview((prev) => (prev ? { ...prev, hasMore: r.hasMore } : prev));
+        }
+      })
+      .catch(() => {});
+  };
+
+  const run = async (op: () => Promise<{ ok: boolean; error?: string }>) => {
+    setBusy(true);
+    setOpError(null);
+    try {
+      const r = await op();
+      // Real stderr passthrough (error-message standard) — never a guessed cause.
+      if (!r.ok) setOpError(r.error ?? 'git operation failed');
+      else refresh();
+      return r.ok;
+    } finally { setBusy(false); }
+  };
+
+  const stagedCount = review?.stagedCount ?? 0;
+  const canCommit = !busy && stagedCount > 0 && message.trim().length > 0;
+  const uncommitted = review?.uncommitted ?? null;
+  const log = [...(review?.log ?? []), ...extraLog];
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      {/* sub-header BENEATH the standard drawer top bar (ledger 10, locked) */}
+      <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-edge-dim bg-well shrink-0">
+        <button
+          type="button"
+          onClick={onBack}
+          title="Back to file view"
+          className="w-7 h-7 rounded-md inline-flex items-center justify-center shrink-0 border transition-colors text-fg-dim border-transparent hover:text-fg hover:bg-inset hover:border-edge"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+            <path d="M19 12H5M11 18l-6-6 6-6" />
+          </svg>
+        </button>
+        <span className="text-xs font-medium text-fg-2 truncate">Reviewing changes for “{fileName}”</span>
+        <div className="flex-1" />
+        {review?.branch && (
+          <span className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-mono text-fg-dim border border-edge-dim" title="Current branch">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+              <circle cx="6" cy="6" r="2.5" /><circle cx="6" cy="18" r="2.5" /><circle cx="18" cy="8" r="2.5" />
+              <path d="M6 8.5v7M18 10.5c0 3-4 3.5-7 3.5" />
+            </svg>
+            {review.branch}
+          </span>
+        )}
+      </div>
+
+      {/* card timeline */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-3 flex flex-col gap-2">
+        {uncommitted && (
+          <GitReviewCard
+            accent
+            expanded={expanded.has('uncommitted')}
+            onToggle={() => toggle('uncommitted')}
+            headerLeft={<span className="text-xs font-semibold text-fg flex-1">Uncommitted changes</span>}
+            headerRight={
+              <>
+                <span className="text-[10px] font-mono text-green-400">+{uncommitted.counts.added}</span>
+                <span className="text-[10px] font-mono text-red-400">−{uncommitted.counts.removed}</span>
+              </>
+            }
+          >
+            {uncommitted.binary ? (
+              <div className="text-[11px] text-fg-muted py-1">Binary or oversized file — no line diff.</div>
+            ) : (
+              <UnifiedDiff oldStr="" newStr="" structuredPatch={uncommitted.hunks} />
+            )}
+            <div className="flex items-center gap-1.5 mt-2">
+              {!uncommitted.untracked && (
+                <button
+                  type="button"
+                  onClick={() => run(() => (uncommitted.staged
+                    ? gitApi().unstage(projectRoot, relPath)
+                    : gitApi().stage(projectRoot, relPath)))}
+                  className="flex items-center gap-1.5 text-[11px] text-fg-2 hover:text-fg transition-colors"
+                >
+                  <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                    <rect x="3" y="3" width="18" height="18" rx="3" />
+                    {uncommitted.staged && <path d="m8 12.5 3 3 5.5-6.5" />}
+                  </svg>
+                  Staged for commit
+                </button>
+              )}
+              <div className="flex-1" />
+              <button
+                type="button"
+                onClick={() => onRequestDiscard(!uncommitted.inHead)}
+                className="px-2 py-1 rounded-md text-[11px] text-destructive-fg hover:bg-destructive/10 transition-colors"
+              >
+                {!uncommitted.inHead ? 'Delete file…' : 'Discard changes…'}
+              </button>
+              {uncommitted.hunks.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => onOpenAtLine(uncommitted.hunks[0].newStart)}
+                  className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-fg-dim hover:text-fg hover:bg-inset transition-colors"
+                >
+                  Open file ↗
+                </button>
+              )}
+            </div>
+          </GitReviewCard>
+        )}
+
+        {log.map((entry) => {
+          const body = commitDiffs.get(entry.sha);
+          return (
+            <GitReviewCard
+              key={entry.sha}
+              expanded={expanded.has(entry.sha)}
+              onToggle={() => expandCommit(entry.sha)}
+              headerLeft={
+                <>
+                  <span className="font-mono text-[11px] text-fg-faint">{entry.shortSha}</span>
+                  <span className="text-xs text-fg-2 truncate flex-1">{entry.subject}</span>
+                </>
+              }
+              headerRight={<span className="text-[11px] text-fg-faint whitespace-nowrap">{formatRelativeTime(entry.authorDate)}</span>}
+            >
+              {body === 'loading' && <div className="text-[11px] text-fg-muted py-1">Loading…</div>}
+              {body === 'empty' && <div className="text-[11px] text-fg-muted py-1">No direct changes to this file in this commit.</div>}
+              {Array.isArray(body) && <UnifiedDiff oldStr="" newStr="" structuredPatch={body} />}
+            </GitReviewCard>
+          );
+        })}
+
+        {review?.hasMore && (
+          <button
+            type="button"
+            onClick={showMore}
+            className="text-[10px] uppercase tracking-wider text-fg-muted hover:text-fg-2 py-1"
+          >
+            Show more
+          </button>
+        )}
+      </div>
+
+      {/* composer (ledger 13): counts staged files REPO-WIDE — a commit always
+          commits the whole index, including files the agent staged meanwhile. */}
+      <div className="shrink-0 border-t border-edge px-2 py-2 bg-inset">
+        {opError && (
+          <div className="mb-1 px-2.5 py-1.5 text-[11px] text-fg rounded-md border border-edge bg-well break-all">
+            {opError}
+          </div>
+        )}
+        <Textarea
+          size="sm"
+          rows={2}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Commit message"
+          className="w-full"
+        />
+        <Button
+          size="md"
+          variant="primary"
+          disabled={!canCommit}
+          className="mt-1 w-full"
+          onClick={async () => {
+            const ok = await run(() => gitApi().commit(projectRoot, message));
+            if (ok) setMessage('');
+          }}
+        >
+          {`Commit ${stagedCount} staged file${stagedCount === 1 ? '' : 's'}`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -33,7 +33,10 @@ export function GitReviewView({
   const [review, setReview] = useState<GitFileReviewResult | null>(null);
   const [extraLog, setExtraLog] = useState<GitLogEntry[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(['uncommitted']));
-  const [commitDiffs, setCommitDiffs] = useState<Map<string, StructuredPatchHunk[] | 'loading' | 'empty'>>(new Map());
+  // Error-message standard: a failed `commitFileDiff` fetch (ok:false, or a
+  // rejected promise) must surface the real backend string, never collapse
+  // into the same 'empty' state as a genuinely change-free commit.
+  const [commitDiffs, setCommitDiffs] = useState<Map<string, StructuredPatchHunk[] | 'loading' | 'empty' | { error: string }>>(new Map());
   const [message, setMessage] = useState('');
   const [busy, setBusy] = useState(false);
   const [opError, setOpError] = useState<string | null>(null);
@@ -63,11 +66,17 @@ export function GitReviewView({
     if (!commitDiffs.has(sha)) {
       setCommitDiffs((m) => new Map(m).set(sha, 'loading'));
       gitApi()?.commitFileDiff?.(projectRoot, sha, relPath)
-        .then((d: { ok: boolean; hunks: StructuredPatchHunk[] }) => {
+        .then((d: { ok: boolean; hunks: StructuredPatchHunk[]; error?: string }) => {
           if (!aliveRef.current) return;
-          setCommitDiffs((m) => new Map(m).set(sha, d.ok && d.hunks.length > 0 ? d.hunks : 'empty'));
+          // ok:false is a real backend failure, not "no changes" — surface it.
+          if (!d.ok) { setCommitDiffs((m) => new Map(m).set(sha, { error: d.error ?? 'git show failed' })); return; }
+          setCommitDiffs((m) => new Map(m).set(sha, d.hunks.length > 0 ? d.hunks : 'empty'));
         })
-        .catch(() => { if (aliveRef.current) setCommitDiffs((m) => new Map(m).set(sha, 'empty')); });
+        .catch((e: unknown) => {
+          if (aliveRef.current) {
+            setCommitDiffs((m) => new Map(m).set(sha, { error: e instanceof Error ? e.message : String(e) }));
+          }
+        });
     }
   };
 
@@ -84,6 +93,10 @@ export function GitReviewView({
   };
 
   const run = async (op: () => Promise<{ ok: boolean; error?: string }>) => {
+    // Serialize git ops: without this guard, a second run() while one is
+    // in-flight wipes the first's opError and re-enables mid-op (the commit
+    // button already checked `busy` via canCommit, but stage/unstage didn't).
+    if (busy) return false;
     setBusy(true);
     setOpError(null);
     try {
@@ -151,10 +164,11 @@ export function GitReviewView({
               {!uncommitted.untracked && (
                 <button
                   type="button"
+                  disabled={busy}
                   onClick={() => run(() => (uncommitted.staged
                     ? gitApi().unstage(projectRoot, relPath)
                     : gitApi().stage(projectRoot, relPath)))}
-                  className="flex items-center gap-1.5 text-[11px] text-fg-2 hover:text-fg transition-colors"
+                  className="flex items-center gap-1.5 text-[11px] text-fg-2 hover:text-fg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
                     <rect x="3" y="3" width="18" height="18" rx="3" />
@@ -201,6 +215,9 @@ export function GitReviewView({
             >
               {body === 'loading' && <div className="text-[11px] text-fg-muted py-1">Loading…</div>}
               {body === 'empty' && <div className="text-[11px] text-fg-muted py-1">No direct changes to this file in this commit.</div>}
+              {body && typeof body === 'object' && !Array.isArray(body) && (
+                <div className="text-[11px] text-fg-muted py-1 break-words">{body.error}</div>
+              )}
               {Array.isArray(body) && <UnifiedDiff oldStr="" newStr="" structuredPatch={body} />}
             </GitReviewCard>
           );

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -180,7 +180,16 @@ export function GitReviewView({
             {uncommitted.binary ? (
               <div className="text-[11px] text-fg-muted py-1">Binary or oversized file — no line diff.</div>
             ) : (
-              <UnifiedDiff oldStr="" newStr="" structuredPatch={uncommitted.hunks} />
+              // Cap the diff's own height and let IT scroll, not the card —
+              // a long diff used to render full-height, ballooning the card
+              // to the point it looked scrollable but wasn't. UnifiedDiff
+              // already frames itself (rounded-sm border-edge), so this outer
+              // box only adds the height cap, no second border. The action
+              // row below (staged checkbox / discard / open-file) stays a
+              // sibling of this div, not a child, so it's always visible.
+              <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
+                <UnifiedDiff oldStr="" newStr="" structuredPatch={uncommitted.hunks} />
+              </div>
             )}
             <div className="flex items-center gap-1.5 mt-2">
               {!uncommitted.untracked && (
@@ -236,7 +245,20 @@ export function GitReviewView({
                   <span className="text-xs text-fg-2 truncate flex-1">{entry.subject}</span>
                 </>
               }
-              headerRight={<span className="text-[11px] text-fg-faint whitespace-nowrap">{formatRelativeTime(entry.authorDate)}</span>}
+              headerRight={
+                <>
+                  {/* Same +N/−N glyphs as the uncommitted card's headerRight —
+                      null (binary, or a chunk with no numstat line) shows no
+                      count at all rather than a misleading +0/−0. */}
+                  {entry.counts && (
+                    <>
+                      <span className="text-[10px] font-mono text-green-400">+{entry.counts.added}</span>
+                      <span className="text-[10px] font-mono text-red-400">−{entry.counts.removed}</span>
+                    </>
+                  )}
+                  <span className="text-[11px] text-fg-faint whitespace-nowrap">{formatRelativeTime(entry.authorDate)}</span>
+                </>
+              }
             >
               {body === 'loading' && <div className="text-[11px] text-fg-muted py-1">Loading…</div>}
               {/* A rename-only commit (renamedFrom set) with no content change is an
@@ -251,7 +273,13 @@ export function GitReviewView({
               {body && typeof body === 'object' && !Array.isArray(body) && (
                 <div className="text-[11px] text-fg-muted py-1 break-words">{body.error}</div>
               )}
-              {Array.isArray(body) && <UnifiedDiff oldStr="" newStr="" structuredPatch={body} />}
+              {/* Same height-cap-with-inner-scroll wrapper as the uncommitted
+                  card above — see the WHY comment there. */}
+              {Array.isArray(body) && (
+                <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
+                  <UnifiedDiff oldStr="" newStr="" structuredPatch={body} />
+                </div>
+              )}
             </GitReviewCard>
           );
         })}

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -16,8 +16,6 @@ export interface GitReviewViewProps {
   relPath: string;
   fileName: string;
   onBack: () => void;
-  /** jump into the editor at a 1-indexed line (Task 7 host wires revealLine) */
-  onOpenAtLine: (line: number) => void;
   /** open the L3 discard confirm; willTrash = HEAD has no copy, so discard
    *  trashes the file instead of restoring (Task 9 wires the dialog) */
   onRequestDiscard: (willTrash: boolean) => void;
@@ -34,7 +32,7 @@ function gitApi(): any {
 }
 
 export function GitReviewView({
-  projectRoot, relPath, fileName, onBack, onOpenAtLine, onRequestDiscard,
+  projectRoot, relPath, fileName, onBack, onRequestDiscard,
   externalError, onExternalErrorClear,
 }: GitReviewViewProps) {
   const [review, setReview] = useState<GitFileReviewResult | null>(null);
@@ -192,42 +190,34 @@ export function GitReviewView({
               </div>
             )}
             <div className="flex items-center gap-1.5 mt-2">
-              {!uncommitted.untracked && (
-                <button
-                  type="button"
-                  disabled={busy}
-                  onClick={() => run(() => (uncommitted.staged
-                    ? gitApi().unstage(projectRoot, relPath)
-                    : gitApi().stage(projectRoot, relPath)))}
-                  className="flex items-center gap-1.5 text-[11px] text-fg-2 hover:text-fg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
-                    <rect x="3" y="3" width="18" height="18" rx="3" />
-                    {uncommitted.staged && <path d="m8 12.5 3 3 5.5-6.5" />}
-                  </svg>
-                  Staged for commit
-                </button>
-              )}
+              {/* Legible mirror (owner decision 2026-07-23): the checkbox used
+                  to hide behind !uncommitted.untracked, so a brand-new file
+                  had no way to be included in a commit from this view. The
+                  backend already handles it — staging an untracked file is a
+                  plain `git add`, and the mirror refresh flips the card to
+                  staged like any other file. */}
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => run(() => (uncommitted.staged
+                  ? gitApi().unstage(projectRoot, relPath)
+                  : gitApi().stage(projectRoot, relPath)))}
+                className="flex items-center gap-1.5 text-[11px] text-fg-2 hover:text-fg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+                  <rect x="3" y="3" width="18" height="18" rx="3" />
+                  {uncommitted.staged && <path d="m8 12.5 3 3 5.5-6.5" />}
+                </svg>
+                Include in commit
+              </button>
               <div className="flex-1" />
               <button
                 type="button"
                 onClick={() => onRequestDiscard(!uncommitted.inHead)}
                 className="px-2 py-1 rounded-md text-[11px] text-destructive-fg hover:bg-destructive/10 transition-colors"
               >
-                {!uncommitted.inHead ? 'Delete file…' : 'Discard changes…'}
+                Revert Changes…
               </button>
-              {uncommitted.hunks.length > 0 && (
-                <button
-                  type="button"
-                  // A pure-deletion hunk has newStart: 0 (nothing added at that
-                  // position); revealLine is 1-indexed, so clamp to 1 instead
-                  // of asking the editor to reveal a nonexistent line 0.
-                  onClick={() => onOpenAtLine(Math.max(1, uncommitted.hunks[0].newStart))}
-                  className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-fg-dim hover:text-fg hover:bg-inset transition-colors"
-                >
-                  Open file ↗
-                </button>
-              )}
             </div>
           </GitReviewCard>
         )}
@@ -323,6 +313,14 @@ export function GitReviewView({
         >
           {`Commit ${stagedCount} staged file${stagedCount === 1 ? '' : 's'}`}
         </Button>
+        {/* Empty-cart hint (owner decision 2026-07-23): the commit button is
+            disabled whenever nothing is staged, but that gave no clue WHY —
+            this line only shows up in that state. */}
+        {stagedCount === 0 && (
+          <div className="mt-1 text-[11px] text-fg-muted">
+            Tick “Include in commit” on a change above to choose what gets committed.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -72,11 +72,19 @@ export function GitReviewView({
     return next;
   });
 
-  const expandCommit = (sha: string) => {
+  const expandCommit = (entry: GitLogEntry) => {
+    const sha = entry.sha;
     toggle(sha);
     if (!commitDiffs.has(sha)) {
       setCommitDiffs((m) => new Map(m).set(sha, 'loading'));
-      gitApi()?.commitFileDiff?.(projectRoot, sha, relPath)
+      // WHY entry.pathAtCommit not relPath: git log --follow tracks renames,
+      // so a commit before the file's rename lived at a different path —
+      // asking git show with the CURRENT path returns an empty diff for
+      // those commits (the bug this fixes). Pass the historical name, and
+      // for the rename commit itself also pass renamedFrom so the main
+      // process can pair the rename with -M instead of rendering the
+      // add-side full-file wall.
+      gitApi()?.commitFileDiff?.(projectRoot, sha, entry.pathAtCommit ?? relPath, entry.renamedFrom)
         .then((d: { ok: boolean; hunks: StructuredPatchHunk[]; error?: string }) => {
           if (!aliveRef.current) return;
           // ok:false is a real backend failure, not "no changes" — surface it.
@@ -221,7 +229,7 @@ export function GitReviewView({
             <GitReviewCard
               key={entry.sha}
               expanded={expanded.has(entry.sha)}
-              onToggle={() => expandCommit(entry.sha)}
+              onToggle={() => expandCommit(entry)}
               headerLeft={
                 <>
                   <span className="font-mono text-[11px] text-fg-faint">{entry.shortSha}</span>
@@ -231,7 +239,15 @@ export function GitReviewView({
               headerRight={<span className="text-[11px] text-fg-faint whitespace-nowrap">{formatRelativeTime(entry.authorDate)}</span>}
             >
               {body === 'loading' && <div className="text-[11px] text-fg-muted py-1">Loading…</div>}
-              {body === 'empty' && <div className="text-[11px] text-fg-muted py-1">No direct changes to this file in this commit.</div>}
+              {/* A rename-only commit (renamedFrom set) with no content change is an
+                  honest "moved" state, not the generic "no changes" line — that
+                  copy stays reserved for the merge-commit case (no name-status
+                  line at all, entry.renamedFrom undefined). */}
+              {body === 'empty' && (
+                entry.renamedFrom
+                  ? <div className="text-[11px] text-fg-muted py-1">Moved from “{entry.renamedFrom}” — no content changes in this commit.</div>
+                  : <div className="text-[11px] text-fg-muted py-1">No direct changes to this file in this commit.</div>
+              )}
               {body && typeof body === 'object' && !Array.isArray(body) && (
                 <div className="text-[11px] text-fg-muted py-1 break-words">{body.error}</div>
               )}

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -21,6 +21,12 @@ export interface GitReviewViewProps {
   /** open the L3 discard confirm; willTrash = HEAD has no copy, so discard
    *  trashes the file instead of restoring (Task 9 wires the dialog) */
   onRequestDiscard: (willTrash: boolean) => void;
+  /** Surfaced by the caller (e.g. a failed discard) in the same error slot as
+   *  opError — ONE error surface, not two competing banners (Task 9). */
+  externalError?: string | null;
+  /** Called at the top of run() so a new git op supersedes a stale external
+   *  error (e.g. discardError) instead of leaving it displayed forever. */
+  onExternalErrorClear?: () => void;
 }
 
 function gitApi(): any {
@@ -29,6 +35,7 @@ function gitApi(): any {
 
 export function GitReviewView({
   projectRoot, relPath, fileName, onBack, onOpenAtLine, onRequestDiscard,
+  externalError, onExternalErrorClear,
 }: GitReviewViewProps) {
   const [review, setReview] = useState<GitFileReviewResult | null>(null);
   const [extraLog, setExtraLog] = useState<GitLogEntry[]>([]);
@@ -99,6 +106,9 @@ export function GitReviewView({
     if (busy) return false;
     setBusy(true);
     setOpError(null);
+    // A new op (stage/unstage/commit) supersedes any stale externally-surfaced
+    // error (e.g. a prior failed discard) — one error surface, not a leftover.
+    onExternalErrorClear?.();
     try {
       const r = await op();
       // Real stderr passthrough (error-message standard) — never a guessed cause.
@@ -237,9 +247,9 @@ export function GitReviewView({
       {/* composer (ledger 13): counts staged files REPO-WIDE — a commit always
           commits the whole index, including files the agent staged meanwhile. */}
       <div className="shrink-0 border-t border-edge px-2 py-2 bg-inset">
-        {opError && (
+        {(opError ?? externalError) && (
           <div className="mb-1 px-2.5 py-1.5 text-[11px] text-fg rounded-md border border-edge bg-well break-all">
-            {opError}
+            {opError ?? externalError}
           </div>
         )}
         <Textarea

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -178,15 +178,20 @@ export function GitReviewView({
             {uncommitted.binary ? (
               <div className="text-[11px] text-fg-muted py-1">Binary or oversized file — no line diff.</div>
             ) : (
-              // Cap the diff's own height and let IT scroll, not the card —
-              // a long diff used to render full-height, ballooning the card
-              // to the point it looked scrollable but wasn't. UnifiedDiff
-              // already frames itself (rounded-sm border-edge), so this outer
-              // box only adds the height cap, no second border. The action
-              // row below (staged checkbox / revert button) stays a
-              // sibling of this div, not a child, so it's always visible.
-              <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
-                <UnifiedDiff oldStr="" newStr="" structuredPatch={uncommitted.hunks} />
+              // This box is the SOLE scroll surface for the diff text: it caps
+              // at 45vh and scrolls, while UnifiedDiff renders full-height via
+              // `fill` (its own 15-line cap + "Expand" button would otherwise
+              // stack a second, redundant scrollbar inside this one). No
+              // `overscroll-contain` — trapping the wheel here created a
+              // dead-zone where hovering a diff blocked the outer timeline from
+              // scrolling; letting it chain lets a long list of expanded
+              // commits and each diff's own text both scroll naturally.
+              // UnifiedDiff frames itself (rounded-sm border-edge), so this box
+              // adds only the height cap, no second border. The action row
+              // below stays a sibling of this div, not a child, so it's always
+              // visible.
+              <div className="max-h-[45vh] overflow-y-auto">
+                <UnifiedDiff oldStr="" newStr="" structuredPatch={uncommitted.hunks} fill />
               </div>
             )}
             <div className="flex items-center gap-1.5 mt-2">
@@ -263,11 +268,11 @@ export function GitReviewView({
               {body && typeof body === 'object' && !Array.isArray(body) && (
                 <div className="text-[11px] text-fg-muted py-1 break-words">{body.error}</div>
               )}
-              {/* Same height-cap-with-inner-scroll wrapper as the uncommitted
-                  card above — see the WHY comment there. */}
+              {/* Same single-scroll-surface wrapper as the uncommitted card
+                  above — see the WHY comment there. */}
               {Array.isArray(body) && (
-                <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
-                  <UnifiedDiff oldStr="" newStr="" structuredPatch={body} />
+                <div className="max-h-[45vh] overflow-y-auto">
+                  <UnifiedDiff oldStr="" newStr="" structuredPatch={body} fill />
                 </div>
               )}
             </GitReviewCard>

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -183,7 +183,7 @@ export function GitReviewView({
               // to the point it looked scrollable but wasn't. UnifiedDiff
               // already frames itself (rounded-sm border-edge), so this outer
               // box only adds the height cap, no second border. The action
-              // row below (staged checkbox / discard / open-file) stays a
+              // row below (staged checkbox / revert button) stays a
               // sibling of this div, not a child, so it's always visible.
               <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
                 <UnifiedDiff oldStr="" newStr="" structuredPatch={uncommitted.hunks} />
@@ -286,42 +286,46 @@ export function GitReviewView({
       </div>
 
       {/* composer (ledger 13): counts staged files REPO-WIDE — a commit always
-          commits the whole index, including files the agent staged meanwhile. */}
-      <div className="shrink-0 border-t border-edge px-2 py-2 bg-inset">
-        {(opError ?? externalError) && (
-          <div className="mb-1 px-2.5 py-1.5 text-[11px] text-fg rounded-md border border-edge bg-well break-all">
-            {opError ?? externalError}
-          </div>
-        )}
-        <Textarea
-          size="sm"
-          rows={2}
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Commit message"
-          className="w-full"
-        />
-        <Button
-          size="md"
-          variant="primary"
-          disabled={!canCommit}
-          className="mt-1 w-full"
-          onClick={async () => {
-            const ok = await run(() => gitApi().commit(projectRoot, message));
-            if (ok) setMessage('');
-          }}
-        >
-          {`Commit ${stagedCount} staged file${stagedCount === 1 ? '' : 's'}`}
-        </Button>
-        {/* Empty-cart hint (owner decision 2026-07-23): the commit button is
-            disabled whenever nothing is staged, but that gave no clue WHY —
-            this line only shows up in that state. */}
-        {stagedCount === 0 && (
-          <div className="mt-1 text-[11px] text-fg-muted">
-            Tick “Include in commit” on a change above to choose what gets committed.
-          </div>
-        )}
-      </div>
+          commits the whole index, including files the agent staged meanwhile.
+          WHY conditional on uncommitted: a clean file's review is read-only, so
+          no commit affordance should appear. */}
+      {uncommitted && (
+        <div className="shrink-0 border-t border-edge px-2 py-2 bg-inset">
+          {(opError ?? externalError) && (
+            <div className="mb-1 px-2.5 py-1.5 text-[11px] text-fg rounded-md border border-edge bg-well break-all">
+              {opError ?? externalError}
+            </div>
+          )}
+          <Textarea
+            size="sm"
+            rows={2}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Commit message"
+            className="w-full"
+          />
+          <Button
+            size="md"
+            variant="primary"
+            disabled={!canCommit}
+            className="mt-1 w-full"
+            onClick={async () => {
+              const ok = await run(() => gitApi().commit(projectRoot, message));
+              if (ok) setMessage('');
+            }}
+          >
+            {`Commit ${stagedCount} staged file${stagedCount === 1 ? '' : 's'}`}
+          </Button>
+          {/* Empty-cart hint (owner decision 2026-07-23): the commit button is
+              disabled whenever nothing is staged, but that gave no clue WHY —
+              this line only shows up in that state. */}
+          {stagedCount === 0 && (
+            <div className="mt-1 text-[11px] text-fg-muted">
+              Tick “Include in commit” on a change above to choose what gets committed.
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -58,6 +58,10 @@ export function GitReviewView({
   useEffect(() => {
     aliveRef.current = true;
     refresh();
+    // NOTE: this only re-fetches ON a `git:changed` event — it does not itself
+    // register the `git:watch` subscription that produces those events. That
+    // registration lives in the host footer's useGitFileStatus hook, so this
+    // view's live refresh depends on the host keeping that subscription alive.
     const off = gitApi()?.onChanged?.(() => refresh()) ?? (() => {});
     return () => { aliveRef.current = false; off(); };
   }, [refresh]);
@@ -198,7 +202,10 @@ export function GitReviewView({
               {uncommitted.hunks.length > 0 && (
                 <button
                   type="button"
-                  onClick={() => onOpenAtLine(uncommitted.hunks[0].newStart)}
+                  // A pure-deletion hunk has newStart: 0 (nothing added at that
+                  // position); revealLine is 1-indexed, so clamp to 1 instead
+                  // of asking the editor to reveal a nonexistent line 0.
+                  onClick={() => onOpenAtLine(Math.max(1, uncommitted.hunks[0].newStart))}
                   className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-fg-dim hover:text-fg hover:bg-inset transition-colors"
                 >
                   Open file ↗

--- a/desktop/src/renderer/hooks/useGitFileStatus.ts
+++ b/desktop/src/renderer/hooks/useGitFileStatus.ts
@@ -1,0 +1,46 @@
+// Footer data for the git surface. Fetches git:file-status for the open file
+// and refreshes on BOTH change feeds: artifacts:changed (worktree edits, from
+// the chokidar watcher) and git:changed (commits/checkouts/staging, from the
+// .git watcher — the chokidar one ignores .git/ by design).
+// On Android/remote every call rejects (unsupported) and the hook settles to
+// null — the footer then renders exactly as it does today. Same graceful
+// degradation as content search (FilesTab).
+import { useEffect, useState } from 'react';
+import type { GitFileStatusResult } from '../../shared/git-types';
+
+export function useGitFileStatus(
+  projectRoot: string,
+  relPath: string | null,
+  enabled: boolean,
+): GitFileStatusResult | null {
+  const [status, setStatus] = useState<GitFileStatusResult | null>(null);
+
+  useEffect(() => {
+    setStatus(null);
+    if (!enabled || !relPath || !projectRoot) return;
+    const api = (window as any).claude?.git;
+    if (!api?.fileStatus) return;
+    let alive = true;
+
+    const refresh = () => {
+      api.fileStatus(projectRoot, relPath)
+        .then((r: GitFileStatusResult) => { if (alive) setStatus(r?.ok ? r : null); })
+        .catch(() => { if (alive) setStatus(null); });
+    };
+    refresh();
+    api.watch?.(projectRoot)?.catch?.(() => {});
+    const offGit = api.onChanged?.(() => refresh()) ?? (() => {});
+    const offArtifacts = (window as any).claude?.artifacts?.onChanged?.((evt: any) => {
+      if (evt?.projectRoot === projectRoot) refresh();
+    }) ?? (() => {});
+
+    return () => {
+      alive = false;
+      offGit();
+      offArtifacts();
+      api.unwatch?.(projectRoot)?.catch?.(() => {});
+    };
+  }, [projectRoot, relPath, enabled]);
+
+  return status;
+}

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -359,6 +359,9 @@ function handleMessage(data: string): void {
       // modified, or excluded. The payload contains change metadata.
       dispatchEvent('artifacts:changed', payload);
       break;
+    case 'git:changed':
+      dispatchEvent('git:changed', payload);
+      break;
     case 'social:presence-event':
       // Presence relay (Task 6). The host forwards one presence event (server
       // protocol frame or synthetic connection-state event). window.claude.social
@@ -1242,6 +1245,25 @@ export function installShim(): void {
         const handler: Callback = (evt: any) => cb(evt);
         addListener('artifacts:changed', handler);
         return () => removeListener('artifacts:changed', handler);
+      },
+    },
+    git: {
+      fileStatus: (projectRoot: string, relPath: string) =>
+        invoke('git:file-status', { projectRoot, relPath }),
+      fileReview: (projectRoot: string, relPath: string, opts?: { logSkip?: number }) =>
+        invoke('git:file-review', { projectRoot, relPath, ...opts }),
+      commitFileDiff: (projectRoot: string, sha: string, relPath: string) =>
+        invoke('git:commit-file-diff', { projectRoot, sha, relPath }),
+      stage: (projectRoot: string, relPath: string) => invoke('git:stage', { projectRoot, relPath }),
+      unstage: (projectRoot: string, relPath: string) => invoke('git:unstage', { projectRoot, relPath }),
+      commit: (projectRoot: string, message: string) => invoke('git:commit', { projectRoot, message }),
+      discard: (projectRoot: string, relPath: string) => invoke('git:discard', { projectRoot, relPath }),
+      watch: (projectRoot: string) => invoke('git:watch', { projectRoot }),
+      unwatch: (projectRoot: string) => invoke('git:unwatch', { projectRoot }),
+      onChanged: (cb: (event: any) => void) => {
+        const handler: Callback = (evt: any) => cb(evt);
+        addListener('git:changed', handler);
+        return () => removeListener('git:changed', handler);
       },
     },
     // Project View IPC — sibling to artifacts. Object-payload invoke style

--- a/desktop/src/renderer/remote-shim.ts
+++ b/desktop/src/renderer/remote-shim.ts
@@ -1252,8 +1252,10 @@ export function installShim(): void {
         invoke('git:file-status', { projectRoot, relPath }),
       fileReview: (projectRoot: string, relPath: string, opts?: { logSkip?: number }) =>
         invoke('git:file-review', { projectRoot, relPath, ...opts }),
-      commitFileDiff: (projectRoot: string, sha: string, relPath: string) =>
-        invoke('git:commit-file-diff', { projectRoot, sha, relPath }),
+      // prevPath (project-root-relative old name) is passed for the rename
+      // commit itself so pairing with -M can happen, same as preload.ts.
+      commitFileDiff: (projectRoot: string, sha: string, relPath: string, prevPath?: string) =>
+        invoke('git:commit-file-diff', { projectRoot, sha, relPath, prevPath }),
       stage: (projectRoot: string, relPath: string) => invoke('git:stage', { projectRoot, relPath }),
       unstage: (projectRoot: string, relPath: string) => invoke('git:unstage', { projectRoot, relPath }),
       commit: (projectRoot: string, message: string) => invoke('git:commit', { projectRoot, message }),

--- a/desktop/src/renderer/state/artifact-actions.ts
+++ b/desktop/src/renderer/state/artifact-actions.ts
@@ -34,4 +34,7 @@ export type ArtifactAction =
   // Clears the session's selection back to null (back gesture goes to the list).
   | { type: 'ACTIVE_ARTIFACT_CLEARED'; sessionId: string }
   | { type: 'PROJECT_VIEW_OPENED' }
-  | { type: 'PROJECT_VIEW_CLOSED' };
+  | { type: 'PROJECT_VIEW_CLOSED' }
+  // Git review sub-view within the drawer, per session (see DRAWER_* above).
+  | { type: 'GIT_REVIEW_OPENED'; sessionId: string }
+  | { type: 'GIT_REVIEW_CLOSED'; sessionId: string };

--- a/desktop/src/renderer/state/artifact-tracker.ts
+++ b/desktop/src/renderer/state/artifact-tracker.ts
@@ -57,7 +57,9 @@ export function artifactReducer(s: ArtifactState, a: ArtifactAction): ArtifactSt
       return { ...s, drawerOpenBySession: { ...s.drawerOpenBySession, [a.sessionId]: true } };
     case 'DRAWER_CLOSED':
       // Reset expand + clear this session's selection (and any pill-error note)
-      // so a re-opened drawer starts at its normal width on the list.
+      // so a re-opened drawer starts at its normal width on the list. Also
+      // resets the git-review flag so a re-opened drawer lands on the file
+      // view, not back inside a stale review sub-view.
       return {
         ...s,
         drawerOpenBySession: { ...s.drawerOpenBySession, [a.sessionId]: false },

--- a/desktop/src/renderer/state/artifact-tracker.ts
+++ b/desktop/src/renderer/state/artifact-tracker.ts
@@ -19,6 +19,8 @@ export interface ArtifactState {
   // session's drawer remembers which file was open across session switches.
   // ProjectView uses the literal 'project-view' key for its own selection.
   activeArtifactBySession: Record<string, string | null>;
+  /** Per-session: the drawer is showing the git review sub-view for the active file. */
+  gitReviewBySession: Record<string, boolean>;
 }
 
 export const initialArtifactState: ArtifactState = {
@@ -30,6 +32,7 @@ export const initialArtifactState: ArtifactState = {
   drawerExpanded: false,
   projectViewOpen: false,
   activeArtifactBySession: {},
+  gitReviewBySession: {},
 };
 
 export function artifactReducer(s: ArtifactState, a: ArtifactAction): ArtifactState {
@@ -61,6 +64,7 @@ export function artifactReducer(s: ArtifactState, a: ArtifactAction): ArtifactSt
         drawerExpanded: false,
         activeArtifactBySession: { ...s.activeArtifactBySession, [a.sessionId]: null },
         pillError: { ...s.pillError, [a.sessionId]: null },
+        gitReviewBySession: { ...s.gitReviewBySession, [a.sessionId]: false },
       };
     case 'DRAWER_EXPAND_TOGGLED':
       return { ...s, drawerExpanded: !s.drawerExpanded };
@@ -70,6 +74,9 @@ export function artifactReducer(s: ArtifactState, a: ArtifactAction): ArtifactSt
         activeArtifactBySession: { ...s.activeArtifactBySession, [a.sessionId]: a.artifactId },
         // A successful open supersedes any earlier failure note.
         pillError: { ...s.pillError, [a.sessionId]: null },
+        // Clicking a file in the list always lands on the file view — the review
+        // view belongs to the file it was opened from, not the newly selected one.
+        gitReviewBySession: { ...s.gitReviewBySession, [a.sessionId]: false },
       };
     // Back gesture in detail view: return to list without closing the drawer.
     case 'ACTIVE_ARTIFACT_CLEARED':
@@ -78,6 +85,10 @@ export function artifactReducer(s: ArtifactState, a: ArtifactAction): ArtifactSt
       return { ...s, projectViewOpen: true };
     case 'PROJECT_VIEW_CLOSED':
       return { ...s, projectViewOpen: false };
+    case 'GIT_REVIEW_OPENED':
+      return { ...s, gitReviewBySession: { ...s.gitReviewBySession, [a.sessionId]: true } };
+    case 'GIT_REVIEW_CLOSED':
+      return { ...s, gitReviewBySession: { ...s.gitReviewBySession, [a.sessionId]: false } };
     default:
       return s;
   }

--- a/desktop/src/renderer/utils/git-footer.ts
+++ b/desktop/src/renderer/utils/git-footer.ts
@@ -1,0 +1,12 @@
+// Footer-entry visibility (mockup ledger 9): show the Review Changes button
+// when the file has uncommitted changes OR any git history; counts render only
+// when there are uncommitted changes. Pure so it unit-tests without React.
+import type { GitFileStatusResult, GitFileCounts } from '../../shared/git-types';
+
+export function gitFooterState(
+  s: GitFileStatusResult | null,
+): { show: boolean; counts: GitFileCounts | null } {
+  if (!s || !s.ok || !s.isRepo) return { show: false, counts: null };
+  const changed = s.counts !== null;
+  return { show: changed || s.hasHistory, counts: changed ? s.counts : null };
+}

--- a/desktop/src/shared/git-types.ts
+++ b/desktop/src/shared/git-types.ts
@@ -40,6 +40,10 @@ export interface GitLogEntry {
   /** Set only on the commit that renamed/moved the file TO its tracked path
    *  — the old (pre-move) path, so the diff fetch can pair the rename. */
   renamedFrom?: string;
+  /** Per-commit added/removed line counts for this file (from --numstat),
+   *  rendered in the card header. Null for a binary file or when the chunk
+   *  has no numstat line at all (e.g. a surfaced merge commit). */
+  counts: GitFileCounts | null;
 }
 
 export interface GitUncommitted {

--- a/desktop/src/shared/git-types.ts
+++ b/desktop/src/shared/git-types.ts
@@ -1,0 +1,71 @@
+// Git surface IPC payload types (spec docs/active/specs/2026-07-22-git-surface.md).
+// Shared main <-> renderer; keep JSON-serializable.
+import type { StructuredPatchHunk } from './types';
+
+export interface GitFileCounts {
+  added: number;
+  removed: number;
+}
+
+/** Answer to git:file-status — drives the SessionDrawer footer entry. */
+export interface GitFileStatusResult {
+  ok: boolean;
+  error?: string;
+  /** false = not a git repo (or git missing) — footer renders exactly as today. */
+  isRepo: boolean;
+  branch: string | null;
+  /** null when the file has no uncommitted changes vs HEAD. */
+  counts: GitFileCounts | null;
+  /** true when at least one commit touches this file. */
+  hasHistory: boolean;
+  /** true when this file has staged (index) changes. */
+  staged: boolean;
+}
+
+export interface GitLogEntry {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  /** ISO-8601 author date; relative time is rendered client-side. */
+  authorDate: string;
+}
+
+export interface GitUncommitted {
+  hunks: StructuredPatchHunk[];
+  counts: GitFileCounts;
+  staged: boolean;
+  untracked: boolean;
+  /** false when HEAD has no copy of this file (untracked, staged-new, or a
+   *  repo with no commits yet) — discard then trashes instead of restoring. */
+  inHead: boolean;
+  binary: boolean;
+}
+
+/** Answer to git:file-review — one payload renders the whole review view. */
+export interface GitFileReviewResult {
+  ok: boolean;
+  error?: string;
+  isRepo: boolean;
+  branch: string | null;
+  uncommitted: GitUncommitted | null;
+  log: GitLogEntry[];
+  hasMore: boolean;
+  /** Repo-wide count of files with staged changes — the commit button label. */
+  stagedCount: number;
+}
+
+export interface GitCommitFileDiffResult {
+  ok: boolean;
+  error?: string;
+  hunks: StructuredPatchHunk[];
+  binary: boolean;
+}
+
+export interface GitOpResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface GitChangedEvent {
+  repoRoot: string;
+}

--- a/desktop/src/shared/git-types.ts
+++ b/desktop/src/shared/git-types.ts
@@ -28,6 +28,18 @@ export interface GitLogEntry {
   subject: string;
   /** ISO-8601 author date; relative time is rendered client-side. */
   authorDate: string;
+  // WHY these two: `git log --follow` tracks a file across renames/moves, but
+  // a per-commit diff fetch (`git show`) needs the name the file had AT THAT
+  // COMMIT, not its current name — asking with the current name returns an
+  // empty diff for every commit before the rename. PROJECT-ROOT-relative
+  // (converted from git's repo-relative name-status output by the service).
+  /** The file's path as of this commit. Undefined only for the rare chunk
+   *  with no name-status line (e.g. a surfaced merge commit) — callers fall
+   *  back to the file's current project-relative path. */
+  pathAtCommit?: string;
+  /** Set only on the commit that renamed/moved the file TO its tracked path
+   *  — the old (pre-move) path, so the diff fetch can pair the rename. */
+  renamedFrom?: string;
 }
 
 export interface GitUncommitted {

--- a/desktop/tests/__mocks__/electron.ts
+++ b/desktop/tests/__mocks__/electron.ts
@@ -49,6 +49,8 @@ export const nativeImage = {
 export const shell = {
   openExternal: vi.fn(),
   openPath: vi.fn(),
+  // git surface discard of untracked files (git-service.ts) — resolves like Electron 41
+  trashItem: vi.fn(async (_path: string) => undefined),
 };
 
 export const powerSaveBlocker = {

--- a/desktop/tests/artifacts/content-search.test.ts
+++ b/desktop/tests/artifacts/content-search.test.ts
@@ -45,7 +45,8 @@ describe('searchProjectContent (real ripgrep)', () => {
     await fs.promises.writeFile(path.join(root, '.youcoded/artifacts.json'), '{"note":"port 5223"}\n');
   });
   afterEach(async () => {
-    await fs.promises.rm(root, { recursive: true, force: true });
+    // Fix: retry on Windows EBUSY race with spawned ripgrep
+    await fs.promises.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('finds matches with 1-indexed lines, case-insensitively, skipping node_modules and .youcoded', async () => {

--- a/desktop/tests/git/git-exec.test.ts
+++ b/desktop/tests/git/git-exec.test.ts
@@ -44,4 +44,31 @@ describe.skipIf(!hasGit())('git-exec (integration, real git)', () => {
   it('resolveRepoRoot returns null outside any repo', async () => {
     expect(await resolveRepoRoot(dir)).toBeNull();
   });
+
+  it('strips inherited GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE so calls stay targeted at cwd', async () => {
+    // An app launched from a shell/hook that exports these would otherwise
+    // have every git call below silently retarget at whatever repo/index
+    // those env vars point to, instead of the `dir` this runner was given.
+    const other = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-exec-other-'));
+    try {
+      await execGit(other, ['init']);
+      const prevGitDir = process.env.GIT_DIR;
+      const prevGitWorkTree = process.env.GIT_WORK_TREE;
+      process.env.GIT_DIR = path.join(other, '.git');
+      process.env.GIT_WORK_TREE = other;
+      try {
+        await execGit(dir, ['init']);
+        // If GIT_DIR/GIT_WORK_TREE had leaked through, this would report
+        // `other` as the toplevel instead of `dir`.
+        const r = await execGit(dir, ['rev-parse', '--show-toplevel']);
+        expect(r.code).toBe(0);
+        expect(await fs.promises.realpath(r.stdout.trim())).toBe(await fs.promises.realpath(dir));
+      } finally {
+        if (prevGitDir === undefined) delete process.env.GIT_DIR; else process.env.GIT_DIR = prevGitDir;
+        if (prevGitWorkTree === undefined) delete process.env.GIT_WORK_TREE; else process.env.GIT_WORK_TREE = prevGitWorkTree;
+      }
+    } finally {
+      await fs.promises.rm(other, { recursive: true, force: true });
+    }
+  });
 });

--- a/desktop/tests/git/git-exec.test.ts
+++ b/desktop/tests/git/git-exec.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execGit, resolveRepoRoot, invalidateRepoRootCache } from '../../src/main/git/git-exec';
+
+function hasGit(): boolean {
+  try { execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+}
+
+describe.skipIf(!hasGit())('git-exec (integration, real git)', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-exec-'));
+    invalidateRepoRootCache();
+  });
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+
+  it('execGit returns code 0 + stdout on success', async () => {
+    const r = await execGit(dir, ['--version']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('git version');
+  });
+
+  it('execGit returns nonzero code + real stderr on failure', async () => {
+    const r = await execGit(dir, ['rev-parse', '--show-toplevel']);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr.toLowerCase()).toContain('not a git repository');
+  });
+
+  it('resolveRepoRoot finds the toplevel from a subdirectory and caches', async () => {
+    await execGit(dir, ['init']);
+    const sub = path.join(dir, 'a', 'b');
+    await fs.promises.mkdir(sub, { recursive: true });
+    const root = await resolveRepoRoot(sub);
+    expect(root && (await fs.promises.realpath(root))).toBe(await fs.promises.realpath(dir));
+    // cached: second call resolves identically without re-shelling (same value)
+    expect(await resolveRepoRoot(sub)).toBe(root);
+  });
+
+  it('resolveRepoRoot returns null outside any repo', async () => {
+    expect(await resolveRepoRoot(dir)).toBeNull();
+  });
+});

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -36,6 +36,10 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     root = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-svc-')));
     invalidateRepoRootCache();
     sh(root, ['init', '-b', 'main']);
+    // WHY: GitHub Windows runners default core.autocrlf=true globally, so
+    // `git checkout HEAD` writes back CRLF and breaks byte-exact fixture
+    // assertions (and can produce phantom eol-only diffs). Pin it off per-repo.
+    sh(root, ['config', 'core.autocrlf', 'false']);
     await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\ntwo\n');
     sh(root, ['add', '.']);
     sh(root, ['commit', '-m', 'initial']);
@@ -222,6 +226,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     const fresh = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-')));
     try {
       sh(fresh, ['init']);
+      sh(fresh, ['config', 'core.autocrlf', 'false']);
       await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
       sh(fresh, ['add', 'f.txt']);
       const r = await gitFileReview(fresh, 'f.txt');
@@ -236,6 +241,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     const fresh = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-')));
     try {
       sh(fresh, ['init']);
+      sh(fresh, ['config', 'core.autocrlf', 'false']);
       await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
       sh(fresh, ['add', 'f.txt']);
       const r = await gitDiscard(fresh, 'f.txt');
@@ -251,6 +257,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     const fresh = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-')));
     try {
       sh(fresh, ['init']);
+      sh(fresh, ['config', 'core.autocrlf', 'false']);
       await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
       sh(fresh, ['add', 'f.txt']);
       const r = await gitUnstage(fresh, 'f.txt');
@@ -295,7 +302,9 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     expect(r.hasMore).toBe(true);
     const page2 = await gitFileReview(root, 'a.txt', { logSkip: LOG_PAGE });
     expect(page2.log.length).toBeGreaterThan(0);
-  });
+    // WHY 60000: this fixture spawns 2 git processes per commit (LOG_PAGE + 2
+    // commits) — Windows process-spawn latency blows past vitest's 5000ms default.
+  }, 60000);
 
   // Regression for the macOS/Windows CI failure: locate() computed
   // `path.relative(repoRoot, abs)` from the CALLER's projectRoot while
@@ -316,6 +325,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
       await fs.promises.symlink(real, alias);
 
       sh(real, ['init', '-b', 'main']);
+      sh(real, ['config', 'core.autocrlf', 'false']);
       await fs.promises.writeFile(path.join(real, 'a.txt'), 'one\ntwo\n');
       sh(real, ['add', '.']);
       sh(real, ['commit', '-m', 'initial']);

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -64,6 +64,21 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     expect(r.error).toBe('path-outside-project');
   });
 
+  it('mutation op in a non-repo dir reports not-a-git-repository, not path-outside-project', async () => {
+    const bare = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-norepo-'));
+    try {
+      const r = await gitStage(bare, 'x.txt');
+      expect(r.ok).toBe(false);
+      expect(r.error).toBe('not-a-git-repository');
+    } finally { await fs.promises.rm(bare, { recursive: true, force: true }); }
+  });
+
+  it('mutation op with an escaping relPath still reports path-outside-project', async () => {
+    const r = await gitStage(root, '../outside.txt');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('path-outside-project');
+  });
+
   it('fileReview: modified file -> uncommitted hunks + log + stagedCount', async () => {
     await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\nTWO\n');
     const r = await gitFileReview(root, 'a.txt');
@@ -87,6 +102,12 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
       { oldStart: 0, oldLines: 0, newStart: 1, newLines: 2, lines: ['+alpha', '+beta'] },
     ]);
     expect(r.log).toEqual([]);
+  });
+
+  it('fileReview: oversize untracked file renders as a binary stub, not synthesized hunks', async () => {
+    await fs.promises.writeFile(path.join(root, 'huge.txt'), 'x'.repeat(1024 * 1024 + 1));
+    const r = await gitFileReview(root, 'huge.txt');
+    expect(r.uncommitted).toMatchObject({ untracked: true, binary: true, hunks: [] });
   });
 
   it('stage/unstage flip index state and stagedCount', async () => {
@@ -121,6 +142,11 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     const d = await gitCommitFileDiff(root, sha, 'a.txt');
     expect(d.ok).toBe(true);
     expect(d.hunks[0].lines).toContain('+three');
+  });
+
+  it('commitFileDiff rejects a malformed sha before touching git', async () => {
+    const d = await gitCommitFileDiff(root, 'not-a-sha!', 'a.txt');
+    expect(d).toMatchObject({ ok: false, error: 'invalid-sha' });
   });
 
   it('discard tracked restores HEAD content', async () => {
@@ -165,6 +191,33 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
       expect(r.uncommitted?.inHead).toBe(false);
       expect(r.uncommitted?.hunks[0].lines).toEqual(['+hello']);
       expect(r.log).toEqual([]);
+    } finally { await fs.promises.rm(fresh, { recursive: true, force: true }); }
+  });
+
+  it('discard on unborn HEAD unstages (rm --cached) then trashes, leaving the file untracked', async () => {
+    const fresh = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-'));
+    try {
+      sh(fresh, ['init']);
+      await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
+      sh(fresh, ['add', 'f.txt']);
+      const r = await gitDiscard(fresh, 'f.txt');
+      expect(r.ok).toBe(true);
+      expect(shell.trashItem).toHaveBeenCalledWith(path.join(fresh, 'f.txt'));
+      // The mocked trash leaves the file on disk, so git now sees it as plain
+      // untracked — proving rm --cached ran against the unresolvable HEAD.
+      expect(sh(fresh, ['status', '--porcelain']).trim()).toBe('?? f.txt');
+    } finally { await fs.promises.rm(fresh, { recursive: true, force: true }); }
+  });
+
+  it('unstage on unborn HEAD falls back to rm --cached, leaving the file untracked', async () => {
+    const fresh = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-'));
+    try {
+      sh(fresh, ['init']);
+      await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
+      sh(fresh, ['add', 'f.txt']);
+      const r = await gitUnstage(fresh, 'f.txt');
+      expect(r.ok).toBe(true);
+      expect(sh(fresh, ['status', '--porcelain']).trim()).toBe('?? f.txt');
     } finally { await fs.promises.rm(fresh, { recursive: true, force: true }); }
   });
 

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -104,6 +104,39 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     expect(r.log).toEqual([]);
   });
 
+  it('fileReview: untracked symlink outside the repo renders as binary stub, never follows the link', async () => {
+    // A malicious/careless untracked symlink pointing outside the repo root
+    // (e.g. at /etc/passwd) must never have its TARGET content read into
+    // hunks — that would leak arbitrary filesystem content through the git
+    // review surface. lstat (not stat) is what prevents the follow.
+    const outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-target-'));
+    try {
+      const secretPath = path.join(outside, 'secret.txt');
+      await fs.promises.writeFile(secretPath, 'TOP SECRET CONTENT\n');
+      const linkPath = path.join(root, 'link.txt');
+      await fs.promises.symlink(secretPath, linkPath);
+
+      const r = await gitFileReview(root, 'link.txt');
+      expect(r.ok).toBe(true);
+      expect(r.uncommitted).toMatchObject({ untracked: true, binary: true, hunks: [] });
+      expect(JSON.stringify(r)).not.toContain('TOP SECRET');
+    } finally { await fs.promises.rm(outside, { recursive: true, force: true }); }
+  });
+
+  it('fileStatus: untracked symlink outside the repo counts as 0/0, never follows the link', async () => {
+    const outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-target-'));
+    try {
+      const secretPath = path.join(outside, 'secret.txt');
+      await fs.promises.writeFile(secretPath, 'TOP SECRET CONTENT\n');
+      const linkPath = path.join(root, 'link2.txt');
+      await fs.promises.symlink(secretPath, linkPath);
+
+      const r = await gitFileStatus(root, 'link2.txt');
+      expect(r.ok).toBe(true);
+      expect(r.counts).toEqual({ added: 0, removed: 0 });
+    } finally { await fs.promises.rm(outside, { recursive: true, force: true }); }
+  });
+
   it('fileReview: oversize untracked file renders as a binary stub, not synthesized hunks', async () => {
     await fs.promises.writeFile(path.join(root, 'huge.txt'), 'x'.repeat(1024 * 1024 + 1));
     const r = await gitFileReview(root, 'huge.txt');
@@ -219,6 +252,32 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
       expect(r.ok).toBe(true);
       expect(sh(fresh, ['status', '--porcelain']).trim()).toBe('?? f.txt');
     } finally { await fs.promises.rm(fresh, { recursive: true, force: true }); }
+  });
+
+  it('handles non-ASCII filenames despite core.quotepath default (fix: -c core.quotepath=false)', async () => {
+    // With the default core.quotepath=true, git C-quotes "café.md" as
+    // "caf\303\251.md" in porcelain/numstat output, which never matches the
+    // plain `rel` string this service compares against — undercounting
+    // stagedCount and dropping the file's review card entirely.
+    const name = 'café.md';
+    await fs.promises.writeFile(path.join(root, name), 'one\n');
+    sh(root, ['add', '.']);
+    sh(root, ['commit', '-m', 'add café.md']);
+    await fs.promises.writeFile(path.join(root, name), 'one\ntwo\n');
+
+    const status = await gitFileStatus(root, name);
+    expect(status.ok).toBe(true);
+    expect(status.counts).toEqual({ added: 1, removed: 0 });
+    expect(status.hasHistory).toBe(true);
+
+    const review = await gitFileReview(root, name);
+    expect(review.ok).toBe(true);
+    expect(review.uncommitted?.hunks[0].lines).toContain('+two');
+    expect(review.stagedCount).toBe(0);
+
+    sh(root, ['add', name]);
+    const staged = await gitFileReview(root, name);
+    expect(staged.stagedCount).toBe(1);
   });
 
   it('LOG_PAGE caps the log and reports hasMore', async () => {

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -28,7 +28,12 @@ function sh(cwd: string, args: string[]): string {
 describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   let root: string;
   beforeEach(async () => {
-    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-svc-'));
+    // WHY realpath: on macOS os.tmpdir() is a /var -> /private/var symlink
+    // alias; git's own toplevel answer is always canonical. Tests below
+    // compare absolute paths (e.g. shell.trashItem args) against `root` —
+    // without this, those assertions would fail on macOS CI even with the
+    // production fix applied, since `root` itself would be the alias form.
+    root = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-svc-')));
     invalidateRepoRootCache();
     sh(root, ['init', '-b', 'main']);
     await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\ntwo\n');
@@ -51,7 +56,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   });
 
   it('fileStatus: non-repo dir -> isRepo false, ok true', async () => {
-    const bare = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-norepo-'));
+    const bare = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-norepo-')));
     try {
       const r = await gitFileStatus(bare, 'x.txt');
       expect(r).toMatchObject({ ok: true, isRepo: false, counts: null, hasHistory: false });
@@ -65,7 +70,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   });
 
   it('mutation op in a non-repo dir reports not-a-git-repository, not path-outside-project', async () => {
-    const bare = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-norepo-'));
+    const bare = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-norepo-')));
     try {
       const r = await gitStage(bare, 'x.txt');
       expect(r.ok).toBe(false);
@@ -109,7 +114,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     // (e.g. at /etc/passwd) must never have its TARGET content read into
     // hunks — that would leak arbitrary filesystem content through the git
     // review surface. lstat (not stat) is what prevents the follow.
-    const outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-target-'));
+    const outside = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-target-')));
     try {
       const secretPath = path.join(outside, 'secret.txt');
       await fs.promises.writeFile(secretPath, 'TOP SECRET CONTENT\n');
@@ -124,7 +129,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   });
 
   it('fileStatus: untracked symlink outside the repo counts as 0/0, never follows the link', async () => {
-    const outside = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-target-'));
+    const outside = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-target-')));
     try {
       const secretPath = path.join(outside, 'secret.txt');
       await fs.promises.writeFile(secretPath, 'TOP SECRET CONTENT\n');
@@ -214,7 +219,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   });
 
   it('fileReview works in a repo with no commits yet (unborn HEAD)', async () => {
-    const fresh = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-'));
+    const fresh = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-')));
     try {
       sh(fresh, ['init']);
       await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
@@ -228,7 +233,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   });
 
   it('discard on unborn HEAD unstages (rm --cached) then trashes, leaving the file untracked', async () => {
-    const fresh = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-'));
+    const fresh = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-')));
     try {
       sh(fresh, ['init']);
       await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
@@ -243,7 +248,7 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
   });
 
   it('unstage on unborn HEAD falls back to rm --cached, leaving the file untracked', async () => {
-    const fresh = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-'));
+    const fresh = await fs.promises.realpath(await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-')));
     try {
       sh(fresh, ['init']);
       await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
@@ -290,5 +295,41 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     expect(r.hasMore).toBe(true);
     const page2 = await gitFileReview(root, 'a.txt', { logSkip: LOG_PAGE });
     expect(page2.log.length).toBeGreaterThan(0);
+  });
+
+  // Regression for the macOS/Windows CI failure: locate() computed
+  // `path.relative(repoRoot, abs)` from the CALLER's projectRoot while
+  // repoRoot came from `git rev-parse --show-toplevel`, which git resolves to
+  // the CANONICAL physical path. Any non-canonical alias for the same
+  // directory (macOS `/var` -> `/private/var` symlink, Windows short 8.3
+  // names, or — as reproduced here — a plain symlink into the repo) makes
+  // `rel` a garbage `../../...` string and every git call fails as
+  // "outside repository". This test builds that exact symlink-alias
+  // situation on Linux (where it wouldn't otherwise occur, since /tmp isn't
+  // a symlink) so the bug is caught here without needing macOS/Windows CI.
+  it('resolves paths through a symlinked projectRoot alias (macOS /var + Windows short-path regression)', async () => {
+    const parent = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-symlink-alias-'));
+    try {
+      const real = path.join(parent, 'real-repo');
+      const alias = path.join(parent, 'alias-repo');
+      await fs.promises.mkdir(real);
+      await fs.promises.symlink(real, alias);
+
+      sh(real, ['init', '-b', 'main']);
+      await fs.promises.writeFile(path.join(real, 'a.txt'), 'one\ntwo\n');
+      sh(real, ['add', '.']);
+      sh(real, ['commit', '-m', 'initial']);
+      await fs.promises.writeFile(path.join(real, 'a.txt'), 'one\nTWO\nthree\n');
+
+      const status = await gitFileStatus(alias, 'a.txt');
+      expect(status.ok).toBe(true);
+      expect(status.isRepo).toBe(true);
+      expect(status.counts).toEqual({ added: 2, removed: 1 });
+
+      const review = await gitFileReview(alias, 'a.txt');
+      expect(review.ok).toBe(true);
+      expect(review.uncommitted?.inHead).toBe(true);
+      expect(review.uncommitted?.hunks.length).toBeGreaterThan(0);
+    } finally { await fs.promises.rm(parent, { recursive: true, force: true }); }
   });
 });

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -337,6 +337,11 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     expect(moveCommit).toMatchObject({ subject: 'move to docs/new.md', pathAtCommit: 'docs/new.md', renamedFrom: 'old.md' });
     expect(editOld).toMatchObject({ subject: 'edit old.md', pathAtCommit: 'old.md', renamedFrom: undefined });
     expect(addOld).toMatchObject({ subject: 'add old.md', pathAtCommit: 'old.md', renamedFrom: undefined });
+    // Per-commit counts (--numstat, replacing --name-status): the pre-move
+    // edit added one real line ('beta'); the pure-move commit changed no
+    // content, so numstat reports 0/0 for it despite the rename.
+    expect(editOld.counts).toEqual({ added: 1, removed: 0 });
+    expect(moveCommit.counts).toEqual({ added: 0, removed: 0 });
 
     // THE BUG, pinned: asking for the pre-move edit commit's diff with the
     // CURRENT path returns nothing — this is what shipped and read as "No

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -306,6 +306,59 @@ describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
     // commits) — Windows process-spawn latency blows past vitest's 5000ms default.
   }, 60000);
 
+  // Rename-tracking regression: `git log --follow` lists a file's commits
+  // across a rename, but per-commit diffs must ask `git show` with the
+  // HISTORICAL path (the name the file had AT that commit), not its current
+  // path — otherwise every pre-rename commit's diff comes back empty even
+  // though the timeline lists it as touching the file.
+  it('gitFileReview + gitCommitFileDiff follow a rename: historical paths, empty rename-only diff', async () => {
+    // WHY this exact content: --follow's rename detection is CONTENT-based
+    // (-M), not name-based — if old.md's content ever became byte-identical
+    // to a.txt's ('one\ntwo\n', committed in beforeEach), git would spuriously
+    // attach a.txt's unrelated "initial" commit to this file's history too.
+    // Keep old.md's content disjoint from a.txt's at every step.
+    await fs.promises.writeFile(path.join(root, 'old.md'), 'alpha\n');
+    sh(root, ['add', '.']); sh(root, ['commit', '-m', 'add old.md']);
+    await fs.promises.writeFile(path.join(root, 'old.md'), 'alpha\nbeta\n');
+    sh(root, ['add', '.']); sh(root, ['commit', '-m', 'edit old.md']);
+    await fs.promises.mkdir(path.join(root, 'docs'));
+    sh(root, ['mv', 'old.md', 'docs/new.md']);
+    sh(root, ['commit', '-m', 'move to docs/new.md']);
+    await fs.promises.writeFile(path.join(root, 'docs', 'new.md'), 'alpha\nbeta\ngamma\n');
+    sh(root, ['add', '.']); sh(root, ['commit', '-m', 'edit docs/new.md']);
+
+    const r = await gitFileReview(root, 'docs/new.md');
+    expect(r.ok).toBe(true);
+    // 4 of ours + the fixture's own "initial" commit for a.txt is NOT in this
+    // file's history (--follow is pathspec-scoped) — exactly our 4 commits.
+    expect(r.log).toHaveLength(4);
+    const [editNew, moveCommit, editOld, addOld] = r.log;
+    expect(editNew).toMatchObject({ subject: 'edit docs/new.md', pathAtCommit: 'docs/new.md', renamedFrom: undefined });
+    expect(moveCommit).toMatchObject({ subject: 'move to docs/new.md', pathAtCommit: 'docs/new.md', renamedFrom: 'old.md' });
+    expect(editOld).toMatchObject({ subject: 'edit old.md', pathAtCommit: 'old.md', renamedFrom: undefined });
+    expect(addOld).toMatchObject({ subject: 'add old.md', pathAtCommit: 'old.md', renamedFrom: undefined });
+
+    // THE BUG, pinned: asking for the pre-move edit commit's diff with the
+    // CURRENT path returns nothing — this is what shipped and read as "No
+    // direct changes to this file in this commit." despite the timeline
+    // listing the commit.
+    const buggy = await gitCommitFileDiff(root, editOld.sha, 'docs/new.md');
+    expect(buggy.ok).toBe(true);
+    expect(buggy.hunks).toEqual([]);
+
+    // THE FIX: asking with the HISTORICAL path (what the timeline now hands
+    // back as pathAtCommit) returns the real content diff.
+    const fixed = await gitCommitFileDiff(root, editOld.sha, editOld.pathAtCommit!);
+    expect(fixed.ok).toBe(true);
+    expect(fixed.hunks[0].lines).toContain('+beta');
+
+    // The move commit itself, paired with prevPath (-M), is rename-only —
+    // empty hunks, not a full-file `+` wall.
+    const moveDiff = await gitCommitFileDiff(root, moveCommit.sha, moveCommit.pathAtCommit!, moveCommit.renamedFrom);
+    expect(moveDiff.ok).toBe(true);
+    expect(moveDiff.hunks).toEqual([]);
+  });
+
   // Regression for the macOS/Windows CI failure: locate() computed
   // `path.relative(repoRoot, abs)` from the CALLER's projectRoot while
   // repoRoot came from `git rev-parse --show-toplevel`, which git resolves to

--- a/desktop/tests/git/git-service.test.ts
+++ b/desktop/tests/git/git-service.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { shell } from 'electron'; // vitest alias -> tests/__mocks__/electron.ts
+import {
+  gitFileStatus, gitFileReview, gitCommitFileDiff,
+  gitStage, gitUnstage, gitCommit, gitDiscard, LOG_PAGE,
+} from '../../src/main/git/git-service';
+import { invalidateRepoRootCache } from '../../src/main/git/git-exec';
+
+function hasGit(): boolean {
+  try { execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+}
+function sh(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test', GIT_AUTHOR_EMAIL: 't@t.t',
+      GIT_COMMITTER_NAME: 'Test', GIT_COMMITTER_EMAIL: 't@t.t',
+    },
+  });
+}
+
+describe.skipIf(!hasGit())('git-service (integration, real git)', () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-svc-'));
+    invalidateRepoRootCache();
+    sh(root, ['init', '-b', 'main']);
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\ntwo\n');
+    sh(root, ['add', '.']);
+    sh(root, ['commit', '-m', 'initial']);
+  });
+  afterEach(async () => {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  });
+
+  it('fileStatus: clean tracked file -> no counts, hasHistory true', async () => {
+    const r = await gitFileStatus(root, 'a.txt');
+    expect(r).toMatchObject({ ok: true, isRepo: true, branch: 'main', counts: null, hasHistory: true, staged: false });
+  });
+
+  it('fileStatus: modified file -> counts vs HEAD', async () => {
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\nTWO\nthree\n');
+    const r = await gitFileStatus(root, 'a.txt');
+    expect(r.counts).toEqual({ added: 2, removed: 1 });
+  });
+
+  it('fileStatus: non-repo dir -> isRepo false, ok true', async () => {
+    const bare = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-norepo-'));
+    try {
+      const r = await gitFileStatus(bare, 'x.txt');
+      expect(r).toMatchObject({ ok: true, isRepo: false, counts: null, hasHistory: false });
+    } finally { await fs.promises.rm(bare, { recursive: true, force: true }); }
+  });
+
+  it('fileStatus: escaping relPath is refused', async () => {
+    const r = await gitFileStatus(root, '../outside.txt');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('path-outside-project');
+  });
+
+  it('fileReview: modified file -> uncommitted hunks + log + stagedCount', async () => {
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\nTWO\n');
+    const r = await gitFileReview(root, 'a.txt');
+    expect(r.ok).toBe(true);
+    expect(r.uncommitted?.untracked).toBe(false);
+    expect(r.uncommitted?.inHead).toBe(true);
+    expect(r.uncommitted?.counts).toEqual({ added: 1, removed: 1 });
+    expect(r.uncommitted?.hunks[0].lines).toContain('-two');
+    expect(r.log).toHaveLength(1);
+    expect(r.log[0].subject).toBe('initial');
+    expect(r.hasMore).toBe(false);
+    expect(r.stagedCount).toBe(0);
+  });
+
+  it('fileReview: untracked file -> synthesized all-additions hunk', async () => {
+    await fs.promises.writeFile(path.join(root, 'new.txt'), 'alpha\nbeta\n');
+    const r = await gitFileReview(root, 'new.txt');
+    expect(r.uncommitted?.untracked).toBe(true);
+    expect(r.uncommitted?.inHead).toBe(false);
+    expect(r.uncommitted?.hunks).toEqual([
+      { oldStart: 0, oldLines: 0, newStart: 1, newLines: 2, lines: ['+alpha', '+beta'] },
+    ]);
+    expect(r.log).toEqual([]);
+  });
+
+  it('stage/unstage flip index state and stagedCount', async () => {
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'changed\n');
+    expect((await gitStage(root, 'a.txt')).ok).toBe(true);
+    expect((await gitFileStatus(root, 'a.txt')).staged).toBe(true);
+    expect((await gitFileReview(root, 'a.txt')).stagedCount).toBe(1);
+    expect((await gitUnstage(root, 'a.txt')).ok).toBe(true);
+    expect((await gitFileStatus(root, 'a.txt')).staged).toBe(false);
+  });
+
+  it('commit commits the index and clears the uncommitted card', async () => {
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'committed\n');
+    await gitStage(root, 'a.txt');
+    const c = await gitCommit(root, 'test: from the drawer');
+    expect(c.ok).toBe(true);
+    const r = await gitFileReview(root, 'a.txt');
+    expect(r.uncommitted).toBeNull();
+    expect(r.log[0].subject).toBe('test: from the drawer');
+  });
+
+  it('commit with empty index fails with real git stderr', async () => {
+    const c = await gitCommit(root, 'nothing to commit');
+    expect(c.ok).toBe(false);
+    expect(c.error!.length).toBeGreaterThan(0); // git's own message, passed through
+  });
+
+  it('commitFileDiff returns the hunks of a past commit for the file', async () => {
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'one\ntwo\nthree\n');
+    sh(root, ['add', '.']); sh(root, ['commit', '-m', 'add three']);
+    const sha = sh(root, ['rev-parse', 'HEAD']).trim();
+    const d = await gitCommitFileDiff(root, sha, 'a.txt');
+    expect(d.ok).toBe(true);
+    expect(d.hunks[0].lines).toContain('+three');
+  });
+
+  it('discard tracked restores HEAD content', async () => {
+    await fs.promises.writeFile(path.join(root, 'a.txt'), 'garbage\n');
+    expect((await gitDiscard(root, 'a.txt')).ok).toBe(true);
+    expect(await fs.promises.readFile(path.join(root, 'a.txt'), 'utf8')).toBe('one\ntwo\n');
+  });
+
+  it('discard untracked goes through shell.trashItem, never git clean', async () => {
+    const p = path.join(root, 'junk.txt');
+    await fs.promises.writeFile(p, 'x\n');
+    expect((await gitDiscard(root, 'junk.txt')).ok).toBe(true);
+    expect(shell.trashItem).toHaveBeenCalledWith(p);
+  });
+
+  it('discard of a staged-but-never-committed file unstages then trashes', async () => {
+    const p = path.join(root, 'staged-new.txt');
+    await fs.promises.writeFile(p, 'x\n');
+    sh(root, ['add', 'staged-new.txt']);
+    expect((await gitDiscard(root, 'staged-new.txt')).ok).toBe(true);
+    expect(shell.trashItem).toHaveBeenCalledWith(p);
+    // Index no longer holds it (the mocked trash leaves the file on disk, so
+    // git now sees it as plain untracked — proving rm --cached ran).
+    expect(sh(root, ['status', '--porcelain']).trim()).toBe('?? staged-new.txt');
+  });
+
+  it('fileStatus sees an untracked file inside an untracked directory', async () => {
+    await fs.promises.mkdir(path.join(root, 'newdir'));
+    await fs.promises.writeFile(path.join(root, 'newdir', 'inner.txt'), 'a\nb\n');
+    const r = await gitFileStatus(root, 'newdir/inner.txt');
+    expect(r.counts).toEqual({ added: 2, removed: 0 });
+  });
+
+  it('fileReview works in a repo with no commits yet (unborn HEAD)', async () => {
+    const fresh = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-unborn-'));
+    try {
+      sh(fresh, ['init']);
+      await fs.promises.writeFile(path.join(fresh, 'f.txt'), 'hello\n');
+      sh(fresh, ['add', 'f.txt']);
+      const r = await gitFileReview(fresh, 'f.txt');
+      expect(r.ok).toBe(true);
+      expect(r.uncommitted?.inHead).toBe(false);
+      expect(r.uncommitted?.hunks[0].lines).toEqual(['+hello']);
+      expect(r.log).toEqual([]);
+    } finally { await fs.promises.rm(fresh, { recursive: true, force: true }); }
+  });
+
+  it('LOG_PAGE caps the log and reports hasMore', async () => {
+    for (let i = 0; i < LOG_PAGE + 2; i++) {
+      await fs.promises.writeFile(path.join(root, 'a.txt'), `rev ${i}\n`);
+      sh(root, ['add', '.']); sh(root, ['commit', '-m', `rev ${i}`]);
+    }
+    const r = await gitFileReview(root, 'a.txt');
+    expect(r.log).toHaveLength(LOG_PAGE);
+    expect(r.hasMore).toBe(true);
+    const page2 = await gitFileReview(root, 'a.txt', { logSkip: LOG_PAGE });
+    expect(page2.log.length).toBeGreaterThan(0);
+  });
+});

--- a/desktop/tests/git/git-watcher.test.ts
+++ b/desktop/tests/git/git-watcher.test.ts
@@ -19,7 +19,9 @@ describe('git-watcher', () => {
     initGitWatchers((e) => events.push(e));
   });
   afterEach(async () => {
-    closeAllGitWatchers();
+    // Guard: the error-handler teardown (root deleted while still watched)
+    // may have already closed and removed this root's entry — tolerate that.
+    try { closeAllGitWatchers(); } catch { /* already torn down */ }
     await fs.promises.rm(root, { recursive: true, force: true });
   });
 
@@ -55,5 +57,71 @@ describe('git-watcher', () => {
     await fs.promises.writeFile(path.join(root, '.git', 'index'), 'x');
     await wait(500);
     expect(events).toEqual([]);
+  });
+
+  it('survives the watched root being deleted without unwatching first', async () => {
+    // NOTE: on Linux, deleting a watched directory does not reliably make
+    // fs.watch emit 'error' — inotify just stops delivering useful events
+    // (verified empirically: rm -rf on a watched dir produced only 'rename'
+    // change events, never 'error' or 'close'). The platforms/conditions the
+    // review finding is guarding against (Windows, network filesystems,
+    // inotify queue overflow) DO emit 'error' on the FSWatcher. To exercise
+    // our handler deterministically regardless of platform, we spy on
+    // fs.watch to capture the real FSWatcher instances it creates, then
+    // manually fire 'error' on one of them after the real deletion — this
+    // simulates exactly what those platforms do without depending on OS-
+    // specific watch semantics.
+    const watchSpy = vi.spyOn(fs, 'watch');
+    expect(watchGit(root, 1).ok).toBe(true);
+    const watchers = watchSpy.mock.results.map((r) => r.value as fs.FSWatcher);
+    expect(watchers.length).toBeGreaterThan(0);
+
+    // Simulate `git worktree remove` / external surgery: the root (and its
+    // .git dir) disappears while we're still subscribed, with no unwatchGit
+    // call first.
+    await fs.promises.rm(root, { recursive: true, force: true });
+
+    // This used to throw an uncaught exception (no 'error' listener on an
+    // EventEmitter) and crash the Electron main process.
+    expect(() => watchers[0].emit('error', new Error('simulated ENOENT'))).not.toThrow();
+    await wait(200);
+
+    // Confirm the entry actually self-healed: a fresh subscribe on the now-
+    // missing root goes back through the existsSync check and reports
+    // {ok:false}, rather than reusing a stale map entry.
+    expect(watchGit(root, 9).ok).toBe(false);
+    watchSpy.mockRestore();
+  });
+
+  it('same subscriber watching the same root twice needs two unwatches before events stop', async () => {
+    expect(watchGit(root, 1).ok).toBe(true);
+    expect(watchGit(root, 1).ok).toBe(true); // refcount for subscriber 1 is now 2
+    unwatchGit(root, 1); // refcount 2 -> 1, entry must still be alive
+    await fs.promises.writeFile(path.join(root, '.git', 'index'), 'x1');
+    await wait(500);
+    expect(events.length).toBe(1);
+
+    unwatchGit(root, 1); // refcount 1 -> 0, last subscriber gone, entry closes
+    events = [];
+    await fs.promises.writeFile(path.join(root, '.git', 'index'), 'x2');
+    await wait(500);
+    expect(events).toEqual([]);
+  });
+
+  it('dropGitSubscriber releases multiple roots held by one subscriber at once', async () => {
+    const root2 = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-watch2-'));
+    await fs.promises.mkdir(path.join(root2, '.git', 'refs', 'heads'), { recursive: true });
+    await fs.promises.writeFile(path.join(root2, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    try {
+      expect(watchGit(root, 5).ok).toBe(true);
+      expect(watchGit(root2, 5).ok).toBe(true);
+      dropGitSubscriber(5);
+      await fs.promises.writeFile(path.join(root, '.git', 'index'), 'x');
+      await fs.promises.writeFile(path.join(root2, '.git', 'index'), 'x');
+      await wait(500);
+      expect(events).toEqual([]);
+    } finally {
+      await fs.promises.rm(root2, { recursive: true, force: true });
+    }
   });
 });

--- a/desktop/tests/git/git-watcher.test.ts
+++ b/desktop/tests/git/git-watcher.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  initGitWatchers, watchGit, unwatchGit, dropGitSubscriber, closeAllGitWatchers,
+} from '../../src/main/git/git-watcher';
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('git-watcher', () => {
+  let root: string;
+  let events: Array<{ repoRoot: string }>;
+  beforeEach(async () => {
+    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-watch-'));
+    await fs.promises.mkdir(path.join(root, '.git', 'refs', 'heads'), { recursive: true });
+    await fs.promises.writeFile(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    events = [];
+    initGitWatchers((e) => events.push(e));
+  });
+  afterEach(async () => {
+    closeAllGitWatchers();
+    await fs.promises.rm(root, { recursive: true, force: true });
+  });
+
+  it('refuses a root without .git', async () => {
+    const bare = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-nogit-'));
+    try { expect(watchGit(bare, 1).ok).toBe(false); }
+    finally { await fs.promises.rm(bare, { recursive: true, force: true }); }
+  });
+
+  it('emits one debounced event for a burst of .git changes', async () => {
+    expect(watchGit(root, 1).ok).toBe(true);
+    await fs.promises.writeFile(path.join(root, '.git', 'index'), 'i1');
+    await fs.promises.writeFile(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/other\n');
+    await fs.promises.writeFile(path.join(root, '.git', 'index'), 'i2');
+    await wait(700); // debounce is 300ms; fs.watch latency varies by platform
+    expect(events.length).toBe(1);
+    expect(events[0]).toEqual({ repoRoot: root });
+  });
+
+  it('stops emitting after the last subscriber unwatches', async () => {
+    watchGit(root, 1);
+    watchGit(root, 2);
+    unwatchGit(root, 1);
+    unwatchGit(root, 2);
+    await fs.promises.writeFile(path.join(root, '.git', 'index'), 'x');
+    await wait(500);
+    expect(events).toEqual([]);
+  });
+
+  it('dropGitSubscriber releases every root a renderer held', async () => {
+    watchGit(root, 7);
+    dropGitSubscriber(7);
+    await fs.promises.writeFile(path.join(root, '.git', 'index'), 'x');
+    await wait(500);
+    expect(events).toEqual([]);
+  });
+});

--- a/desktop/tests/git/git-watcher.test.ts
+++ b/desktop/tests/git/git-watcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -7,6 +8,21 @@ import {
 } from '../../src/main/git/git-watcher';
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function hasGit(): boolean {
+  try { execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+}
+function sh(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test', GIT_AUTHOR_EMAIL: 't@t.t',
+      GIT_COMMITTER_NAME: 'Test', GIT_COMMITTER_EMAIL: 't@t.t',
+    },
+  });
+}
 
 describe('git-watcher', () => {
   let root: string;
@@ -123,5 +139,48 @@ describe('git-watcher', () => {
     } finally {
       await fs.promises.rm(root2, { recursive: true, force: true });
     }
+  });
+});
+
+describe.skipIf(!hasGit())('git-watcher (linked worktree, real git)', () => {
+  let mainRoot: string;
+  let linkedRoot: string;
+  let events: Array<{ repoRoot: string }>;
+
+  beforeEach(async () => {
+    mainRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ycd-git-watch-main-'));
+    sh(mainRoot, ['init', '-b', 'main']);
+    await fs.promises.writeFile(path.join(mainRoot, 'a.txt'), 'one\n');
+    sh(mainRoot, ['add', '.']);
+    sh(mainRoot, ['commit', '-m', 'initial']);
+    linkedRoot = path.join(path.dirname(mainRoot), path.basename(mainRoot) + '-linked');
+    sh(mainRoot, ['worktree', 'add', linkedRoot, '-b', 'feature']);
+    events = [];
+    initGitWatchers((e) => events.push(e));
+  });
+
+  afterEach(async () => {
+    try { closeAllGitWatchers(); } catch { /* already torn down */ }
+    try { sh(mainRoot, ['worktree', 'remove', '--force', linkedRoot]); } catch { /* best effort */ }
+    await fs.promises.rm(mainRoot, { recursive: true, force: true });
+    await fs.promises.rm(linkedRoot, { recursive: true, force: true });
+  });
+
+  it('watchGit on a linked worktree root resolves the real gitdir/commondir and reports ok:true', async () => {
+    // <linkedRoot>/.git is a FILE (`gitdir: <main>/.git/worktrees/feature`),
+    // not a directory — the pre-fix code only handled the directory case and
+    // reported {ok:true} on a dead watcher (see resolveGitDirs in git-watcher.ts).
+    expect(fs.statSync(path.join(linkedRoot, '.git')).isFile()).toBe(true);
+    expect(watchGit(linkedRoot, 1).ok).toBe(true);
+  });
+
+  it('emits a debounced event when a commit is made in the linked worktree', async () => {
+    expect(watchGit(linkedRoot, 1).ok).toBe(true);
+    await fs.promises.writeFile(path.join(linkedRoot, 'a.txt'), 'one\ntwo\n');
+    sh(linkedRoot, ['add', '.']);
+    sh(linkedRoot, ['commit', '-m', 'change from linked worktree']);
+    await wait(700); // debounce is 300ms; fs.watch latency varies by platform
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]).toEqual({ repoRoot: linkedRoot });
   });
 });

--- a/desktop/tests/git/porcelain.test.ts
+++ b/desktop/tests/git/porcelain.test.ts
@@ -72,6 +72,13 @@ describe('parseRenamePath', () => {
     });
   });
 
+  it('collapses the doubled slash from an empty new-side brace rename', () => {
+    expect(parseRenamePath('dir/{sub => }/g.md')).toEqual({
+      path: 'dir/g.md',
+      renamedFrom: 'dir/sub/g.md',
+    });
+  });
+
   it('splits the plain "old => new" form when there is no common affix', () => {
     expect(parseRenamePath('old.md => new.md')).toEqual({
       path: 'new.md',

--- a/desktop/tests/git/porcelain.test.ts
+++ b/desktop/tests/git/porcelain.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  parsePorcelainV2, parseNumstat, parseLogRecords,
+  parsePorcelainV2, parseNumstat, parseLogRecords, parseRenamePath,
   parseUnifiedDiff, countsFromHunks, synthesizeAddHunk,
 } from '../../src/main/git/porcelain';
 
@@ -50,19 +50,49 @@ describe('parseNumstat', () => {
   });
 });
 
+describe('parseRenamePath', () => {
+  // Pure helper for a `--numstat` pathfield: plain path (no rename), the
+  // brace form git emits when old/new share a common prefix/suffix, and the
+  // plain "old => new" form when they don't.
+  it('returns a plain path unchanged when there is no rename', () => {
+    expect(parseRenamePath('src/reducer.ts')).toEqual({ path: 'src/reducer.ts' });
+  });
+
+  it('splits the brace form with a common prefix/suffix into old/new', () => {
+    expect(parseRenamePath('docs/{superpowers => archive}/plans/x.md')).toEqual({
+      path: 'docs/archive/plans/x.md',
+      renamedFrom: 'docs/superpowers/plans/x.md',
+    });
+  });
+
+  it('collapses the doubled slash produced by an empty brace side', () => {
+    expect(parseRenamePath('dir/{ => sub}/f.md')).toEqual({
+      path: 'dir/sub/f.md',
+      renamedFrom: 'dir/f.md',
+    });
+  });
+
+  it('splits the plain "old => new" form when there is no common affix', () => {
+    expect(parseRenamePath('old.md => new.md')).toEqual({
+      path: 'new.md',
+      renamedFrom: 'old.md',
+    });
+  });
+});
+
 describe('parseLogRecords', () => {
-  // New format rides with `--name-status`: a LEADING record separator, so
-  // splitting on \x1e yields an empty first chunk, then one chunk per commit
-  // shaped "sha\x1fsubject\x1fauthorDate\n<name-status line>\n".
+  // Format rides with `--numstat`: a LEADING record separator, so splitting
+  // on \x1e yields an empty first chunk, then one chunk per commit shaped
+  // "sha\x1fsubject\x1fauthorDate\n<added>\t<removed>\t<pathfield>\n".
   const U = '\x1f'; // unit separator between header fields
   const R = '\x1e'; // record separator, LEADS each commit chunk
 
-  it('splits unit/record separators into entries and reads the name-status line', () => {
+  it('splits unit/record separators into entries and reads the numstat line', () => {
     const text =
       R + ['3f1c9a2deadbeef00000000000000000000000', 'fix(reducer): drop stale tool ids', '2026-07-22T14:03:11-05:00'].join(U) + '\n' +
-      'M\tsrc/reducer.ts\n' +
+      '12\t4\tsrc/reducer.ts\n' +
       R + ['c9718267cafebabe0000000000000000000000', 'fix(ws): consolidate duplicate clients', '2026-07-22T11:00:00-05:00'].join(U) + '\n' +
-      'M\tsrc/ws.ts\n';
+      '3\t0\tsrc/ws.ts\n';
     const log = parseLogRecords(text);
     expect(log).toHaveLength(2);
     expect(log[0]).toEqual({
@@ -72,26 +102,58 @@ describe('parseLogRecords', () => {
       authorDate: '2026-07-22T14:03:11-05:00',
       pathAtCommit: 'src/reducer.ts',
       renamedFrom: undefined,
+      counts: { added: 12, removed: 4 },
     });
     expect(log[1].pathAtCommit).toBe('src/ws.ts');
+    expect(log[1].counts).toEqual({ added: 3, removed: 0 });
   });
 
-  it('extracts renamedFrom + pathAtCommit (new name) from an R<score> name-status line', () => {
+  it('extracts renamedFrom + pathAtCommit (new name) from a brace-rename numstat pathfield', () => {
     const text =
       R + ['80e65644d13b133b901ef4274c1094b30f34246d', 'move to docs/new.md', '2026-07-23T10:35:16-07:00'].join(U) + '\n' +
-      'R100\told.md\tdocs/new.md\n';
+      '0\t0\tdocs/{superpowers => archive}/new.md\n';
     const log = parseLogRecords(text);
     expect(log).toHaveLength(1);
-    expect(log[0].pathAtCommit).toBe('docs/new.md');
-    expect(log[0].renamedFrom).toBe('old.md');
+    expect(log[0].pathAtCommit).toBe('docs/archive/new.md');
+    expect(log[0].renamedFrom).toBe('docs/superpowers/new.md');
+    expect(log[0].counts).toEqual({ added: 0, removed: 0 });
   });
 
-  it('leaves pathAtCommit undefined when a chunk has no name-status line', () => {
+  it('extracts renamedFrom + pathAtCommit from an empty-side brace rename, collapsing the doubled slash', () => {
+    const text =
+      R + ['deadbeefcafe0000000000000000000000000000', 'move into sub/', '2026-07-23T10:35:16-07:00'].join(U) + '\n' +
+      '0\t0\tdir/{ => sub}/f.md\n';
+    const log = parseLogRecords(text);
+    expect(log[0].pathAtCommit).toBe('dir/sub/f.md');
+    expect(log[0].renamedFrom).toBe('dir/f.md');
+  });
+
+  it('extracts renamedFrom + pathAtCommit from a plain "old => new" numstat pathfield (no common affix)', () => {
+    const text =
+      R + ['1111111111111111111111111111111111111', 'rename old to new', '2026-07-23T10:35:16-07:00'].join(U) + '\n' +
+      '1\t1\told.md => new.md\n';
+    const log = parseLogRecords(text);
+    expect(log[0].pathAtCommit).toBe('new.md');
+    expect(log[0].renamedFrom).toBe('old.md');
+    expect(log[0].counts).toEqual({ added: 1, removed: 1 });
+  });
+
+  it('reports counts as null for a binary file (numstat "-\\t-")', () => {
+    const text =
+      R + ['2222222222222222222222222222222222222', 'add logo', '2026-07-23T10:35:16-07:00'].join(U) + '\n' +
+      '-\t-\tassets/logo.png\n';
+    const log = parseLogRecords(text);
+    expect(log[0].pathAtCommit).toBe('assets/logo.png');
+    expect(log[0].counts).toBeNull();
+  });
+
+  it('leaves pathAtCommit/counts undefined+null when a chunk has no numstat line (e.g. a surfaced merge commit)', () => {
     const text = R + ['deadbeef', 'merge commit', '2026-07-22T00:00:00-05:00'].join(U) + '\n';
     const log = parseLogRecords(text);
     expect(log).toHaveLength(1);
     expect(log[0].pathAtCommit).toBeUndefined();
     expect(log[0].renamedFrom).toBeUndefined();
+    expect(log[0].counts).toBeNull();
   });
 
   it('returns [] for empty output', () => {

--- a/desktop/tests/git/porcelain.test.ts
+++ b/desktop/tests/git/porcelain.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePorcelainV2, parseNumstat, parseLogRecords,
+  parseUnifiedDiff, countsFromHunks, synthesizeAddHunk,
+} from '../../src/main/git/porcelain';
+
+describe('parsePorcelainV2', () => {
+  it('extracts branch and per-file staged/unstaged/untracked', () => {
+    const text = [
+      '# branch.oid 1234567890abcdef',
+      '# branch.head master',
+      '1 .M N... 100644 100644 100644 aaa bbb src/renderer/state/chat-reducer.ts',
+      '1 M. N... 100644 100644 100644 aaa bbb src/shared/types.ts',
+      '1 MM N... 100644 100644 100644 aaa bbb src/both.ts',
+      '? src/renderer/state/undo-stack.ts',
+      '',
+    ].join('\n');
+    const r = parsePorcelainV2(text);
+    expect(r.branch).toBe('master');
+    expect(r.files).toEqual([
+      { path: 'src/renderer/state/chat-reducer.ts', staged: false, unstaged: true, untracked: false, kind: 'modified' },
+      { path: 'src/shared/types.ts', staged: true, unstaged: false, untracked: false, kind: 'modified' },
+      { path: 'src/both.ts', staged: true, unstaged: true, untracked: false, kind: 'modified' },
+      { path: 'src/renderer/state/undo-stack.ts', staged: false, unstaged: true, untracked: true, kind: 'untracked' },
+    ]);
+  });
+
+  it('reports detached HEAD as null branch and classifies add/delete/rename', () => {
+    const text = [
+      '# branch.head (detached)',
+      '1 A. N... 000000 100644 100644 000 bbb new.ts',
+      '1 .D N... 100644 100644 000000 aaa bbb gone.ts',
+      '2 R. N... 100644 100644 100644 aaa bbb R100 renamed.ts\told-name.ts',
+      '',
+    ].join('\n');
+    const r = parsePorcelainV2(text);
+    expect(r.branch).toBeNull();
+    expect(r.files[0]).toMatchObject({ path: 'new.ts', kind: 'added', staged: true });
+    expect(r.files[1]).toMatchObject({ path: 'gone.ts', kind: 'deleted', unstaged: true });
+    expect(r.files[2]).toMatchObject({ path: 'renamed.ts', kind: 'renamed', staged: true });
+  });
+});
+
+describe('parseNumstat', () => {
+  it('maps path to added/removed and flags binary', () => {
+    const text = '41\t12\tsrc/renderer/state/chat-reducer.ts\n-\t-\tassets/logo.png\n';
+    const m = parseNumstat(text);
+    expect(m.get('src/renderer/state/chat-reducer.ts')).toEqual({ added: 41, removed: 12, binary: false });
+    expect(m.get('assets/logo.png')).toEqual({ added: 0, removed: 0, binary: true });
+  });
+});
+
+describe('parseLogRecords', () => {
+  it('splits unit/record separators into entries', () => {
+    const U = '\x1f'; // unit separator between fields
+    const R = '\x1e'; // record separator between commits
+    const text =
+      ['3f1c9a2deadbeef00000000000000000000000', 'fix(reducer): drop stale tool ids', '2026-07-22T14:03:11-05:00'].join(U) + R +
+      ['c9718267cafebabe0000000000000000000000', 'fix(ws): consolidate duplicate clients', '2026-07-22T11:00:00-05:00'].join(U) + R;
+    const log = parseLogRecords(text);
+    expect(log).toHaveLength(2);
+    expect(log[0]).toEqual({
+      sha: '3f1c9a2deadbeef00000000000000000000000',
+      shortSha: '3f1c9a2',
+      subject: 'fix(reducer): drop stale tool ids',
+      authorDate: '2026-07-22T14:03:11-05:00',
+    });
+  });
+  it('returns [] for empty output', () => {
+    expect(parseLogRecords('')).toEqual([]);
+  });
+});
+
+describe('parseUnifiedDiff', () => {
+  it('parses hunks with absolute line numbers', () => {
+    const text = [
+      'diff --git a/f.ts b/f.ts',
+      'index aaa..bbb 100644',
+      '--- a/f.ts',
+      '+++ b/f.ts',
+      '@@ -142,4 +142,6 @@ case block',
+      "     case 'TRANSCRIPT_TOOL_RESULT': {",
+      '-      const tool = state.toolCalls.get(action.id);',
+      '+      const tool = state.toolCalls.get(action.id) ?? null;',
+      '+      if (!tool) return state;',
+      '       const next = new Map(state.toolCalls);',
+      '@@ -231,2 +233,2 @@',
+      '-      return old;',
+      '+      return fresh;',
+      '',
+    ].join('\n');
+    const r = parseUnifiedDiff(text);
+    expect(r.binary).toBe(false);
+    expect(r.hunks).toHaveLength(2);
+    expect(r.hunks[0]).toMatchObject({ oldStart: 142, oldLines: 4, newStart: 142, newLines: 6 });
+    expect(r.hunks[0].lines[1]).toBe('-      const tool = state.toolCalls.get(action.id);');
+    expect(r.hunks[1]).toMatchObject({ oldStart: 231, newStart: 233 });
+  });
+  it('handles single-line hunk headers (no comma) and binary diffs', () => {
+    const one = parseUnifiedDiff('--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b\n');
+    expect(one.hunks[0]).toMatchObject({ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1 });
+    const bin = parseUnifiedDiff('diff --git a/x b/x\nBinary files a/x and b/x differ\n');
+    expect(bin.binary).toBe(true);
+    expect(bin.hunks).toEqual([]);
+  });
+});
+
+describe('countsFromHunks / synthesizeAddHunk', () => {
+  it('sums additions and removals across hunks', () => {
+    const r = parseUnifiedDiff('--- a/f\n+++ b/f\n@@ -1,2 +1,3 @@\n-x\n+y\n+z\n ctx\n');
+    expect(countsFromHunks(r.hunks)).toEqual({ added: 2, removed: 1 });
+  });
+  it('synthesizes an all-additions hunk for an untracked file', () => {
+    const h = synthesizeAddHunk('line one\nline two\n');
+    expect(h).toEqual({ oldStart: 0, oldLines: 0, newStart: 1, newLines: 2, lines: ['+line one', '+line two'] });
+  });
+});

--- a/desktop/tests/git/porcelain.test.ts
+++ b/desktop/tests/git/porcelain.test.ts
@@ -51,12 +51,18 @@ describe('parseNumstat', () => {
 });
 
 describe('parseLogRecords', () => {
-  it('splits unit/record separators into entries', () => {
-    const U = '\x1f'; // unit separator between fields
-    const R = '\x1e'; // record separator between commits
+  // New format rides with `--name-status`: a LEADING record separator, so
+  // splitting on \x1e yields an empty first chunk, then one chunk per commit
+  // shaped "sha\x1fsubject\x1fauthorDate\n<name-status line>\n".
+  const U = '\x1f'; // unit separator between header fields
+  const R = '\x1e'; // record separator, LEADS each commit chunk
+
+  it('splits unit/record separators into entries and reads the name-status line', () => {
     const text =
-      ['3f1c9a2deadbeef00000000000000000000000', 'fix(reducer): drop stale tool ids', '2026-07-22T14:03:11-05:00'].join(U) + R +
-      ['c9718267cafebabe0000000000000000000000', 'fix(ws): consolidate duplicate clients', '2026-07-22T11:00:00-05:00'].join(U) + R;
+      R + ['3f1c9a2deadbeef00000000000000000000000', 'fix(reducer): drop stale tool ids', '2026-07-22T14:03:11-05:00'].join(U) + '\n' +
+      'M\tsrc/reducer.ts\n' +
+      R + ['c9718267cafebabe0000000000000000000000', 'fix(ws): consolidate duplicate clients', '2026-07-22T11:00:00-05:00'].join(U) + '\n' +
+      'M\tsrc/ws.ts\n';
     const log = parseLogRecords(text);
     expect(log).toHaveLength(2);
     expect(log[0]).toEqual({
@@ -64,8 +70,30 @@ describe('parseLogRecords', () => {
       shortSha: '3f1c9a2',
       subject: 'fix(reducer): drop stale tool ids',
       authorDate: '2026-07-22T14:03:11-05:00',
+      pathAtCommit: 'src/reducer.ts',
+      renamedFrom: undefined,
     });
+    expect(log[1].pathAtCommit).toBe('src/ws.ts');
   });
+
+  it('extracts renamedFrom + pathAtCommit (new name) from an R<score> name-status line', () => {
+    const text =
+      R + ['80e65644d13b133b901ef4274c1094b30f34246d', 'move to docs/new.md', '2026-07-23T10:35:16-07:00'].join(U) + '\n' +
+      'R100\told.md\tdocs/new.md\n';
+    const log = parseLogRecords(text);
+    expect(log).toHaveLength(1);
+    expect(log[0].pathAtCommit).toBe('docs/new.md');
+    expect(log[0].renamedFrom).toBe('old.md');
+  });
+
+  it('leaves pathAtCommit undefined when a chunk has no name-status line', () => {
+    const text = R + ['deadbeef', 'merge commit', '2026-07-22T00:00:00-05:00'].join(U) + '\n';
+    const log = parseLogRecords(text);
+    expect(log).toHaveLength(1);
+    expect(log[0].pathAtCommit).toBeUndefined();
+    expect(log[0].renamedFrom).toBeUndefined();
+  });
+
   it('returns [] for empty output', () => {
     expect(parseLogRecords('')).toEqual([]);
   });

--- a/desktop/tests/global-setup.ts
+++ b/desktop/tests/global-setup.ts
@@ -17,4 +17,13 @@ export default function setup() {
   // whole sandbox exists to remove.
   fs.rmSync(testHome, { recursive: true, force: true });
   fs.mkdirSync(path.join(testHome, '.claude'), { recursive: true });
+  // git-service.ts's gitCommit shells out to real `git commit` with no author
+  // env vars (that's the production code path) — it needs SOME identity to
+  // resolve, and the redirected HOME above means it can no longer see the
+  // developer's real ~/.gitconfig. A throwaway identity here (never the real
+  // one) keeps git-service integration tests hermetic. See tests/git/git-service.test.ts.
+  fs.writeFileSync(
+    path.join(testHome, '.gitconfig'),
+    '[user]\n\tname = YouCoded Test\n\temail = test@youcoded.test\n',
+  );
 }

--- a/desktop/tests/ipc-channels.test.ts
+++ b/desktop/tests/ipc-channels.test.ts
@@ -900,3 +900,39 @@ describe('model memory lifecycle channel parity (2026-07-14)', () => {
     for (const [ch] of invokeChannels) expect(src).toContain(`"${ch}"`);
   });
 });
+
+describe('git:* IPC parity (git surface, spec 2026-07-22)', () => {
+  const preload = fs.readFileSync(path.join(__dirname, '../src/main/preload.ts'), 'utf8');
+  const shim = fs.readFileSync(path.join(__dirname, '../src/renderer/remote-shim.ts'), 'utf8');
+  const handlers = fs.readFileSync(path.join(__dirname, '../src/main/ipc-handlers.ts'), 'utf8');
+  const kotlinPath = path.join(__dirname, '../../app/src/main/kotlin/com/youcoded/app/runtime/SessionService.kt');
+  const kotlin = fs.existsSync(kotlinPath) ? fs.readFileSync(kotlinPath, 'utf8') : null;
+
+  const channels: Array<[string, string]> = [
+    ['git:file-status', 'GIT_IPC.FILE_STATUS'],
+    ['git:file-review', 'GIT_IPC.FILE_REVIEW'],
+    ['git:commit-file-diff', 'GIT_IPC.COMMIT_FILE_DIFF'],
+    ['git:stage', 'GIT_IPC.STAGE'],
+    ['git:unstage', 'GIT_IPC.UNSTAGE'],
+    ['git:commit', 'GIT_IPC.COMMIT'],
+    ['git:discard', 'GIT_IPC.DISCARD'],
+    ['git:watch', 'GIT_IPC.WATCH'],
+    ['git:unwatch', 'GIT_IPC.UNWATCH'],
+  ];
+
+  for (const [ch, constant] of channels) {
+    it(`${ch} present in preload + remote-shim + ipc-handlers`, () => {
+      expect(preload).toContain(`'${ch}'`);
+      expect(shim).toContain(`'${ch}'`);
+      expect(handlers.includes(`'${ch}'`) || handlers.includes(constant)).toBe(true);
+    });
+    it(`${ch} has an Android not-implemented-on-mobile stub`, () => {
+      if (kotlin) expect(kotlin).toContain(`"${ch}"`);
+    });
+  }
+
+  it('git:changed push channel present in preload + remote-shim', () => {
+    expect(preload).toContain(`'git:changed'`);
+    expect(shim).toContain(`'git:changed'`);
+  });
+});

--- a/desktop/tests/renderer/git-footer.test.ts
+++ b/desktop/tests/renderer/git-footer.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { gitFooterState } from '../../src/renderer/utils/git-footer';
+
+const base = { ok: true, isRepo: true, branch: 'main', counts: null, hasHistory: false, staged: false };
+
+describe('gitFooterState', () => {
+  it('hidden when status is unknown or not a repo', () => {
+    expect(gitFooterState(null).show).toBe(false);
+    expect(gitFooterState({ ...base, isRepo: false }).show).toBe(false);
+  });
+  it('hidden for a clean file with no history (footer reads exactly as today)', () => {
+    expect(gitFooterState(base)).toEqual({ show: false, counts: null });
+  });
+  it('shown with counts when the file has uncommitted changes', () => {
+    const r = gitFooterState({ ...base, counts: { added: 41, removed: 12 } });
+    expect(r).toEqual({ show: true, counts: { added: 41, removed: 12 } });
+  });
+  it('shown without counts when clean but with history', () => {
+    expect(gitFooterState({ ...base, hasHistory: true })).toEqual({ show: true, counts: null });
+  });
+  it('zero-zero counts (binary/oversize) still count as changed', () => {
+    expect(gitFooterState({ ...base, counts: { added: 0, removed: 0 } }).show).toBe(true);
+  });
+});

--- a/desktop/tests/renderer/git-review-state.test.ts
+++ b/desktop/tests/renderer/git-review-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { artifactReducer, initialArtifactState } from '../../src/renderer/state/artifact-tracker';
+
+const open = (s = initialArtifactState) =>
+  artifactReducer(s, { type: 'GIT_REVIEW_OPENED', sessionId: 's1' } as any);
+
+describe('git review view state', () => {
+  it('defaults closed', () => {
+    expect(initialArtifactState.gitReviewBySession).toEqual({});
+  });
+
+  it('GIT_REVIEW_OPENED / GIT_REVIEW_CLOSED flip the per-session flag', () => {
+    let s = open();
+    expect(s.gitReviewBySession['s1']).toBe(true);
+    s = artifactReducer(s, { type: 'GIT_REVIEW_CLOSED', sessionId: 's1' } as any);
+    expect(s.gitReviewBySession['s1']).toBe(false);
+  });
+
+  it('DRAWER_CLOSED clears the flag for that session', () => {
+    let s = open();
+    s = artifactReducer(s, { type: 'DRAWER_CLOSED', sessionId: 's1' } as any);
+    expect(s.gitReviewBySession['s1']).toBeFalsy();
+  });
+
+  it('selecting a different artifact exits review (view follows the file)', () => {
+    let s = open();
+    s = artifactReducer(s, { type: 'ACTIVE_ARTIFACT_SET', sessionId: 's1', artifactId: 'a2' } as any);
+    expect(s.gitReviewBySession['s1']).toBe(false);
+  });
+
+  it('is per-session', () => {
+    const s = open();
+    expect(s.gitReviewBySession['s2']).toBeUndefined();
+  });
+});

--- a/desktop/tests/unified-diff-fill.test.tsx
+++ b/desktop/tests/unified-diff-fill.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+// unified-diff-fill.test.tsx — pins the `fill` prop that the git review
+// timeline relies on (2026-07-23). The review wraps each diff in its own
+// 45vh scroll box; UnifiedDiff's internal 15-line preview cap + "Expand"
+// button would stack a second, redundant scrollbar inside that box and the
+// "Expand" click barely moved anything. `fill` must suppress BOTH the cap and
+// the button so the host is the sole scroll surface — this test is the guard
+// against that regressing back to the nested-scroll jank Destin reported.
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+import { UnifiedDiff } from '../src/renderer/components/diff/UnifiedDiff';
+import type { StructuredPatchHunk } from '../src/shared/types';
+
+afterEach(cleanup);
+
+// A hunk with far more than DIFF_PREVIEW_LINES (15) rows, so the internal cap
+// + Expand button WOULD appear without `fill`.
+const bigHunk: StructuredPatchHunk = {
+  oldStart: 1,
+  oldLines: 0,
+  newStart: 1,
+  newLines: 40,
+  lines: Array.from({ length: 40 }, (_, i) => `+line ${i + 1}`),
+};
+
+describe('UnifiedDiff fill prop', () => {
+  it('without fill: a long diff caps and shows the Expand button', () => {
+    render(<UnifiedDiff oldStr="" newStr="" structuredPatch={[bigHunk]} />);
+    expect(screen.getByText(/Expand \(40 lines\)/)).toBeInTheDocument();
+  });
+
+  it('with fill: no Expand button and no maxHeight cap on the scroll container', () => {
+    const { container } = render(
+      <UnifiedDiff oldStr="" newStr="" structuredPatch={[bigHunk]} fill />
+    );
+    // The redundant inner button is gone — the host owns the height cap.
+    expect(screen.queryByText(/Expand \(/)).not.toBeInTheDocument();
+    // The diff container renders full-height (no inline maxHeight style).
+    const diffBox = container.querySelector('.font-mono') as HTMLElement | null;
+    expect(diffBox).not.toBeNull();
+    expect(diffBox!.style.maxHeight).toBe('');
+  });
+});


### PR DESCRIPTION
Implements the git surface MVP per `youcoded-dev/docs/active/plans/2026-07-22-git-surface.md` (spec: `docs/active/specs/2026-07-22-git-surface.md`).

## What this adds

- **Footer entry** in the SessionDrawer for the open file: `+N −N · Review Changes →` when the file has uncommitted changes or git history; footer renders exactly as before otherwise (and on non-repo projects, Android, remote).
- **Review view** (pushed sub-view under the standard drawer top bar): expandable card timeline — Uncommitted changes first (accent, expanded), then commits touching the file (lazy per-commit diffs via `git show`), Show more pagination, branch chip.
- **Stage/unstage** (real index, mirror-not-gate — no app-local staging state), **repo-wide commit composer** (`Commit N staged files`), **discard** with an L3 destructive confirm: restore-from-HEAD for committed files, recoverable OS-trash (never `git clean`) for files HEAD has no copy of.
- **Live mirror**: debounced refcounted `fs.watch` on `.git` state (HEAD/index/refs, linked-worktree `gitdir:` layouts supported) + the existing chokidar feed, so terminal/agent commits update the view in place.

## Architecture

New main-process `desktop/src/main/git/` module shelling to system git (`execFile`, cwd-based, `core.quotepath=false`, `GIT_TERMINAL_PROMPT=0`, inherited `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` stripped — deliberately NOT the sync transport's hidden-GIT_DIR pattern). `git:*` IPC gated to known project roots (same allow-list as `artifacts:read-binary`) with path-escape defense, sha validation, and symlink `lstat` guards; parity pinned across preload/remote-shim/Kotlin stub (desktop-only: Android/remote degrade to the unchanged footer). Renderer: `gitReviewBySession` reducer flag, `useGitFileStatus` hook, `GitReviewView`/`GitReviewCard`/`DiscardConfirmDialog` reusing `UnifiedDiff`, shared overlay/Button/Textarea primitives, and the app's `useEscClose` stack.

## Testing

- 106 new tests (full suite: **3188 passed / 39 skipped, 0 failures**; `tsc --noEmit` clean; vite build clean).
- Integration tests run against real git in temp repos: porcelain/numstat/log/diff parsing, unborn HEAD, staged-new, untracked-in-new-directory, >1MB truncation, non-ASCII filenames (`café.md`), symlink refusal, linked-worktree watcher, discard/unstage edge routing, pagination.
- Error strings carry real git stderr end to end (`docs/error-message-standards.md`).
- Built with subagent-driven development: per-task spec+quality reviews, then a whole-branch final review — all findings fixed and re-verified (details in the workspace plan's audit trail).

## Notes for review

- **Android**: `SessionService.kt` gets a grouped `not-implemented-on-mobile` stub only; no local Android SDK on the dev box, so the Kotlin compile check rides this PR's CI.
- **Known deferred follow-ups** are filed in `youcoded-dev/ROADMAP.md` (2026-07-22 entries): unmerged-conflict entries, pagination-vs-refresh reconciliation, stale discard-error race, `-z` parsing residual, profiling checkpoint, and one UX decision (untracked files have no stage checkbox per the locked mockup).

## Pre-merge interactive checklist (Destin)

1. Open a session in a real git project; modify a file; open it in the drawer → footer shows `+N −N · Review Changes →`.
2. Click Review Changes → standard header stays, sub-header appears beneath, uncommitted card expanded.
3. Commit from a terminal while the view is open → uncommitted card collapses into a new commit card (mirror check).
4. Stage via checkbox, commit with a message, discard a scratch file (lands in OS trash).
5. ESC walks back: review → file view → drawer close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)