### PR TITLE
fix(social): user-idle gate — presence tracks the human, not the process

### DIFF
--- a/desktop/src/main/presence-socket.ts
+++ b/desktop/src/main/presence-socket.ts
@@ -25,6 +25,11 @@ export interface PresenceSocket {
   // setDesired: desired is the RENDERER's intent (sign-in/incognito/leader)
   // and must survive a sleep/wake cycle unchanged.
   setSuspended(asleep: boolean): void;
+  // User-idle gate (no system OR remote input for the idle threshold — see the
+  // poller in social-handlers.ts). Same composition rule as setSuspended:
+  // presence means a HUMAN is around, so an app left running 24/7 on an awake
+  // machine (remote-access keep-awake) must not read "Online" forever.
+  setIdle(idle: boolean): void;
   send(message: Record<string, unknown>): void;
   isConnected(): boolean;
   destroy(): void;
@@ -105,13 +110,22 @@ export function createPresenceSocket(opts: {
   // wake restores whatever the renderer wanted.
   let rendererDesired = false;
   let suspended = false;
-  const applyDesire = () => engine.setDesired(rendererDesired && !suspended);
+  let idle = false;
+  const applyDesire = () => engine.setDesired(rendererDesired && !suspended && !idle);
 
   return {
     setDesired(want) { rendererDesired = want; applyDesire(); },
     setSuspended(asleep) {
       if (suspended === asleep) return;
       suspended = asleep;
+      applyDesire();
+    },
+    // Independent axis from suspend: a dark wake clears suspended but not
+    // idle, so a lid bumped open cannot flash a false "Online" — only real
+    // input (which clears idle via the poller) reconnects.
+    setIdle(nowIdle) {
+      if (idle === nowIdle) return;
+      idle = nowIdle;
       applyDesire();
     },
     send(message) { engine.send(JSON.stringify(message)); },

--- a/desktop/src/main/remote-server.ts
+++ b/desktop/src/main/remote-server.ts
@@ -71,6 +71,7 @@ export class RemoteServer {
   // and never cancelled, so it survived stop() and a restart stacked another.
   private uploadCleanupTimer: ReturnType<typeof setInterval> | null = null;
   private clients = new Set<AuthenticatedClient>();
+  private lastClientActivityMs = 0; // see getLastClientActivityMs()
   private tokens = new Map<string, boolean>(); // token → valid
   private tokensPath: string;
   // `${encoding}:${urlPath}` → compressed bytes. Safe to hold indefinitely
@@ -350,6 +351,14 @@ export class RemoteServer {
   /** Number of currently connected remote clients. */
   getClientCount(): number {
     return this.clients.size;
+  }
+
+  /** Epoch ms of the last authenticated remote-client message (0 = never).
+   *  Read by the presence idle poller (social-handlers.ts): someone driving
+   *  the app through remote access produces no LOCAL keyboard/mouse input, so
+   *  system idle time alone would wrongly mark them away. */
+  getLastClientActivityMs(): number {
+    return this.lastClientActivityMs;
   }
 
   /** List all connected remote clients. */
@@ -702,6 +711,11 @@ export class RemoteServer {
     } catch {
       return;
     }
+
+    // Presence-activity stamp (see getLastClientActivityMs). Any parsed frame
+    // counts: a remote user's typing arrives as pty:input / chat sends, and
+    // even passive viewing produces periodic client messages.
+    this.lastClientActivityMs = Date.now();
 
     const { type, id, payload } = msg;
 

--- a/desktop/src/main/social-handlers.ts
+++ b/desktop/src/main/social-handlers.ts
@@ -35,6 +35,18 @@ let presenceSocket: PresenceSocket | null = null;
 // on a destroyed socket and could resurrect it via the engine).
 let onSuspend: (() => void) | null = null;
 let onResume: (() => void) | null = null;
+let idlePoller: NodeJS.Timeout | null = null;
+
+// Presence idle threshold: no system input AND no remote-client activity for
+// this long → presence drops ("Last seen …"), because Online must mean a HUMAN
+// is around, not that the process exists. Discovered via tjmorin's Mac
+// (2026-07-23): the remote-access keep-awake powerSaveBlocker keeps machines
+// permanently awake, so an idle app pings forever and reads Online for days.
+// 10 min matches the server's staleness threshold by design.
+const IDLE_DISCONNECT_MS = 10 * 60 * 1000;
+// 15s poll: cheap native sync call; bounds the reconnect delay after the user
+// returns (friends see them come back online within ~15s of first input).
+const IDLE_POLL_MS = 15_000;
 
 // ── Channel list for double-registration guard ───────────────────────────────
 // Byte-identical to the strings in preload.ts (IPC.SOCIAL_*), remote-shim.ts,
@@ -115,6 +127,20 @@ export function registerSocialHandlers(
   onResume = () => presence.setSuspended(false);
   powerMonitor.on("suspend", onSuspend);
   powerMonitor.on("resume", onResume);
+
+  // Idle gate poller (see IDLE_DISCONNECT_MS). Two activity sources, either
+  // keeps presence alive: local keyboard/mouse (getSystemIdleTime — returns
+  // seconds; on platforms where the desktop offers no idle API it reports 0,
+  // which fails SAFE to "active", i.e. current behavior), and remote-access
+  // clients (their input never touches local idle time — without this, a user
+  // driving the app from their phone would wrongly read as away).
+  if (idlePoller) clearInterval(idlePoller);
+  idlePoller = setInterval(() => {
+    const localIdleMs = powerMonitor.getSystemIdleTime() * 1000;
+    const lastRemote = remoteServer?.getLastClientActivityMs() ?? 0;
+    const remoteIdleMs = lastRemote === 0 ? Number.POSITIVE_INFINITY : Date.now() - lastRemote;
+    presence.setIdle(localIdleMs >= IDLE_DISCONNECT_MS && remoteIdleMs >= IDLE_DISCONNECT_MS);
+  }, IDLE_POLL_MS);
 
   // One client instance shared across all handlers. getToken() is read lazily
   // per-request so sign-out takes effect immediately.

--- a/desktop/tests/presence-socket.test.ts
+++ b/desktop/tests/presence-socket.test.ts
@@ -258,6 +258,54 @@ describe('presence-socket state machine', () => {
     sock.destroy();
   });
 
+  it('user-idle gate: extended idleness closes the socket, activity reconnects, renderer intent preserved', () => {
+    const { sock, events } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    const inst = FakeSocket.instances[0];
+    inst.emit('open');
+
+    // 10+ min with no input anywhere (system or remote): presence must drop so
+    // "Online" means a HUMAN is around — an app left running on an awake
+    // machine (e.g. remote-access keep-awake) must not read online forever.
+    sock.setIdle(true);
+    expect(inst.closeCalls).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: 'disconnected', reason: 'local' });
+    expect(sock.isConnected()).toBe(false);
+
+    // Input returns → reconnect (renderer still wants presence on).
+    sock.setIdle(false);
+    expect(FakeSocket.instances).toHaveLength(2);
+
+    // Idle while the renderer wants presence OFF: clearing idle must not
+    // conjure a connection.
+    sock.setDesired(false);
+    sock.setIdle(true);
+    sock.setIdle(false);
+    expect(FakeSocket.instances).toHaveLength(2);
+    sock.destroy();
+  });
+
+  it('idle and suspend gates are independent: both must clear before reconnecting', () => {
+    const { sock } = makeSocket(() => 'tok');
+    sock.setDesired(true);
+    FakeSocket.instances[0].emit('open');
+
+    // Machine goes idle, THEN sleeps (the normal order at a desk).
+    sock.setIdle(true);
+    sock.setSuspended(true);
+    expect(FakeSocket.instances).toHaveLength(1);
+
+    // Wake without input (dark wake / lid opened by a bump): still idle — the
+    // resume alone must NOT reconnect and flash a false "Online" at friends.
+    sock.setSuspended(false);
+    expect(FakeSocket.instances).toHaveLength(1);
+
+    // Real input arrives → both gates clear → reconnect.
+    sock.setIdle(false);
+    expect(FakeSocket.instances).toHaveLength(2);
+    sock.destroy();
+  });
+
   it('send is a silent no-op when disconnected; isConnected gates the honest handler receipt', () => {
     const { sock } = makeSocket(() => 'tok');
     // The manager itself no-ops; the HANDLER (social-handlers.ts) consults


### PR DESCRIPTION
Day-2 follow-up to #209/#211 and the stuck-"Online" investigation. tjmorin still read Online 24/7 after the server fixes — server forensics proved his client's app-level pings arrive **continuously**: his Mac never sleeps (very likely the remote-access **keep-awake powerSaveBlocker**, `applyKeepAwake` in `ipc-handlers.ts`), so the app process runs forever and presence truthfully-but-uselessly reported the process. The suspend gate never fires on a machine that never suspends.

## The fix

**"Online" now requires a human**: a 15s poller in Electron main reads `powerMonitor.getSystemIdleTime()`; after **10 min** with no local input **and** no remote-access activity, the presence socket closes (friends see "Last seen …"). First input reconnects within ~15s.

- **Remote activity counts as presence** — new `RemoteServer.getLastClientActivityMs()` stamped on every authenticated client frame. A user driving their home machine from a phone has zero local input and must not read as away.
- **Idle ⊥ suspend**: independent gates on the presence manager. A dark wake clears `suspended` but not `idle`, so a bumped lid can't flash a false Online.
- **Fails safe**: platforms whose desktop offers no idle API report 0 → treated as active → current behavior.
- Renderer intent (sign-in/incognito/leader) remains its own axis, preserved across both gates.

Design call (flagged in-session for veto): idle reads as **offline/"Last seen…"**, not a new "Away" status — zero protocol/UI changes; an explicit Away state can layer on later.

## Verification

Two new state-machine tests, written first, watched fail. 13/13 presence-socket tests, `tsc --noEmit` clean. Full-suite note: `ipc-handlers.test.ts` flaked during verification via a pre-existing `/tmp/youcoded-vitest-home` import-race (passes alone; master flakes identically) — ROADMAP'd separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)