### PR TITLE
docs(git-surface): repoint spec comments to the archived path

### DIFF
--- a/desktop/src/main/git/porcelain.ts
+++ b/desktop/src/main/git/porcelain.ts
@@ -1,6 +1,6 @@
 // Pure parsers for git plumbing output. No I/O, no electron imports — every
 // function takes strings so the whole module unit-tests with fixtures.
-// Spec: docs/active/specs/2026-07-22-git-surface.md section 3.
+// Spec: docs/archive/specs/2026-07-22-git-surface.md section 3.
 import type { StructuredPatchHunk } from '../../shared/types';
 import type { GitFileCounts, GitLogEntry } from '../../shared/git-types';
 

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -3263,7 +3263,7 @@ export function registerIpcHandlers(
     return { ok: true };
   });
 
-  // ── Git surface (spec docs/active/specs/2026-07-22-git-surface.md) ──
+  // ── Git surface (spec docs/archive/specs/2026-07-22-git-surface.md) ──
   // Known-roots gate: a git operation may only target a saved folder or an
   // indexed project root — same allow-list the read-binary guard builds.
   const knownGitRoot = async (projectRoot: unknown): Promise<boolean> => {

--- a/desktop/src/shared/git-types.ts
+++ b/desktop/src/shared/git-types.ts
@@ -1,4 +1,4 @@
-// Git surface IPC payload types (spec docs/active/specs/2026-07-22-git-surface.md).
+// Git surface IPC payload types (spec docs/archive/specs/2026-07-22-git-surface.md).
 // Shared main <-> renderer; keep JSON-serializable.
 import type { StructuredPatchHunk } from './types';
 


### PR DESCRIPTION
## What

Three source comments cite the git-surface spec at `docs/active/specs/2026-07-22-git-surface.md`. That file moved to `docs/archive/specs/` in the workspace repo when the feature shipped (PR #213), so those pointers now dangle — a future session grepping for the spec finds nothing.

Comment-only change, no behavior.

- `desktop/src/main/git/porcelain.ts`
- `desktop/src/main/ipc-handlers.ts`
- `desktop/src/shared/git-types.ts`

## Verification

- `tsc --noEmit` clean
- `tests/ipc-channels.test.ts` 190/190 (`ipc-handlers.ts` is parity-scanned, so comment edits there are worth re-pinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)