### PR TITLE
ci: check every PR via pull_request, not a branch-name allowlist

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,10 +1,14 @@
 name: Android CI
 
 on:
+  # See desktop-ci.yml for the full rationale: `pull_request` checks every PR
+  # regardless of branch name, replacing the branch-name allowlist whose
+  # 'feat/**' vs 'feature/**' gap left pushes unchecked, and letting
+  # Dependabot's `dependabot/**` PRs run. `push: [master]` keeps the
+  # post-merge run on master.
   push:
-    # Same gap as desktop-ci.yml: this repo names branches 'feat/**', which
-    # 'feature/**' does not match, so those pushes ran no Android checks either.
-    branches: [master, 'feat/**', 'feature/**', 'fix/**']
+    branches: [master]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -1,12 +1,17 @@
 name: Desktop CI
 
 on:
+  # Every PR is checked via `pull_request`, regardless of branch name. This
+  # replaces the branch-name allowlist that caused the incident below: that
+  # list was a proxy for "is this a PR", and the proxy failed when 'feat/**'
+  # was listed but 'feature/**' matched nothing — so those branches and their
+  # PRs got NO checks and master stayed red from 2026-07-14 to 07-16 (18
+  # failing pushes) without anyone noticing. `pull_request` also lets
+  # Dependabot's `dependabot/**` PRs run checks; they matched none of the old
+  # push patterns. `push: [master]` keeps the post-merge run on master.
   push:
-    # 'feat/**' is the name this repo actually uses (feat/mascot-rig-core,
-    # feat/beta-build-channel); only 'feature/**' was listed, so those branches
-    # and their PRs got NO checks at all. That's how master stayed red from
-    # 2026-07-14 to 07-16 — 18 failing pushes — without anyone noticing.
-    branches: [master, 'feat/**', 'feature/**', 'fix/**']
+    branches: [master]
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds a `pull_request:` trigger to desktop-ci and android-ci so every PR is checked regardless of branch name. Prerequisite for Dependabot (its `dependabot/**` branches match none of the current push patterns). Also closes checks for chore/refactor/docs branches. Self-verifies: this PR is on a `chore/` branch that gets zero checks today, so if the full desktop+android matrix appears on it, the fix works. Spec: youcoded-dev/docs/active/specs/2026-07-23-dependabot-design.md §4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)