### PR TITLE
fix(sync): stop telling GitHub-synced machines that no sync is configured

### DIFF
--- a/desktop/src/main/sync-service.ts
+++ b/desktop/src/main/sync-service.ts
@@ -102,6 +102,7 @@ export class SyncService extends EventEmitter {
   private lockDir: string;
   private backupLogPath: string;
   private appSyncMarkerPath: string;
+  private syncSpacesStatePath: string;
   private conversationIndexPath: string;
   private pushing = false;
   // Hourly daily-snapshot poll (see SNAPSHOT_POLL_INTERVAL_MS). Cleared in stop().
@@ -121,6 +122,9 @@ export class SyncService extends EventEmitter {
     this.lockDir = path.join(this.claudeDir, 'toolkit-state', '.sync-lock');
     this.backupLogPath = path.join(this.claudeDir, 'backup.log');
     this.appSyncMarkerPath = path.join(this.claudeDir, 'toolkit-state', '.app-sync-active');
+    // Owned by SpaceManager (sync-spaces/space-manager.ts) — read-only here.
+    // Pinned to SpaceManager's default path by sync-health-primary-system.test.ts.
+    this.syncSpacesStatePath = path.join(this.claudeDir, 'toolkit-state', 'sync-spaces.json');
     this.conversationIndexPath = path.join(this.claudeDir, 'conversation-index.json');
   }
 
@@ -1053,6 +1057,24 @@ export class SyncService extends EventEmitter {
     }
 
     // 1. Personal data sync backend status
+    //
+    // Fix (2026-07-24): this section knew about the LEGACY additional-backup
+    // backends only — `getSyncEnabledBackends()` reads `storage_backends` in
+    // toolkit-state/config.json (Drive/iCloud/rclone). The app's PRIMARY sync,
+    // GitHub sync spaces, keeps its own state file and is invisible to it, so a
+    // machine syncing happily to GitHub with no Drive/iCloud backend got a
+    // danger-level, NON-dismissible "No sync configured — your backups aren't
+    // set up", which the StatusBar renders as a red "Sync Failing" chip. Seen on
+    // a fresh macOS install running 1.3.0-beta.9. Long-lived installs hid the bug
+    // via autoDetectBackend(): it probes `rclone lsd gdrive:…`/the iCloud folder
+    // and, on a machine that used the legacy backups years ago, silently succeeds
+    // and skips the warning — without enabling any backend (verified on the Z13:
+    // storage_backends is [], rclone exits 0). A clean machine has no rclone, so
+    // the probe fails and the warning fires — i.e. the bug lands precisely on new
+    // installs, and the release population is all new installs.
+    // The warning now describes the whole picture: it fires only when NOTHING is
+    // syncing, and the stale warning names the additional backups it's about.
+    const primarySyncOn = this.isPrimarySyncEnabled();
     const syncBackends = this.getSyncEnabledBackends();
     if (syncBackends.length === 0) {
       const detected = await this.autoDetectBackend();
@@ -1063,12 +1085,12 @@ export class SyncService extends EventEmitter {
           this.atomicWrite(this.configPath, JSON.stringify(config, null, 2));
           this.logBackup('INFO', `Auto-detected sync backend: ${detected}`, 'sync.health');
         } catch {}
-      } else {
+      } else if (!primarySyncOn) {
         warnings.push({
           code: 'PERSONAL_NOT_CONFIGURED',
           level: 'danger',
           title: 'No sync configured',
-          body: "Your backups aren't set up. Connect a cloud provider so your data is protected.",
+          body: "Nothing is backing up your data yet. Set up sync so your conversations and settings are protected.",
           fixAction: { label: 'Set up sync', kind: 'open-sync-setup' },
           dismissible: false,
           createdEpoch: now,
@@ -1084,8 +1106,11 @@ export class SyncService extends EventEmitter {
             warnings.push({
               code: 'PERSONAL_STALE',
               level: 'warn',
-              title: 'Sync is stale',
-              body: "Backups haven't succeeded in over 24 hours. Check the sync panel for details.",
+              // Named for what the marker actually tracks: the legacy
+              // Drive/iCloud snapshot pushes. GitHub sync spaces has its own
+              // status in the panel and never stamps this marker.
+              title: 'Extra backups are stale',
+              body: "Your additional cloud backups (Drive or iCloud) haven't succeeded in over 24 hours. Check Backup & Sync for details.",
               dismissible: true,
               createdEpoch: now,
             });
@@ -1109,6 +1134,20 @@ export class SyncService extends EventEmitter {
     await writeWarnings([...preserved, ...warnings]);
 
     return warnings;
+  }
+
+  /**
+   * True when the app's PRIMARY sync — GitHub sync spaces — is turned on.
+   *
+   * Reads SpaceManager's state file directly instead of importing
+   * `sync-spaces/service.ts`: that module pulls in the sync engine, chokidar and
+   * electron's BrowserWindow, none of which belong in a startup health check
+   * (and SyncService's tests run under plain node against a tmp home). The path
+   * agreement is pinned by `sync-health-primary-system.test.ts`, which drives a
+   * real SpaceManager and asserts this reader sees what it wrote.
+   */
+  private isPrimarySyncEnabled(): boolean {
+    return !!this.readJson(this.syncSpacesStatePath)?.enabled;
   }
 
   /** Try to auto-detect a sync backend (Drive via rclone, iCloud via folder). */

--- a/desktop/tests/sync-health-primary-system.test.ts
+++ b/desktop/tests/sync-health-primary-system.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { SyncService } from '../src/main/sync-service';
+import { SpaceManager } from '../src/main/sync-spaces/space-manager';
+import { readWarnings, writeWarnings, setClaudeDirForTests } from '../src/main/sync-state';
+
+/**
+ * The startup health check must describe the sync system the user actually has.
+ *
+ * Regression (fixed 2026-07-24): runHealthCheck() only ever looked at the LEGACY
+ * additional-backup backends (`storage_backends` in toolkit-state/config.json —
+ * Drive/iCloud). GitHub sync spaces, the app's PRIMARY sync since Phase 1, keeps
+ * its own state file, so a machine syncing happily to GitHub with no Drive/iCloud
+ * backend was told "No sync configured — your backups aren't set up" at
+ * danger level, non-dismissible, which the StatusBar paints as a red
+ * "Sync Failing" chip. Reported on a fresh macOS install of 1.3.0-beta.9. Older
+ * installs masked it through autoDetectBackend(), whose `rclone lsd gdrive:…`
+ * probe succeeds on a machine that used the legacy backups years ago (and skips
+ * the warning without enabling anything). New installs have no rclone, so they
+ * take the warning — which is the whole release population.
+ *
+ * These tests drive a REAL SpaceManager at its default path, which is the point:
+ * SyncService reads that file by path rather than importing the sync-spaces
+ * service (which would drag the engine, chokidar and electron into a health
+ * check). If either side ever moves the file, case 1 fails.
+ */
+
+const tmpHome = path.join(os.tmpdir(), `sync-health-primary-${process.pid}-${Date.now()}`);
+const claudeDir = path.join(tmpHome, '.claude');
+const toolkitState = path.join(claudeDir, 'toolkit-state');
+
+setClaudeDirForTests(tmpHome);
+
+function makeService() {
+  const svc = new SyncService(tmpHome);
+  // The primary-sync gate is what's under test, not backend auto-detection —
+  // stub it so a developer machine with a real rclone/gdrive remote (or a real
+  // ~/Library iCloud folder) can't decide the outcome.
+  vi.spyOn(svc as any, 'autoDetectBackend').mockResolvedValue(null);
+  return svc;
+}
+
+/** Codes this suite asserts on; OFFLINE depends on the runner's network. */
+async function codes(): Promise<string[]> {
+  return (await readWarnings()).map((w) => w.code);
+}
+
+beforeEach(async () => {
+  fs.mkdirSync(toolkitState, { recursive: true });
+  await writeWarnings([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+describe('runHealthCheck — primary (GitHub sync spaces) vs additional backups', () => {
+  it('stays quiet when GitHub sync is on and no legacy backend exists', async () => {
+    // Written through the real SpaceManager, at its real default path.
+    const homedir = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    new SpaceManager().setEnabled(true);
+    homedir.mockRestore();
+    expect(fs.existsSync(path.join(toolkitState, 'sync-spaces.json'))).toBe(true);
+
+    await makeService().runHealthCheck();
+
+    expect(await codes()).not.toContain('PERSONAL_NOT_CONFIGURED');
+  });
+
+  it('still warns when GitHub sync is off and nothing else is configured', async () => {
+    const homedir = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    new SpaceManager().setEnabled(false);
+    homedir.mockRestore();
+
+    await makeService().runHealthCheck();
+
+    expect(await codes()).toContain('PERSONAL_NOT_CONFIGURED');
+  });
+
+  it('warns on a fresh install with no sync state file at all', async () => {
+    expect(fs.existsSync(path.join(toolkitState, 'sync-spaces.json'))).toBe(false);
+
+    await makeService().runHealthCheck();
+
+    const warning = (await readWarnings()).find((w) => w.code === 'PERSONAL_NOT_CONFIGURED');
+    expect(warning).toBeDefined();
+    // Copy check: the old body told users to "connect a cloud provider", which
+    // is the additional-backups flow, not the GitHub sync the app leads with.
+    expect(warning!.body).toMatch(/Nothing is backing up your data yet/);
+  });
+
+  it('a stale legacy backend is reported as EXTRA backups, not as sync failing', async () => {
+    const homedir = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    new SpaceManager().setEnabled(true);
+    homedir.mockRestore();
+    fs.writeFileSync(path.join(toolkitState, 'config.json'), JSON.stringify({
+      storage_backends: [
+        { id: 'drive-1', type: 'drive', label: 'Personal Drive', syncEnabled: true, config: {} },
+      ],
+    }));
+    // Two days ago — past the 24h staleness threshold.
+    const twoDaysAgo = Math.floor(Date.now() / 1000) - 2 * 86400;
+    fs.writeFileSync(path.join(toolkitState, '.sync-marker'), String(twoDaysAgo));
+
+    await makeService().runHealthCheck();
+
+    const stale = (await readWarnings()).find((w) => w.code === 'PERSONAL_STALE');
+    expect(stale).toBeDefined();
+    expect(stale!.level).toBe('warn');
+    expect(stale!.title).toBe('Extra backups are stale');
+    // GitHub sync doesn't stamp this marker, so the copy must not blame it.
+    expect(stale!.body).toMatch(/Drive or iCloud/);
+  });
+});


### PR DESCRIPTION
## The bug

On a fresh macOS install running `1.3.0-beta.9`, with GitHub sync set up, connected and green, the StatusBar showed a red **"Sync Failing"** chip and a non-dismissible **"No sync configured — your backups aren't set up"** warning.

Root cause: `SyncService.runHealthCheck()` only ever looked at the **legacy additional-backup** backends. `getSyncEnabledBackends()` reads `storage_backends` from `~/.claude/toolkit-state/config.json` (Drive / iCloud / rclone). **GitHub sync spaces** — the app's primary sync since Phase 1 — keeps its own state at `~/.claude/toolkit-state/sync-spaces.json` and is invisible to that read. Zero legacy backends therefore meant "no sync configured", no matter how healthy the primary system was.

**Why it survived to beta.9:** `autoDetectBackend()` masks it on old machines. Its `rclone lsd gdrive:Claude/Backup/` probe still succeeds on a machine that used the legacy backups years ago, so the warning is skipped — without enabling any backend (verified on the reporter's Linux box: `storage_backends` is `[]`, `rclone` exits 0, no warnings file on disk). A clean machine has no `rclone` and no `~/Library/…/Claude/Backup` folder, so the probe fails and the warning fires. The bug lands precisely on **new installs** — which is the entire release population.

## The fix

- `runHealthCheck()` reads the primary system's enabled flag and warns only when **nothing** is syncing. The read is by path, with the WHY at the reader: importing `sync-spaces/service.ts` would drag the engine, chokidar and electron's `BrowserWindow` into a startup health check (and `SyncService`'s tests run under plain node against a tmp home).
- `PERSONAL_NOT_CONFIGURED` body no longer says "connect a cloud provider" — that's the additional-backups flow, not the GitHub sync the app leads with.
- `PERSONAL_STALE` renamed to what its marker actually tracks: **"Extra backups are stale"** / "Drive or iCloud". Only legacy pushes stamp `.sync-marker`, so the old "Sync is stale" read as an indictment of GitHub sync, which reports its own status in the panel.

Behavior is otherwise unchanged: auto-detection still runs, the warning still fires (and stays non-dismissible) when nothing at all is set up, and the health check still clears its own codes each launch — so an affected install self-heals on the next start, no file surgery.

## Verification

- New guard `desktop/tests/sync-health-primary-system.test.ts` drives a **real `SpaceManager` at its default path**, so the by-path read stays pinned to the writer. Mutation-verified both directions: removing the gate fails case 1, renaming the state file fails case 1.
- Full desktop suite green — 3390 passed / 39 skipped, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)