### PR TITLE
Tranche 6: name the type scale (35) + make hyperlinks readable (36)

### DIFF
--- a/desktop/scripts/vendor/contrast-rules.js
+++ b/desktop/scripts/vendor/contrast-rules.js
@@ -188,6 +188,18 @@
     // hence the separate token. Synthesized in evaluate() when undeclared.
     { name: 'destructive-fg on canvas', tier: 'HARD', type: 'contrast', fg: 'destructive-fg', bg: 'canvas', threshold: 4.5, description: 'Destructive TEXT on content (AA)' },
     { name: 'destructive-fg on panel',  tier: 'HARD', type: 'contrast', fg: 'destructive-fg', bg: 'panel',  threshold: 4.5, description: 'Destructive TEXT on popups/headers (AA)' },
+    // Hyperlinks. `link` is OPTIONAL — most packs never declare it and the app
+    // derives one from accent, so auditing only declared tokens skipped every
+    // community theme. Synthesized in evaluate() to match theme-engine.ts.
+    //
+    // Three surfaces, not the full TEXT_RULES sweep: `inset` is the assistant
+    // bubble and is where MarkdownContent actually paints links, `panel` covers
+    // tool cards and popups, `canvas` covers loose prose. `well` is excluded on
+    // purpose — it is the command-drawer search surface and renders no links, so
+    // gating on it would fail packs over a combination that never appears.
+    { name: 'link on canvas', tier: 'HARD', type: 'contrast', fg: 'link', bg: 'canvas', threshold: 4.5, description: 'Hyperlinks in content must be readable (AA)' },
+    { name: 'link on panel',  tier: 'HARD', type: 'contrast', fg: 'link', bg: 'panel',  threshold: 4.5, description: 'Hyperlinks on tool cards and popups must be readable (AA)' },
+    { name: 'link on inset',  tier: 'HARD', type: 'contrast', fg: 'link', bg: 'inset',  threshold: 4.5, description: 'Hyperlinks inside assistant bubbles must be readable (AA)' },
 
     // ── SURFACE: Elements disappear if these fail ──
     { name: 'panel vs canvas',      tier: 'SURFACE', type: 'distinction', fg: 'panel',     bg: 'canvas',  threshold: 1.07, description: 'Chrome (headers, drawers, popups) must separate from the content behind it' },
@@ -353,6 +365,48 @@
           if (worst(c) >= 4.5) { picked = c; break; }
         }
         parsed['destructive-fg'] = picked;
+      }
+    }
+
+    // ── Synthesize the link colour ──
+    // `link` is optional and almost no pack declares it, so without this the
+    // three link rules silently skipped every community theme — the same way
+    // the danger pair used to be skipped. Mirrors theme-engine.ts: pick accent
+    // when it is far enough from fg (else fg-2), then nudge toward white/black
+    // until it clears AA against the WORST of canvas, panel and inset. `inset`
+    // is in the set because it is the assistant bubble, where links live.
+    //
+    // Only DERIVED links are nudged. A declared `link` is the pack author's
+    // explicit choice and stays exactly as written, so the HARD rules can still
+    // fail it — which is the point of having them.
+    if (!parsed.link && parsed.accent && parsed.fg && parsed.canvas && parsed.panel && parsed.inset) {
+      const d = (a, b) => Math.sqrt((a.r - b.r) ** 2 + (a.g - b.g) ** 2 + (a.b - b.b) ** 2);
+      const base = d(parsed.accent, parsed.fg) > 40 ? parsed.accent : parsed['fg-2'];
+      if (base) {
+        const worst = (c) => Math.min(
+          contrastRatio(luminance(c), luminance(parsed.canvas)),
+          contrastRatio(luminance(c), luminance(parsed.panel)),
+          contrastRatio(luminance(c), luminance(parsed.inset)),
+        );
+        if (worst(base) >= 4.5) {
+          parsed.link = base;
+        } else {
+          const target = luminance(parsed.canvas) < 0.5 ? parseHex('#FFFFFF') : parseHex('#000000');
+          let picked = target;
+          for (let t = 0.02; t <= 1.0001; t += 0.02) {
+            // Math.round for the same reason as destructive-fg above: the engine
+            // serialises to hex at every step, so the two must round identically
+            // or they can straddle the threshold on the same input.
+            const c = {
+              r: Math.round(base.r + (target.r - base.r) * t),
+              g: Math.round(base.g + (target.g - base.g) * t),
+              b: Math.round(base.b + (target.b - base.b) * t),
+              a: 1,
+            };
+            if (worst(c) >= 4.5) { picked = c; break; }
+          }
+          parsed.link = picked;
+        }
       }
     }
 

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2932,7 +2932,7 @@ function AppInner() {
                 /* Expanded new-session form with toggles */
                 <div className="layer-surface w-full p-3 flex flex-col gap-2">
                   <div>
-                    <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Project Folder</label>
+                    <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Project Folder</label>
                     {/* Match SessionStrip: the picker's "Manage projects…"
                         footer opens Project View (where adding lives). */}
                     <FolderSwitcher
@@ -2955,13 +2955,13 @@ function AppInner() {
                       picks its model via the binding picker above. */}
                   {welcomeRuntime !== 'native' && (
                     <div>
-                      <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
+                      <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
                       <div className="flex gap-1">
                         {MODELS.map((m) => (
                           <button
                             key={m}
                             onClick={() => setWelcomeModel(m)}
-                            className={`flex-1 px-1 py-1 rounded-sm text-[10px] transition-colors ${
+                            className={`flex-1 px-1 py-1 rounded-sm text-3xs transition-colors ${
                               welcomeModel === m
                                 ? 'bg-accent text-on-accent font-medium'
                                 : 'bg-inset text-fg-dim hover:bg-edge'
@@ -2974,7 +2974,7 @@ function AppInner() {
                     </div>
                   )}
                   <div className="flex items-center justify-between">
-                    <label className="text-[10px] uppercase tracking-wider text-fg-muted">Skip Permissions</label>
+                    <label className="text-3xs uppercase tracking-wider text-fg-muted">Skip Permissions</label>
                     {/* Was a hand-rolled 32x18 track with a raw #DD4444 on-state; now
                         the shared Toggle on the danger tone, so theme packs can restyle
                         it (changes 15/17). The <label> beside it isn't bound to this
@@ -2991,7 +2991,7 @@ function AppInner() {
                       others). Change 17 puts it on the destructive token so it
                       tracks the toggle above it under a community theme. */}
                   {welcomeDangerous && (
-                    <p className="text-[10px] text-destructive-fg">Claude will execute tools without asking for approval.</p>
+                    <p className="text-3xs text-destructive-fg">Claude will execute tools without asking for approval.</p>
                   )}
                   <div className="flex gap-2">
                     {/* secondary, not ghost: this was the filled-grey family

--- a/desktop/src/renderer/components/AboutPopup.tsx
+++ b/desktop/src/renderer/components/AboutPopup.tsx
@@ -72,7 +72,7 @@ function AnalyticsOptInToggle() {
     <div className="flex items-center justify-between mt-2">
       <div>
         <span className="text-xs text-fg font-medium">Share anonymous usage stats</span>
-        <p className="text-[10px] text-fg-muted mt-0.5">Sends a daily ping with the fields listed above.</p>
+        <p className="text-3xs text-fg-muted mt-0.5">Sends a daily ping with the fields listed above.</p>
       </div>
       <Toggle enabled={optIn} onToggle={flip} />
     </div>
@@ -107,7 +107,7 @@ export default function AboutPopup({ open, onClose, platform, version, build, ch
         <div className="shrink-0 border-b border-edge flex items-center justify-between px-5 py-3">
           <div>
             <h3 id="about-popup-title" className="text-sm font-semibold text-fg">About</h3>
-            <p className="text-[10px] text-fg-muted mt-0.5">{versionLine}</p>
+            <p className="text-3xs text-fg-muted mt-0.5">{versionLine}</p>
           </div>
           <CloseButton onClick={onClose} />
         </div>
@@ -118,14 +118,14 @@ export default function AboutPopup({ open, onClose, platform, version, build, ch
           <div className="p-5 space-y-5">
           {/* Disclaimer — identical on both platforms */}
           <section className="space-y-1.5">
-            <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Disclaimer</h4>
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <h4 className="text-3xs font-medium text-fg-muted uppercase tracking-wider">Disclaimer</h4>
+            <p className="text-2xs text-fg-dim leading-relaxed">
               YouCoded is an independent, community-built project. It is not affiliated with, endorsed by, or officially supported by Anthropic.
             </p>
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <p className="text-2xs text-fg-dim leading-relaxed">
               "Claude" and "Claude Code" are trademarks of Anthropic, PBC.
             </p>
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <p className="text-2xs text-fg-dim leading-relaxed">
               Thanks to the Anthropic team for building Claude Code. This project exists because of their work.
             </p>
           </section>
@@ -140,63 +140,63 @@ export default function AboutPopup({ open, onClose, platform, version, build, ch
               games line were added by accounts Phase 2 (wording approved by
               Destin 2026-07-09). */}
           <section className="space-y-1.5">
-            <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Privacy</h4>
+            <h4 className="text-3xs font-medium text-fg-muted uppercase tracking-wider">Privacy</h4>
             {platform === 'desktop' ? (
               <>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   Your Claude Pro/Max sign-in is stored locally on your device. It is never transmitted to or collected by YouCoded. All Claude Code interactions happen directly between the on-device CLI and Anthropic's servers. YouCoded does not collect any personal data or message content.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   <strong className="text-fg-2 font-semibold">Your account (optional).</strong> Signing in with GitHub creates a YouCoded account. We store: your GitHub username, display name, avatar, and handle; your theme likes, plugin reviews, and install records. We never see your GitHub password or private repos — sign-in uses read-only access to your public profile. Delete your account any time in Settings → Account; deletion removes everything above immediately. Analytics stays separate: your account is never linked to the anonymous device statistics described below.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   <strong className="text-fg-2 font-semibold">Friends &amp; presence (optional).</strong> If you use friends, we store your friend list, pending requests, and your block list (your block list is visible only to you). While you're signed in with the app open, your friends — and only your friends — can see that you're online and, after you disconnect, a single "last seen" time. We never keep a history of when you were online. You can appear offline any time (incognito in the games panel), download everything we store (Settings → Account → Download my data), and deleting your account removes all of it immediately.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   By default, your device may send anonymous usage data to YouCoded once per day, including:
                 </p>
-                <ul className="text-[11px] text-fg-dim leading-relaxed list-disc pl-5 space-y-0.5">
+                <ul className="text-2xs text-fg-dim leading-relaxed list-disc pl-5 space-y-0.5">
                   <li>An irreversible hash of your device's hardware ID (the raw ID never leaves your device — it's hashed locally before transmission)</li>
                   <li>Installed app version (e.g. <code>1.3.0</code>)</li>
                   <li>Platform and OS (e.g. <code>desktop / mac</code>)</li>
                   <li>Country and approximate region (e.g. US state), derived from your IP address by Cloudflare. IP addresses are never stored.</li>
                 </ul>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   No message content, no usernames, no tokens, no file paths. The collection of this information helps improve YouCoded for yourself and future users. You may disable this below at any time.
                 </p>
                 <AnalyticsOptInToggle />
-                <p className="text-[11px] text-fg-dim leading-relaxed pt-2">
+                <p className="text-2xs text-fg-dim leading-relaxed pt-2">
                   Remote access (when enabled) serves the UI over your local network or Tailscale. Remote connections are NOT TLS-encrypted — use Tailscale for sensitive conversations since it provides WireGuard encryption end-to-end.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   Multiplayer game moves are relayed through a PartyKit server (Cloudflare) only while a game is open; challenges and the friends lobby go through the YouCoded server. No game traffic is retained server-side beyond the active room.
                 </p>
               </>
             ) : (
               <>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   Your Claude Pro/Max sign-in is stored locally on your device. It is never transmitted to or collected by YouCoded. All Claude Code interactions happen directly between the on-device CLI and Anthropic's servers. YouCoded does not collect any personal data or message content.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   <strong className="text-fg-2 font-semibold">Your account (optional).</strong> Signing in with GitHub creates a YouCoded account. We store: your GitHub username, display name, avatar, and handle; your theme likes, plugin reviews, and install records. We never see your GitHub password or private repos — sign-in uses read-only access to your public profile. Delete your account any time in Settings → Account; deletion removes everything above immediately. Analytics stays separate: your account is never linked to the anonymous device statistics described below.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   <strong className="text-fg-2 font-semibold">Friends &amp; presence (optional).</strong> If you use friends, we store your friend list, pending requests, and your block list (your block list is visible only to you). While you're signed in with the app open, your friends — and only your friends — can see that you're online and, after you disconnect, a single "last seen" time. We never keep a history of when you were online. You can appear offline any time (incognito in the games panel), download everything we store (Settings → Account → Download my data), and deleting your account removes all of it immediately.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   By default, your device may send anonymous usage data to YouCoded once per day, including:
                 </p>
-                <ul className="text-[11px] text-fg-dim leading-relaxed list-disc pl-5 space-y-0.5">
+                <ul className="text-2xs text-fg-dim leading-relaxed list-disc pl-5 space-y-0.5">
                   <li>An irreversible hash of your device's hardware ID (the raw ID never leaves your device — it's hashed locally before transmission)</li>
                   <li>Installed app version (e.g. <code>1.3.0</code>)</li>
                   <li>Platform (<code>android</code>)</li>
                   <li>Country and approximate region (e.g. US state), derived from your IP address by Cloudflare. IP addresses are never stored.</li>
                 </ul>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   No message content, no usernames, no tokens, no file paths. The collection of this information helps improve YouCoded for yourself and future users. You may disable this below at any time.
                 </p>
                 <AnalyticsOptInToggle />
-                <p className="text-[11px] text-fg-dim leading-relaxed pt-2">
+                <p className="text-2xs text-fg-dim leading-relaxed pt-2">
                   During initial setup, Termux runtime packages are downloaded from packages.termux.dev over HTTPS with SHA256 verification.
                 </p>
               </>
@@ -207,22 +207,22 @@ export default function AboutPopup({ open, onClose, platform, version, build, ch
 
           {/* Licenses — platform-specific intro + lib list */}
           <section className="space-y-1.5">
-            <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Licenses</h4>
+            <h4 className="text-3xs font-medium text-fg-muted uppercase tracking-wider">Licenses</h4>
             {platform === 'desktop' ? (
               <>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   The YouCoded desktop application is licensed under the MIT License.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   Note: The YouCoded Android application is distributed under GPLv3 because it links against Termux. The desktop application has no such dependency and is MIT throughout.
                 </p>
               </>
             ) : (
               <>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   The YouCoded Android application is distributed under the GNU General Public License v3.0 (GPLv3) because it links against Termux terminal components, which are GPLv3.
                 </p>
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   The YouCoded source code itself — including the shared React interface that powers this app — is offered under the MIT License. The Android distribution as a whole is GPLv3; the underlying source remains MIT upstream.
                 </p>
               </>
@@ -230,8 +230,8 @@ export default function AboutPopup({ open, onClose, platform, version, build, ch
             <div className="mt-2 space-y-1 pl-2">
               {libs.map(({ lib, license, source }) => (
                 <div key={lib}>
-                  <span className="text-[10px] text-fg-2 font-medium">{lib}</span>
-                  <span className="text-[10px] text-fg-muted ml-1">· {license} · {source}</span>
+                  <span className="text-3xs text-fg-2 font-medium">{lib}</span>
+                  <span className="text-3xs text-fg-muted ml-1">· {license} · {source}</span>
                 </div>
               ))}
             </div>

--- a/desktop/src/renderer/components/AccountSection.tsx
+++ b/desktop/src/renderer/components/AccountSection.tsx
@@ -194,7 +194,7 @@ function AccountPopup({ onClose }: { onClose: () => void }) {
                     </span>
                     <span className="flex-1 min-w-0">
                       <span className="block text-xs text-fg font-medium">Connected accounts</span>
-                      <span className="block text-[10px] text-fg-muted truncate">{ghSummary}</span>
+                      <span className="block text-3xs text-fg-muted truncate">{ghSummary}</span>
                     </span>
                     <svg className="w-3.5 h-3.5 text-fg-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
@@ -225,7 +225,7 @@ function SignedOutBody({
   const [signInError, setSignInError] = useState<string | null>(null);
   return (
     <div className="flex flex-col items-center gap-4 py-2 text-center">
-      <p className="text-[11px] text-fg-dim leading-relaxed">
+      <p className="text-2xs text-fg-dim leading-relaxed">
         One YouCoded account for the marketplace, games, and syncing with friends.
       </p>
       {/* Page-level CTA -> lg. Also drops hover:brightness-110, which was
@@ -250,10 +250,10 @@ function SignedOutBody({
       >
         {signInPending ? 'Signing in…' : 'Sign in to YouCoded'}
       </Button>
-      <p className="text-[10px] text-fg-muted leading-relaxed">
+      <p className="text-3xs text-fg-muted leading-relaxed">
         Uses your GitHub profile to sign in — GitHub only shares your public info.
       </p>
-      {signInError && <p className="text-[10px] text-destructive-fg">{signInError}</p>}
+      {signInError && <p className="text-3xs text-destructive-fg">{signInError}</p>}
     </div>
   );
 }
@@ -384,7 +384,7 @@ function SignedInBody({
         <div className="min-w-0">
           <p className="text-sm text-fg font-medium truncate">{user.display_name ?? user.login}</p>
           {/* Plain words when there's no handle yet — no placeholder glyphs. */}
-          <p className="text-[11px] text-fg-muted truncate">
+          <p className="text-2xs text-fg-muted truncate">
             {user.handle ? `@${user.handle}` : 'No handle yet'}
           </p>
         </div>
@@ -403,13 +403,13 @@ function SignedInBody({
           empty both leave `blocks` falsy so nothing shows in settings). */}
       {blocks && blocks.length > 0 && (
         <section className="space-y-2">
-          <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Blocked users</h4>
+          <h4 className="text-3xs font-medium text-fg-muted uppercase tracking-wider">Blocked users</h4>
           {blocks.map((b) => (
             <div key={b.id} className="space-y-1">
               <div className="flex items-center gap-2">
                 <div className="flex-1 min-w-0 flex items-baseline gap-1.5">
                   <span className="text-xs text-fg truncate">{b.display_name}</span>
-                  {b.handle && <span className="text-[11px] text-fg-muted truncate">@{b.handle}</span>}
+                  {b.handle && <span className="text-2xs text-fg-muted truncate">@{b.handle}</span>}
                 </div>
                 {/* No confirm — unblocking is the recovery action, not the
                     destructive one (blocking is what's consequence-gated). */}
@@ -422,7 +422,7 @@ function SignedInBody({
                   {unblockingId === b.id ? 'Unblocking…' : 'Unblock'}
                 </Button>
               </div>
-              {unblockErrors[b.id] && <p className="text-[10px] text-destructive-fg">{unblockErrors[b.id]}</p>}
+              {unblockErrors[b.id] && <p className="text-3xs text-destructive-fg">{unblockErrors[b.id]}</p>}
             </div>
           ))}
         </section>
@@ -469,11 +469,11 @@ function SignedInBody({
         >
           {exporting ? 'Preparing export…' : 'Download my data'}
         </Button>
-        <p className="text-[10px] text-fg-muted leading-relaxed">
+        <p className="text-3xs text-fg-muted leading-relaxed">
           Downloads a file containing everything YouCoded's server stores about your account.
         </p>
-        {exportSavedPath && <p className="text-[10px] text-fg-muted">Saved to {exportSavedPath}</p>}
-        {exportError && <p className="text-[10px] text-destructive-fg">{exportError}</p>}
+        {exportSavedPath && <p className="text-3xs text-fg-muted">Saved to {exportSavedPath}</p>}
+        {exportError && <p className="text-3xs text-destructive-fg">{exportError}</p>}
       </section>
     </>
   ) : (
@@ -592,7 +592,7 @@ function EditAccountBody({
     <>
       {/* Edit-mode header: label + the way back to view mode. */}
       <div className="flex items-center justify-between">
-        <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Edit account</h4>
+        <h4 className="text-3xs font-medium text-fg-muted uppercase tracking-wider">Edit account</h4>
         <Button variant="secondary" onClick={onDone}>
           Done
         </Button>
@@ -600,7 +600,7 @@ function EditAccountBody({
 
       {/* Display name */}
       <section className="space-y-1.5">
-        <label htmlFor="account-display-name" className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">
+        <label htmlFor="account-display-name" className="text-3xs font-medium text-fg-muted uppercase tracking-wider">
           Display name
         </label>
         {/* Change 77: Save moved INSIDE the field. Besides matching the spec, this
@@ -623,13 +623,13 @@ function EditAccountBody({
             {nameSaving ? 'Saving…' : 'Save'}
           </Button>
         </InputGroup>
-        {nameError && <p className="text-[10px] text-destructive-fg">{nameError}</p>}
-        {nameSaved && !nameError && <p className="text-[10px] text-fg-muted">Saved</p>}
+        {nameError && <p className="text-3xs text-destructive-fg">{nameError}</p>}
+        {nameSaved && !nameError && <p className="text-3xs text-fg-muted">Saved</p>}
       </section>
 
       {/* Handle */}
       <section className="space-y-1.5">
-        <label htmlFor="account-handle" className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">
+        <label htmlFor="account-handle" className="text-3xs font-medium text-fg-muted uppercase tracking-wider">
           Handle
         </label>
         {/* Change 77: this was already a hand-rolled InputGroup (bordered wrapper +
@@ -667,7 +667,7 @@ function EditAccountBody({
         {/* Handle-change consequences + explicit confirm (existing handle only). */}
         {handleConfirming && (
           <div className="space-y-2 rounded-lg bg-inset border border-edge-dim p-3">
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <p className="text-2xs text-fg-dim leading-relaxed">
               Changing your handle frees @{currentHandle} for anyone else to claim after 30 days — and
               you can't take it back during those 30 days. Friends who know you by @{currentHandle} will
               need your new handle.
@@ -697,15 +697,15 @@ function EditAccountBody({
         )}
 
         {/* Plain words for status, never glyphs. */}
-        {handleError && <p className="text-[10px] text-destructive-fg">{handleError}</p>}
-        {handleSaved && !handleError && <p className="text-[10px] text-fg-muted">Saved</p>}
+        {handleError && <p className="text-3xs text-destructive-fg">{handleError}</p>}
+        {handleSaved && !handleError && <p className="text-3xs text-fg-muted">Saved</p>}
       </section>
 
       <hr className="border-edge-dim" />
 
       {/* Danger zone — 2-step: expand, then typed confirm + explicit button. */}
       <section className="space-y-2">
-        <h4 className="text-[10px] font-medium text-red-500 uppercase tracking-wider">Danger zone</h4>
+        <h4 className="text-3xs font-medium text-red-500 uppercase tracking-wider">Danger zone</h4>
         {!deleteExpanded ? (
           // Arming step -> danger-outline. red-500 becomes the --destructive
           // token so packs can restyle it (#C62828 today — no longer identical
@@ -715,18 +715,18 @@ function EditAccountBody({
           </Button>
         ) : (
           <div className="space-y-2">
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <p className="text-2xs text-fg-dim leading-relaxed">
               Deleting your account removes everything attached to it immediately — your likes,
               reviews, and install history are all gone. This cannot be undone.
             </p>
             {/* The freed-handle lock only applies when there IS a handle to free. */}
             {currentHandle.length > 0 && (
-              <p className="text-[11px] text-fg-dim leading-relaxed">
+              <p className="text-2xs text-fg-dim leading-relaxed">
                 Your handle @{currentHandle} is freed, but locked for 30 days before anyone else can
                 claim it.
               </p>
             )}
-            <label htmlFor="account-delete-confirm" className="block text-[10px] text-fg-muted">
+            <label htmlFor="account-delete-confirm" className="block text-3xs text-fg-muted">
               Type <span className="font-semibold text-fg">delete</span> to confirm
             </label>
             {/* Deliberately NOT migrated to <TextInput>: this field already IS the
@@ -765,7 +765,7 @@ function EditAccountBody({
                 {deleting ? 'Deleting…' : 'Delete my account'}
               </Button>
             </div>
-            {deleteError && <p className="text-[10px] text-destructive-fg">{deleteError}</p>}
+            {deleteError && <p className="text-3xs text-destructive-fg">{deleteError}</p>}
           </div>
         )}
       </section>

--- a/desktop/src/renderer/components/ArtifactThumbnail.tsx
+++ b/desktop/src/renderer/components/ArtifactThumbnail.tsx
@@ -193,7 +193,7 @@ export function ArtifactThumbnail({ artifact, projectPath, className = '', bgCla
         // First ~8 lines, monospace, very small — readable enough to identify
         // a plan / walkthrough / note at a glance. whitespace-pre-wrap so long
         // lines wrap inside the card instead of overflowing horizontally.
-        <pre className="absolute inset-0 m-0 p-2 text-[8px] leading-tight font-mono text-fg-2 overflow-hidden whitespace-pre-wrap break-words">
+        <pre className="absolute inset-0 m-0 p-2 text-4xs leading-tight font-mono text-fg-2 overflow-hidden whitespace-pre-wrap break-words">
           {content.split('\n').slice(0, 8).join('\n')}
         </pre>
       )}

--- a/desktop/src/renderer/components/AssistantTurnBubble.tsx
+++ b/desktop/src/renderer/components/AssistantTurnBubble.tsx
@@ -53,7 +53,7 @@ function ReasoningSection({ content }: { content: string }) {
     <div className="mb-2">
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-1 text-[11px] text-fg-muted hover:text-fg-dim select-none"
+        className="flex items-center gap-1 text-2xs text-fg-muted hover:text-fg-dim select-none"
         title="Show the model's reasoning"
       >
         <ChevronIcon className="w-3 h-3" expanded={expanded} />
@@ -420,7 +420,7 @@ export default React.memo(function AssistantTurnBubble({ turn, toolGroups, toolC
                   carries no abnormal signal worth surfacing to the user. */}
               {isLastBubble && turn.stopReason && turn.stopReason !== 'end_turn' && <StopReasonFooter reason={turn.stopReason} provider={provider} />}
               {showTimestamps && isLastBubble && turn.timestamp && (
-                <div className="bubble-timestamp text-[9px] text-fg-muted/60 text-right mt-1 -mb-0.5 select-none leading-none">
+                <div className="bubble-timestamp text-4xs text-fg-muted/60 text-right mt-1 -mb-0.5 select-none leading-none">
                   {formatBubbleTime(turn.timestamp)}
                 </div>
               )}
@@ -466,13 +466,13 @@ function PlanBubbleContent({
         <div className="mt-2 pt-2 border-t border-edge-dim">
           <button
             onClick={() => setShowPrompts((v) => !v)}
-            className="text-[11px] text-fg-muted hover:text-fg-dim flex items-center gap-1"
+            className="text-2xs text-fg-muted hover:text-fg-dim flex items-center gap-1"
           >
             <ChevronIcon className="w-3 h-3" expanded={showPrompts} />
             {prompts.length} allowed {prompts.length === 1 ? 'action' : 'actions'} if approved
           </button>
           {showPrompts && (
-            <pre className="mt-1 text-[11px] text-fg-dim bg-panel rounded-sm p-2 overflow-auto max-h-40">
+            <pre className="mt-1 text-2xs text-fg-dim bg-panel rounded-sm p-2 overflow-auto max-h-40">
               {JSON.stringify(prompts, null, 2)}
             </pre>
           )}

--- a/desktop/src/renderer/components/BrailleBurst.tsx
+++ b/desktop/src/renderer/components/BrailleBurst.tsx
@@ -70,7 +70,7 @@ export default function BrailleBurst({ children, onTrigger, disabled, className,
         return (
           <span
             key={p.id}
-            className="absolute pointer-events-none text-[10px]"
+            className="absolute pointer-events-none text-3xs"
             style={{
               color: p.color,
               left: '50%',

--- a/desktop/src/renderer/components/CloseSessionPrompt.tsx
+++ b/desktop/src/renderer/components/CloseSessionPrompt.tsx
@@ -128,15 +128,15 @@ export default function CloseSessionPrompt({ open, sessionName, sessionId, onCan
           <div className="px-4 pt-4 pb-3 border-b border-edge">
             <h2 className="text-sm font-bold text-fg">Close session</h2>
             {sessionName && (
-              <p className="text-[11px] text-fg-muted mt-1 truncate">{sessionName}</p>
+              <p className="text-2xs text-fg-muted mt-1 truncate">{sessionName}</p>
             )}
           </div>
           <div className="px-4 py-4 flex flex-col gap-3">
             {!metaLoaded ? null : !metaSupported ? (
-              <p className="text-[11px] text-fg-muted leading-snug">{metaReason}</p>
+              <p className="text-2xs text-fg-muted leading-snug">{metaReason}</p>
             ) : (
               <>
-              <label className="text-[10px] uppercase tracking-wider text-fg-muted">Tag before closing</label>
+              <label className="text-3xs uppercase tracking-wider text-fg-muted">Tag before closing</label>
               <div className="flex gap-1">
                 {FLAG_ORDER.map((flag) => {
                   const active = sel[flag];
@@ -144,7 +144,7 @@ export default function CloseSessionPrompt({ open, sessionName, sessionId, onCan
                     <button
                       key={flag}
                       onClick={() => setSel((prev) => ({ ...prev, [flag]: !prev[flag] }))}
-                      className={`flex-1 px-1 py-1.5 rounded-sm text-[11px] transition-colors ${
+                      className={`flex-1 px-1 py-1.5 rounded-sm text-2xs transition-colors ${
                         active
                           ? 'bg-accent text-on-accent font-medium'
                           : 'bg-inset text-fg-dim hover:bg-edge'
@@ -156,19 +156,19 @@ export default function CloseSessionPrompt({ open, sessionName, sessionId, onCan
                   );
                 })}
               </div>
-              <p className="text-[10px] text-fg-muted">
+              <p className="text-3xs text-fg-muted">
                 {sel.complete
                   ? 'Complete hides this from the resume menu by default.'
                   : 'Tap a flag to tag this session, or close with none.'}
               </p>
               <div className="flex flex-col gap-1.5 mt-2">
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted">Tags</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted">Tags</label>
                 <TagPicker
                   appliedIds={tagIds}
                   onToggle={(id, next) => setTagIds((prev) => { const s = new Set(prev); if (next) s.add(id); else s.delete(id); return s; })}
                   registry={registry}
                 />
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted mt-1">Note</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted mt-1">Note</label>
                 <NoteEditor value={note} onSave={setNote} />
               </div>
               </>
@@ -179,7 +179,7 @@ export default function CloseSessionPrompt({ open, sessionName, sessionId, onCan
                 skips this prompt on future closes and destroys sessions directly. */}
             <button
               onClick={() => setDontShowAgain((v) => !v)}
-              className="flex items-center gap-1.5 text-[10px] text-fg-muted hover:text-fg transition-colors"
+              className="flex items-center gap-1.5 text-3xs text-fg-muted hover:text-fg transition-colors"
               aria-pressed={dontShowAgain}
             >
               <span

--- a/desktop/src/renderer/components/CommandDrawer.tsx
+++ b/desktop/src/renderer/components/CommandDrawer.tsx
@@ -312,7 +312,7 @@ export default function CommandDrawer({ open, searchMode, externalFilter, onSele
               {/* Favorites section */}
               {favsSorted.length > 0 && (
                 <section className="px-2 pt-2">
-                  <h3 className="text-[10px] uppercase tracking-wide text-fg-dim mb-1 px-1">Favorites</h3>
+                  <h3 className="text-3xs uppercase tracking-wide text-fg-dim mb-1 px-1">Favorites</h3>
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-1.5">
                     {favsSorted.map(renderSkillCard)}
                   </div>
@@ -322,7 +322,7 @@ export default function CommandDrawer({ open, searchMode, externalFilter, onSele
               {/* All installed (non-favorites) — hidden when favoritesOnly toggle is on */}
               {!favoritesOnly && othersSorted.length > 0 && (
                 <section className="px-2 pt-3">
-                  <h3 className="text-[10px] uppercase tracking-wide text-fg-dim mb-1 px-1">All installed</h3>
+                  <h3 className="text-3xs uppercase tracking-wide text-fg-dim mb-1 px-1">All installed</h3>
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-1.5">
                     {othersSorted.map(renderSkillCard)}
                   </div>
@@ -358,7 +358,7 @@ function AddSkillsCard({ onClick }: { onClick: () => void }) {
     >
       <span className="text-lg font-medium leading-none">+</span>
       <span className="text-sm font-medium mt-1">Add Skills</span>
-      <span className="text-[11px] text-fg-muted mt-1">Browse marketplace</span>
+      <span className="text-2xs text-fg-muted mt-1">Browse marketplace</span>
     </button>
   );
 }

--- a/desktop/src/renderer/components/ConnectGithubModal.tsx
+++ b/desktop/src/renderer/components/ConnectGithubModal.tsx
@@ -229,7 +229,7 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
             )}
             {installNote?.kind === 'manual' && (
               <div className="space-y-1">
-                <div className="text-[11px] text-fg-muted">Run this in your terminal, then choose “Check again”:</div>
+                <div className="text-2xs text-fg-muted">Run this in your terminal, then choose “Check again”:</div>
                 {/* copy-inside-container: the Copy button docks INSIDE the code
                     block instead of floating beside it as a second surface.
                     hover:bg-edge overrides ghost's hover:bg-inset, which would be
@@ -298,7 +298,7 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
                   // Remote / touch — no shell access; render a copyable link the
                   // user opens themselves. <a target=_blank> works in a browser.
                   <div className="space-y-1">
-                    <div className="text-[11px] text-fg-muted">Then open this address in your browser:</div>
+                    <div className="text-2xs text-fg-muted">Then open this address in your browser:</div>
                     <div className="flex items-center gap-2">
                       <a
                         href={code.verificationUri}
@@ -320,12 +320,12 @@ export default function ConnectGithubModal({ onClose, onConnected }: Props) {
                   </div>
                 )}
 
-                <p className="text-[11px] text-fg-muted">Waiting for you to approve in your browser…</p>
+                <p className="text-2xs text-fg-muted">Waiting for you to approve in your browser…</p>
 
                 {/* Plain-language scope disclosure (Phase 3, 2026-07-22): the
                     `repo` scope is broad — same as GitHub's own CLI — and the
                     user deserves to know that BEFORE approving, not in a doc. */}
-                <p className="text-[11px] text-fg-faint leading-relaxed">
+                <p className="text-2xs text-fg-faint leading-relaxed">
                   Approving gives YouCoded the same access GitHub's own command-line
                   tool uses: it can read and write the repositories your account can.
                   YouCoded only uses it for your private sync repos, publishing, and

--- a/desktop/src/renderer/components/ConnectedAccounts.tsx
+++ b/desktop/src/renderer/components/ConnectedAccounts.tsx
@@ -62,7 +62,7 @@ export function ConnectedAccountsBody({ status, refresh }: {
       {/* How this page relates to the WeCoded sign-in the user just came from —
           the exact confusion this layout exists to prevent: both use GitHub,
           for two different jobs. */}
-      <p className="text-[11px] text-fg-dim leading-relaxed">
+      <p className="text-2xs text-fg-dim leading-relaxed">
         Services YouCoded connects to on your behalf. These are separate from
         your YouCoded account sign-in.
       </p>
@@ -75,7 +75,7 @@ export function ConnectedAccountsBody({ status, refresh }: {
             <div className="text-xs text-fg font-medium">
               GitHub{connected && status?.login ? ` · @${status.login}` : ''}
             </div>
-            <div className="text-[10px] text-fg-muted">
+            <div className="text-3xs text-fg-muted">
               {connected
                 ? 'Stores your synced data and publishes your themes, skills, and bug reports.'
                 : 'Needed for cross-device sync and publishing themes & skills.'}
@@ -96,7 +96,7 @@ export function ConnectedAccountsBody({ status, refresh }: {
         {/* Keychain-less Linux stores the token as a plain 0600 file — the
             degraded policy is explicit everywhere, including here. */}
         {connected && status?.degradedStorage && (
-          <p className="text-[11px] text-amber-500 leading-relaxed">
+          <p className="text-2xs text-amber-500 leading-relaxed">
             Your sign-in is stored without system-keychain encryption on this
             computer (no keychain service was available). It is protected only
             by file permissions.
@@ -104,7 +104,7 @@ export function ConnectedAccountsBody({ status, refresh }: {
         )}
 
         {viaGhCli && (
-          <p className="text-[11px] text-fg-muted leading-relaxed">
+          <p className="text-2xs text-fg-muted leading-relaxed">
             Connected through the GitHub CLI installed on this computer, so
             there's nothing for YouCoded to disconnect here — to sign out, run{' '}
             <code className="font-mono">gh auth logout</code> in a terminal.
@@ -113,7 +113,7 @@ export function ConnectedAccountsBody({ status, refresh }: {
 
         {confirming && (
           <div className="space-y-2">
-            <p className="text-[11px] text-fg-2 leading-relaxed">
+            <p className="text-2xs text-fg-2 leading-relaxed">
               This removes the saved GitHub sign-in from this device. Sync will
               pause until you reconnect; your data on GitHub is not deleted.
             </p>
@@ -128,7 +128,7 @@ export function ConnectedAccountsBody({ status, refresh }: {
           </div>
         )}
 
-        {error && <p className="text-[11px] text-destructive-fg">{error}</p>}
+        {error && <p className="text-2xs text-destructive-fg">{error}</p>}
       </div>
 
       {showConnect && (

--- a/desktop/src/renderer/components/ContentFindBar.tsx
+++ b/desktop/src/renderer/components/ContentFindBar.tsx
@@ -129,7 +129,7 @@ export function ContentFindBar({ containerRef, onClose, resetKey, highlightName 
         }}
         placeholder={placeholder}
       />
-      <span className="text-[11px] text-fg-muted tabular-nums text-center px-1 min-w-[40px]">{shown}</span>
+      <span className="text-2xs text-fg-muted tabular-nums text-center px-1 min-w-[40px]">{shown}</span>
       {/* Lucide-style SVGs (stroke currentColor) — the app's icon convention;
           these were literal ↑/↓/✕ text characters before. */}
       <button type="button" title="Previous (Shift+Enter)" onClick={() => go(-1)}

--- a/desktop/src/renderer/components/ContextPopup.tsx
+++ b/desktop/src/renderer/components/ContextPopup.tsx
@@ -252,7 +252,7 @@ export default function ContextPopup({
                     >
                       Clear and start over
                     </Button>
-                    <p className="text-[11px] text-fg-muted mt-1 leading-snug">
+                    <p className="text-2xs text-fg-muted mt-1 leading-snug">
                       Erases the visible timeline and resets Claude's memory for this session. No summary is kept.
                     </p>
                   </div>

--- a/desktop/src/renderer/components/DonateConfirm.tsx
+++ b/desktop/src/renderer/components/DonateConfirm.tsx
@@ -41,7 +41,7 @@ export function DonateConfirm({ open, onClose }: { open: boolean; onClose: () =>
           </svg>
           <span className="text-sm font-bold text-fg">Buy Me a Coffee</span>
         </div>
-        <p className="text-[11px] text-fg-dim mb-5">Okay to open donation link?</p>
+        <p className="text-2xs text-fg-dim mb-5">Okay to open donation link?</p>
         <div className="flex gap-2">
           {/* py-2.5 kept as a deliberate override: this two-button footer is
               the whole modal, so md's py-1.5 reads too slight here. */}

--- a/desktop/src/renderer/components/EngineCard.tsx
+++ b/desktop/src/renderer/components/EngineCard.tsx
@@ -93,7 +93,7 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
       <div className="flex items-center justify-between gap-2">
         <div className="min-w-0">
           <p className="text-xs text-fg font-medium">Local engine (llama.cpp)</p>
-          <p className="text-[10px] text-fg-muted">{stateLabel}</p>
+          <p className="text-3xs text-fg-muted">{stateLabel}</p>
         </div>
         {/* Primary row action via the shared primitive — drops the hand-rolled
             accent fill + hover:brightness-110 (invisible on near-black accents). */}
@@ -119,14 +119,14 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
         )}
       </div>
       {busy && progress?.kind === 'download' && (
-        <p className="mt-2 text-[10px] text-fg-dim">
+        <p className="mt-2 text-3xs text-fg-dim">
           Downloading… {mb(progress.receivedBytes)}{progress.totalBytes ? ` of ${mb(progress.totalBytes)}` : ''}
         </p>
       )}
       {busy && (progress?.kind === 'verify' || progress?.kind === 'unpack') && (
-        <p className="mt-2 text-[10px] text-fg-dim">{progress.kind === 'verify' ? 'Verifying download…' : 'Unpacking…'}</p>
+        <p className="mt-2 text-3xs text-fg-dim">{progress.kind === 'verify' ? 'Verifying download…' : 'Unpacking…'}</p>
       )}
-      {error && <p className="mt-2 text-[10px] text-destructive-fg">{error}</p>}
+      {error && <p className="mt-2 text-3xs text-destructive-fg">{error}</p>}
 
       {/* Extra controls for the Local Models panel (Plan C). Only shown once the
           engine is installed — nothing to configure before that. */}
@@ -134,7 +134,7 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
         <div className="mt-3 pt-3 border-t border-edge-dim space-y-2.5">
           {/* Backend line + optional CUDA switch (Windows only). */}
           <div className="flex items-center justify-between gap-2">
-            <p className="text-[11px] text-fg-dim">Using: {status.backend ?? 'default'}</p>
+            <p className="text-2xs text-fg-dim">Using: {status.backend ?? 'default'}</p>
             {isWindows && status.backend !== 'cuda' && (
               <Button
                 variant="secondary"
@@ -150,7 +150,7 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
 
           {/* Context-length knob. Commits on Enter or blur. */}
           <div className="flex items-center justify-between gap-2">
-            <label htmlFor="engine-context-size" className="text-[11px] text-fg-dim">Context length (tokens)</label>
+            <label htmlFor="engine-context-size" className="text-2xs text-fg-dim">Context length (tokens)</label>
             {/* Change 20: the shared field surface. type="number" (plus min/step
                 and the busy-disabled state) passes straight through — TextInput is
                 deliberately not restricted to type="text". size="sm" matches the
@@ -172,8 +172,8 @@ export default function EngineCard({ showDetails = false }: { showDetails?: bool
 
           {/* Cache location — read-only. */}
           <div>
-            <p className="text-[10px] text-fg-muted mb-0.5">Models are stored in</p>
-            <p className="text-[10px] text-fg-dim font-mono break-all">{status.cacheDir}</p>
+            <p className="text-3xs text-fg-muted mb-0.5">Models are stored in</p>
+            <p className="text-3xs text-fg-dim font-mono break-all">{status.cacheDir}</p>
           </div>
         </div>
       )}

--- a/desktop/src/renderer/components/FolderSwitcher.tsx
+++ b/desktop/src/renderer/components/FolderSwitcher.tsx
@@ -194,7 +194,7 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true, onM
 
       {/* Full path hint below trigger */}
       {value && (
-        <div className="mt-0.5 px-1 text-[10px] text-fg-muted truncate" title={value}>
+        <div className="mt-0.5 px-1 text-3xs text-fg-muted truncate" title={value}>
           {value}
         </div>
       )}
@@ -251,14 +251,14 @@ export default function FolderSwitcher({ value, onChange, autoSelect = true, onM
                         Project View via "Manage projects…". Don't re-add. */}
                     <div className="flex-1 min-w-0">
                       <div className="text-xs truncate">{shown}</div>
-                      <div className="text-[10px] text-fg-muted truncate" title={f.path}>
+                      <div className="text-3xs text-fg-muted truncate" title={f.path}>
                         {f.path}
                       </div>
                     </div>
 
                     {/* Stale warning */}
                     {!f.exists && (
-                      <span className="text-[9px] text-[#DD4444]/80 shrink-0" title="Directory not found">
+                      <span className="text-4xs text-[#DD4444]/80 shrink-0" title="Directory not found">
                         missing
                       </span>
                     )}

--- a/desktop/src/renderer/components/HandlePrompt.tsx
+++ b/desktop/src/renderer/components/HandlePrompt.tsx
@@ -107,7 +107,7 @@ function HandlePromptPopup({
         <div className="p-5 space-y-4">
           <div className="space-y-1.5">
             <h3 id="handle-prompt-title" className="text-sm font-semibold text-fg">Pick a handle</h3>
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <p className="text-2xs text-fg-dim leading-relaxed">
               Friends will find you by your handle — like a username. You can change it later in Settings → Account.
             </p>
           </div>
@@ -137,7 +137,7 @@ function HandlePromptPopup({
             </Button>
           </InputGroup>
           {/* Plain words for status, never glyphs. */}
-          {error && <p className="text-[10px] text-destructive-fg">{error}</p>}
+          {error && <p className="text-3xs text-destructive-fg">{error}</p>}
 
           <Button variant="secondary" onClick={skip} className="w-full py-2">
             Skip for now

--- a/desktop/src/renderer/components/HeaderBar.tsx
+++ b/desktop/src/renderer/components/HeaderBar.tsx
@@ -265,7 +265,7 @@ function ArtifactDrawerButton({ activeSessionId, projectRoot }: { activeSessionI
             bg-on-accent/text-accent while open so it stays legible against the
             now-accent-colored button background. */}
         {artifactCount > 0 && (
-          <span className={`text-[10px] rounded-full px-1 min-w-[14px] inline-flex items-center justify-center leading-none py-0.5 ${
+          <span className={`text-3xs rounded-full px-1 min-w-[14px] inline-flex items-center justify-center leading-none py-0.5 ${
             drawerOpen ? 'bg-on-accent text-accent' : 'bg-accent text-on-accent'
           }`}>
             {artifactCount}
@@ -612,7 +612,7 @@ export default function HeaderBar({
         {/* Projects button — wide layouts only; narrow reaches it via ||| . */}
         {!narrow && <ProjectsButton />}
         {isRemoteMode() && (
-          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-sm bg-blue-500/15 text-blue-400 border border-blue-500/25 shrink-0">
+          <span className="text-3xs font-medium px-1.5 py-0.5 rounded-sm bg-blue-500/15 text-blue-400 border border-blue-500/25 shrink-0">
             REMOTE
           </span>
         )}

--- a/desktop/src/renderer/components/ImportProjectModal.tsx
+++ b/desktop/src/renderer/components/ImportProjectModal.tsx
@@ -129,7 +129,7 @@ export default function ImportProjectModal({ sourcePath, defaultName, onClose, o
             </div>
             {/* htmlFor/id pair added: the label was floating unassociated, so
                 screen readers announced this field with no name. */}
-            <label htmlFor="import-project-name" className="block mt-3 text-[10px] uppercase tracking-wide text-fg-muted">Project name</label>
+            <label htmlFor="import-project-name" className="block mt-3 text-3xs uppercase tracking-wide text-fg-muted">Project name</label>
             {/* Shared TextInput (change 20). Stays a plain field, NOT an
                 InputGroup: the "Move and sync" button lives in the modal footer
                 below, not inline beside the field. */}

--- a/desktop/src/renderer/components/InputBar.tsx
+++ b/desktop/src/renderer/components/InputBar.tsx
@@ -654,7 +654,7 @@ const InputBar = forwardRef<InputBarHandle, Props>(function InputBar({ sessionId
                 />
               ) : (
                 <div className="w-12 h-12 rounded-md border border-edge bg-panel flex items-center justify-center">
-                  <span className="text-[9px] text-fg-dim text-center leading-tight px-1 truncate">
+                  <span className="text-4xs text-fg-dim text-center leading-tight px-1 truncate">
                     {att.name}
                   </span>
                 </div>
@@ -669,7 +669,7 @@ const InputBar = forwardRef<InputBarHandle, Props>(function InputBar({ sessionId
                 size="icon"
                 aria-label={`Remove ${att.name ?? 'attachment'}`}
                 onClick={() => removeAttachment(att.path)}
-                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-inset text-fg-2 hover:bg-edge text-[10px] leading-none opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-inset text-fg-2 hover:bg-edge text-3xs leading-none opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
               >
                 ×
               </Button>

--- a/desktop/src/renderer/components/LocalModelsSection.tsx
+++ b/desktop/src/renderer/components/LocalModelsSection.tsx
@@ -75,7 +75,7 @@ export default function LocalModelsSection({ embedded = false }: { embedded?: bo
   return (
     <section>
       {!embedded && (
-        <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Local Models</h3>
+        <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Local Models</h3>
       )}
 
       <div className="space-y-4">
@@ -119,13 +119,13 @@ function DownloadProgressRow({ dl }: { dl: DownloadProgress }) {
         <div className="h-full bg-accent transition-[width]" style={{ width: `${pct}%` }} />
       </div>
       <div className="flex items-center justify-between">
-        <p className="text-[10px] text-fg-muted">
+        <p className="text-3xs text-fg-muted">
           {dl.state === 'verifying' ? 'Verifying…' : `${gb(dl.receivedBytes)} of ${gb(dl.totalBytes)}`}
           {dl.parts > 1 ? ` · part ${dl.currentPart} of ${dl.parts}` : ''}
         </p>
         <button
           onClick={() => void window.claude.models.downloadCancel(dl.downloadId)}
-          className="text-[10px] font-medium text-red-500 hover:underline"
+          className="text-3xs font-medium text-red-500 hover:underline"
         >
           Cancel
         </button>
@@ -225,13 +225,13 @@ function ModelBrowser({
       </InputGroup>
 
       {curated === null || installed === null ? (
-        <p className="text-[11px] text-fg-muted px-1">Loading…</p>
+        <p className="text-2xs text-fg-muted px-1">Loading…</p>
       ) : (
         <div className="space-y-3">
           {/* Installed (+ in-progress) */}
           {(installedFiltered.length > 0 || partials.length > 0) && (
             <div className="space-y-2">
-              <p className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">Installed</p>
+              <p className="text-3xs font-medium text-fg-muted tracking-wider uppercase">Installed</p>
               {installedFiltered.map((m) => (
                 <InstalledRow key={m.id} model={m} onRefresh={onRefreshInstalled} />
               ))}
@@ -250,7 +250,7 @@ function ModelBrowser({
           {/* Recommended (label changes to "matches" while filtering) */}
           {curatedFiltered.length > 0 && (
             <div className="space-y-2">
-              <p className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">
+              <p className="text-3xs font-medium text-fg-muted tracking-wider uppercase">
                 {q ? 'Recommended matches' : 'Recommended'}
               </p>
               {curatedFiltered.map((m) => (
@@ -273,11 +273,11 @@ function ModelBrowser({
           {/* Hugging Face — only while actively searching */}
           {searching && (
             <div className="space-y-2">
-              <p className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">More on Hugging Face</p>
-              {hfState === 'loading' && <p className="text-[11px] text-fg-muted px-1">Searching Hugging Face…</p>}
-              {hfState === 'error' && <p className="text-[11px] text-destructive-fg px-1">Couldn't reach Hugging Face.</p>}
+              <p className="text-3xs font-medium text-fg-muted tracking-wider uppercase">More on Hugging Face</p>
+              {hfState === 'loading' && <p className="text-2xs text-fg-muted px-1">Searching Hugging Face…</p>}
+              {hfState === 'error' && <p className="text-2xs text-destructive-fg px-1">Couldn't reach Hugging Face.</p>}
               {hfState === 'idle' && hfFiltered.length === 0 && (
-                <p className="text-[11px] text-fg-muted px-1">No other models found.</p>
+                <p className="text-2xs text-fg-muted px-1">No other models found.</p>
               )}
               {hfFiltered.map((h) => (
                 <RepoCard
@@ -295,7 +295,7 @@ function ModelBrowser({
             </div>
           )}
 
-          {nothing && <p className="text-[11px] text-fg-muted px-1">No models match “{query}”.</p>}
+          {nothing && <p className="text-2xs text-fg-muted px-1">No models match “{query}”.</p>}
         </div>
       )}
     </div>
@@ -375,19 +375,19 @@ function RepoCard({
           </svg>
           <div className="min-w-0 flex-1">
             <p className="text-xs text-fg font-medium truncate">{label}</p>
-            {sub && <p className="text-[10px] text-fg-muted truncate">{sub}</p>}
+            {sub && <p className="text-3xs text-fg-muted truncate">{sub}</p>}
             {loadState === 'loading' && quants === null && (
-              <p className="text-[10px] text-fg-muted mt-0.5">Checking size…</p>
+              <p className="text-3xs text-fg-muted mt-0.5">Checking size…</p>
             )}
             {chosen && (
-              <p className="text-[10px] mt-0.5">
+              <p className="text-3xs mt-0.5">
                 <span className="text-fg-dim">{gb(chosen.totalSizeBytes)} · {chosen.quant}</span>
                 {' · '}
                 <span className={fitColor(chosen.fit.fit)}>{chosen.fit.label}</span>
               </p>
             )}
             {loadState === 'error' && quants === null && (
-              <p className="text-[10px] text-amber-500 mt-0.5">Couldn't reach Hugging Face — expand to retry</p>
+              <p className="text-3xs text-amber-500 mt-0.5">Couldn't reach Hugging Face — expand to retry</p>
             )}
           </div>
         </button>
@@ -399,14 +399,14 @@ function RepoCard({
         )}
       </div>
       {dl && <DownloadProgressRow dl={dl} />}
-      {dlError && <p className="text-[10px] text-destructive-fg mt-1">{dlError}</p>}
+      {dlError && <p className="text-3xs text-destructive-fg mt-1">{dlError}</p>}
 
       {/* Expanded: the full quant list. */}
       {expanded && (
         <div className="mt-2 pl-5">
-          {loadState === 'loading' && <p className="text-[10px] text-fg-muted px-1">Loading versions…</p>}
+          {loadState === 'loading' && <p className="text-3xs text-fg-muted px-1">Loading versions…</p>}
           {loadState === 'error' && (
-            <button onClick={() => void loadQuants()} className="text-[10px] text-amber-500 hover:underline px-1">
+            <button onClick={() => void loadQuants()} className="text-3xs text-amber-500 hover:underline px-1">
               Couldn't reach Hugging Face — tap to retry
             </button>
           )}
@@ -416,7 +416,7 @@ function RepoCard({
                 <QuantDownloadRow key={qq.quant} repo={repo} q={qq} downloads={downloads} />
               ))}
               {!showAll && hiddenCount > 0 && (
-                <button onClick={() => setShowAll(true)} className="text-[10px] text-fg-2 hover:underline px-1">
+                <button onClick={() => setShowAll(true)} className="text-3xs text-fg-2 hover:underline px-1">
                   Show all {(quants ?? []).length}
                 </button>
               )}
@@ -455,7 +455,7 @@ function InstalledRow({ model, onRefresh }: { model: InstalledLocalModel; onRefr
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-xs text-fg font-medium truncate">{model.id}</p>
-          <p className="text-[10px] text-fg-muted">
+          <p className="text-3xs text-fg-muted">
             {gb(model.sizeBytes)}
             {model.quant ? ` · ${model.quant}` : ''}
             {model.quantDescription ? ` · ${model.quantDescription}` : ''}
@@ -471,7 +471,7 @@ function InstalledRow({ model, onRefresh }: { model: InstalledLocalModel; onRefr
       {/* Consequence-gated delete — plain-language warning before the file is removed. */}
       {confirming && (
         <div className="mt-2 space-y-2 rounded-lg bg-inset border border-edge-dim p-3">
-          <p className="text-[11px] text-fg-dim leading-relaxed">
+          <p className="text-2xs text-fg-dim leading-relaxed">
             This removes the model file ({gb(model.sizeBytes)}) from this computer. Re-downloading it later will take a while.
           </p>
           <div className="flex gap-2">
@@ -489,7 +489,7 @@ function InstalledRow({ model, onRefresh }: { model: InstalledLocalModel; onRefr
               {busy ? 'Deleting…' : 'Delete model'}
             </Button>
           </div>
-          {delError && <p className="text-[10px] text-destructive-fg">{delError}</p>}
+          {delError && <p className="text-3xs text-destructive-fg">{delError}</p>}
         </div>
       )}
     </div>
@@ -571,7 +571,7 @@ function PartialRow({
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-xs text-fg font-medium truncate">{dl.repo}</p>
-          <p className="text-[10px] text-fg-muted">
+          <p className="text-3xs text-fg-muted">
             {dl.quant} · {label}
             {dl.totalBytes > 0 ? ` · ${gb(dl.receivedBytes)} of ${gb(dl.totalBytes)}` : ''}
           </p>
@@ -612,9 +612,9 @@ function QuantDownloadRow({ repo, q, downloads }: { repo: string; q: QuantWithFi
     <div className="px-2 py-1.5 rounded-md bg-well">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] text-fg font-medium">{q.quant}</p>
-          <p className="text-[10px] text-fg-muted">{q.description}</p>
-          <p className="text-[10px] mt-0.5">
+          <p className="text-2xs text-fg font-medium">{q.quant}</p>
+          <p className="text-3xs text-fg-muted">{q.description}</p>
+          <p className="text-3xs mt-0.5">
             <span className="text-fg-dim">{gb(q.totalSizeBytes)}</span>
             {' · '}
             <span className={fitColor(q.fit.fit)}>{q.fit.label}</span>
@@ -627,7 +627,7 @@ function QuantDownloadRow({ repo, q, downloads }: { repo: string; q: QuantWithFi
         )}
       </div>
       {dl && <DownloadProgressRow dl={dl} />}
-      {dlError && <p className="text-[10px] text-destructive-fg mt-1">{dlError}</p>}
+      {dlError && <p className="text-3xs text-destructive-fg mt-1">{dlError}</p>}
     </div>
   );
 }
@@ -688,7 +688,7 @@ function OtherLocalApps() {
 
       {hits !== null && (
         hits.length === 0 ? (
-          <p className="text-[11px] text-fg-muted mt-2 px-1">No other local model apps found running.</p>
+          <p className="text-2xs text-fg-muted mt-2 px-1">No other local model apps found running.</p>
         ) : (
           <div className="space-y-2 mt-2">
             {hits.map((hit) => {
@@ -702,10 +702,10 @@ function OtherLocalApps() {
                         {hit.modelCount != null ? ` (${hit.modelCount} models)` : ''}
                       </p>
                       {isAdded && (
-                        <p className="text-[10px] text-fg-muted mt-0.5">Added — manage it in Providers above.</p>
+                        <p className="text-3xs text-fg-muted mt-0.5">Added — manage it in Providers above.</p>
                       )}
                       {addError[hit.baseUrl] && (
-                        <p className="text-[10px] text-destructive-fg mt-0.5">{addError[hit.baseUrl]}</p>
+                        <p className="text-3xs text-destructive-fg mt-0.5">{addError[hit.baseUrl]}</p>
                       )}
                     </div>
                     {!isAdded && (

--- a/desktop/src/renderer/components/ModelPickerPopup.tsx
+++ b/desktop/src/renderer/components/ModelPickerPopup.tsx
@@ -94,7 +94,7 @@ export function ModelInfoTooltip({ model }: { model: ModelAlias }) {
             <p className="text-xs font-semibold text-fg mb-2">{info.tagline}</p>
             <div className="space-y-1">
               {info.pros.map((pro) => (
-                <div key={pro} className="flex items-start gap-1.5 text-[11px] text-fg-2 leading-snug">
+                <div key={pro} className="flex items-start gap-1.5 text-2xs text-fg-2 leading-snug">
                   <span className="text-green-500 shrink-0 font-bold mt-px">✓</span>
                   <span>{pro}</span>
                 </div>
@@ -103,7 +103,7 @@ export function ModelInfoTooltip({ model }: { model: ModelAlias }) {
             {info.cons.length > 0 && (
               <div className="space-y-1 mt-2 pt-2 border-t border-edge-dim">
                 {info.cons.map((con) => (
-                  <div key={con} className="flex items-start gap-1.5 text-[11px] text-fg-muted leading-snug">
+                  <div key={con} className="flex items-start gap-1.5 text-2xs text-fg-muted leading-snug">
                     <span className="shrink-0 mt-px">·</span>
                     <span>{con}</span>
                   </div>
@@ -352,7 +352,7 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
             ) : (
               [...groups.entries()].map(([label, models]) => (
                 <section key={label}>
-                  <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-1.5">{label}</div>
+                  <div className="text-3xs uppercase tracking-wider text-fg-muted mb-1.5">{label}</div>
                   <div className="flex flex-col gap-1">
                     {models.map((m) => {
                       // Prefer App's live SessionInfo.model (updated on every swap)
@@ -454,7 +454,7 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
                   );
                 })}
               </div>
-              <p className="text-[11px] text-fg-muted mt-1.5">
+              <p className="text-2xs text-fg-muted mt-1.5">
                 How hard Claude thinks before responding. Higher = slower but smarter.
               </p>
             </section>
@@ -516,7 +516,7 @@ export default function ModelPickerPopup({ open, onClose, sessionId, currentMode
                   <span className="text-fg-2">Input:</span> $30 / million tokens<br />
                   <span className="text-fg-2">Output:</span> $150 / million tokens
                 </div>
-                <div className="text-[11px] text-fg-muted pt-1 border-t border-[#FF9800]/25">
+                <div className="text-2xs text-fg-muted pt-1 border-t border-[#FF9800]/25">
                   Your Claude Pro/Max subscription does not cover these charges. They bill directly against API credits on your Anthropic account.
                 </div>
               </div>

--- a/desktop/src/renderer/components/ModelProvidersPopup.tsx
+++ b/desktop/src/renderer/components/ModelProvidersPopup.tsx
@@ -110,7 +110,7 @@ function ModelProvidersPopupInner({
 
         <div ref={scrollRef} className="scroll-fade">
           <div className="p-5 space-y-6">
-            <p className="text-[11px] text-fg-dim leading-relaxed">
+            <p className="text-2xs text-fg-dim leading-relaxed">
               Choose which AI engine powers your sessions. Claude Code is the default; OpenRouter and
               local models are optional alternatives.
             </p>
@@ -220,10 +220,10 @@ function ClaudeCodeBlock({
 
       <div className="bg-inset/50 rounded-lg px-3 py-2.5">
         <p className="text-xs text-fg font-medium">Default engine</p>
-        <p className={`text-[11px] mt-0.5 ${statusTone === 'ok' ? 'text-green-600' : 'text-fg-muted'}`}>
+        <p className={`text-2xs mt-0.5 ${statusTone === 'ok' ? 'text-green-600' : 'text-fg-muted'}`}>
           {statusText}
         </p>
-        <p className="text-[10px] text-fg-muted mt-1.5 leading-relaxed">
+        <p className="text-3xs text-fg-muted mt-1.5 leading-relaxed">
           Every session runs through Claude Code unless you pick another provider below.
         </p>
 
@@ -304,7 +304,7 @@ function OpenRouterBlock() {
         <div className="flex items-center gap-3">
           <div className="flex-1 min-w-0">
             <p className="text-xs text-fg font-medium">OpenRouter</p>
-            <p className="text-[10px] text-fg-muted">
+            <p className="text-3xs text-fg-muted">
               {openrouter === undefined ? 'Checking…' : connected ? 'Connected' : 'Not connected'}
             </p>
           </div>
@@ -323,7 +323,7 @@ function OpenRouterBlock() {
           </div>
         )}
         {testNote && (
-          <p className={`text-[10px] mt-2 ${testNote.tone === 'ok' ? 'text-green-600' : 'text-red-500'}`}>
+          <p className={`text-3xs mt-2 ${testNote.tone === 'ok' ? 'text-green-600' : 'text-red-500'}`}>
             {testNote.text}
           </p>
         )}
@@ -400,7 +400,7 @@ function ConnectOpenRouterModal({
         </div>
 
         <div className="p-4 space-y-3">
-          <ol className="text-[11px] text-fg-2 leading-relaxed space-y-1 list-decimal pl-4">
+          <ol className="text-2xs text-fg-2 leading-relaxed space-y-1 list-decimal pl-4">
             <li>
               Create a free account at{' '}
               <button
@@ -430,7 +430,7 @@ function ConnectOpenRouterModal({
           />
 
           {note && (
-            <p className={`text-[10px] ${note.tone === 'ok' ? 'text-green-600' : 'text-red-500'}`}>{note.text}</p>
+            <p className={`text-3xs ${note.tone === 'ok' ? 'text-green-600' : 'text-red-500'}`}>{note.text}</p>
           )}
 
           <div className="flex gap-2 pt-1">
@@ -587,7 +587,7 @@ function SearchProvidersBlock() {
         }}
       />
 
-      <p className="text-[10px] text-fg-muted mb-2.5 leading-relaxed">
+      <p className="text-3xs text-fg-muted mb-2.5 leading-relaxed">
         Web search works for free with no setup. Add an optional key to make it faster and more reliable.
       </p>
 
@@ -601,11 +601,11 @@ function SearchProvidersBlock() {
               <div className="flex items-center gap-3">
                 <div className="flex-1 min-w-0">
                   <p className="text-xs text-fg font-medium">{row.label}</p>
-                  <p className="text-[10px] text-fg-muted">{meta.hint}</p>
+                  <p className="text-3xs text-fg-muted">{meta.hint}</p>
                 </div>
                 {row.hasKey ? (
                   <div className="flex items-center gap-1.5 shrink-0">
-                    <span className="text-[10px] font-medium text-green-600">Key saved</span>
+                    <span className="text-3xs font-medium text-green-600">Key saved</span>
                     {/* danger-outline per spec change 68: "Remove" reads the same
                         everywhere. This one was the neutral half of the
                         ProvidersSection(red)-vs-here(neutral) contradiction; it
@@ -646,7 +646,7 @@ function SearchProvidersBlock() {
                   <div className="flex items-center justify-between gap-2">
                     <button
                       onClick={() => void (window as any).claude.shell.openExternal(meta.url)}
-                      className="text-[10px] text-accent hover:underline"
+                      className="text-3xs text-accent hover:underline"
                     >
                       Get a free key
                     </button>
@@ -658,7 +658,7 @@ function SearchProvidersBlock() {
               )}
 
               {note && (
-                <p className={`text-[10px] mt-2 ${note.ok ? 'text-fg-muted' : 'text-red-500'}`}>
+                <p className={`text-3xs mt-2 ${note.ok ? 'text-fg-muted' : 'text-red-500'}`}>
                   {note.text}
                 </p>
               )}

--- a/desktop/src/renderer/components/NativeModelSelect.tsx
+++ b/desktop/src/renderer/components/NativeModelSelect.tsx
@@ -147,7 +147,7 @@ export default function NativeModelSelect({ prefill, onSelect }: NativeModelSele
         ) : (
           [...groups.entries()].map(([label, models]) => (
             <section key={label}>
-              <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-1">{label}</div>
+              <div className="text-3xs uppercase tracking-wider text-fg-muted mb-1">{label}</div>
               <div className="flex flex-col gap-1">
                 {models.map((m) => {
                   const isSelected = selected?.providerId === m.providerId && selected?.modelId === m.id;

--- a/desktop/src/renderer/components/OpenTasksPopup.tsx
+++ b/desktop/src/renderer/components/OpenTasksPopup.tsx
@@ -57,13 +57,13 @@ function Row({ t, group, onMarkInactive, onUnhide }: {
       <div className="pt-1.5"><StatusDot group={group} /></div>
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline gap-1.5">
-          <span className="text-[11px] font-mono text-fg-muted">#{t.id}</span>
+          <span className="text-2xs font-mono text-fg-muted">#{t.id}</span>
           <span className={`text-xs ${group === 'in_progress' ? 'text-blue-400 italic' : 'text-fg'} ${group === 'completed' ? 'line-through' : ''}`}>
             {title}
           </span>
-          {isDeleted && <span className="text-[10px] px-1 rounded bg-inset text-fg-muted">deleted</span>}
+          {isDeleted && <span className="text-3xs px-1 rounded bg-inset text-fg-muted">deleted</span>}
         </div>
-        {showDesc && <div className="text-[11px] text-fg-muted mt-0.5 leading-tight">{t.description}</div>}
+        {showDesc && <div className="text-2xs text-fg-muted mt-0.5 leading-tight">{t.description}</div>}
       </div>
       {group === 'inactive' ? (
         <Button
@@ -96,7 +96,7 @@ function Row({ t, group, onMarkInactive, onUnhide }: {
 
 function SectionHeader({ label }: { label: string }) {
   return (
-    <div className="text-[10px] uppercase tracking-wider text-fg-muted px-2 pt-2 pb-1">
+    <div className="text-3xs uppercase tracking-wider text-fg-muted px-2 pt-2 pb-1">
       {label}
     </div>
   );
@@ -180,7 +180,7 @@ export default function OpenTasksPopup({ open, tasks, onClose, onMarkInactive, o
             <>
               <button
                 aria-expanded={completedOpen}
-                className="w-full text-left text-[10px] uppercase tracking-wider text-fg-muted px-2 pt-2 pb-1 flex justify-between items-baseline hover:text-fg"
+                className="w-full text-left text-3xs uppercase tracking-wider text-fg-muted px-2 pt-2 pb-1 flex justify-between items-baseline hover:text-fg"
                 onClick={() => setCompletedOpen(v => !v)}
               >
                 <span>Completed</span>
@@ -197,7 +197,7 @@ export default function OpenTasksPopup({ open, tasks, onClose, onMarkInactive, o
             <>
               <button
                 aria-expanded={inactiveOpen}
-                className="w-full text-left text-[10px] uppercase tracking-wider text-fg-muted px-2 pt-2 pb-1 flex justify-between items-baseline hover:text-fg border-t border-edge-dim mt-1"
+                className="w-full text-left text-3xs uppercase tracking-wider text-fg-muted px-2 pt-2 pb-1 flex justify-between items-baseline hover:text-fg border-t border-edge-dim mt-1"
                 onClick={() => setInactiveOpen(v => !v)}
               >
                 <span>Marked Inactive</span>

--- a/desktop/src/renderer/components/PerformancePopup.tsx
+++ b/desktop/src/renderer/components/PerformancePopup.tsx
@@ -158,7 +158,7 @@ export default function PerformancePopup({
             )}
 
             {gpuList.length > 0 && (
-              <p className="text-[11px] text-fg-muted">
+              <p className="text-2xs text-fg-muted">
                 Detected GPUs: {gpuList.join(', ')}
               </p>
             )}
@@ -170,7 +170,7 @@ export default function PerformancePopup({
 
             {PERFORMANCE_EXPLAINER.sections.map((section, i) => (
               <section key={i}>
-                <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">
+                <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">
                   {section.heading}
                 </h3>
                 {section.paragraphs?.map((p, j) => (

--- a/desktop/src/renderer/components/PreferencesPopup.tsx
+++ b/desktop/src/renderer/components/PreferencesPopup.tsx
@@ -214,7 +214,7 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced, showAd
                 aria-label="Output Style"
                 className="w-full"
               />
-              <p className="text-[11px] text-fg-muted mt-1.5">Preset name that tunes Claude's response style. Leave blank for default.</p>
+              <p className="text-2xs text-fg-muted mt-1.5">Preset name that tunes Claude's response style. Leave blank for default.</p>
             </section>
 
             {/* Toggles */}
@@ -254,7 +254,7 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced, showAd
                 aria-label="System Prompt"
                 className="w-full"
               />
-              <p className="text-[11px] text-fg-muted mt-1.5">Applied globally. Leave blank to use Claude Code defaults.</p>
+              <p className="text-2xs text-fg-muted mt-1.5">Applied globally. Leave blank to use Claude Code defaults.</p>
             </section>
 
             {/* Advanced escape hatch — opens Claude Code's native TUI for any option not covered here */}
@@ -272,7 +272,7 @@ export default function PreferencesPopup({ open, onClose, onOpenAdvanced, showAd
               >
                 Advanced (terminal) →
               </Button>
-              <p className="text-[11px] text-fg-muted mt-1.5 text-center">
+              <p className="text-2xs text-fg-muted mt-1.5 text-center">
                 Switches to terminal view and runs Claude Code's full <code>/config</code>
               </p>
             </section>

--- a/desktop/src/renderer/components/ProvidersSection.tsx
+++ b/desktop/src/renderer/components/ProvidersSection.tsx
@@ -151,12 +151,12 @@ export default function ProvidersSection({ embedded = false }: { embedded?: bool
   return (
     <section>
       {!embedded && (
-        <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Providers</h3>
+        <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Providers</h3>
       )}
 
       {visibleRows === null ? (
         // Loading — quiet skeleton (a single muted line) rather than a spinner.
-        <p className="text-[11px] text-fg-muted px-1">Loading…</p>
+        <p className="text-2xs text-fg-muted px-1">Loading…</p>
       ) : (
         <div className="space-y-2">
           {/* Load/refresh error — shown inline with a Retry so a transient
@@ -165,7 +165,7 @@ export default function ProvidersSection({ embedded = false }: { embedded?: bool
               still renders, and Retry re-runs list(). */}
           {listError && (
             <div className="flex items-center gap-2 px-1">
-              <p className="text-[11px] text-destructive-fg flex-1">
+              <p className="text-2xs text-destructive-fg flex-1">
                 {visibleRows.length === 0
                   ? `Couldn't load providers — ${listError}`
                   : `Couldn't refresh — ${listError}`}
@@ -273,7 +273,7 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
       <div className="flex items-center gap-3">
         <div className="flex-1 min-w-0">
           <p className="text-xs text-fg font-medium truncate">{provider.label}</p>
-          <p className="text-[10px] text-fg-muted">{stateWord(provider)}</p>
+          <p className="text-3xs text-fg-muted">{stateWord(provider)}</p>
         </div>
 
         {/* Enable/disable toggle — hidden for the dormant local engine (nothing
@@ -346,7 +346,7 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
       {/* Remove confirm — plain-language consequence (the key is deleted). */}
       {confirmingRemove && (
         <div className="mt-2 space-y-2 rounded-lg bg-inset border border-edge-dim p-3">
-          <p className="text-[11px] text-fg-dim leading-relaxed">
+          <p className="text-2xs text-fg-dim leading-relaxed">
             Remove {provider.label}? Its API key is deleted from this computer.
           </p>
           <div className="flex gap-2">
@@ -366,7 +366,7 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
       {/* Inline result — green-ish tone for ok, destructive for a failure.
           Plain words only. */}
       {note && (
-        <p className={`text-[10px] mt-2 ${note.tone === 'ok' ? 'text-green-600' : 'text-red-500'}`}>
+        <p className={`text-3xs mt-2 ${note.tone === 'ok' ? 'text-green-600' : 'text-red-500'}`}>
           {note.text}
         </p>
       )}
@@ -374,7 +374,7 @@ function ProviderRow({ provider, onChanged }: { provider: ProviderStatus; onChan
       {/* Local engine install/status/restart controls moved to the Local Models
           section (Plan C) — the local row just points there now. */}
       {isLocal && (
-        <p className="text-[10px] text-fg-muted mt-2">Managed in Local Models below.</p>
+        <p className="text-3xs text-fg-muted mt-2">Managed in Local Models below.</p>
       )}
     </div>
   );
@@ -423,14 +423,14 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
 
   return (
     <div className="space-y-2 rounded-lg bg-inset border border-edge-dim p-3">
-      <h4 className="text-[10px] font-medium text-fg-muted uppercase tracking-wider">Add provider</h4>
+      <h4 className="text-3xs font-medium text-fg-muted uppercase tracking-wider">Add provider</h4>
 
       {/* Type — change 21: the native <select> is gone. A native option list is
           drawn by the OS, so a themed app dropped an OS-blue menu out of it;
           <Select> renders the list itself. The old <label htmlFor> can't point at
           a <button> trigger, so the name moves onto the control as aria-label. */}
       <div className="space-y-1">
-        <p className="text-[10px] text-fg-muted">Type</p>
+        <p className="text-3xs text-fg-muted">Type</p>
         <Select
           options={ADD_TYPE_SELECT_OPTIONS}
           value={type}
@@ -441,7 +441,7 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
 
       {/* Label */}
       <div className="space-y-1">
-        <label htmlFor="add-provider-label" className="text-[10px] text-fg-muted">Name</label>
+        <label htmlFor="add-provider-label" className="text-3xs text-fg-muted">Name</label>
         <TextInput
           id="add-provider-label"
           value={label}
@@ -454,7 +454,7 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
       {/* Base URL — custom endpoints only. */}
       {needsBaseUrl && (
         <div className="space-y-1">
-          <label htmlFor="add-provider-baseurl" className="text-[10px] text-fg-muted">Base URL</label>
+          <label htmlFor="add-provider-baseurl" className="text-3xs text-fg-muted">Base URL</label>
           <TextInput
             id="add-provider-baseurl"
             value={baseUrl}
@@ -467,7 +467,7 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
 
       {/* Optional key */}
       <div className="space-y-1">
-        <label htmlFor="add-provider-key" className="text-[10px] text-fg-muted">API key (optional)</label>
+        <label htmlFor="add-provider-key" className="text-3xs text-fg-muted">API key (optional)</label>
         <TextInput
           id="add-provider-key"
           type="password"
@@ -478,7 +478,7 @@ function AddProviderForm({ onDone, onCancel }: { onDone: () => Promise<void>; on
         />
       </div>
 
-      {error && <p className="text-[10px] text-destructive-fg">{error}</p>}
+      {error && <p className="text-3xs text-destructive-fg">{error}</p>}
 
       <div className="flex gap-2 pt-1">
         <Button variant="secondary" onClick={onCancel} className="flex-1 py-2">

--- a/desktop/src/renderer/components/QueuedMessagesStrip.tsx
+++ b/desktop/src/renderer/components/QueuedMessagesStrip.tsx
@@ -67,7 +67,7 @@ const QueuedMessagesStrip = React.forwardRef<HTMLDivElement, Props>(function Que
           key={q.queueId}
           className="layer-surface flex items-center gap-2 rounded-xl px-3 py-2 shadow-lg"
         >
-          <div className="text-[9px] uppercase tracking-wider text-fg-muted select-none shrink-0">
+          <div className="text-4xs uppercase tracking-wider text-fg-muted select-none shrink-0">
             Queued
           </div>
           <div className="flex-1 min-w-0 truncate text-sm text-fg-2">{q.content}</div>

--- a/desktop/src/renderer/components/QuickChips.tsx
+++ b/desktop/src/renderer/components/QuickChips.tsx
@@ -79,7 +79,7 @@ export default function QuickChips({ onChipTap }: Props) {
           <button
             key={chip.label}
             onClick={() => onChipTap(chip)}
-            className={`shrink-0 ${chipHeight} px-2.5 rounded-md bg-panel border border-edge-dim text-[11px] text-fg-2 hover:bg-inset hover:text-fg transition-colors`}
+            className={`shrink-0 ${chipHeight} px-2.5 rounded-md bg-panel border border-edge-dim text-2xs text-fg-2 hover:bg-inset hover:text-fg transition-colors`}
           >
             {chip.label}
           </button>
@@ -294,7 +294,7 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
                       onPointerDown={(e) => handlePointerDown(e, i)}
                       onPointerMove={handlePointerMove}
                       onPointerUp={handlePointerUp}
-                      className={`group/row flex items-center gap-2 px-2 py-1.5 rounded-md bg-well border border-edge-dim text-[11px] select-none touch-none ${
+                      className={`group/row flex items-center gap-2 px-2 py-1.5 rounded-md bg-well border border-edge-dim text-2xs select-none touch-none ${
                         isBeingDragged ? 'opacity-30' : ''
                       }`}
                       style={{
@@ -332,7 +332,7 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
             {chips.length < 10 && !showAddForm && (
               <button
                 onClick={() => setShowAddForm(true)}
-                className="w-full py-1.5 text-[11px] text-fg-muted border border-dashed border-edge-dim rounded-md hover:border-edge hover:text-fg transition-colors"
+                className="w-full py-1.5 text-2xs text-fg-muted border border-dashed border-edge-dim rounded-md hover:border-edge hover:text-fg transition-colors"
               >
                 + Add Chip
               </button>
@@ -371,7 +371,7 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
                     >
                       Add Custom
                     </Button>
-                    <button onClick={() => setShowAddForm(false)} className="px-2 py-1 text-[10px] text-fg-muted hover:text-fg">Cancel</button>
+                    <button onClick={() => setShowAddForm(false)} className="px-2 py-1 text-3xs text-fg-muted hover:text-fg">Cancel</button>
                   </div>
                 </div>
 
@@ -379,13 +379,13 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
                 {availableSkills.length > 0 && (
                   <>
                     <div className="border-t border-edge-dim" />
-                    <p className="text-[10px] text-fg-muted font-medium">Or pick from installed skills:</p>
+                    <p className="text-3xs text-fg-muted font-medium">Or pick from installed skills:</p>
                     <div ref={skillPickerRef} className="scroll-fade max-h-32 space-y-0.5">
                       {availableSkills.map(skill => (
                         <button
                           key={skill.id}
                           onClick={() => addFromSkill(skill)}
-                          className="w-full text-left px-2 py-1 text-[11px] text-fg-muted hover:text-fg hover:bg-well rounded-sm transition-colors"
+                          className="w-full text-left px-2 py-1 text-2xs text-fg-muted hover:text-fg hover:bg-well rounded-sm transition-colors"
                         >
                           {skill.displayName || skill.id}
                         </button>
@@ -397,7 +397,7 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
             )}
 
             {chips.length >= 10 && (
-              <p className="text-[10px] text-fg-muted text-center">Maximum 10 chips reached</p>
+              <p className="text-3xs text-fg-muted text-center">Maximum 10 chips reached</p>
             )}
           </div>
         </div>
@@ -430,7 +430,7 @@ function ChipEditorPopup({ open, chips, setChips, installed, onClose }: ChipEdit
           }}
         >
           <DragGrip />
-          <span className="text-[11px] font-medium text-fg whitespace-nowrap max-w-[180px] truncate">
+          <span className="text-2xs font-medium text-fg whitespace-nowrap max-w-[180px] truncate">
             {dragLabel}
           </span>
         </div>

--- a/desktop/src/renderer/components/RemoteUnsupportedNotice.tsx
+++ b/desktop/src/renderer/components/RemoteUnsupportedNotice.tsx
@@ -43,7 +43,7 @@ export default function RemoteUnsupportedNotice() {
       aria-live="polite"
       // Bottom-center, above the input chrome. --vvp-offset keeps it clear of
       // the soft keyboard on a phone, the same way .jump-to-bottom does.
-      className="fixed left-1/2 -translate-x-1/2 z-[9500] max-w-[min(28rem,calc(100vw-2rem))] px-3 py-2 rounded-lg bg-panel border border-edge shadow-lg text-[13px] text-fg-2 flex items-start gap-2"
+      className="fixed left-1/2 -translate-x-1/2 z-[9500] max-w-[min(28rem,calc(100vw-2rem))] px-3 py-2 rounded-lg bg-panel border border-edge shadow-lg text-sm-tight text-fg-2 flex items-start gap-2"
       style={{ bottom: `calc(var(--bottom-chrome-height, 5rem) + var(--vvp-offset, 0px) + 0.75rem)` }}
     >
       <span className="shrink-0 mt-0.5 text-fg-muted" aria-hidden>

--- a/desktop/src/renderer/components/ResumeBrowser.tsx
+++ b/desktop/src/renderer/components/ResumeBrowser.tsx
@@ -87,7 +87,7 @@ function FilterPill({
       aria-pressed={active}
       aria-haspopup={hasPopup ? 'listbox' : undefined}
       aria-expanded={hasPopup ? !!expanded : undefined}
-      className={`px-2.5 py-1 rounded-full text-[11px] flex items-center gap-1.5 transition-colors duration-75 ${
+      className={`px-2.5 py-1 rounded-full text-2xs flex items-center gap-1.5 transition-colors duration-75 ${
         active
           ? 'bg-accent/10 border border-accent/40 text-fg'
           : 'bg-inset border border-edge-dim text-fg-muted hover:text-fg'
@@ -520,13 +520,13 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
           <>
             {/* Model selector */}
             <div>
-              <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
+              <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
               <div className="flex gap-1">
                 {MODELS.map((m) => (
                   <button
                     key={m}
                     onClick={() => setResumeModel(m)}
-                    className={`flex-1 px-1 py-1 rounded-sm text-[10px] transition-colors ${
+                    className={`flex-1 px-1 py-1 rounded-sm text-3xs transition-colors ${
                       resumeModel === m
                         ? 'bg-accent text-on-accent font-medium'
                         : 'bg-inset text-fg-dim hover:bg-edge'
@@ -540,7 +540,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
 
             {/* Skip Permissions */}
             <div className="flex items-center justify-between">
-              <label className="text-[10px] uppercase tracking-wider text-fg-muted inline-flex items-center">
+              <label className="text-3xs uppercase tracking-wider text-fg-muted inline-flex items-center">
                 Skip Permissions
                 <SkipPermissionsInfoTooltip />
               </label>
@@ -559,12 +559,12 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 the same token as the toggle beside it, so a community theme
                 restyling its red doesn't leave the two out of sync. */}
             {resumeDangerous && (
-              <p className="text-[10px] text-destructive-fg">Claude will execute tools without asking for approval.</p>
+              <p className="text-3xs text-destructive-fg">Claude will execute tools without asking for approval.</p>
             )}
           </>
         ) : (
           <div>
-            <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
+            <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
             {/* Task 6 — native resume ALWAYS offers this selector (never
                 auto-launches a binding). Prefilled from the conversation's
                 synced lastUsedModel when it matches a model available on
@@ -583,7 +583,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
         {/* Launch in new window — hidden on remote/Android (single-window) */}
         {detachAvailable && (
           <div className="flex items-center justify-between">
-            <label className="text-[10px] uppercase tracking-wider text-fg-muted">Launch in New Window</label>
+            <label className="text-3xs uppercase tracking-wider text-fg-muted">Launch in New Window</label>
             {/* Shared Toggle (change 15) — same accent on-state as before. */}
             <Toggle
               checked={resumeLaunchInNewWindow}
@@ -601,7 +601,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
         <>
           {/* Reserved flags — Priority pins to top; Complete hides from the menu. */}
           <div>
-            <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Flags</label>
+            <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Flags</label>
             <div className="flex gap-1">
               {FLAG_ORDER.map((flag) => {
                 const active = !!s.flags?.[flag];
@@ -609,7 +609,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                   <button
                     key={flag}
                     onClick={(e) => { e.stopPropagation(); toggleFlag(s.sessionId, flag, !active); }}
-                    className={`flex-1 px-1 py-1 rounded-sm text-[10px] transition-colors ${
+                    className={`flex-1 px-1 py-1 rounded-sm text-3xs transition-colors ${
                       active ? 'bg-accent text-on-accent font-medium' : 'bg-inset text-fg-dim hover:bg-edge'
                     }`}
                     aria-pressed={active}
@@ -623,7 +623,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
 
           {/* Custom tags — stopPropagation so interacting doesn't collapse the row. */}
           <div onClick={(e) => e.stopPropagation()}>
-            <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Tags</label>
+            <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Tags</label>
             <TagPicker
               appliedIds={new Set(s.tags ?? [])}
               onToggle={(tagId, next) => toggleTag(s.sessionId, tagId, next)}
@@ -633,7 +633,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
 
           {/* Note — stopPropagation so editing doesn't collapse the row. */}
           <div onClick={(e) => e.stopPropagation()}>
-            <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Note</label>
+            <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Note</label>
             <NoteEditor value={s.note ?? ''} onSave={(text) => saveNote(s.sessionId, text)} />
           </div>
         </>
@@ -690,7 +690,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 word, no glyph; distinguishes them from Claude Code transcripts. */}
             {s.provider === 'native' && (
               <span
-                className="text-[9px] px-1.5 py-0.5 rounded bg-inset text-fg-muted shrink-0"
+                className="text-4xs px-1.5 py-0.5 rounded bg-inset text-fg-muted shrink-0"
                 title="YouCoded native session"
               >YouCoded</span>
             )}
@@ -698,7 +698,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 as. Legacy 'chat' (and any unknown id) falls back to Assistant. */}
             {s.provider === 'native' && (
               <span
-                className="text-[9px] px-1.5 py-0.5 rounded bg-inset text-fg-muted shrink-0"
+                className="text-4xs px-1.5 py-0.5 rounded bg-inset text-fg-muted shrink-0"
                 title="YouCoded native session"
               >{s.harnessId === 'coder' ? 'Coder' : 'Assistant'}</span>
             )}
@@ -707,13 +707,13 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
           {/* Reserved-flag indicators + custom-tag chips, AFTER the name. */}
           {(s.flags?.priority || s.flags?.complete || (s.tags && s.tags.length > 0) || s.note) && (
             <div className="flex items-center gap-1 mt-0.5 flex-wrap">
-              {s.flags?.priority && <span className="text-[9px] text-accent" title="Priority">Priority</span>}
-              {s.flags?.complete && <span className="text-[9px] text-fg-muted" title="Complete">Complete</span>}
+              {s.flags?.priority && <span className="text-4xs text-accent" title="Priority">Priority</span>}
+              {s.flags?.complete && <span className="text-4xs text-fg-muted" title="Complete">Complete</span>}
               {(s.tags ?? []).map((id) => {
                 const t = registry.byId.get(id);
                 return t ? <TagChip key={id} tag={t} /> : null;
               })}
-              {s.note && <span className="text-[9px] text-fg-muted" title={s.note}>📝 note</span>}
+              {s.note && <span className="text-4xs text-fg-muted" title={s.note}>📝 note</span>}
             </div>
           )}
           {/* Second line: in flat (chronological) mode each row carries its
@@ -724,18 +724,18 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
             // Plain words, no glyphs (house rule). The conversation is visible
             // everywhere; resume needs the project folder AND its transcript
             // present on this device — the two notes say which one is missing.
-            <div className="text-[10px] text-fg-muted truncate">
+            <div className="text-3xs text-fg-muted truncate">
               {s.notSyncedYet ? 'Not synced to this device yet' : 'Project folder not on this device'}
             </div>
           ) : (
-            <div className="text-[10px] text-fg-muted truncate">
+            <div className="text-3xs text-fg-muted truncate">
               {showPath
                 ? `${s.projectPath.replace(/\\/g, '/').split('/').pop()} · ${formatSize(s.size)}`
                 : formatSize(s.size)}
             </div>
           )}
         </div>
-        <span className="text-[10px] text-fg-muted shrink-0">
+        <span className="text-3xs text-fg-muted shrink-0">
           {formatRelativeTime(s.lastModified)}
         </span>
       </button>
@@ -761,7 +761,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
               {/* Show Complete — same toggle pattern as Skip Permissions
                   in SessionStrip, but accent-colored to signal "on" rather than "danger". */}
               <div className="flex items-center gap-2">
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted">Show Complete</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted">Show Complete</label>
                 {/* Shared Toggle (change 15). role="switch" + aria-checked comes
                     from the primitive, which is strictly better than the
                     aria-pressed this used to carry. */}
@@ -810,7 +810,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 }}
               >
                 <span>{projectsLabel}</span>
-                <span className="text-fg-faint text-[9px]">▾</span>
+                <span className="text-fg-faint text-4xs">▾</span>
               </FilterPill>
               {openPill === 'projects' && projectsDropdownPos && createPortal(
                 <div
@@ -830,7 +830,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                   <button
                     type="button"
                     onClick={() => setSelectedProjects(new Set())}
-                    className="w-full text-left px-2.5 py-1.5 text-[11px] uppercase tracking-wider text-fg-muted hover:text-fg hover:bg-inset transition-colors"
+                    className="w-full text-left px-2.5 py-1.5 text-2xs uppercase tracking-wider text-fg-muted hover:text-fg hover:bg-inset transition-colors"
                   >
                     Clear
                   </button>
@@ -853,7 +853,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                         >
                           <span className={`w-3 h-3 shrink-0 rounded-sm border ${checked ? 'bg-accent border-accent' : 'border-edge'}`} />
                           <span className="flex-1 truncate" title={p.path}>{p.label}</span>
-                          <span className="text-[10px] text-fg-muted shrink-0">{p.count}</span>
+                          <span className="text-3xs text-fg-muted shrink-0">{p.count}</span>
                         </button>
                       );
                     })}
@@ -876,7 +876,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 }}
               >
                 <span>{selectedTagIds.size === 0 ? 'Tags' : `${selectedTagIds.size} tag${selectedTagIds.size > 1 ? 's' : ''}`}</span>
-                <span className="text-fg-faint text-[9px]">▾</span>
+                <span className="text-fg-faint text-4xs">▾</span>
               </FilterPill>
               {openPill === 'tags' && tagsDropdownPos && createPortal(
                 <div
@@ -939,7 +939,7 @@ export default function ResumeBrowser({ open, onClose, onResume, defaultModel, d
                 [...grouped.entries()].map(([projectPath, items]) => (
                   <div key={projectPath} className="mb-2">
                     <div className="px-4 py-1">
-                      <span className="text-[10px] uppercase tracking-wider text-fg-muted">
+                      <span className="text-3xs uppercase tracking-wider text-fg-muted">
                         {projectPath.replace(/\\/g, '/').split('/').pop() || projectPath}
                       </span>
                     </div>

--- a/desktop/src/renderer/components/RuntimeBinding.tsx
+++ b/desktop/src/renderer/components/RuntimeBinding.tsx
@@ -224,7 +224,7 @@ export function RuntimeBindingFields({
   return (
     <>
       <div>
-        <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Runtime</label>
+        <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Runtime</label>
         <div className="inline-flex rounded border border-edge overflow-hidden">
           <button
             type="button"
@@ -246,11 +246,11 @@ export function RuntimeBindingFields({
       {runtime === 'native' && (
         <div className="flex flex-col gap-2">
           {nb.readyProviders.length === 0 ? (
-            <p className="text-[10px] text-fg-muted">Add a provider key in Settings → Model Providers first.</p>
+            <p className="text-3xs text-fg-muted">Add a provider key in Settings → Model Providers first.</p>
           ) : (
             <>
               <div>
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Provider</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Provider</label>
                 {/* Change 21: no native <select> — its option list is drawn by the
                     OS, so a themed app dropped an OS-blue menu out of it. The
                     <label> above is not associated (it never had an htmlFor), so
@@ -270,7 +270,7 @@ export function RuntimeBindingFields({
                 />
               </div>
               <div>
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
                 {nb.needsFreeformModel ? (
                   <TextInput
                     type="text"
@@ -302,7 +302,7 @@ export function RuntimeBindingFields({
                   the full tool suite; they differ in prompt + starting permission
                   posture. Stamped at create; drives the resolved harnessId. */}
               <div>
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Preset</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Preset</label>
                 <div className="flex gap-2">
                   {PRESETS.map((p) => (
                     <button
@@ -313,7 +313,7 @@ export function RuntimeBindingFields({
                       className={`flex-1 text-left rounded border px-2 py-1.5 ${preset === p.id ? 'border-accent bg-inset' : 'border-edge bg-panel hover:bg-inset'}`}
                     >
                       <div className="text-xs text-fg">{p.name}</div>
-                      <div className="text-[10px] text-fg-muted leading-snug">{p.description}</div>
+                      <div className="text-3xs text-fg-muted leading-snug">{p.description}</div>
                     </button>
                   ))}
                 </div>
@@ -324,7 +324,7 @@ export function RuntimeBindingFields({
                   local-engine models only. */}
               {nb.memVerdict && nb.memVerdict.verdict !== 'ok' && (
                 <div
-                  className={`text-[11px] rounded-sm px-2 py-1.5 border ${
+                  className={`text-2xs rounded-sm px-2 py-1.5 border ${
                     nb.memVerdict.verdict === 'too-large'
                       ? 'border-[var(--destructive)] text-fg-2'
                       : 'border-edge bg-well text-fg-dim'

--- a/desktop/src/renderer/components/SessionDrawer.tsx
+++ b/desktop/src/renderer/components/SessionDrawer.tsx
@@ -472,7 +472,7 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
         {/* A pill click that couldn't resolve — shown INSTEAD of letting the
             generic empty state contradict the file the user just clicked. */}
         {pillError && (
-          <div className="mx-2 mt-2 px-2.5 py-2 text-[11px] text-fg rounded-md border border-edge bg-well">
+          <div className="mx-2 mt-2 px-2.5 py-2 text-2xs text-fg rounded-md border border-edge bg-well">
             {pillError}
           </div>
         )}
@@ -634,13 +634,13 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
                 onChange={(e) => { setRenameDraft(e.target.value); if (renameError) setRenameError(null); }}
                 onBlur={() => commitRename(false)}
                 onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commitRename(true); } }}
-                className="bg-canvas text-fg text-[13px] font-semibold px-2 py-1 w-[150px] outline-none"
+                className="bg-canvas text-fg text-sm-tight font-semibold px-2 py-1 w-[150px] outline-none"
               />
-              <span className="text-[12px] text-fg-muted font-mono px-2">{extOf(fileName)}</span>
+              <span className="text-xs text-fg-muted font-mono px-2">{extOf(fileName)}</span>
             </span>
             {/* Inline failure note — keeps the field open so the user can correct it. */}
             {renameError && (
-              <span className="absolute left-1 top-full mt-1 text-[11px] text-destructive-fg whitespace-nowrap z-10">
+              <span className="absolute left-1 top-full mt-1 text-2xs text-destructive-fg whitespace-nowrap z-10">
                 {renameError}
               </span>
             )}
@@ -652,7 +652,7 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
             title="Click to rename"
             className="group flex items-center gap-1.5 min-w-0 px-2 py-1 rounded-md cursor-text hover:bg-well transition-colors"
           >
-            <span className="text-[13px] font-semibold text-fg truncate decoration-dotted underline-offset-[3px] group-hover:underline group-hover:decoration-fg-muted">
+            <span className="text-sm-tight font-semibold text-fg truncate decoration-dotted underline-offset-[3px] group-hover:underline group-hover:decoration-fg-muted">
               {fileName}
             </span>
             <span className="text-fg-muted opacity-0 group-hover:opacity-100 shrink-0"><Ic name="pencil" size={12} /></span>
@@ -771,7 +771,7 @@ export function SessionDrawer({ sessionId, projectRoot, projectId, projectName }
               {/* metadata strip — bottom of the DOC column (not a full-width row up
                   top), so it shares the document's width and expands/shrinks with
                   the artifact list (Destin, 2026-07-22). */}
-              <div className="flex items-center gap-2 px-3.5 py-1 text-[11px] text-fg-muted border-t border-edge-dim bg-well shrink-0">
+              <div className="flex items-center gap-2 px-3.5 py-1 text-2xs text-fg-muted border-t border-edge-dim bg-well shrink-0">
                 {/* WHY: status shown as a word, not a ●◐○ glyph (user-disliked — see dislikes-status-glyphs memory). */}
                 <span>{statusWord}</span>
                 <span className="text-fg-faint">·</span>
@@ -815,7 +815,7 @@ export function GitFooterEntry({
         type="button"
         onClick={onOpenReview}
         title="Review this file's changes"
-        className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] text-fg-dim hover:text-fg hover:bg-inset transition-colors"
+        className="flex items-center gap-1 px-2 py-0.5 rounded-md text-2xs text-fg-dim hover:text-fg hover:bg-inset transition-colors"
       >
         Review Changes <Ic name="forward" size={11} />
       </button>
@@ -857,7 +857,7 @@ function ArtifactListItem({ artifact, isActive, isDeleted, onSelect, onRemove }:
           <span className={`font-mono text-xs truncate flex-1 ${isDeleted ? 'line-through' : ''}`}>{fileName}</span>
         </div>
         {/* WHY: status shown as a word, not a ●◐○ glyph (user-disliked — see dislikes-status-glyphs memory). */}
-        <div className="text-[10px] text-fg-muted ml-0.5">{statusWord} · {relTime}</div>
+        <div className="text-3xs text-fg-muted ml-0.5">{statusWord} · {relTime}</div>
       </button>
       {onRemove && (
         <CloseButton

--- a/desktop/src/renderer/components/SessionStrip.tsx
+++ b/desktop/src/renderer/components/SessionStrip.tsx
@@ -801,7 +801,7 @@ export default function SessionStrip({
                     never clutters a collapsed dot-only pill. */}
                 {s.provider === 'native' && showName && (
                   <span
-                    className="shrink-0 text-[9px] px-1 py-0.5 rounded bg-inset text-fg-muted whitespace-nowrap"
+                    className="shrink-0 text-4xs px-1 py-0.5 rounded bg-inset text-fg-muted whitespace-nowrap"
                     title="YouCoded native session"
                   >
                     {`YouCoded · ${s.harnessId === 'coder' ? 'Coder' : 'Assistant'}`}
@@ -818,7 +818,7 @@ export default function SessionStrip({
         {sessions.length - visibleSessions.length > 0 && (
           <button
             onClick={handleMenuToggle}
-            className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 ml-1 rounded-full bg-inset text-fg-2 text-[10px] font-semibold leading-none hover:bg-well transition-colors"
+            className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 ml-1 rounded-full bg-inset text-fg-2 text-3xs font-semibold leading-none hover:bg-well transition-colors"
             title={`${sessions.length - visibleSessions.length} more session${sessions.length - visibleSessions.length === 1 ? '' : 's'}`}
             aria-label={`${sessions.length - visibleSessions.length} more sessions`}
           >
@@ -867,7 +867,7 @@ export default function SessionStrip({
           {/* Android only ever has one window, so the "in this window" scoping label is meaningless there */}
           {sessions.length > 0 && !isAndroid() && (
             <>
-              <div className="px-3 pt-1.5 text-[10px] uppercase tracking-wider text-fg-muted">
+              <div className="px-3 pt-1.5 text-3xs uppercase tracking-wider text-fg-muted">
                 Sessions in this window
               </div>
             </>
@@ -915,11 +915,11 @@ export default function SessionStrip({
                       <SessionName name={s.name} />
                       <span className="shrink-0 flex flex-col items-end gap-0.5 ml-auto">
                         {s.permissionMode === 'bypass' && (
-                          <span className="text-[9px] font-medium px-1 py-0.5 rounded-sm bg-[#DD4444]/20 text-[#DD4444]">
+                          <span className="text-4xs font-medium px-1 py-0.5 rounded-sm bg-[#DD4444]/20 text-[#DD4444]">
                             DANGER
                           </span>
                         )}
-                        <span className="text-[10px] text-fg-muted whitespace-nowrap">
+                        <span className="text-3xs text-fg-muted whitespace-nowrap">
                           {s.cwd.replace(/\\/g, '/').split('/').pop()}
                         </span>
                       </span>
@@ -963,7 +963,7 @@ export default function SessionStrip({
             return (
               <>
                 <div className="border-t border-edge" />
-                <div className="px-3 pt-1.5 text-[10px] uppercase tracking-wider text-fg-muted">
+                <div className="px-3 pt-1.5 text-3xs uppercase tracking-wider text-fg-muted">
                   Sessions in other windows
                 </div>
                 <div className="py-1">
@@ -981,7 +981,7 @@ export default function SessionStrip({
                         >
                           <SessionDot color={color} isActive={false} />
                           <SessionName name={s.name} />
-                          <span className="ml-auto shrink-0 text-[10px] text-fg-muted whitespace-nowrap flex items-center gap-1">
+                          <span className="ml-auto shrink-0 text-3xs text-fg-muted whitespace-nowrap flex items-center gap-1">
                             <span>→</span>
                             <span>{g.label}</span>
                           </span>
@@ -999,7 +999,7 @@ export default function SessionStrip({
           {showNewForm ? (
             <div className="p-3 flex flex-col gap-2 rounded-b-lg overflow-hidden">
               <div>
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Project Folder</label>
+                <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Project Folder</label>
                 <FolderSwitcher
                   value={newCwd}
                   onChange={setNewCwd}
@@ -1022,13 +1022,13 @@ export default function SessionStrip({
                   which chooses a model via the provider/model binding picker above. */}
               {runtime !== 'native' && (
                 <div>
-                  <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
+                  <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Model</label>
                   <div className="flex gap-1">
                     {MODELS.map((m) => (
                       <button
                         key={m}
                         onClick={() => setNewModel(m)}
-                        className={`flex-1 px-1 py-1 rounded-sm text-[10px] transition-colors flex items-center justify-center ${
+                        className={`flex-1 px-1 py-1 rounded-sm text-3xs transition-colors flex items-center justify-center ${
                           newModel === m
                             ? 'bg-accent text-on-accent font-medium'
                             : 'bg-inset text-fg-dim hover:bg-edge'
@@ -1043,7 +1043,7 @@ export default function SessionStrip({
               )}
               {/* Skip Permissions */}
               <div className="flex items-center justify-between">
-                <label className="text-[10px] uppercase tracking-wider text-fg-muted inline-flex items-center">
+                <label className="text-3xs uppercase tracking-wider text-fg-muted inline-flex items-center">
                   Skip Permissions
                   <SkipPermissionsInfoTooltip />
                 </label>
@@ -1062,12 +1062,12 @@ export default function SessionStrip({
                   the same token as the toggle beside it, so a community theme
                   restyling its red doesn't leave the two out of sync. */}
               {dangerous && (
-                <p className="text-[10px] text-destructive-fg">Claude will execute tools without asking for approval.</p>
+                <p className="text-3xs text-destructive-fg">Claude will execute tools without asking for approval.</p>
               )}
               {/* Launch in new window — hidden on platforms without multi-window support */}
               {detachAvailable && (
                 <div className="flex items-center justify-between">
-                  <label className="text-[10px] uppercase tracking-wider text-fg-muted">Launch in New Window</label>
+                  <label className="text-3xs uppercase tracking-wider text-fg-muted">Launch in New Window</label>
                   {/* Shared Toggle (change 15) — same accent on-state as before. */}
                   <Toggle
                     checked={launchInNewWindow}

--- a/desktop/src/renderer/components/SettingsExplainer.tsx
+++ b/desktop/src/renderer/components/SettingsExplainer.tsx
@@ -73,7 +73,7 @@ export default function SettingsExplainer({ title, intro, sections, onBack, onCl
 
         {sections.map((section, i) => (
           <section key={i}>
-            <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">
+            <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">
               {section.heading}
             </h3>
             {section.paragraphs?.map((p, j) => (

--- a/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/components/SettingsPanel.tsx
@@ -175,8 +175,8 @@ function ShortcutsPopup({ open, onClose }: { open: boolean; onClose: () => void 
         <div className="space-y-1.5">
           {SHORTCUTS.map(({ keys, description }) => (
             <div key={keys} className="flex items-center justify-between gap-3 py-1.5">
-              <span className="text-[11px] text-fg-dim">{description}</span>
-              <kbd className="shrink-0 text-[10px] font-mono text-fg-2 bg-inset border border-edge-dim rounded px-1.5 py-0.5">{keys}</kbd>
+              <span className="text-2xs text-fg-dim">{description}</span>
+              <kbd className="shrink-0 text-3xs font-mono text-fg-2 bg-inset border border-edge-dim rounded px-1.5 py-0.5">{keys}</kbd>
             </div>
           ))}
         </div>
@@ -340,7 +340,7 @@ function PresetSelector({ category, selectedId, onSelect, customName }: {
         <button
           key={p.id}
           onClick={() => { onSelect(p.id); playPreview(p.id); }}
-          className={`px-2 py-1 rounded text-[10px] transition-colors ${
+          className={`px-2 py-1 rounded text-3xs transition-colors ${
             selectedId === p.id
               ? 'bg-accent text-on-accent font-medium'
               : 'bg-inset text-fg-dim hover:bg-edge'
@@ -353,7 +353,7 @@ function PresetSelector({ category, selectedId, onSelect, customName }: {
       {customName ? (
         <button
           onClick={() => { onSelect(CUSTOM_SOUND_ID); playPreview(CUSTOM_SOUND_ID, category); }}
-          className={`px-2 py-1 rounded text-[10px] transition-colors ${
+          className={`px-2 py-1 rounded text-3xs transition-colors ${
             selectedId === CUSTOM_SOUND_ID
               ? 'bg-accent text-on-accent font-medium'
               : 'bg-inset text-fg-dim hover:bg-edge'
@@ -429,7 +429,7 @@ function SoundCategorySection({ category, label, description, dotColor }: {
         </div>
         <Toggle enabled={enabled} onToggle={handleToggle} label={label} />
       </div>
-      <p className="text-[10px] text-fg-muted mb-2">{description}</p>
+      <p className="text-3xs text-fg-muted mb-2">{description}</p>
       {enabled && (
         <>
           <PresetSelector
@@ -547,7 +547,7 @@ function SoundButton() {
                 <div className="px-4 py-4 space-y-5">
                 {/* Master volume */}
                 <section>
-                  <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Volume</h3>
+                  <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Volume</h3>
                   <div className="flex items-center gap-3">
                     {/* Mute toggle */}
                     <button onClick={handleToggleMute} className="text-fg-muted hover:text-fg shrink-0">
@@ -575,7 +575,7 @@ function SoundButton() {
                       onChange={handleVolumeChange}
                       className="flex-1 h-1 accent-accent"
                     />
-                    <span className="text-[10px] text-fg-muted w-8 text-right">{Math.round(volume * 100)}%</span>
+                    <span className="text-3xs text-fg-muted w-8 text-right">{Math.round(volume * 100)}%</span>
                   </div>
                 </section>
 
@@ -821,9 +821,9 @@ function BuddyButton() {
                 <span className="text-xs text-fg font-medium">Show buddy floater</span>
                 <Toggle enabled={enabled} onToggle={toggle} label="Show buddy floater" />
               </div>
-              <p className="text-[10px] text-fg-muted mt-2">A small always-on-top mascot that stays visible even when the app is minimized.</p>
+              <p className="text-3xs text-fg-muted mt-2">A small always-on-top mascot that stays visible even when the app is minimized.</p>
               {enabled && dismissed && (
-                <p className="text-[10px] text-fg-muted mt-2">
+                <p className="text-3xs text-fg-muted mt-2">
                   Hidden until restart{' · '}
                   <button onClick={showNow} className="text-accent hover:underline">Show now</button>
                 </p>
@@ -835,12 +835,12 @@ function BuddyButton() {
                 <div className="flex items-center justify-between mt-3 pt-3 border-t border-edge">
                   <div>
                     <span className="text-xs text-fg font-medium block">Pin buddy above other windows (KDE only)</span>
-                    <p className="text-[10px] text-fg-muted mt-1">Requires KDE Plasma. No effect on other desktops.</p>
+                    <p className="text-3xs text-fg-muted mt-1">Requires KDE Plasma. No effect on other desktops.</p>
                     {/* Honest, non-committal per-action feedback — NOT the toggle's
                         own state (that's the preference, above). Only appears right
                         after a click that couldn't reach KWin; see toggleKeepAbove. */}
                     {keepAboveHint && (
-                      <p className="text-[10px] text-fg-muted mt-1">{keepAboveHint}</p>
+                      <p className="text-3xs text-fg-muted mt-1">{keepAboveHint}</p>
                     )}
                   </div>
                   <Toggle enabled={keepAboveEnabled} onToggle={toggleKeepAbove} label="Pin buddy above other windows" />
@@ -993,14 +993,14 @@ function RemoteButton({
                             <div className="mt-2">
                               {/* Remind users that Tailscale must be installed + running on the receiving device too */}
                               <div className="bg-amber-500/10 border border-amber-500/25 rounded-md px-2.5 py-2 mb-2">
-                                <p className="text-[10px] text-amber-400 font-medium mb-0.5">Before scanning:</p>
-                                <p className="text-[10px] text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running. The page won't load without it.</p>
+                                <p className="text-3xs text-amber-400 font-medium mb-0.5">Before scanning:</p>
+                                <p className="text-3xs text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running. The page won't load without it.</p>
                               </div>
-                              <p className="text-[10px] text-fg-muted mb-2">Then scan to connect:</p>
+                              <p className="text-3xs text-fg-muted mb-2">Then scan to connect:</p>
                               <div className="flex justify-center bg-white rounded-lg p-3 w-fit mx-auto">
                                 <QRCodeSVG value={tailscale.url} size={140} />
                               </div>
-                              <p className="text-[10px] text-fg-muted mt-2 text-center font-mono">{tailscale.url}</p>
+                              <p className="text-3xs text-fg-muted mt-2 text-center font-mono">{tailscale.url}</p>
                               <Button variant="secondary" size="sm" onClick={onCopyLink} className="w-full mt-2">
                                 {copied ? 'Copied!' : 'Copy link'}
                               </Button>
@@ -1009,8 +1009,8 @@ function RemoteButton({
                             <div className="space-y-2">
                               {/* Persistent reminder — visible whenever Tailscale is ready but no device has connected yet */}
                               <div className="bg-amber-500/10 border border-amber-500/25 rounded-md px-2.5 py-2">
-                                <p className="text-[10px] text-amber-400 font-medium mb-0.5">Other device setup required:</p>
-                                <p className="text-[10px] text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running before scanning. The page won't load without it.</p>
+                                <p className="text-3xs text-amber-400 font-medium mb-0.5">Other device setup required:</p>
+                                <p className="text-3xs text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running before scanning. The page won't load without it.</p>
                               </div>
                               {/* Was bg-blue-600 with NO text-color class, so the
                                   label inherited the theme fg — near-black on blue
@@ -1022,7 +1022,7 @@ function RemoteButton({
                           )
                         ) : setupStatus === 'confirm' ? (
                           <div className="space-y-2">
-                            <p className="text-[10px] text-fg-2 text-center">This will download and install Tailscale (~50MB) for secure remote access.</p>
+                            <p className="text-3xs text-fg-2 text-center">This will download and install Tailscale (~50MB) for secure remote access.</p>
                             <div className="flex gap-2">
                               <Button variant="secondary" onClick={onCancelSetup} className="flex-1">Cancel</Button>
                               <Button onClick={onConfirmSetup} className="flex-1">Install</Button>
@@ -1031,12 +1031,12 @@ function RemoteButton({
                         ) : setupStatus === 'installing' ? (
                           <div className="text-center py-1">
                             <p className="text-xs text-fg-2 animate-pulse">Installing Tailscale...</p>
-                            <p className="text-[10px] text-fg-muted mt-1">This may take a few minutes</p>
+                            <p className="text-3xs text-fg-muted mt-1">This may take a few minutes</p>
                           </div>
                         ) : setupStatus === 'authenticating' ? (
                           <div className="text-center py-1">
                             <p className="text-xs text-fg-2 animate-pulse">Authenticating...</p>
-                            <p className="text-[10px] text-fg-muted mt-1">Check your browser to sign in to Tailscale</p>
+                            <p className="text-3xs text-fg-muted mt-1">Check your browser to sign in to Tailscale</p>
                           </div>
                         ) : setupStatus === 'done' ? (
                           <p className="text-xs text-green-400 text-center py-1">Tailscale installed and connected!</p>
@@ -1048,13 +1048,13 @@ function RemoteButton({
                         ) : tailscale?.installed && !tailscale.connected ? (
                           // Fix: Tailscale is installed but VPN is off — tailscale.url is null in this state,
                           // so we used to fall through to the install-button branch and pretend it wasn't installed.
-                          <p className="text-[11px] text-fg-2 text-center py-1">
+                          <p className="text-2xs text-fg-2 text-center py-1">
                             Tailscale is installed, but the VPN isn't active. Open the Tailscale app and turn it on, then come back here.
                           </p>
                         ) : tailscale?.installed && !config?.hasPassword ? (
                           // Installed + connected but no password yet — guide the user down to the password field
                           // rather than re-prompting to install.
-                          <p className="text-[11px] text-fg-2 text-center py-1">
+                          <p className="text-2xs text-fg-2 text-center py-1">
                             Set a password below to finish enabling remote access.
                           </p>
                         ) : (
@@ -1067,7 +1067,7 @@ function RemoteButton({
 
                     {/* Server settings */}
                     <section>
-                      <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Server</h3>
+                      <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Server</h3>
 
                       <label className="flex items-center justify-between py-2 cursor-pointer">
                         <span className="text-xs text-fg-2">Enabled</span>
@@ -1077,14 +1077,14 @@ function RemoteButton({
                           (port already bound, permission denied). Show the real
                           reason here — the toggle has already snapped back off. */}
                       {enableError && (
-                        <p className="text-[11px] text-destructive-fg pb-2">{enableError}</p>
+                        <p className="text-2xs text-destructive-fg pb-2">{enableError}</p>
                       )}
 
                       <div className="py-2">
                         <div className="flex items-center justify-between mb-1">
                           <span className="text-xs text-fg-2">Password</span>
                           {config?.hasPassword && (
-                            <span className="text-[10px] text-green-400">Set</span>
+                            <span className="text-3xs text-green-400">Set</span>
                           )}
                         </div>
                         {/* The Set button moves INSIDE the field (change 77): this is a
@@ -1120,7 +1120,7 @@ function RemoteButton({
                             <button
                               key={opt.value}
                               onClick={() => onSetKeepAwake(opt.value)}
-                              className={`flex-1 px-1.5 py-1 rounded-sm text-[10px] transition-colors ${
+                              className={`flex-1 px-1.5 py-1 rounded-sm text-3xs transition-colors ${
                                 config?.keepAwakeHours === opt.value
                                   ? 'bg-accent text-on-accent font-medium'
                                   : 'bg-inset text-fg-dim hover:bg-edge'
@@ -1154,14 +1154,14 @@ function RemoteButton({
                     {/* Remote Clients section */}
                     {hasClients && (
                       <section>
-                        <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Connected Devices</h3>
+                        <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Connected Devices</h3>
 
                         <div className="space-y-1">
                           {clients.map(client => (
                             <div key={client.id} className="flex items-center justify-between py-1.5 px-2 rounded-sm bg-inset/50">
                               <div>
                                 <span className="text-xs text-fg-2 font-mono">{client.ip}</span>
-                                <span className="text-[10px] text-fg-muted ml-2">{timeAgo(client.connectedAt)}</span>
+                                <span className="text-3xs text-fg-muted ml-2">{timeAgo(client.connectedAt)}</span>
                               </div>
                               <button
                                 onClick={() => onDisconnectClient(client.id)}
@@ -1190,14 +1190,14 @@ function RemoteButton({
                         </div>
                         {/* Remind users that Tailscale must be installed + running on the receiving device too */}
                         <div className="bg-amber-500/10 border border-amber-500/25 rounded-md px-2.5 py-2 mb-2">
-                          <p className="text-[10px] text-amber-400 font-medium mb-0.5">Before scanning:</p>
-                          <p className="text-[10px] text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running. The page won't load without it.</p>
+                          <p className="text-3xs text-amber-400 font-medium mb-0.5">Before scanning:</p>
+                          <p className="text-3xs text-fg-muted">Download Tailscale on your other device, sign in to the same account, and make sure it's running. The page won't load without it.</p>
                         </div>
-                        <p className="text-[10px] text-fg-muted mb-2">Then scan QR or copy link to connect:</p>
+                        <p className="text-3xs text-fg-muted mb-2">Then scan QR or copy link to connect:</p>
                         <div className="flex justify-center bg-white rounded-lg p-3 w-fit mx-auto">
                           <QRCodeSVG value={tailscale.url} size={140} />
                         </div>
-                        <p className="text-[10px] text-fg-muted mt-2 text-center font-mono">{tailscale.url}</p>
+                        <p className="text-3xs text-fg-muted mt-2 text-center font-mono">{tailscale.url}</p>
                         <Button variant="secondary" onClick={onCopyLink} className="w-full mt-2">
                           {copied ? 'Copied!' : 'Copy Link'}
                         </Button>
@@ -1206,7 +1206,7 @@ function RemoteButton({
 
                     {/* Tailscale section */}
                     <section>
-                      <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Tailscale</h3>
+                      <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Tailscale</h3>
 
                       {tailscale?.installed ? (
                         <>
@@ -1215,11 +1215,11 @@ function RemoteButton({
                           <div className="py-2 flex items-center justify-between">
                             <span className="text-xs text-fg-2">Status</span>
                             {tailscale.connected ? (
-                              <span className="text-[10px] text-green-400">
+                              <span className="text-3xs text-green-400">
                                 Connected{tailscale.hostname ? ` · ${tailscale.hostname}` : ''}
                               </span>
                             ) : (
-                              <span className="text-[10px] text-fg-muted">VPN not active</span>
+                              <span className="text-3xs text-fg-muted">VPN not active</span>
                             )}
                           </div>
 
@@ -1318,8 +1318,8 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
     <section>
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">Skip Permissions</h3>
-          <p className="text-[10px] text-fg-muted mt-0.5">New sessions will skip tool approval</p>
+          <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase">Skip Permissions</h3>
+          <p className="text-3xs text-fg-muted mt-0.5">New sessions will skip tool approval</p>
         </div>
         <Toggle
           enabled={defaults.skipPermissions}
@@ -1330,7 +1330,7 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
       </div>
       {defaults.skipPermissions && (
         <>
-          <p className="text-[10px] text-[#DD4444] mt-1.5">Claude will execute tools without asking for approval.</p>
+          <p className="text-3xs text-[#DD4444] mt-1.5">Claude will execute tools without asking for approval.</p>
 
           {/* Advanced expandable section */}
           <button
@@ -1345,7 +1345,7 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
             >
               <path d="M9 5l7 7-7 7" />
             </svg>
-            <span className="text-[10px] text-fg-muted group-hover:text-fg-2 transition-colors">Advanced</span>
+            <span className="text-3xs text-fg-muted group-hover:text-fg-2 transition-colors">Advanced</span>
           </button>
 
           {advancedOpen && (
@@ -1353,8 +1353,8 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
               {/* Approve All toggle */}
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-[10px] text-fg-dim font-medium">Auto-approve all</p>
-                  <p className="text-[9px] text-fg-muted">Silently approve all protected requests</p>
+                  <p className="text-3xs text-fg-dim font-medium">Auto-approve all</p>
+                  <p className="text-4xs text-fg-muted">Silently approve all protected requests</p>
                 </div>
                 <Toggle enabled={overrides.approveAll} onToggle={handleApproveAllToggle} color="red" label="Auto-approve all" />
               </div>
@@ -1362,7 +1362,7 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
               {/* Separator */}
               <div className="flex items-center gap-2">
                 <div className="flex-1 border-t border-edge-dim" />
-                <span className="text-[9px] text-fg-muted">or approve by category</span>
+                <span className="text-4xs text-fg-muted">or approve by category</span>
                 <div className="flex-1 border-t border-edge-dim" />
               </div>
 
@@ -1370,8 +1370,8 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
               {OVERRIDE_CATEGORIES.map(({ key, label, description }) => (
                 <div key={key} className={`flex items-center justify-between ${overrides.approveAll ? 'opacity-40 pointer-events-none' : ''}`}>
                   <div>
-                    <p className="text-[10px] text-fg-dim font-medium">{label}</p>
-                    <p className="text-[9px] text-fg-muted">{description}</p>
+                    <p className="text-3xs text-fg-dim font-medium">{label}</p>
+                    <p className="text-4xs text-fg-muted">{description}</p>
                   </div>
                   <Toggle enabled={overrides[key]} onToggle={() => updateOverride(key, !overrides[key])} label={`Auto-approve ${label}`} />
                 </div>
@@ -1394,21 +1394,21 @@ function SkipPermissionsSection({ defaults, onDefaultsChange }: {
                   <h3 className="text-xs font-bold text-[#DD4444]">&#9888; This is extremely dangerous</h3>
                 </div>
                 <div className="px-4 py-3 space-y-2">
-                  <p className="text-[10px] text-fg-dim leading-relaxed">
+                  <p className="text-3xs text-fg-dim leading-relaxed">
                     <strong className="text-[#DD4444]">This setting is not recommended or condoned by Claude, Anthropic, or YouCoded.</strong>{' '}
                     Do not enable this unless you fully understand the consequences.
                   </p>
-                  <p className="text-[10px] text-fg-dim leading-relaxed">
+                  <p className="text-3xs text-fg-dim leading-relaxed">
                     Full auto-approve silently grants <strong>every</strong> remaining permission request with zero human review. Claude will be able to:
                   </p>
-                  <ul className="text-[10px] text-fg-muted space-y-1 ml-3 list-disc">
+                  <ul className="text-3xs text-fg-muted space-y-1 ml-3 list-disc">
                     <li>Overwrite your <code className="text-fg-dim">.git/</code> history and repository internals</li>
                     <li>Modify shell config files (<code className="text-fg-dim">.bashrc</code>, <code className="text-fg-dim">.gitconfig</code>, <code className="text-fg-dim">.zshrc</code>)</li>
                     <li>Rewrite <code className="text-fg-dim">.claude/</code> configuration and MCP settings</li>
                     <li>Execute compound commands that bypass path resolution safety checks</li>
                     <li>Execute compound commands that bypass bare repository attack protections</li>
                   </ul>
-                  <p className="text-[10px] text-[#DD4444]/80 leading-relaxed font-medium">
+                  <p className="text-3xs text-[#DD4444]/80 leading-relaxed font-medium">
                     These protections exist for a reason. Disabling them means a single bad model output could corrupt your repository, hijack your shell environment, or escalate access beyond this project. There is no undo.
                   </p>
                   <div className="flex gap-2 pt-2">
@@ -1498,13 +1498,13 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
                 <div className="px-4 py-4 space-y-5">
                 {/* Default Model */}
                 <section>
-                  <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Default Model</h3>
+                  <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Default Model</h3>
                   <div className="flex gap-1">
                     {MODELS.map((m) => (
                       <button
                         key={m}
                         onClick={() => onDefaultsChange({ model: m })}
-                        className={`flex-1 px-1.5 py-1.5 rounded-sm text-[11px] transition-colors flex items-center justify-center ${
+                        className={`flex-1 px-1.5 py-1.5 rounded-sm text-2xs transition-colors flex items-center justify-center ${
                           defaults.model === m
                             ? 'bg-accent text-on-accent font-medium'
                             : 'bg-inset text-fg-dim hover:bg-edge'
@@ -1522,7 +1522,7 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
 
                 {/* Default Project Folder */}
                 <section>
-                  <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">Project Folder</h3>
+                  <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">Project Folder</h3>
                   <button
                     onClick={handleBrowseFolder}
                     className="w-full text-left px-2.5 py-1.5 bg-inset border border-edge-dim rounded-md text-xs text-fg-2 hover:border-edge transition-colors truncate"
@@ -1532,7 +1532,7 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
                   {defaults.projectFolder && (
                     <button
                       onClick={() => onDefaultsChange({ projectFolder: '' })}
-                      className="text-[10px] text-fg-muted hover:text-fg-2 mt-1"
+                      className="text-3xs text-fg-muted hover:text-fg-2 mt-1"
                     >
                       Reset to home directory
                     </button>
@@ -1545,8 +1545,8 @@ function DefaultsButton({ defaults, onDefaultsChange }: DefaultsButtonProps) {
                 <section>
                   <div className="flex items-center justify-between">
                     <div>
-                      <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">Close-session prompt</h3>
-                      <p className="text-[10px] text-fg-muted mt-0.5">Show tag options when closing a session</p>
+                      <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase">Close-session prompt</h3>
+                      <p className="text-3xs text-fg-muted mt-0.5">Show tag options when closing a session</p>
                     </div>
                     {/* Was a hand-rolled 32x18 track with an inline var(--accent)
                         background; one geometry now (change 16). The state is stored
@@ -1647,9 +1647,9 @@ function TierSelector({ tier, onSetTier }: { tier: string; onSetTier: (t: string
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <span className={`text-xs font-medium ${isActive ? 'text-fg' : 'text-fg-2'}`}>{t.name}</span>
-                        {isActive && <span className="text-[9px] font-medium px-1.5 py-0.5 rounded-sm bg-accent text-on-accent">Active</span>}
+                        {isActive && <span className="text-4xs font-medium px-1.5 py-0.5 rounded-sm bg-accent text-on-accent">Active</span>}
                       </div>
-                      <p className="text-[10px] text-fg-muted mt-0.5">{t.desc}</p>
+                      <p className="text-3xs text-fg-muted mt-0.5">{t.desc}</p>
                     </div>
                   </button>
                 );
@@ -1829,7 +1829,7 @@ function ConnectToDesktopButton() {
                     </svg>
                     <span className="text-xs text-amber-400 font-medium">Tailscale not connected</span>
                   </div>
-                  <p className="text-[10px] text-fg-dim">Enable Tailscale on this phone before connecting. Both devices must be on the same Tailscale network.</p>
+                  <p className="text-3xs text-fg-dim">Enable Tailscale on this phone before connecting. Both devices must be on the same Tailscale network.</p>
                 </div>
               )}
 
@@ -1856,14 +1856,14 @@ function ConnectToDesktopButton() {
               {/* Error */}
               {connectError && (
                 <div className="bg-red-500/10 border border-red-500/25 rounded-lg p-2">
-                  <p className="text-[10px] text-destructive-fg">{connectError}</p>
+                  <p className="text-3xs text-destructive-fg">{connectError}</p>
                 </div>
               )}
 
               {/* Saved devices — always listed */}
               {pairedDevices.length > 0 && (
                 <section>
-                  <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">Saved Devices</h3>
+                  <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">Saved Devices</h3>
                   <div className="space-y-1">
                     {pairedDevices.map(device => (
                       <div key={`${device.host}:${device.port}`} className="flex items-center justify-between py-2 px-3 rounded-sm bg-inset/50">
@@ -1873,7 +1873,7 @@ function ConnectToDesktopButton() {
                           className="min-w-0 flex-1 text-left disabled:opacity-50"
                         >
                           <span className="text-xs text-fg block">{device.name}</span>
-                          <span className="text-[10px] text-fg-muted font-mono block">{device.host}:{device.port}</span>
+                          <span className="text-3xs text-fg-muted font-mono block">{device.host}:{device.port}</span>
                         </button>
                         <button
                           onClick={() => handleRemoveDevice(device)}
@@ -1897,7 +1897,7 @@ function ConnectToDesktopButton() {
               {!remoteConnected && !connecting && (
                 <section>
                   {pairedDevices.length > 0 && (
-                    <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">Add Device</h3>
+                    <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">Add Device</h3>
                   )}
                   {!showConnectForm ? (
                     <div className="space-y-2">
@@ -1918,7 +1918,7 @@ function ConnectToDesktopButton() {
                           form footer — it sits under the whole form, not beside one
                           field, so it is NOT an InputGroup. */}
                       <div>
-                        <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Device Name</label>
+                        <label className="text-3xs text-fg-muted uppercase tracking-wider block mb-1">Device Name</label>
                         <TextInput
                           size="sm"
                           value={formName}
@@ -1929,7 +1929,7 @@ function ConnectToDesktopButton() {
                         />
                       </div>
                       <div>
-                        <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Host / IP</label>
+                        <label className="text-3xs text-fg-muted uppercase tracking-wider block mb-1">Host / IP</label>
                         <TextInput
                           size="sm"
                           value={formHost}
@@ -1940,7 +1940,7 @@ function ConnectToDesktopButton() {
                         />
                       </div>
                       <div>
-                        <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Port</label>
+                        <label className="text-3xs text-fg-muted uppercase tracking-wider block mb-1">Port</label>
                         <TextInput
                           size="sm"
                           value={formPort}
@@ -1951,7 +1951,7 @@ function ConnectToDesktopButton() {
                         />
                       </div>
                       <div>
-                        <label className="text-[10px] text-fg-muted uppercase tracking-wider block mb-1">Password</label>
+                        <label className="text-3xs text-fg-muted uppercase tracking-wider block mb-1">Password</label>
                         <TextInput
                           size="sm"
                           type="password"
@@ -1977,7 +1977,7 @@ function ConnectToDesktopButton() {
                 </section>
               )}
 
-              <p className="text-[10px] text-fg-muted">
+              <p className="text-3xs text-fg-muted">
                 Connect to the YouCoded desktop app on your computer. Set up remote access in the desktop app's settings first.
               </p>
               </div>

--- a/desktop/src/renderer/components/SettingsRow.tsx
+++ b/desktop/src/renderer/components/SettingsRow.tsx
@@ -31,7 +31,7 @@ export default function SettingsRow({ icon, title, subtitle, subtitleClassName, 
       </div>
       <div className="flex-1 min-w-0">
         <span className="text-xs text-fg font-medium">{title}</span>
-        {subtitle && <p className={`text-[10px] truncate ${subtitleClassName ?? 'text-fg-muted'}`}>{subtitle}</p>}
+        {subtitle && <p className={`text-3xs truncate ${subtitleClassName ?? 'text-fg-muted'}`}>{subtitle}</p>}
       </div>
       {rightAccessory}
       <svg className="w-3.5 h-3.5 text-fg-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/desktop/src/renderer/components/ShareSheet.tsx
+++ b/desktop/src/renderer/components/ShareSheet.tsx
@@ -114,7 +114,7 @@ export default function ShareSheet({ skillId, onClose }: ShareSheetProps) {
         {shareLink && (
           <div className="mb-4">
             <div className="flex items-center gap-2 bg-well border border-edge-dim rounded-lg px-3 py-2">
-              <span className="flex-1 text-[11px] text-fg-muted truncate select-all">{shareLink}</span>
+              <span className="flex-1 text-2xs text-fg-muted truncate select-all">{shareLink}</span>
               <Button size="sm" onClick={handleCopy} className="shrink-0">
                 {copied ? 'Copied!' : 'Copy'}
               </Button>

--- a/desktop/src/renderer/components/SkillCard.tsx
+++ b/desktop/src/renderer/components/SkillCard.tsx
@@ -47,7 +47,7 @@ function PluginBadge({ name, onClick }: PluginBadgeProps) {
       type="button"
       onClick={(e) => { e.stopPropagation(); onClick(); }}
       title={`Open ${name}`}
-      className={`text-[9px] font-medium px-1 py-0.5 rounded-sm shrink-0 ${IDENTITY_BADGE} hover:bg-accent/25 transition-colors truncate max-w-[120px]`}
+      className={`text-4xs font-medium px-1 py-0.5 rounded-sm shrink-0 ${IDENTITY_BADGE} hover:bg-accent/25 transition-colors truncate max-w-[120px]`}
     >
       {name}
     </button>
@@ -61,7 +61,7 @@ function SourceTag({ skill }: { skill: SkillEntry }) {
     ? 'YC'
     : (typeLabels[skill.type] ?? 'Plugin');
   return (
-    <span className={`text-[9px] font-medium px-1 py-0.5 rounded-sm shrink-0 ${IDENTITY_BADGE}`}>
+    <span className={`text-4xs font-medium px-1 py-0.5 rounded-sm shrink-0 ${IDENTITY_BADGE}`}>
       {label}
     </span>
   );
@@ -121,7 +121,7 @@ function SkillCardImpl({ skill, onClick, favorite, pluginBadge }: Props) {
         <FavoriteStar corner size="sm" filled={favorite.filled} onToggle={favorite.onToggle} />
       )}
       <span className="text-sm font-medium text-fg leading-tight">{skill.displayName}</span>
-      <span className="text-[11px] text-fg-muted mt-1 leading-snug line-clamp-2 flex-1">{skill.description}</span>
+      <span className="text-2xs text-fg-muted mt-1 leading-snug line-clamp-2 flex-1">{skill.description}</span>
       <div className="mt-2 self-start">{badge}</div>
     </div>
   );

--- a/desktop/src/renderer/components/SkillEditor.tsx
+++ b/desktop/src/renderer/components/SkillEditor.tsx
@@ -98,7 +98,7 @@ export default function SkillEditor({ skillId, onClose }: SkillEditorProps) {
 
         {/* Name */}
         <label className="block mb-3">
-          <span className="text-[10px] font-medium text-fg-muted tracking-wider">NAME</span>
+          <span className="text-3xs font-medium text-fg-muted tracking-wider">NAME</span>
           {/* Shared field surface (change 20) — the hand-rolled recipe here used
               bg-well + placeholder-fg-muted; FIELD is bg-inset + fg-faint. */}
           <TextInput
@@ -111,7 +111,7 @@ export default function SkillEditor({ skillId, onClose }: SkillEditorProps) {
 
         {/* Description */}
         <label className="block mb-3">
-          <span className="text-[10px] font-medium text-fg-muted tracking-wider">DESCRIPTION</span>
+          <span className="text-3xs font-medium text-fg-muted tracking-wider">DESCRIPTION</span>
           {/* Same migration as NAME above (change 20). Stays a single-line input —
               it was never a textarea. */}
           <TextInput
@@ -129,7 +129,7 @@ export default function SkillEditor({ skillId, onClose }: SkillEditorProps) {
             <button>, which is what the Select trigger is, so the accessible name
             moves to aria-label instead. */}
         <div className="block mb-5">
-          <span className="text-[10px] font-medium text-fg-muted tracking-wider">CATEGORY</span>
+          <span className="text-3xs font-medium text-fg-muted tracking-wider">CATEGORY</span>
           <Select
             options={categories}
             value={category}

--- a/desktop/src/renderer/components/StatusBar.tsx
+++ b/desktop/src/renderer/components/StatusBar.tsx
@@ -556,7 +556,7 @@ function WidgetConfigPopup({ open, onClose, visible, toggle }: {
             <div className="px-4 py-3 space-y-4">
             {WIDGET_CATEGORIES.map((cat) => (
               <section key={cat.name}>
-                <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">
+                <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">
                   {cat.name}
                 </h3>
                 <div className="space-y-0.5">
@@ -587,8 +587,8 @@ function WidgetConfigPopup({ open, onClose, visible, toggle }: {
                                 </svg>
                               )}
                             </span>
-                            <span className="text-[11px] text-fg">{w.label}</span>
-                            {w.locked && <span className="text-[9px] text-fg-muted">always on</span>}
+                            <span className="text-2xs text-fg">{w.label}</span>
+                            {w.locked && <span className="text-4xs text-fg-muted">always on</span>}
                           </button>
 
                           {/* Pencil — Theme widget only. Opens the cycle editor
@@ -629,7 +629,7 @@ function WidgetConfigPopup({ open, onClose, visible, toggle }: {
 
                         {/* Expanded info panel */}
                         {isExpanded && (
-                          <div className="ml-7 mr-2 mb-1.5 px-2.5 py-2 rounded-md bg-inset border border-edge-dim text-[10px] space-y-1.5">
+                          <div className="ml-7 mr-2 mb-1.5 px-2.5 py-2 rounded-md bg-inset border border-edge-dim text-3xs space-y-1.5">
                             <p className="text-fg-dim leading-relaxed">{w.description}</p>
                             <p className="text-fg-muted leading-relaxed">
                               <span className="font-medium text-fg-muted">Best for:</span> {w.bestFor}
@@ -641,7 +641,7 @@ function WidgetConfigPopup({ open, onClose, visible, toggle }: {
                             Tapping the theme pill in the status bar rotates through
                             every theme checked here. Must keep ≥1 in the cycle. */}
                         {showCycleEditor && (
-                          <div className="ml-7 mr-2 mb-1.5 px-2.5 py-2 rounded-md bg-inset border border-edge-dim text-[10px] space-y-1.5">
+                          <div className="ml-7 mr-2 mb-1.5 px-2.5 py-2 rounded-md bg-inset border border-edge-dim text-3xs space-y-1.5">
                             <p className="text-fg-dim leading-relaxed">
                               Pick which themes the pill rotates through when you tap it.
                             </p>
@@ -722,7 +722,7 @@ export default function StatusBar({
   const ss = sessionStats; // shorthand
 
   return (
-    <div className="status-bar flex flex-wrap items-center gap-x-2 gap-y-1 px-2 sm:px-3 py-1 text-[10px] text-fg-muted">
+    <div className="status-bar flex flex-wrap items-center gap-x-2 gap-y-1 px-2 sm:px-3 py-1 text-3xs text-fg-muted">
       {/* Combined model + effort pill — clicking opens the full picker (same as /effort).
          Shift+Space still cycles models via the keyboard shortcut in App.tsx. */}
       {model && (model.kind === 'native' ? (
@@ -1011,7 +1011,7 @@ export default function StatusBar({
         return (
           <button
             onClick={handler}
-            className={`px-1.5 py-0.5 rounded-sm border text-[9px] sm:text-[10px] ${styleClass} ${handler ? 'cursor-pointer hover:brightness-125 transition-all' : ''}`}
+            className={`px-1.5 py-0.5 rounded-sm border text-4xs sm:text-3xs ${styleClass} ${handler ? 'cursor-pointer hover:brightness-125 transition-all' : ''}`}
             title={isFailing ? 'Sync is failing — click for details' : 'Sync warnings — click for details'}
           >
             {label}

--- a/desktop/src/renderer/components/SyncPanel.tsx
+++ b/desktop/src/renderer/components/SyncPanel.tsx
@@ -177,14 +177,14 @@ function primaryLabelForState(state: SyncDisplayState, loading: boolean): string
 function badgeForState(state: SyncDisplayState): React.ReactNode {
   if (state.kind === 'failing') {
     return (
-      <span className="px-1.5 py-0.5 rounded-full bg-[#DD4444]/15 text-[#DD4444] text-[9px] font-medium shrink-0">
+      <span className="px-1.5 py-0.5 rounded-full bg-[#DD4444]/15 text-[#DD4444] text-4xs font-medium shrink-0">
         {state.warningCount}
       </span>
     );
   }
   if (state.kind === 'attention') {
     return (
-      <span className="px-1.5 py-0.5 rounded-full bg-[#FF9800]/15 text-[#FF9800] text-[9px] font-medium shrink-0">
+      <span className="px-1.5 py-0.5 rounded-full bg-[#FF9800]/15 text-[#FF9800] text-4xs font-medium shrink-0">
         {state.warningCount}
       </span>
     );
@@ -1100,9 +1100,9 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         <div className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${dot}`} />
                         <div className="min-w-0">
                           <div className="text-sm font-semibold text-fg">{title}</div>
-                          <div className={`text-[11px] mt-0.5 leading-relaxed ${subWarn ? 'text-destructive-fg' : 'text-fg-muted'}`}>{sub}</div>
+                          <div className={`text-2xs mt-0.5 leading-relaxed ${subWarn ? 'text-destructive-fg' : 'text-fg-muted'}`}>{sub}</div>
                           {/* Off-but-errored: keep the normal off sub AND show why the last attempt failed. */}
-                          {offError && <div className="text-[11px] mt-0.5 leading-relaxed text-destructive-fg">{offError}</div>}
+                          {offError && <div className="text-2xs mt-0.5 leading-relaxed text-destructive-fg">{offError}</div>}
                         </div>
                       </div>
                       {/* Enable toggle — migrated to the shared Toggle (spec changes
@@ -1128,8 +1128,8 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         Native <details> — no React state needed inside this render. */}
                     {errorMsg && (hk === 'error' || offError) && (
                       <details className="mt-2 pl-[18px]">
-                        <summary className="text-[11px] text-fg-muted cursor-pointer hover:text-fg-2 select-none">Show details</summary>
-                        <pre className="mt-1 text-[10px] leading-relaxed text-fg-dim whitespace-pre-wrap break-words max-h-32 overflow-y-auto">{errorMsg as string}</pre>
+                        <summary className="text-2xs text-fg-muted cursor-pointer hover:text-fg-2 select-none">Show details</summary>
+                        <pre className="mt-1 text-3xs leading-relaxed text-fg-dim whitespace-pre-wrap break-words max-h-32 overflow-y-auto">{errorMsg as string}</pre>
                       </details>
                     )}
                   </div>
@@ -1161,7 +1161,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                               aria-selected={active}
                               tabIndex={active ? 0 : -1}
                               onClick={() => setCountTab(t.key)}
-                              className={`inline-flex items-baseline gap-1.5 rounded-full px-3 py-1 text-[11px] transition-colors ${active ? 'bg-accent text-on-accent border border-accent' : 'bg-inset border border-edge-dim text-fg-dim hover:text-fg-2'}`}
+                              className={`inline-flex items-baseline gap-1.5 rounded-full px-3 py-1 text-2xs transition-colors ${active ? 'bg-accent text-on-accent border border-accent' : 'bg-inset border border-edge-dim text-fg-dim hover:text-fg-2'}`}
                             >
                               <span className="font-bold text-xs">{t.count}</span> {t.word}
                             </button>
@@ -1172,13 +1172,13 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         {countTab === 'dev' && <DevicesTab devices={devices} onRename={handleRenameDevice} onRemove={handleRemoveDevice} syncInProgress={status?.syncInProgress ?? false} lastSyncByDevice={status?.lastSyncByDevice} lastSyncEpoch={status?.lastSyncEpoch ?? null} />}
                         {countTab === 'proj' && (() => {
                           const projects = ((spacesStatus?.spaces ?? []) as any[]).filter(s => s.kind === 'project');
-                          if (projects.length === 0) return <p className="text-[11px] text-fg-muted">Turn on sync for a project folder to add it here.</p>;
+                          if (projects.length === 0) return <p className="text-2xs text-fg-muted">Turn on sync for a project folder to add it here.</p>;
                           return (
                             <ul className="space-y-1">
                               {projects.map((s: any) => (
                                 <li key={s.id} className="flex items-center justify-between gap-2">
                                   <span className="text-xs text-fg-2 truncate">{s.displayName || s.id.replace('project:', '')}</span>
-                                  <span className="text-[10px] text-fg-muted shrink-0">{s.remote ? 'connected' : 'local only'}</span>
+                                  <span className="text-3xs text-fg-muted shrink-0">{s.remote ? 'connected' : 'local only'}</span>
                                 </li>
                               ))}
                             </ul>
@@ -1187,7 +1187,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         {countTab === 'conv' && (() => {
                           // Most-recent first; show up to 4 with a "+ N more" muted tail.
                           const sorted = [...(conversations ?? [])].sort((a, b) => b.lastModified - a.lastModified);
-                          if (sorted.length === 0) return <p className="text-[11px] text-fg-muted">No conversations yet.</p>;
+                          if (sorted.length === 0) return <p className="text-2xs text-fg-muted">No conversations yet.</p>;
                           const shown = sorted.slice(0, 4);
                           return (
                             <>
@@ -1195,12 +1195,12 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                                 {shown.map(c => (
                                   <li key={c.sessionId} className="flex items-center justify-between gap-2">
                                     <span className="text-xs text-fg-2 truncate">{c.name}</span>
-                                    <span className="text-[10px] text-fg-muted shrink-0">{relativeMs(c.lastModified)}</span>
+                                    <span className="text-3xs text-fg-muted shrink-0">{relativeMs(c.lastModified)}</span>
                                   </li>
                                 ))}
                               </ul>
                               {sorted.length > shown.length && (
-                                <p className="text-[10px] text-fg-muted mt-1.5">+ {sorted.length - shown.length} more, all backed up</p>
+                                <p className="text-3xs text-fg-muted mt-1.5">+ {sorted.length - shown.length} more, all backed up</p>
                               )}
                             </>
                           );
@@ -1253,9 +1253,9 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-semibold text-fg">Additional backups</span>
-                        <span className="text-[9px] font-medium text-fg-muted tracking-wider uppercase px-1.5 py-0.5 rounded-full bg-inset">optional</span>
+                        <span className="text-4xs font-medium text-fg-muted tracking-wider uppercase px-1.5 py-0.5 rounded-full bg-inset">optional</span>
                       </div>
-                      <p className="text-[11px] text-fg-muted mt-1 leading-relaxed">{sub}</p>
+                      <p className="text-2xs text-fg-muted mt-1 leading-relaxed">{sub}</p>
                     </div>
                     {/* Master toggle: pause-all / resume-all / reveal picker (handleAdditionalToggle). */}
                     {/* Shared Toggle (spec changes 15/16) — same 36x20 geometry, but the
@@ -1299,17 +1299,17 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                             {/* Name + detail */}
                             <div className="flex-1 min-w-0">
                               <div className="text-xs text-fg font-medium truncate">{b.label}</div>
-                              <div className="text-[10px] text-fg-muted truncate">
+                              <div className="text-3xs text-fg-muted truncate">
                                 {b.lastError ? b.lastError :
                                  b.lastPushEpoch ? `Backed up ${timeAgo(b.lastPushEpoch)}` :
                                  !b.syncEnabled ? 'Auto-backup paused' :
                                  'Never backed up'}
                               </div>
                               {isPending && !actionFeedback[b.id] && (
-                                <span className="text-[9px] font-medium text-amber-400">Changes pending upload</span>
+                                <span className="text-4xs font-medium text-amber-400">Changes pending upload</span>
                               )}
                               {actionFeedback[b.id] && (
-                                <span className={`text-[9px] font-medium ${
+                                <span className={`text-4xs font-medium ${
                                   actionFeedback[b.id] === 'error' ? 'text-destructive-fg' :
                                   actionFeedback[b.id]?.includes('ing') ? 'text-blue-400' :
                                   'text-green-400'
@@ -1363,14 +1363,14 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         onClick={() => { setAddType('drive'); setView('add-config'); }}
                         className="flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border border-edge bg-well hover:bg-inset text-xs text-fg-2 transition-colors"
                       >
-                        <span className="w-5 h-5 rounded-full flex items-center justify-center text-[11px] bg-blue-500/10 text-blue-400">{'☁'}</span>
+                        <span className="w-5 h-5 rounded-full flex items-center justify-center text-2xs bg-blue-500/10 text-blue-400">{'☁'}</span>
                         Google Drive
                       </button>
                       <button
                         onClick={() => { setAddType('icloud'); setView('add-config'); }}
                         className="flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border border-edge bg-well hover:bg-inset text-xs text-fg-2 transition-colors"
                       >
-                        <span className="w-5 h-5 rounded-full flex items-center justify-center text-[11px] bg-sky-500/10 text-sky-400">{'⬡'}</span>
+                        <span className="w-5 h-5 rounded-full flex items-center justify-center text-2xs bg-sky-500/10 text-sky-400">{'⬡'}</span>
                         iCloud
                       </button>
                     </div>
@@ -1395,7 +1395,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                         <button
                           onClick={handleForceSync}
                           disabled={syncing}
-                          className="text-[11px] underline text-fg-muted hover:text-fg-2 disabled:opacity-50 disabled:cursor-wait"
+                          className="text-2xs underline text-fg-muted hover:text-fg-2 disabled:opacity-50 disabled:cursor-wait"
                         >
                           {syncing || status?.syncInProgress ? 'Backing up…' : 'Back up all now'}
                         </button>
@@ -1409,7 +1409,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
             {/* 3. Warnings — typed SyncWarning objects with title/body/fix-action/stderr */}
             {status?.warnings && status.warnings.length > 0 && (
               <div>
-                <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-2">Warnings</h3>
+                <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-2">Warnings</h3>
                 <div className="space-y-2">
                   {status.warnings.map((w) => (
                     <div
@@ -1421,14 +1421,14 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                       }`}
                     >
                       <div className="text-xs font-medium text-fg">{w.title}</div>
-                      <div className="text-[11px] text-fg-muted mt-0.5">{w.body}</div>
+                      <div className="text-2xs text-fg-muted mt-0.5">{w.body}</div>
                       {/* Collapsible stderr for UNKNOWN-code warnings where raw output helps diagnose */}
                       {w.code === 'UNKNOWN' && w.stderr && (
                         <details className="mt-1">
-                          <summary className="text-[10px] text-fg-muted cursor-pointer">
+                          <summary className="text-3xs text-fg-muted cursor-pointer">
                             Show error details
                           </summary>
-                          <pre className="mt-1 p-2 bg-inset rounded text-[10px] whitespace-pre-wrap font-mono">
+                          <pre className="mt-1 p-2 bg-inset rounded text-3xs whitespace-pre-wrap font-mono">
                             {w.stderr}
                           </pre>
                         </details>
@@ -1456,8 +1456,8 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                 Now passive text with per-item hover tooltips on the default cursor. */}
             {status && status.syncedCategories.length > 0 && (
               <div>
-                <span className="text-[10px] font-medium text-fg-muted tracking-wider uppercase">Includes </span>
-                <span className="text-[11px] text-fg-dim">
+                <span className="text-3xs font-medium text-fg-muted tracking-wider uppercase">Includes </span>
+                <span className="text-2xs text-fg-dim">
                   {status.syncedCategories.flatMap((cat, i) => {
                     const label = (
                       <span key={cat} title={CATEGORY_DESCRIPTIONS[cat] || ''}>
@@ -1479,7 +1479,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                     try { const log = await claude.sync.getLog(30); setLogLines(log); } catch {}
                   }
                 }}
-                className="flex items-center gap-1.5 text-[10px] font-medium text-fg-muted tracking-wider uppercase hover:text-fg-2 transition-colors"
+                className="flex items-center gap-1.5 text-3xs font-medium text-fg-muted tracking-wider uppercase hover:text-fg-2 transition-colors"
               >
                 <svg className={`w-3 h-3 transition-transform ${showLog ? 'rotate-90' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
@@ -1490,10 +1490,10 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
               {showLog && (
                 <div className="mt-2">
                   {logLines.length === 0 ? (
-                    <div className="text-[11px] text-fg-muted px-2 py-3">No sync log entries yet.</div>
+                    <div className="text-2xs text-fg-muted px-2 py-3">No sync log entries yet.</div>
                   ) : (
                     <div ref={logScrollRef} className="scroll-fade max-h-48 rounded-lg bg-inset/40 border border-edge-dim">
-                      <pre className="text-[10px] text-fg-dim font-mono px-2 py-2 whitespace-pre-wrap break-all leading-relaxed">
+                      <pre className="text-3xs text-fg-dim font-mono px-2 py-2 whitespace-pre-wrap break-all leading-relaxed">
                         {logLines.map((line, i) => {
                           try {
                             const entry = JSON.parse(line);
@@ -1516,7 +1516,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
                   )}
                   <button
                     onClick={async () => { try { setLogLines(await claude.sync.getLog(30)); } catch {} }}
-                    className="mt-1.5 text-[10px] text-fg-muted hover:text-fg-2 transition-colors"
+                    className="mt-1.5 text-3xs text-fg-muted hover:text-fg-2 transition-colors"
                   >
                     Refresh
                   </button>
@@ -1530,7 +1530,7 @@ function SyncPopup({ popupRef, initialStatus, onClose, onRefresh }: SyncPopupPro
             {!status && !loading && (
               <div className="text-center py-6">
                 <div className="text-fg-muted text-sm mb-1">No Sync Data</div>
-                <div className="text-fg-muted text-[11px]">Sync hasn't run yet. Configure a backup destination to get started.</div>
+                <div className="text-fg-muted text-2xs">Sync hasn't run yet. Configure a backup destination to get started.</div>
               </div>
             )}
             </div>
@@ -1601,7 +1601,7 @@ function ConfirmDialog({
           <h3 className="text-xs font-bold text-destructive-fg">{title}</h3>
         </div>
         <div className="px-4 py-3 space-y-3">
-          <p className="text-[11px] text-fg-dim leading-relaxed">{message}</p>
+          <p className="text-2xs text-fg-dim leading-relaxed">{message}</p>
           <div className="flex gap-2 pt-1">
             {/* Was a filled-grey button (bg-inset/hover:bg-edge). Spec decision 60 folds
                 that whole family into `secondary` (outline) — it sits beside a real
@@ -1671,7 +1671,7 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
 
   // null = not loaded yet; [] = loaded-but-empty (sync off / no personal root).
   if (devices !== null && devices.length === 0) {
-    return <p className="text-[11px] text-fg-muted">No devices yet — they appear here once sync has run.</p>;
+    return <p className="text-2xs text-fg-muted">No devices yet — they appear here once sync has run.</p>;
   }
 
   return (
@@ -1732,10 +1732,10 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
                     {d.name}
                   </button>
                 )}
-                {d.self && <span className="text-[10px] text-fg-muted shrink-0">(this device)</span>}
+                {d.self && <span className="text-3xs text-fg-muted shrink-0">(this device)</span>}
               </div>
               <div className="flex items-center gap-2 shrink-0">
-                <span className="text-[10px] text-fg-muted">{right}</span>
+                <span className="text-3xs text-fg-muted">{right}</span>
                 {/* No Remove for self: upsertSelf re-creates this row on the next
                     launch, so offering it would read as a button that does nothing.
                     Hidden while confirming — the confirm block below replaces it. */}
@@ -1744,7 +1744,7 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
                     type="button"
                     onClick={() => { setConfirmingId(d.id); setRemoveNote(null); }}
                     aria-label={`Remove ${d.name}`}
-                    className="text-[10px] text-fg-muted hover:text-fg"
+                    className="text-3xs text-fg-muted hover:text-fg"
                   >
                     Remove
                   </button>
@@ -1759,7 +1759,7 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
                 className="mt-1.5 space-y-2 rounded-lg bg-inset border border-edge-dim p-2.5"
                 onKeyDown={(e) => { if (e.key === 'Escape') setConfirmingId(null); }} // matches the rename input's Escape
               >
-                <p className="text-[11px] text-fg-dim leading-relaxed">
+                <p className="text-2xs text-fg-dim leading-relaxed">
                   Remove {d.name}? It stops being listed here. If this device syncs again, it comes back.
                 </p>
                 <div className="flex gap-2">
@@ -1793,7 +1793,7 @@ function DevicesTab({ devices, onRename, onRemove, syncInProgress, lastSyncByDev
             {/* Why the remove didn't take. Never invents a cause: the handler's own
                 reason when it gave one, otherwise non-committal. */}
             {removeNote?.id === d.id && (
-              <p className="text-[10px] text-destructive-fg mt-1">{removeNote.text}</p>
+              <p className="text-3xs text-destructive-fg mt-1">{removeNote.text}</p>
             )}
           </li>
         );
@@ -1808,7 +1808,7 @@ function MenuButton({ children, onClick, danger }: { children: React.ReactNode; 
   return (
     <button
       onClick={onClick}
-      className={`w-full text-left px-3 py-1.5 text-[11px] transition-colors ${
+      className={`w-full text-left px-3 py-1.5 text-2xs transition-colors ${
         danger ? 'text-red-400 hover:bg-red-500/10' : 'text-fg hover:bg-inset'
       }`}
     >
@@ -1868,7 +1868,7 @@ function EditBackendForm({
       <div ref={actionsScrollRef} className="scroll-fade flex-1">
         <div className="px-4 py-4 space-y-4">
         <div>
-          <label className="block text-[10px] text-fg-muted mb-1">Name</label>
+          <label className="block text-3xs text-fg-muted mb-1">Name</label>
           {/* Shared FIELD surface (spec change 20). The visible label above isn't
               wired up with htmlFor, so aria-label gives it the same name. Left as a
               plain field rather than an InputGroup: its Save button sits at the very
@@ -1885,13 +1885,13 @@ function EditBackendForm({
         {/* Config fields are read-only — prevents users from breaking rclone remotes or repo URLs */}
         {displayFields.map(field => (
           <div key={field.key}>
-            <div className="text-[10px] text-fg-muted mb-1">{field.label}</div>
+            <div className="text-3xs text-fg-muted mb-1">{field.label}</div>
             <div className="px-2 py-1.5 rounded-md bg-inset/30 border border-edge-dim text-xs text-fg-dim">
               {backend.config[field.key] || '(not set)'}
             </div>
           </div>
         ))}
-        <div className="text-[10px] text-fg-muted">
+        <div className="text-3xs text-fg-muted">
           To change these settings, remove this backup and add a new one.
         </div>
 

--- a/desktop/src/renderer/components/SyncSetupWizard.tsx
+++ b/desktop/src/renderer/components/SyncSetupWizard.tsx
@@ -211,9 +211,9 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="text-xs text-fg font-medium">{BACKEND_LABELS[type]}</div>
-                  <div className="text-[10px] text-fg-muted mt-0.5">{desc}</div>
+                  <div className="text-3xs text-fg-muted mt-0.5">{desc}</div>
                   {existing > 0 && (
-                    <div className="text-[9px] text-fg-muted mt-1">
+                    <div className="text-4xs text-fg-muted mt-1">
                       {disabled
                         ? `Already connected — ${BACKEND_LABELS[type]} only supports one backup`
                         : `(${existing} already connected)`}
@@ -350,7 +350,7 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
           <div className="px-4 py-4 space-y-4">
           {/* Name */}
           <div>
-            <label className="block text-[10px] text-fg-muted mb-1">Give this backup a name</label>
+            <label className="block text-3xs text-fg-muted mb-1">Give this backup a name</label>
             {/* Migrated to the shared TextInput (spec change 20): the hand-rolled
                 bg-inset/rounded-md/focus recipe is now the one FIELD surface, so
                 every text box in the app focuses and rounds the same way. The
@@ -364,13 +364,13 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
               className="w-full"
               autoFocus
             />
-            <div className="text-[10px] text-fg-muted mt-0.5">This is just for you — to tell your backups apart.</div>
+            <div className="text-3xs text-fg-muted mt-0.5">This is just for you — to tell your backups apart.</div>
           </div>
 
           {/* Drive: folder name */}
           {backendType === 'drive' && (
             <div>
-              <label className="block text-[10px] text-fg-muted mb-1">Folder in Google Drive</label>
+              <label className="block text-3xs text-fg-muted mb-1">Folder in Google Drive</label>
               {/* Shared FIELD surface (spec change 20). aria-label mirrors the
                   visible label, which isn't linked via htmlFor. */}
               <TextInput
@@ -380,7 +380,7 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
                 aria-label="Folder in Google Drive"
                 className="w-full"
               />
-              <div className="text-[10px] text-fg-muted mt-0.5">
+              <div className="text-3xs text-fg-muted mt-0.5">
                 We'll create a folder called "{driveFolder || 'Claude'}" in your Drive if it doesn't exist.
               </div>
             </div>
@@ -422,7 +422,7 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
                         className="w-full"
                       />
                       {ghUsername && (
-                        <div className="text-[10px] text-fg-muted mt-0.5">
+                        <div className="text-3xs text-fg-muted mt-0.5">
                           This will be created as {ghUsername}/{repoName || 'claude-sync'}
                         </div>
                       )}
@@ -453,7 +453,7 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
                         aria-label="Existing repository URL"
                         className="w-full"
                       />
-                      <div className="text-[10px] text-fg-muted mt-0.5">Paste the full URL of your private repository.</div>
+                      <div className="text-3xs text-fg-muted mt-0.5">Paste the full URL of your private repository.</div>
                     </div>
                   )}
                 </div>
@@ -463,9 +463,9 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
 
           {/* iCloud: show detected path */}
           {backendType === 'icloud' && icloudPath && (
-            <div className="px-3 py-2.5 rounded-lg bg-inset/50 text-[11px] text-fg-dim">
+            <div className="px-3 py-2.5 rounded-lg bg-inset/50 text-2xs text-fg-dim">
               Your data will be stored in iCloud Drive at:<br />
-              <span className="text-fg font-mono text-[10px]">{icloudPath}</span>
+              <span className="text-fg font-mono text-3xs">{icloudPath}</span>
             </div>
           )}
 
@@ -485,14 +485,14 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
               />
               <span className="text-xs text-fg">Back up automatically after changes</span>
             </label>
-            <div className="text-[10px] text-fg-muted mt-0.5 ml-10">
+            <div className="text-3xs text-fg-muted mt-0.5 ml-10">
               Turn off to only sync when you choose to.
             </div>
           </div>
 
           {/* Error message */}
           {error && (
-            <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-[11px] text-red-400">
+            <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-2xs text-red-400">
               {error}
             </div>
           )}
@@ -525,7 +525,7 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
               isDup = dupes.some(b => (b.config.ICLOUD_PATH || '') === icloudPath);
             }
             return isDup ? (
-              <div className="px-3 py-2 rounded-lg bg-inset/50 text-[11px] text-fg-dim">
+              <div className="px-3 py-2 rounded-lg bg-inset/50 text-2xs text-fg-dim">
                 Heads up: you already have a backup pointing to this exact destination (same account and folder). Adding another is safe, but it'll just duplicate what the existing one does. If you meant a different account, cancel and sign into that account first.
               </div>
             ) : null;
@@ -569,7 +569,7 @@ export default function SyncSetupWizard({ initialType, existingBackends, onCompl
             <span className="text-green-400 text-3xl">{'\u2713'}</span>
           </div>
           <div className="text-fg font-medium text-sm mb-2">You're all set!</div>
-          <div className="text-fg-muted text-[11px] mb-6 max-w-xs">
+          <div className="text-fg-muted text-2xs mb-6 max-w-xs">
             Your first backup is syncing now. Backups happen automatically every 15 minutes.
             You can manage them anytime from the Sync panel.
           </div>
@@ -681,7 +681,7 @@ function PrereqCheckStep({
         {/* Action: install rclone */}
         {needsRclone && !checking && (
           <div className="pt-2 space-y-2">
-            <div className="text-[11px] text-fg-dim">
+            <div className="text-2xs text-fg-dim">
               YouCoded needs a small helper tool to connect to Google Drive.
             </div>
             {/* Another hardcoded blue survivor (spec change 55) — now the theme accent.
@@ -695,7 +695,7 @@ function PrereqCheckStep({
               )}
               {installing ? 'Installing...' : 'Install Now'}
             </Button>
-            <div className="text-[10px] text-fg-muted">This usually takes about a minute.</div>
+            <div className="text-3xs text-fg-muted">This usually takes about a minute.</div>
           </div>
         )}
 
@@ -711,7 +711,7 @@ function PrereqCheckStep({
 
         {/* Install error */}
         {installError && (
-          <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-[11px] text-red-400">
+          <div className="px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-2xs text-red-400">
             {installError}
             <div className="mt-1">
               <button className="text-accent underline" onClick={() => claude.openExternal('https://rclone.org/install/')}>
@@ -735,17 +735,17 @@ function IcloudMissingHelp({ onRecheck }: { onRecheck: () => void }) {
   const os: DesktopOS = checkIsAndroid() ? 'other' : detectDesktopOS();
   return (
     <div className="pt-2 space-y-2">
-      <div className="text-[11px] text-fg-dim">
+      <div className="text-2xs text-fg-dim">
         iCloud Drive wasn't found on this computer.
       </div>
       {os === 'mac' && (
-        <div className="text-[10px] text-fg-muted space-y-1">
+        <div className="text-3xs text-fg-muted space-y-1">
           <div>On macOS, enable it in <span className="text-fg-dim">System Settings &gt; Apple ID &gt; iCloud &gt; iCloud Drive</span>.</div>
           <div>Make sure iCloud Drive is turned on and has finished its first sync, then check again.</div>
         </div>
       )}
       {os === 'windows' && (
-        <div className="text-[10px] text-fg-muted space-y-1">
+        <div className="text-3xs text-fg-muted space-y-1">
           <div>On Windows, iCloud isn't built in — you need to install <span className="text-fg-dim">iCloud for Windows</span> from the Microsoft Store or Apple's website.</div>
           <div className="flex flex-wrap gap-2 pt-1">
             <button className="text-accent underline" onClick={() => claude.openExternal('https://apps.microsoft.com/detail/9PKTQ5699M62')}>
@@ -760,13 +760,13 @@ function IcloudMissingHelp({ onRecheck }: { onRecheck: () => void }) {
         </div>
       )}
       {os === 'linux' && (
-        <div className="text-[10px] text-fg-muted space-y-1">
+        <div className="text-3xs text-fg-muted space-y-1">
           <div>iCloud Drive isn't officially supported on Linux — Apple doesn't provide a client.</div>
           <div>Use <span className="text-fg-dim">Google Drive</span> or <span className="text-fg-dim">GitHub</span> for backup on this computer instead.</div>
         </div>
       )}
       {os === 'other' && (
-        <div className="text-[10px] text-fg-muted">
+        <div className="text-3xs text-fg-muted">
           Couldn't detect your operating system. iCloud Drive works best on macOS and Windows. If you're on Linux, try Google Drive or GitHub instead.
         </div>
       )}
@@ -823,7 +823,7 @@ function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
 
   return (
     <div className="pt-2 space-y-2">
-      <div className="text-[11px] text-fg-dim">
+      <div className="text-2xs text-fg-dim">
         YouCoded needs GitHub's command-line tool (gh) to connect your account.
       </div>
 
@@ -837,12 +837,12 @@ function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
             )}
             {installing ? 'Installing...' : 'Install Now'}
           </Button>
-          <div className="text-[10px] text-fg-muted">This usually takes about a minute.</div>
+          <div className="text-3xs text-fg-muted">This usually takes about a minute.</div>
         </div>
       )}
 
       {installError && (
-        <div className="text-[10px] text-destructive-fg">
+        <div className="text-3xs text-destructive-fg">
           Couldn't install it automatically: {installError}
         </div>
       )}
@@ -850,21 +850,21 @@ function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
       {/* Manual instructions: only after an automated attempt failed (or on a
           platform where we can't run one). */}
       {(installError || !canAutoInstall) && os === 'mac' && (
-        <div className="text-[10px] text-fg-muted space-y-1">
+        <div className="text-3xs text-fg-muted space-y-1">
           <div>On macOS, the easiest way is Homebrew. In Terminal, run:</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">brew install gh</div>
           <div>No Homebrew? Download the installer from <button className="text-accent underline" onClick={() => claude.openExternal('https://cli.github.com')}>cli.github.com</button>.</div>
         </div>
       )}
       {(installError || !canAutoInstall) && os === 'windows' && (
-        <div className="text-[10px] text-fg-muted space-y-1">
+        <div className="text-3xs text-fg-muted space-y-1">
           <div>On Windows, download the installer from <button className="text-accent underline" onClick={() => claude.openExternal('https://cli.github.com')}>cli.github.com</button>.</div>
           <div>Or, if you use winget, open PowerShell and run:</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">winget install GitHub.cli</div>
         </div>
       )}
       {(installError || !canAutoInstall) && os === 'linux' && (
-        <div className="text-[10px] text-fg-muted space-y-1">
+        <div className="text-3xs text-fg-muted space-y-1">
           <div>On Linux, install with your package manager:</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">sudo apt install gh  # Debian/Ubuntu</div>
           <div className="font-mono text-fg-dim bg-inset/50 px-2 py-1 rounded">sudo dnf install gh  # Fedora</div>
@@ -872,12 +872,12 @@ function GhInstallHelp({ onRecheck }: { onRecheck: () => void }) {
         </div>
       )}
       {(installError || !canAutoInstall) && os === 'other' && (
-        <div className="text-[10px] text-fg-muted">
+        <div className="text-3xs text-fg-muted">
           Install from <button className="text-accent underline" onClick={() => claude.openExternal('https://cli.github.com')}>cli.github.com</button>, then come back and tap "Check Again".
         </div>
       )}
       {(installError || !canAutoInstall) && (
-        <div className="text-[10px] text-fg-muted">After installing, come back and tap "Check Again".</div>
+        <div className="text-3xs text-fg-muted">After installing, come back and tap "Check Again".</div>
       )}
       {/* Filled-grey (bg-inset) becomes the outline `secondary` — spec decision 60. */}
       <Button variant="secondary" onClick={onRecheck}>
@@ -894,7 +894,7 @@ function PrereqRow({ label, status }: { label: string; status: 'checking' | 'rea
     <div className="flex items-center gap-3 px-3 py-2 rounded-lg bg-inset/30">
       <StatusIcon status={status} />
       <span className="text-xs text-fg">{label}</span>
-      <span className="text-[10px] text-fg-muted ml-auto">
+      <span className="text-3xs text-fg-muted ml-auto">
         {status === 'checking' ? 'checking...' : status === 'ready' ? 'ready' : 'needed'}
       </span>
     </div>
@@ -972,15 +972,15 @@ function AuthStep({
 
         {!waiting ? (
           <>
-            <div className="text-fg-dim text-[11px] mb-6 max-w-xs space-y-2">
+            <div className="text-fg-dim text-2xs mb-6 max-w-xs space-y-2">
               <div>A browser window will open for you to sign in. After you sign in, come back here — it'll update automatically.</div>
               {isReconnect && backendType === 'drive' && (
-                <div className="text-amber-400 text-[10px] pt-1">
+                <div className="text-amber-400 text-3xs pt-1">
                   Important: sign in with the <strong>same Google account</strong> you originally connected. Picking a different account would start a new backup instead of restoring the existing one.
                 </div>
               )}
               {isAdditionalDrive && (
-                <div className="text-amber-400 text-[10px] pt-1">
+                <div className="text-amber-400 text-3xs pt-1">
                   Tip: make sure you pick the <strong>other</strong> Google account (e.g., work vs. personal vs. school) in the browser — not the same one you already connected. You may need to sign out of Google in your browser first, or use an incognito window.
                 </div>
               )}
@@ -993,11 +993,11 @@ function AuthStep({
           </>
         ) : (
           <>
-            <div className="flex items-center gap-2 text-blue-400 text-[11px] mb-4">
+            <div className="flex items-center gap-2 text-blue-400 text-2xs mb-4">
               <span className="w-4 h-4 border-2 border-blue-400/30 border-t-blue-400 rounded-full animate-spin" />
               Waiting for sign-in...
             </div>
-            <div className="text-fg-muted text-[10px] max-w-xs">
+            <div className="text-fg-muted text-3xs max-w-xs">
               Complete the sign-in in your browser, then come back here. This page will update automatically.
             </div>
           </>
@@ -1006,7 +1006,7 @@ function AuthStep({
         {/* Error + retry */}
         {error && (
           <div className="mt-4 space-y-2 text-center">
-            <div className="text-[11px] text-fg-dim">
+            <div className="text-2xs text-fg-dim">
               Looks like the sign-in didn't complete. No worries — try again when you're ready.
             </div>
             {/* Filled-grey (bg-inset) becomes the outline `secondary` — spec decision 60. */}

--- a/desktop/src/renderer/components/SystemMarker.tsx
+++ b/desktop/src/renderer/components/SystemMarker.tsx
@@ -30,7 +30,7 @@ export default function SystemMarker({ marker }: Props) {
             type="button"
             onClick={() => setExpanded((v) => !v)}
             aria-expanded={expanded}
-            className="text-[11px] uppercase tracking-wider whitespace-nowrap inline-flex items-center gap-1.5 hover:text-fg-2 transition-colors cursor-pointer"
+            className="text-2xs uppercase tracking-wider whitespace-nowrap inline-flex items-center gap-1.5 hover:text-fg-2 transition-colors cursor-pointer"
           >
             <svg
               width="8"
@@ -48,7 +48,7 @@ export default function SystemMarker({ marker }: Props) {
             </span>
           </button>
         ) : (
-          <span className="text-[11px] uppercase tracking-wider whitespace-nowrap">
+          <span className="text-2xs uppercase tracking-wider whitespace-nowrap">
             {marker.label}
             <span className="ml-2 text-fg-faint normal-case tracking-normal">· {time}</span>
           </span>
@@ -60,7 +60,7 @@ export default function SystemMarker({ marker }: Props) {
         // summaries. Pre-wrap preserves CC's numbered-list formatting;
         // break-words so long paths/URLs wrap rather than overflow.
         <div className="mt-2 mx-auto max-w-3xl rounded-md border border-edge-dim bg-inset/60 px-4 py-3">
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-2">
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-2">
             Compaction summary
           </div>
           <pre className="text-xs text-fg-2 whitespace-pre-wrap break-words font-sans leading-relaxed max-h-96 overflow-y-auto">

--- a/desktop/src/renderer/components/TerminalToolbar.tsx
+++ b/desktop/src/renderer/components/TerminalToolbar.tsx
@@ -96,7 +96,7 @@ function ToolbarButton({
       type="button"
       onClick={onClick}
       title={title || label}
-      className={`shrink-0 ${heightClass} min-w-[2.25rem] px-2.5 rounded-md border text-[11px] transition-colors select-none ${
+      className={`shrink-0 ${heightClass} min-w-[2.25rem] px-2.5 rounded-md border text-2xs transition-colors select-none ${
         active
           ? 'bg-accent text-on-accent border-accent'
           : 'bg-panel border-edge-dim text-fg-2 hover:bg-inset hover:text-fg'

--- a/desktop/src/renderer/components/ThemeScreen.tsx
+++ b/desktop/src/renderer/components/ThemeScreen.tsx
@@ -154,7 +154,7 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
         {/* Theme grid — pencil on each card opens the per-theme edit view.
             Cycle membership moved to the status bar widget editor. */}
         <div>
-          <p className="text-[9px] text-fg-muted uppercase tracking-wider mb-2">Your Themes</p>
+          <p className="text-4xs text-fg-muted uppercase tracking-wider mb-2">Your Themes</p>
           <div className="grid grid-cols-2 gap-2">
             {gridThemes.map(t => {
               const isActive = t.slug === activeSlug;
@@ -179,8 +179,8 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
                   <div style={{ height: 6, background: `linear-gradient(90deg, ${t.tokens.canvas}, ${t.tokens.accent})` }} />
                   <div className="px-2 py-1.5" style={{ background: t.tokens.canvas }}>
                     {/* Leave room on right for the pencil and star icons */}
-                    <p className="text-[10px] font-medium truncate pr-8" style={{ color: t.tokens.fg }}>{t.name}</p>
-                    {isActive && <span className="text-[8px]" style={{ color: t.tokens.accent }}>active</span>}
+                    <p className="text-3xs font-medium truncate pr-8" style={{ color: t.tokens.fg }}>{t.name}</p>
+                    {isActive && <span className="text-4xs" style={{ color: t.tokens.accent }}>active</span>}
                   </div>
                   {/* Pencil — opens the per-theme edit menu. Positioned bottom-right
                       to avoid overlap with the star which occupies top-right. */}
@@ -260,7 +260,7 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs text-fg-2">Reduce Visual Effects</p>
-            <p className="text-[10px] text-fg-muted">Disables particles, blur, and animations</p>
+            <p className="text-3xs text-fg-muted">Disables particles, blur, and animations</p>
           </div>
           {/* Was a hand-rolled 36x20 switch (change 15): same geometry, but the
               shared Toggle also carries role="switch" + aria-checked, which this
@@ -276,7 +276,7 @@ export default function ThemeScreen({ onClose, onSendInput, onOpenMarketplace, o
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs text-fg-2">Message Timestamps</p>
-            <p className="text-[10px] text-fg-muted">Show time sent in each chat bubble</p>
+            <p className="text-3xs text-fg-muted">Show time sent in each chat bubble</p>
           </div>
           {/* Same migration as the toggle above (change 15). */}
           <Toggle
@@ -399,7 +399,7 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
         <div className="p-3 space-y-4">
         {/* Locked banner for non-user themes so it's clear why most controls are absent */}
         {!isUserTheme && (
-          <p className="text-[10px] text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 leading-relaxed">
+          <p className="text-3xs text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 leading-relaxed">
             {isCommunityTheme
               ? 'Marketplace themes are kept in sync with their author\u2019s updates. Glass + terminal transparency sliders are customizable per-theme. Use "Build New Theme with Claude" to fork an editable copy.'
               : 'Built-in themes are locked. Only glass + terminal transparency sliders are customizable. Use "Build New Theme with Claude" to make an editable copy.'}
@@ -418,20 +418,20 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
                   onChange={e => updateAccent(e.target.value)}
                   className="w-6 h-6 rounded-sm cursor-pointer border-0 bg-transparent"
                 />
-                <span className="text-[10px] text-fg-muted font-mono">{theme.tokens.accent}</span>
+                <span className="text-3xs text-fg-muted font-mono">{theme.tokens.accent}</span>
               </div>
             </div>
             <div className="flex items-center justify-between gap-3">
               <span className="text-xs text-fg-2">Roundness</span>
               <div className="flex items-center gap-2 flex-1">
-                <span className="text-[10px] text-fg-faint">□</span>
+                <span className="text-3xs text-fg-faint">□</span>
                 <input
                   type="range" min="0" max="1" step="0.05"
                   value={roundnessDraft}
                   onChange={e => { const v = parseFloat(e.target.value); setRoundnessDraft(v); updateRoundness(v); }}
                   className="flex-1 accent-accent"
                 />
-                <span className="text-[10px] text-fg-faint">◯</span>
+                <span className="text-3xs text-fg-faint">◯</span>
               </div>
             </div>
             <div className="flex items-center justify-between">
@@ -461,9 +461,9 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
             are greyed when Reduce Visual Effects is on (the engine forces blur:0). */}
         {(hasWallpaper || hasGradient) && (
           <div>
-            <p className="text-[9px] text-fg-muted uppercase tracking-wider mb-2">Glass</p>
+            <p className="text-4xs text-fg-muted uppercase tracking-wider mb-2">Glass</p>
             {reducedEffects && (
-              <p className="text-[10px] text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 mb-2 leading-relaxed">
+              <p className="text-3xs text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 mb-2 leading-relaxed">
                 Reduce Visual Effects is active — blur is disabled. Opacity still applies.
               </p>
             )}
@@ -509,14 +509,14 @@ function ThemeEditView({ theme, reducedEffects, setGlassOverride, onPublishTheme
             those values) or when there's no wallpaper to blur. */}
         {canTuneTerminalOpacity && (
           <div>
-            <p className="text-[9px] text-fg-muted uppercase tracking-wider mb-2">Terminal</p>
+            <p className="text-4xs text-fg-muted uppercase tracking-wider mb-2">Terminal</p>
             {canTuneTerminalFilter && reducedEffects && (
-              <p className="text-[10px] text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 mb-2 leading-relaxed">
+              <p className="text-3xs text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 mb-2 leading-relaxed">
                 Reduce Visual Effects is active — wallpaper blur is disabled. Opacity + brightness still apply.
               </p>
             )}
             {hasBakedTerminalBg && (
-              <p className="text-[10px] text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 mb-2 leading-relaxed">
+              <p className="text-3xs text-fg-muted bg-inset border border-edge-dim rounded-md px-2.5 py-1.5 mb-2 leading-relaxed">
                 This theme ships a pre-blurred terminal wallpaper — blur + brightness are baked in. Only opacity is adjustable here.
               </p>
             )}
@@ -593,7 +593,7 @@ function GlassSlider({
           onChange={e => onChange(parseFloat(e.target.value))}
           className="flex-1 accent-accent"
         />
-        <span className="text-[10px] text-fg-muted w-9 text-right">{format(value)}</span>
+        <span className="text-3xs text-fg-muted w-9 text-right">{format(value)}</span>
       </div>
     </div>
   );

--- a/desktop/src/renderer/components/ThemeShareSheet.tsx
+++ b/desktop/src/renderer/components/ThemeShareSheet.tsx
@@ -128,7 +128,7 @@ export default function ThemeShareSheet({ themeSlug, onClose }: ThemeShareSheetP
               <div style={{ height: 6, background: `linear-gradient(90deg, ${theme.tokens.canvas}, ${theme.tokens.accent})` }} />
               <div className="px-3 py-2.5" style={{ background: theme.tokens.canvas }}>
                 <p className="text-xs font-medium" style={{ color: theme.tokens.fg }}>{theme.name}</p>
-                <p className="text-[10px] mt-0.5" style={{ color: theme.tokens['fg-muted'] }}>
+                <p className="text-3xs mt-0.5" style={{ color: theme.tokens['fg-muted'] }}>
                   {theme.dark ? 'Dark' : 'Light'} theme
                   {theme.effects?.particles && theme.effects.particles !== 'none' ? ` \u00b7 ${theme.effects.particles} particles` : ''}
                   {theme.font?.family ? ` \u00b7 ${theme.font.family.split(',')[0].replace(/'/g, '')}` : ''}
@@ -139,14 +139,14 @@ export default function ThemeShareSheet({ themeSlug, onClose }: ThemeShareSheetP
         </div>
 
         {/* Info */}
-        <p className="text-[11px] text-fg-muted mb-4 leading-relaxed">
+        <p className="text-2xs text-fg-muted mb-4 leading-relaxed">
           This will create a pull request to the{' '}
           <span className="text-fg-2 font-medium">wecoded-themes</span>{' '}
           repository on GitHub. Your theme will be reviewed and, if approved, added to the marketplace for all users.
           {previewPath && ' A preview image will be included in the submission.'}
         </p>
 
-        <p className="text-[10px] text-fg-muted mb-4">
+        <p className="text-3xs text-fg-muted mb-4">
           Requires the <span className="font-mono">gh</span> CLI to be installed and authenticated.
         </p>
 
@@ -228,7 +228,7 @@ function renderPublishButton(args: {
         >
           {publishing ? 'Publishing update…' : 'Publish update'}
         </Button>
-        <p className="text-[10px] text-fg-muted text-center mt-1.5">
+        <p className="text-3xs text-fg-muted text-center mt-1.5">
           Local changes not yet published
         </p>
       </>
@@ -246,7 +246,7 @@ function renderPublishButton(args: {
         >
           {publishing ? 'Publishing…' : previewLoading ? 'Generating preview…' : '⚠ Publish to Marketplace'}
         </Button>
-        <p className="text-[10px] text-fg-muted text-center mt-1.5">
+        <p className="text-3xs text-fg-muted text-center mt-1.5">
           Could not verify status: {state.reason}
         </p>
       </>

--- a/desktop/src/renderer/components/ToolCard.tsx
+++ b/desktop/src/renderer/components/ToolCard.tsx
@@ -362,11 +362,11 @@ function PermissionButtons({ requestId, suggestions, denyListed, command, folder
           Always allow this exact command{folderName ? ` in ${folderName}` : ''}?
         </p>
         {command && (
-          <p className="text-[11px] leading-relaxed text-fg-2 bg-inset/70 px-2 py-1.5 rounded-sm break-all">
+          <p className="text-2xs leading-relaxed text-fg-2 bg-inset/70 px-2 py-1.5 rounded-sm break-all">
             {command}
           </p>
         )}
-        <p className="text-[11px] text-fg-dim leading-relaxed">
+        <p className="text-2xs text-fg-dim leading-relaxed">
           It can delete files or change published code, and you won't be asked again.
         </p>
         <div className="flex items-center gap-2">

--- a/desktop/src/renderer/components/UserMessage.tsx
+++ b/desktop/src/renderer/components/UserMessage.tsx
@@ -72,7 +72,7 @@ export default React.memo(function UserMessage({ message, sessionId, showTimesta
       <div className="user-bubble max-w-[80%] break-words rounded-2xl rounded-br-sm bg-accent px-5 py-3 text-sm text-on-accent whitespace-pre-wrap">
         {body}
         {showTimestamps && (
-          <div className="bubble-timestamp text-[9px] text-on-accent/50 text-right mt-1 -mb-0.5 select-none leading-none">
+          <div className="bubble-timestamp text-4xs text-on-accent/50 text-right mt-1 -mb-0.5 select-none leading-none">
             {formatBubbleTime(message.timestamp)}
           </div>
         )}

--- a/desktop/src/renderer/components/artifact-views/ActiveArtifactView.tsx
+++ b/desktop/src/renderer/components/artifact-views/ActiveArtifactView.tsx
@@ -427,7 +427,7 @@ export const ActiveArtifactView = forwardRef<ActiveArtifactHandle, ActiveArtifac
           diff at all (spec §6.2). */}
       {showDiff && conflict && (
         <div className="border-b border-edge shrink-0 overflow-auto max-h-[40%] p-2">
-          <div className="text-[10px] text-fg-muted mb-1 font-semibold uppercase tracking-wide">
+          <div className="text-3xs text-fg-muted mb-1 font-semibold uppercase tracking-wide">
             What keeping yours changes (disk → your draft)
           </div>
           <UnifiedDiff oldStr={conflict.disk} newStr={draft} />

--- a/desktop/src/renderer/components/context-menu/ContextMenu.tsx
+++ b/desktop/src/renderer/components/context-menu/ContextMenu.tsx
@@ -157,7 +157,7 @@ export function ContextMenu({
               <MenuIcon name={entry.icon} />
             </span>
             <span className="flex-1 truncate">{entry.label}</span>
-            {entry.kbd && <span className="text-fg-muted text-[10px] tracking-wide">{entry.kbd}</span>}
+            {entry.kbd && <span className="text-fg-muted text-3xs tracking-wide">{entry.kbd}</span>}
           </button>
         );
       })}

--- a/desktop/src/renderer/components/development/BugReportPopup.tsx
+++ b/desktop/src/renderer/components/development/BugReportPopup.tsx
@@ -222,16 +222,16 @@ function ReviewScreen({ kind, summary, logTail, setLogTail, onEdit, onSubmit, on
       <div className="text-xs text-fg mb-3">{summary.summary}</div>
       {kind === 'bug' && (
         <details className="mb-3">
-          <summary className="text-[10px] text-fg-muted cursor-pointer">Logs to include (editable)</summary>
+          <summary className="text-3xs text-fg-muted cursor-pointer">Logs to include (editable)</summary>
           {summary.flagged_strings.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1">
               {summary.flagged_strings.map((s: string) => (
-                <span key={s} className="text-[9px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400">⚠ {s.slice(0, 30)}</span>
+                <span key={s} className="text-4xs px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400">⚠ {s.slice(0, 30)}</span>
               ))}
             </div>
           )}
           {/* Change 42: same migration as the describe screen. `sm` (11px) is the
-              nearest field size to the old text-[10px] — the scale has no 10px
+              nearest field size to the old raw 10px — the scale has no 10px
               field step, and arbitrary text-[Npx] is retired (see globals.css).
               font-mono is kept: this is a log tail and column alignment matters. */}
           <Textarea
@@ -261,8 +261,8 @@ function ReviewScreen({ kind, summary, logTail, setLogTail, onEdit, onSubmit, on
         >
           {ctaLabel}
         </Button>
-        <p className="text-[10px] text-amber-400/80 text-center">⚠ High Claude usage — not recommended for Pro plans</p>
-        <button onClick={onEdit} className="text-[10px] text-fg-muted hover:text-fg underline">Edit description</button>
+        <p className="text-3xs text-amber-400/80 text-center">⚠ High Claude usage — not recommended for Pro plans</p>
+        <button onClick={onEdit} className="text-3xs text-fg-muted hover:text-fg underline">Edit description</button>
       </div>
     </>
   );

--- a/desktop/src/renderer/components/development/ContributePopup.tsx
+++ b/desktop/src/renderer/components/development/ContributePopup.tsx
@@ -77,7 +77,7 @@ export function ContributePopup({ open, onClose }: Props) {
           <>
             <h3 className="text-sm font-medium text-fg mb-2">Contribute to YouCoded</h3>
             <p className="text-xs text-fg-2 mb-2">
-              <code className="text-[11px] bg-inset/60 px-1 rounded">youcoded-dev</code> is the workspace scaffold
+              <code className="text-2xs bg-inset/60 px-1 rounded">youcoded-dev</code> is the workspace scaffold
               that clones all five YouCoded sub-repos side by side, with shared docs and the <code>/audit</code> command.
             </p>
             <p className="text-xs text-fg-2 mb-3">
@@ -106,7 +106,7 @@ export function ContributePopup({ open, onClose }: Props) {
         {done && (
           <>
             <div className="text-xs text-fg mb-3">
-              Workspace installed at <code className="text-[11px]">{done.path}</code>. Added to your project folders.
+              Workspace installed at <code className="text-2xs">{done.path}</code>. Added to your project folders.
             </div>
             <div className="flex gap-2">
               <Button variant="secondary" onClick={onClose} className="flex-1 py-2.5">Done</Button>

--- a/desktop/src/renderer/components/development/DevelopmentPopup.tsx
+++ b/desktop/src/renderer/components/development/DevelopmentPopup.tsx
@@ -33,7 +33,7 @@ export function DevelopmentPopup({ open, onClose, onOpenBug, onOpenContribute }:
         className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-4 w-[320px] max-w-[calc(100%-2rem)]"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-[10px] font-medium text-fg-muted tracking-wider uppercase mb-3">Development</h3>
+        <h3 className="text-3xs font-medium text-fg-muted tracking-wider uppercase mb-3">Development</h3>
         <div className="space-y-2">
           <Row
             icon={<BugIcon />}
@@ -69,7 +69,7 @@ function Row({ icon, title, subtitle, onClick }: { icon: ReactNode; title: strin
       <div className="flex items-center justify-center shrink-0" style={{ width: 32, height: 20 }}>{icon}</div>
       <div className="flex-1 min-w-0">
         <span className="text-xs text-fg font-medium">{title}</span>
-        <p className="text-[10px] text-fg-muted">{subtitle}</p>
+        <p className="text-3xs text-fg-muted">{subtitle}</p>
       </div>
       <svg className="w-3.5 h-3.5 text-fg-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/desktop/src/renderer/components/diff/UnifiedDiff.tsx
+++ b/desktop/src/renderer/components/diff/UnifiedDiff.tsx
@@ -160,7 +160,7 @@ export function UnifiedDiff({
           return (
             <React.Fragment key={idx}>
               {showSeparator && (
-                <div className="flex items-center text-fg-muted text-[10px] border-y border-edge-dim bg-inset/40 select-none">
+                <div className="flex items-center text-fg-muted text-3xs border-y border-edge-dim bg-inset/40 select-none">
                   <span className="px-2 py-0.5">⋯</span>
                 </div>
               )}
@@ -181,7 +181,7 @@ export function UnifiedDiff({
       {overflow && (
         <button
           onClick={() => setOpen(o => !o)}
-          className="mt-1 text-[10px] uppercase tracking-wider text-fg-muted hover:text-fg-2"
+          className="mt-1 text-3xs uppercase tracking-wider text-fg-muted hover:text-fg-2"
         >
           {open ? 'Collapse' : `Expand (${total} lines)`}
         </button>

--- a/desktop/src/renderer/components/game/GameChat.tsx
+++ b/desktop/src/renderer/components/game/GameChat.tsx
@@ -44,7 +44,7 @@ export default function GameChat({ connection }: Props) {
     <div className="border-t border-edge flex flex-col" style={{ maxHeight: '160px', minHeight: '120px' }}>
       {/* Header */}
       <div className="px-3 py-1.5 border-b border-edge shrink-0">
-        <span className="text-[10px] uppercase tracking-wider text-fg-muted">Game Chat</span>
+        <span className="text-3xs uppercase tracking-wider text-fg-muted">Game Chat</span>
       </div>
 
       {/* Messages */}

--- a/desktop/src/renderer/components/game/GameLobby.tsx
+++ b/desktop/src/renderer/components/game/GameLobby.tsx
@@ -339,12 +339,12 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
               green/faint dot was removed 2026-07-09). This screen only renders
               when connected or incognito (the parent gates the rest), so the
               two reachable states are exactly these words. */}
-          <span className="text-[10px] text-fg-muted shrink-0">{incognito ? 'Incognito' : 'Online'}</span>
+          <span className="text-3xs text-fg-muted shrink-0">{incognito ? 'Incognito' : 'Online'}</span>
         </div>
         {onToggleIncognito && (
           <button
             onClick={onToggleIncognito}
-            className={`text-[10px] px-1.5 py-0.5 rounded-sm transition-colors ${
+            className={`text-3xs px-1.5 py-0.5 rounded-sm transition-colors ${
               incognito
                 ? 'bg-inset text-fg-2 hover:bg-edge'
                 : 'text-fg-muted hover:text-fg-2'
@@ -416,7 +416,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
       {/* Incoming friend requests */}
       {incoming.length > 0 && (
         <div className="px-3 py-2 border-b border-edge">
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-2">Friend requests</div>
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-2">Friend requests</div>
           <ul className="flex flex-col gap-2">
             {incoming.map((req) => (
               <li key={req.id} className="flex flex-col gap-1">
@@ -431,14 +431,14 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
                   <button
                     onClick={() => runMutation(() => window.claude.social.acceptRequest(req.id), req.id, "Couldn't accept — try again")}
                     disabled={pendingRows.has(req.id)}
-                    className="text-[10px] px-1.5 py-1.5 text-green-400 hover:text-green-300 disabled:opacity-40 transition-colors shrink-0"
+                    className="text-3xs px-1.5 py-1.5 text-green-400 hover:text-green-300 disabled:opacity-40 transition-colors shrink-0"
                   >
                     Accept
                   </button>
                   <button
                     onClick={() => runMutation(() => window.claude.social.declineRequest(req.id), req.id, "Couldn't decline — try again")}
                     disabled={pendingRows.has(req.id)}
-                    className="text-[10px] px-1.5 py-1.5 text-fg-muted hover:text-fg-2 disabled:opacity-40 transition-colors shrink-0"
+                    className="text-3xs px-1.5 py-1.5 text-fg-muted hover:text-fg-2 disabled:opacity-40 transition-colors shrink-0"
                   >
                     Decline
                   </button>
@@ -452,7 +452,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
 
       {/* Add a friend by handle */}
       <div className="px-3 py-3 border-b border-edge flex flex-col gap-2">
-        <div className="text-[10px] uppercase tracking-wider text-fg-muted">Add a friend</div>
+        <div className="text-3xs uppercase tracking-wider text-fg-muted">Add a friend</div>
         {/* Change 77: "Send request" moves INSIDE the field. It was left
             `variant="secondary" size="lg"` purely so it would height-match the
             input sitting beside it — inside the field there is nothing to
@@ -487,7 +487,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
       {/* Friends list */}
       {merged.length > 0 && (
         <div className="px-3 py-2 border-b border-edge">
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-2">Friends ({merged.length})</div>
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-2">Friends ({merged.length})</div>
           <ul className="flex flex-col gap-2">
             {merged.map((row) => (
               <li key={row.id} className="flex flex-col gap-0.5">
@@ -502,7 +502,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
                     <button
                       onClick={() => connection.challengePlayer(row.id)}
                       // px/py-1.5 = touch-target padding (see the Accept button note).
-                      className="text-[10px] px-1.5 py-1.5 text-[#66AAFF] hover:text-[#88CCFF] transition-colors shrink-0"
+                      className="text-3xs px-1.5 py-1.5 text-[#66AAFF] hover:text-[#88CCFF] transition-colors shrink-0"
                     >
                       Challenge
                     </button>
@@ -514,7 +514,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
                   />
                 </div>
                 {/* Plain-word status — never glyphs (workspace rule). */}
-                <span className="text-[10px] text-fg-muted">{statusLabel(row, Date.now())}</span>
+                <span className="text-3xs text-fg-muted">{statusLabel(row, Date.now())}</span>
                 {rowError[row.id] && <p className="text-xs text-red-400">{rowError[row.id]}</p>}
               </li>
             ))}
@@ -525,7 +525,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
       {/* Sent (outgoing) requests — dim, collapsed-feeling */}
       {outgoing.length > 0 && (
         <div className="px-3 py-2 border-b border-edge">
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-2">Sent requests</div>
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-2">Sent requests</div>
           <ul className="flex flex-col gap-1">
             {outgoing.map((req) => (
               <li key={req.id} className="flex flex-col gap-1">
@@ -537,7 +537,7 @@ function FriendsScreen({ connection, incognito, onToggleIncognito }: Props) {
                     onClick={() => runMutation(() => window.claude.social.cancelRequest(req.id), req.id, "Couldn't cancel — try again")}
                     disabled={pendingRows.has(req.id)}
                     // px/py-1.5 = touch-target padding (see the Accept button note).
-                    className="text-[10px] px-1.5 py-1.5 text-fg-muted hover:text-fg-2 disabled:opacity-40 transition-colors shrink-0"
+                    className="text-3xs px-1.5 py-1.5 text-fg-muted hover:text-fg-2 disabled:opacity-40 transition-colors shrink-0"
                   >
                     Cancel
                   </button>

--- a/desktop/src/renderer/components/git/GitReviewCard.tsx
+++ b/desktop/src/renderer/components/git/GitReviewCard.tsx
@@ -28,7 +28,7 @@ export function GitReviewCard({
         onClick={onToggle}
         className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-inset transition-colors"
       >
-        <span className={`text-fg-muted text-[10px] transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
+        <span className={`text-fg-muted text-3xs transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
         {headerLeft}
         {headerRight}
       </button>

--- a/desktop/src/renderer/components/git/GitReviewView.tsx
+++ b/desktop/src/renderer/components/git/GitReviewView.tsx
@@ -150,7 +150,7 @@ export function GitReviewView({
         <span className="text-xs font-medium text-fg-2 truncate">Reviewing changes for “{fileName}”</span>
         <div className="flex-1" />
         {review?.branch && (
-          <span className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-mono text-fg-dim border border-edge-dim" title="Current branch">
+          <span className="flex items-center gap-1 px-2 py-1 rounded-md text-2xs font-mono text-fg-dim border border-edge-dim" title="Current branch">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
               <circle cx="6" cy="6" r="2.5" /><circle cx="6" cy="18" r="2.5" /><circle cx="18" cy="8" r="2.5" />
               <path d="M6 8.5v7M18 10.5c0 3-4 3.5-7 3.5" />
@@ -170,13 +170,13 @@ export function GitReviewView({
             headerLeft={<span className="text-xs font-semibold text-fg flex-1">Uncommitted changes</span>}
             headerRight={
               <>
-                <span className="text-[10px] font-mono text-green-400">+{uncommitted.counts.added}</span>
-                <span className="text-[10px] font-mono text-red-400">−{uncommitted.counts.removed}</span>
+                <span className="text-3xs font-mono text-green-400">+{uncommitted.counts.added}</span>
+                <span className="text-3xs font-mono text-red-400">−{uncommitted.counts.removed}</span>
               </>
             }
           >
             {uncommitted.binary ? (
-              <div className="text-[11px] text-fg-muted py-1">Binary or oversized file — no line diff.</div>
+              <div className="text-2xs text-fg-muted py-1">Binary or oversized file — no line diff.</div>
             ) : (
               // This box is the SOLE scroll surface for the diff text: it caps
               // at 45vh and scrolls, while UnifiedDiff renders full-height via
@@ -207,7 +207,7 @@ export function GitReviewView({
                 onClick={() => run(() => (uncommitted.staged
                   ? gitApi().unstage(projectRoot, relPath)
                   : gitApi().stage(projectRoot, relPath)))}
-                className="flex items-center gap-1.5 text-[11px] text-fg-2 hover:text-fg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-1.5 text-2xs text-fg-2 hover:text-fg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
                   <rect x="3" y="3" width="18" height="18" rx="3" />
@@ -219,7 +219,7 @@ export function GitReviewView({
               <button
                 type="button"
                 onClick={() => onRequestDiscard(!uncommitted.inHead)}
-                className="px-2 py-1 rounded-md text-[11px] text-destructive-fg hover:bg-destructive/10 transition-colors"
+                className="px-2 py-1 rounded-md text-2xs text-destructive-fg hover:bg-destructive/10 transition-colors"
               >
                 Revert Changes…
               </button>
@@ -236,7 +236,7 @@ export function GitReviewView({
               onToggle={() => expandCommit(entry)}
               headerLeft={
                 <>
-                  <span className="font-mono text-[11px] text-fg-faint">{entry.shortSha}</span>
+                  <span className="font-mono text-2xs text-fg-faint">{entry.shortSha}</span>
                   <span className="text-xs text-fg-2 truncate flex-1">{entry.subject}</span>
                 </>
               }
@@ -247,26 +247,26 @@ export function GitReviewView({
                       count at all rather than a misleading +0/−0. */}
                   {entry.counts && (
                     <>
-                      <span className="text-[10px] font-mono text-green-400">+{entry.counts.added}</span>
-                      <span className="text-[10px] font-mono text-red-400">−{entry.counts.removed}</span>
+                      <span className="text-3xs font-mono text-green-400">+{entry.counts.added}</span>
+                      <span className="text-3xs font-mono text-red-400">−{entry.counts.removed}</span>
                     </>
                   )}
-                  <span className="text-[11px] text-fg-faint whitespace-nowrap">{formatRelativeTime(entry.authorDate)}</span>
+                  <span className="text-2xs text-fg-faint whitespace-nowrap">{formatRelativeTime(entry.authorDate)}</span>
                 </>
               }
             >
-              {body === 'loading' && <div className="text-[11px] text-fg-muted py-1">Loading…</div>}
+              {body === 'loading' && <div className="text-2xs text-fg-muted py-1">Loading…</div>}
               {/* A rename-only commit (renamedFrom set) with no content change is an
                   honest "moved" state, not the generic "no changes" line — that
                   copy stays reserved for the merge-commit case (no name-status
                   line at all, entry.renamedFrom undefined). */}
               {body === 'empty' && (
                 entry.renamedFrom
-                  ? <div className="text-[11px] text-fg-muted py-1">Moved from “{entry.renamedFrom}” — no content changes in this commit.</div>
-                  : <div className="text-[11px] text-fg-muted py-1">No direct changes to this file in this commit.</div>
+                  ? <div className="text-2xs text-fg-muted py-1">Moved from “{entry.renamedFrom}” — no content changes in this commit.</div>
+                  : <div className="text-2xs text-fg-muted py-1">No direct changes to this file in this commit.</div>
               )}
               {body && typeof body === 'object' && !Array.isArray(body) && (
-                <div className="text-[11px] text-fg-muted py-1 break-words">{body.error}</div>
+                <div className="text-2xs text-fg-muted py-1 break-words">{body.error}</div>
               )}
               {/* Same single-scroll-surface wrapper as the uncommitted card
                   above — see the WHY comment there. */}
@@ -283,7 +283,7 @@ export function GitReviewView({
           <button
             type="button"
             onClick={showMore}
-            className="text-[10px] uppercase tracking-wider text-fg-muted hover:text-fg-2 py-1"
+            className="text-3xs uppercase tracking-wider text-fg-muted hover:text-fg-2 py-1"
           >
             Show more
           </button>
@@ -297,7 +297,7 @@ export function GitReviewView({
       {uncommitted && (
         <div className="shrink-0 border-t border-edge px-2 py-2 bg-inset">
           {(opError ?? externalError) && (
-            <div className="mb-1 px-2.5 py-1.5 text-[11px] text-fg rounded-md border border-edge bg-well break-all">
+            <div className="mb-1 px-2.5 py-1.5 text-2xs text-fg rounded-md border border-edge bg-well break-all">
               {opError ?? externalError}
             </div>
           )}
@@ -325,7 +325,7 @@ export function GitReviewView({
               disabled whenever nothing is staged, but that gave no clue WHY —
               this line only shows up in that state. */}
           {stagedCount === 0 && (
-            <div className="mt-1 text-[11px] text-fg-muted">
+            <div className="mt-1 text-2xs text-fg-muted">
               Tick “Include in commit” on a change above to choose what gets committed.
             </div>
           )}

--- a/desktop/src/renderer/components/marketplace/LikeButton.tsx
+++ b/desktop/src/renderer/components/marketplace/LikeButton.tsx
@@ -188,7 +188,7 @@ export default function LikeButton({ themeId, initialLiked = false, initialCount
         title={title}
         aria-label={liked ? `Unlike (${count})` : `Like (${count})`}
         aria-pressed={liked}
-        className={`flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium transition-colors disabled:opacity-50 ${
+        className={`flex items-center gap-1 px-1.5 py-0.5 rounded-md text-3xs font-medium transition-colors disabled:opacity-50 ${
           liked
             ? 'text-red-400 hover:text-red-300'
             : 'text-fg-muted hover:text-red-400'
@@ -204,7 +204,7 @@ export default function LikeButton({ themeId, initialLiked = false, initialCount
         <div
           role="status"
           aria-live="polite"
-          className="absolute bottom-full right-0 mb-1 whitespace-nowrap px-2 py-1 rounded-md bg-panel border border-edge text-[10px] text-fg shadow-md"
+          className="absolute bottom-full right-0 mb-1 whitespace-nowrap px-2 py-1 rounded-md bg-panel border border-edge text-3xs text-fg shadow-md"
           // zIndex 62 = one above CONTENT_Z[2] (61, L2 content). The toast anchors inline
           // beside the button inside an OverlayPanel, so it needs to clear the panel's
           // own surface. Not L3 (70) — destructive confirmations only. Not using the

--- a/desktop/src/renderer/components/marketplace/MarketplaceCard.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceCard.tsx
@@ -204,7 +204,7 @@ export default function MarketplaceCard({ item, onOpen, installed, updateAvailab
         <div className="shrink-0 flex flex-col items-end gap-1.5">
           {compactStatus && (
             <span
-              className={`text-[10px] uppercase tracking-wide px-2 py-0.5 rounded-full ${STATUS_TONE_CLASS[compactStatus.tone]}`}
+              className={`text-3xs uppercase tracking-wide px-2 py-0.5 rounded-full ${STATUS_TONE_CLASS[compactStatus.tone]}`}
             >
               {compactStatus.text}
             </span>
@@ -305,7 +305,7 @@ export default function MarketplaceCard({ item, onOpen, installed, updateAvailab
             {author && <p className="hidden sm:block text-xs text-fg-dim truncate">{author}</p>}
             {isLocalTheme && (
               <div className="mt-1 inline-flex items-center gap-1 group relative">
-                <span className="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/30">
+                <span className="text-3xs uppercase tracking-wide px-2 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/30">
                   Local
                 </span>
                 <button
@@ -342,13 +342,13 @@ export default function MarketplaceCard({ item, onOpen, installed, updateAvailab
             soon" can surface instead of just "Installed". */}
         {statusBadge ? (
           <span
-            className={`relative z-10 text-[10px] uppercase tracking-wide shrink-0 mt-0.5 px-2 py-0.5 rounded-full ${STATUS_TONE_CLASS[statusBadge.tone]}`}
+            className={`relative z-10 text-3xs uppercase tracking-wide shrink-0 mt-0.5 px-2 py-0.5 rounded-full ${STATUS_TONE_CLASS[statusBadge.tone]}`}
           >
             {statusBadge.text}
           </span>
         ) : (isInstalling || updateAvailable || isInstalled) && (
           <span
-            className={`relative z-10 text-[10px] uppercase tracking-wide shrink-0 mt-0.5 px-2 py-0.5 rounded-full ${
+            className={`relative z-10 text-3xs uppercase tracking-wide shrink-0 mt-0.5 px-2 py-0.5 rounded-full ${
               isInstalling
                 ? 'text-accent border border-accent/50 bg-accent/10 animate-pulse'
                 : 'text-fg-dim'
@@ -367,7 +367,7 @@ export default function MarketplaceCard({ item, onOpen, installed, updateAvailab
           type="button"
           onClick={(e) => { e.stopPropagation(); pluginBadge.onClick(); }}
           title={`Open ${pluginBadge.name}`}
-          className="self-start text-[10px] font-medium px-2 py-0.5 rounded-full shrink-0 bg-accent/10 text-accent border border-accent/30 hover:bg-accent/20 transition-colors truncate max-w-full"
+          className="self-start text-3xs font-medium px-2 py-0.5 rounded-full shrink-0 bg-accent/10 text-accent border border-accent/30 hover:bg-accent/20 transition-colors truncate max-w-full"
         >
           {pluginBadge.name}
         </button>

--- a/desktop/src/renderer/components/marketplace/MarketplaceFilterBar.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceFilterBar.tsx
@@ -103,7 +103,7 @@ export default function MarketplaceFilterBar({ value, onChange }: Props) {
                 <line x1="9" y1="18" x2="15" y2="18" />
               </svg>
               {count > 0 && (
-                <span className="absolute -top-1 -right-1 min-w-[16px] h-[16px] px-1 rounded-full bg-accent text-on-accent text-[10px] font-medium leading-[16px] text-center">
+                <span className="absolute -top-1 -right-1 min-w-[16px] h-[16px] px-1 rounded-full bg-accent text-on-accent text-3xs font-medium leading-[16px] text-center">
                   {count}
                 </span>
               )}

--- a/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
+++ b/desktop/src/renderer/components/marketplace/MarketplaceScreen.tsx
@@ -666,7 +666,7 @@ function IntegrationDetailOverlay({
                   <h1 className="text-xl sm:text-2xl font-semibold text-fg">{item.displayName}</h1>
                   {item.tagline && <p className="mt-1 text-sm sm:text-base text-fg-2">{item.tagline}</p>}
                   <div className="mt-3 flex items-center gap-2 flex-wrap">
-                    <span className={`text-[10px] uppercase tracking-wide rounded-full px-2 py-0.5 ${STATUS_TONE_CLASS[statusBadge.tone]}`}>
+                    <span className={`text-3xs uppercase tracking-wide rounded-full px-2 py-0.5 ${STATUS_TONE_CLASS[statusBadge.tone]}`}>
                       {statusBadge.text}
                     </span>
                     {item.state.error && (

--- a/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
+++ b/desktop/src/renderer/components/marketplace/RatingSubmitModal.tsx
@@ -307,7 +307,7 @@ export default function RatingSubmitModal({
               />
               {/* Character counter — shows remaining only when text is present */}
               {reviewText.length > 0 && (
-                <p className="text-right text-[10px] text-fg-muted mt-0.5">
+                <p className="text-right text-3xs text-fg-muted mt-0.5">
                   {reviewText.length}/{MAX_REVIEW_CHARS}
                 </p>
               )}

--- a/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
+++ b/desktop/src/renderer/components/marketplace/ReportReviewButton.tsx
@@ -198,7 +198,7 @@ function ReportDialog({ reviewerLogin, onClose, onSubmit }: ReportDialogProps) {
               />
               {/* Character counter — shows remaining when text is present */}
               {reason.length > 0 && (
-                <p className="text-right text-[10px] text-fg-muted mt-0.5">
+                <p className="text-right text-3xs text-fg-muted mt-0.5">
                   {reason.length}/{REPORT_REASON_MAX}
                 </p>
               )}
@@ -322,7 +322,7 @@ export default function ReportReviewButton({
         <div
           role="status"
           aria-live="polite"
-          className="absolute bottom-full right-0 mb-1 whitespace-nowrap px-2 py-1 rounded-md bg-panel border border-edge text-[10px] text-fg shadow-md"
+          className="absolute bottom-full right-0 mb-1 whitespace-nowrap px-2 py-1 rounded-md bg-panel border border-edge text-3xs text-fg shadow-md"
           // zIndex 62 = one above CONTENT_Z[2] (61, L2 content). Ephemeral
           // position:absolute sibling anchored beside the button — not a full
           // overlay surface so we don't use the layer primitives here.

--- a/desktop/src/renderer/components/marketplace/ReviewList.tsx
+++ b/desktop/src/renderer/components/marketplace/ReviewList.tsx
@@ -62,7 +62,7 @@ function ReviewRow({ r, pluginId }: { r: RatingEntry; pluginId: string }) {
           />
         ) : (
           // Fallback initials circle when avatar URL is absent or image fails to load
-          <span className="w-6 h-6 rounded-full bg-accent/20 shrink-0 flex items-center justify-center text-[9px] font-bold text-accent">
+          <span className="w-6 h-6 rounded-full bg-accent/20 shrink-0 flex items-center justify-center text-4xs font-bold text-accent">
             {r.user_login.charAt(0).toUpperCase()}
           </span>
         )}
@@ -70,7 +70,7 @@ function ReviewRow({ r, pluginId }: { r: RatingEntry; pluginId: string }) {
         {/* StarRating with hideCount=true — individual review rows don't need "(1)" */}
         {/* count=1: each row represents one review; hideCount suppresses the "(1)" suffix */}
         <StarRating value={r.stars} count={1} size="sm" hideCount />
-        <span className="ml-auto text-[10px] text-fg-muted shrink-0">{formatDate(r.created_at)}</span>
+        <span className="ml-auto text-3xs text-fg-muted shrink-0">{formatDate(r.created_at)}</span>
         {/* Report button — far right of the row, subtle until hovered */}
         <ReportReviewButton
           ratingUserId={r.user_id}

--- a/desktop/src/renderer/components/marketplace/SignInPromptModal.tsx
+++ b/desktop/src/renderer/components/marketplace/SignInPromptModal.tsx
@@ -64,7 +64,7 @@ export default function SignInPromptModal({ open, onClose, title, message }: Pro
             </svg>
             {signInPending ? "Waiting for browser…" : "Sign in to YouCoded"}
           </Button>
-          <p className="text-[10px] text-fg-muted text-center">
+          <p className="text-3xs text-fg-muted text-center">
             Uses your GitHub profile to sign in — GitHub only shares your public info.
           </p>
           {signInPending && (

--- a/desktop/src/renderer/components/marketplace/StarRating.tsx
+++ b/desktop/src/renderer/components/marketplace/StarRating.tsx
@@ -40,9 +40,9 @@ export const STAR_GOLD_CLASS = 'text-[#f0ad4e]';
 
 const SIZE_CONFIG = {
   sm: {
-    starText: 'text-[10px]',
-    countText: 'text-[9px]',
-    containerClass: 'text-[10px]',
+    starText: 'text-3xs',
+    countText: 'text-4xs',
+    containerClass: 'text-3xs',
   },
   lg: {
     starText: 'text-sm',

--- a/desktop/src/renderer/components/project-view/AddProjectModal.tsx
+++ b/desktop/src/renderer/components/project-view/AddProjectModal.tsx
@@ -132,7 +132,7 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
 
             {/* Choice 1: start new (inline name + create) */}
             <div className="mt-3 rounded-lg border border-edge p-3">
-              <div className="text-[13px] font-semibold text-fg">Start something new</div>
+              <div className="text-sm-tight font-semibold text-fg">Start something new</div>
               <div className="mt-0.5 text-xs text-fg-dim">Creates an empty project in YouCoded that syncs across your devices.</div>
               {/* Change 77: Create submits this field, so it moves INSIDE the
                   field rather than sitting alongside it. Cancel stays in the
@@ -163,7 +163,7 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
               disabled={busy}
               className="mt-2 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
             >
-              <div className="text-[13px] font-semibold text-fg">Use a folder already on this computer</div>
+              <div className="text-sm-tight font-semibold text-fg">Use a folder already on this computer</div>
               <div className="mt-0.5 text-xs text-fg-dim">Pick any folder — you'll choose whether it syncs next.</div>
             </button>
 
@@ -182,7 +182,7 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
               disabled={busy}
               className="mt-3 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
             >
-              <div className="text-[13px] font-semibold text-fg">Keep it where it is</div>
+              <div className="text-sm-tight font-semibold text-fg">Keep it where it is</div>
               <div className="mt-0.5 text-xs text-fg-dim">Only on this computer. The folder doesn't move and nothing changes.</div>
             </button>
 
@@ -193,7 +193,7 @@ export default function AddProjectModal({ onClose, onAdded }: Props) {
               disabled={busy}
               className="mt-2 w-full text-left rounded-lg border border-edge p-3 hover:border-accent hover:bg-inset transition-colors"
             >
-              <div className="text-[13px] font-semibold text-fg">Move it into YouCoded so it syncs</div>
+              <div className="text-sm-tight font-semibold text-fg">Move it into YouCoded so it syncs</div>
               <div className="mt-0.5 text-xs text-fg-dim">The folder moves to ~/YouCoded/Projects/ and syncs across your devices. Anything pointing at the old location (shortcuts, open terminals) will need the new path.</div>
             </button>
 

--- a/desktop/src/renderer/components/project-view/ContextEditorOverlay.tsx
+++ b/desktop/src/renderer/components/project-view/ContextEditorOverlay.tsx
@@ -203,7 +203,7 @@ export function ContextEditorOverlay({ project, file, onClose }: ContextEditorOv
   // Meta strip: scope badge · load timing · size.
   const meta = (
     <>
-      <span className="inline-flex items-center text-[10px] uppercase tracking-wide font-medium text-fg-dim bg-inset border border-edge-dim rounded px-1.5 py-0.5">
+      <span className="inline-flex items-center text-3xs uppercase tracking-wide font-medium text-fg-dim bg-inset border border-edge-dim rounded px-1.5 py-0.5">
         {SCOPE_LABEL[file.scope]}
       </span>
       <span className="text-fg-faint">·</span>

--- a/desktop/src/renderer/components/project-view/ContextIntroBanner.tsx
+++ b/desktop/src/renderer/components/project-view/ContextIntroBanner.tsx
@@ -55,7 +55,7 @@ export function ContextIntroBanner() {
       </span>
       <div className="min-w-0">
         {/* Uppercase micro-label / eyebrow, consistent with the design language. */}
-        <div className="text-[10px] tracking-wider text-fg-muted uppercase mb-1">About context</div>
+        <div className="text-3xs tracking-wider text-fg-muted uppercase mb-1">About context</div>
         {/* One plain-language paragraph — no jargon, no glyphs. */}
         <p className="text-[12.5px] text-fg-2 leading-relaxed">
           These are the notes and rules YouCoded reads to understand how you want it to work. Some

--- a/desktop/src/renderer/components/project-view/FileFilterPopover.tsx
+++ b/desktop/src/renderer/components/project-view/FileFilterPopover.tsx
@@ -45,7 +45,7 @@ function Chip({ active, onClick, multi, children }: {
       aria-checked={multi ? undefined : active}
       aria-pressed={multi ? active : undefined}
       onClick={onClick}
-      className={`px-2.5 py-1 rounded-full text-[12px] transition-colors ${
+      className={`px-2.5 py-1 rounded-full text-xs transition-colors ${
         active
           ? 'bg-accent text-on-accent'
           : 'bg-inset text-fg-2 hover:text-fg border border-edge hover:border-edge-dim'
@@ -59,7 +59,7 @@ function Chip({ active, onClick, multi, children }: {
 function Group({ label, multi, children }: { label: string; multi?: boolean; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-[10px] tracking-wider text-fg-muted uppercase">{label}</span>
+      <span className="text-3xs tracking-wider text-fg-muted uppercase">{label}</span>
       <div className="flex flex-wrap gap-1.5" role={multi ? 'group' : 'radiogroup'} aria-label={label}>{children}</div>
     </div>
   );

--- a/desktop/src/renderer/components/project-view/HowContextWorksPopup.tsx
+++ b/desktop/src/renderer/components/project-view/HowContextWorksPopup.tsx
@@ -120,7 +120,7 @@ const INFO_TABS: { id: InfoTabId; label: string; Icon: React.ComponentType<IconP
 // Small uppercase micro-label (the prototype's `.lbl`).
 function MicroLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-[10px] font-medium tracking-wider uppercase text-fg-muted">
+    <div className="text-3xs font-medium tracking-wider uppercase text-fg-muted">
       {children}
     </div>
   );
@@ -146,7 +146,7 @@ function TopicPage({ data }: { data: TopicPageData }) {
           <Icon size={20} />
         </span>
         <div className="min-w-0">
-          <h3 className="text-[17px] font-semibold text-fg leading-tight font-mono">{data.heading}</h3>
+          <h3 className="text-lg font-semibold text-fg leading-tight font-mono">{data.heading}</h3>
           <p className="text-[12.5px] text-fg-muted mt-0.5">{data.tag}</p>
         </div>
       </div>
@@ -165,7 +165,7 @@ function TopicPage({ data }: { data: TopicPageData }) {
       {data.secs.map(([heading, body]) => (
         <div key={heading} className="mb-3.5">
           <MicroLabel>{heading}</MicroLabel>
-          <p className="text-[13px] text-fg-2 leading-relaxed mt-1">{body}</p>
+          <p className="text-sm-tight text-fg-2 leading-relaxed mt-1">{body}</p>
         </div>
       ))}
 
@@ -303,11 +303,11 @@ const OVERVIEW_LAYERS: OverviewLayer[] = [
 function OverviewPage() {
   return (
     <div>
-      <h3 className="text-[17px] font-semibold text-fg leading-tight">How context works</h3>
+      <h3 className="text-lg font-semibold text-fg leading-tight">How context works</h3>
       <p className="text-[12.5px] text-fg-muted mt-0.5 mb-4">
         Everything Claude reads before it starts — and which wins when they disagree.
       </p>
-      <p className="text-[13px] text-fg-2 leading-relaxed mb-3.5">
+      <p className="text-sm-tight text-fg-2 leading-relaxed mb-3.5">
         Claude builds its understanding of your project from several sources, all loaded
         automatically. They stack from broad to specific:
       </p>
@@ -324,14 +324,14 @@ function OverviewPage() {
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="text-[13.5px] font-medium text-fg">{l.label}</div>
-                  <div className="font-mono text-[11px] text-fg-muted truncate">{l.path}</div>
+                  <div className="font-mono text-2xs text-fg-muted truncate">{l.path}</div>
                 </div>
                 <div className="text-[11.5px] text-fg-dim text-right shrink-0 max-w-[210px]">
                   {l.timing}
                 </div>
               </div>
               {i < OVERVIEW_LAYERS.length - 1 && (
-                <div className="pl-[30px] text-fg-faint text-[12px] leading-none py-0.5">↓</div>
+                <div className="pl-[30px] text-fg-faint text-xs leading-none py-0.5">↓</div>
               )}
             </React.Fragment>
           );
@@ -393,7 +393,7 @@ export function HowContextWorksPopup({ initialTab, onClose }: HowContextWorksPop
       >
         {/* Header */}
         <header className="flex items-center justify-between px-4 py-3 border-b border-edge shrink-0">
-          <span className="text-[15px] font-semibold text-fg">How context works</span>
+          <span className="text-base font-semibold text-fg">How context works</span>
           <CloseButton onClick={onClose} title="Close" />
         </header>
 
@@ -413,7 +413,7 @@ export function HowContextWorksPopup({ initialTab, onClose }: HowContextWorksPop
                   type="button"
                   // shrink-0 + whitespace-nowrap so the tabs scroll horizontally
                   // as a strip on narrow instead of squashing.
-                  className={`w-auto sm:w-full shrink-0 whitespace-nowrap text-left flex items-center gap-2.5 px-3 py-2 rounded-md text-[13px] transition-colors ${
+                  className={`w-auto sm:w-full shrink-0 whitespace-nowrap text-left flex items-center gap-2.5 px-3 py-2 rounded-md text-sm-tight transition-colors ${
                     active
                       ? 'bg-inset text-fg font-medium'
                       : 'text-fg-2 hover:bg-inset hover:text-fg'

--- a/desktop/src/renderer/components/project-view/ImportFileDialog.tsx
+++ b/desktop/src/renderer/components/project-view/ImportFileDialog.tsx
@@ -105,7 +105,7 @@ export function ImportFileDialog({
                 anything not listed here (see import-file.ts). Capped list with
                 an overflow line so a 50-file batch can't push the buttons off
                 screen. */}
-            <ul className="mb-2 max-h-24 overflow-y-auto text-[12px] font-mono text-fg-2 flex flex-col gap-0.5">
+            <ul className="mb-2 max-h-24 overflow-y-auto text-xs font-mono text-fg-2 flex flex-col gap-0.5">
               {collisions.slice(0, MAX_NAMED_COLLISIONS).map((name) => (
                 <li key={name} className="truncate">{name}</li>
               ))}

--- a/desktop/src/renderer/components/project-view/ProjectDetailOverlay.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectDetailOverlay.tsx
@@ -48,7 +48,7 @@ export function ProjectDetailOverlay({ title, onClose, tools, meta, children }: 
             overlay could not be closed. CloseButton is deliberately outside
             the wrapping group so it stays reachable on the first line. */}
         <header className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 sm:px-4 sm:py-3 border-b border-edge shrink-0">
-          <span className="text-[15px] font-semibold text-fg truncate min-w-0 flex-1">{title}</span>
+          <span className="text-base font-semibold text-fg truncate min-w-0 flex-1">{title}</span>
           {/* order flips the close button: narrow keeps it on the title line
               (tools wrap underneath); sm+ restores the original title · tools ·
               close reading order. */}

--- a/desktop/src/renderer/components/project-view/ProjectHero.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectHero.tsx
@@ -203,7 +203,7 @@ export function ProjectHero({
     <div className="layer-surface p-3 sm:p-5 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4">
       {/* Left: eyebrow + name switcher + path/repo + stat row */}
       <div className="min-w-0">
-        <div className="text-[10px] font-medium tracking-wider text-fg-muted uppercase mb-1.5">
+        <div className="text-3xs font-medium tracking-wider text-fg-muted uppercase mb-1.5">
           Project
         </div>
 
@@ -286,7 +286,7 @@ export function ProjectHero({
                 button inline where it has always been. */}
             {sync.dot.color === 'green' && (
               <>
-                <span className="text-[13px] font-semibold text-[#44A05C]">Syncs across your devices</span>
+                <span className="text-sm-tight font-semibold text-[#44A05C]">Syncs across your devices</span>
                 {sync.lastSynced && <span className="text-xs text-fg-muted">Last synced {sync.lastSynced}</span>}
                 {!narrow && sync.spaceId && (
                   <Button variant="secondary" size="sm" onClick={() => onSyncNow(sync.spaceId!)}>
@@ -297,7 +297,7 @@ export function ProjectHero({
             )}
             {sync.dot.color === 'red' && (
               <>
-                <span className="text-[13px] font-semibold text-[#DD4444]">Sync isn't working</span>
+                <span className="text-sm-tight font-semibold text-[#DD4444]">Sync isn't working</span>
                 {sync.errorMessage && <span className="text-xs text-fg-dim">{sync.errorMessage}</span>}
                 {!narrow && sync.spaceId && (
                   <Button variant="secondary" size="sm" onClick={() => onSyncNow(sync.spaceId!)}>
@@ -309,15 +309,15 @@ export function ProjectHero({
             {sync.dot.color === 'gray' && sync.spaceId && sync.stopped && (
               // Stopped = permanent tombstone (detached on every device). Distinct
               // copy so it doesn't falsely promise it'll resume when sync is on.
-              <span className="text-[13px] text-fg-dim">Sync stopped — this project stays on your devices but no longer syncs between them</span>
+              <span className="text-sm-tight text-fg-dim">Sync stopped — this project stays on your devices but no longer syncs between them</span>
             )}
             {sync.dot.color === 'gray' && sync.spaceId && !sync.stopped && (
               // Managed but global Sync is off — the honesty rule.
-              <span className="text-[13px] text-fg-dim">Sync is turned off — this project will sync once you turn it on in Settings</span>
+              <span className="text-sm-tight text-fg-dim">Sync is turned off — this project will sync once you turn it on in Settings</span>
             )}
             {sync.dot.color === 'gray' && !sync.spaceId && (
               <>
-                <span className="text-[13px] font-semibold text-fg-2">Only on this computer</span>
+                <span className="text-sm-tight font-semibold text-fg-2">Only on this computer</span>
                 {/* py-1 keeps this button compact inside the sync status strip;
                     everything else (accent fill, radius, hover) comes from Button. */}
                 {!narrow && (
@@ -335,7 +335,7 @@ export function ProjectHero({
             state it's about is already on screen. */}
         {confirmingStop && (
           <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-[#DD4444]/40 px-3 py-2">
-            <span className="text-[11px] text-fg-dim max-w-[22rem]">
+            <span className="text-2xs text-fg-dim max-w-[22rem]">
               Stop syncing “{shownName}”? The folder stays on all your devices, but changes will no longer sync between them. This can’t be undone from here.
             </span>
             <Button variant="danger-outline" size="sm" onClick={() => void commitStop()}>
@@ -383,7 +383,7 @@ export function ProjectHero({
               // Already stopped (permanent) — no action to offer, just the state
               // (review #4: don't re-render a "Stop syncing" button for a
               // project that's already a tombstone).
-              <span className="text-[11px] text-fg-muted">Sync stopped</span>
+              <span className="text-2xs text-fg-muted">Sync stopped</span>
             ) : syncedFolderName ? (
               !confirmingStop && (
                 <Button variant="danger-outline" size="sm" onClick={() => setConfirmingStop(true)}>
@@ -391,7 +391,7 @@ export function ProjectHero({
                 </Button>
               )
             ) : (
-              <span className="text-[11px] text-fg-muted">Managed by sync</span>
+              <span className="text-2xs text-fg-muted">Managed by sync</span>
             )}
           </div>
         )}
@@ -445,7 +445,7 @@ export function ProjectHero({
                 type="button"
                 role="menuitem"
                 onClick={menu.choose(item.onClick)}
-                className={`coarse-roomy w-full text-left px-3 py-2 text-[13px] transition-colors hover:bg-inset ${
+                className={`coarse-roomy w-full text-left px-3 py-2 text-sm-tight transition-colors hover:bg-inset ${
                   item.danger ? 'text-[#DD4444]' : 'text-fg-2 hover:text-fg'
                 }`}
               >

--- a/desktop/src/renderer/components/project-view/ProjectSwitcher.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectSwitcher.tsx
@@ -129,16 +129,16 @@ export function ProjectSwitcher({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            className="flex-1 bg-transparent outline-none text-[15px] text-fg placeholder:text-fg-muted"
+            className="flex-1 bg-transparent outline-none text-base text-fg placeholder:text-fg-muted"
           />
-          <span className="text-[10px] text-fg-muted border border-edge-dim rounded px-1.5 py-0.5">
+          <span className="text-3xs text-fg-muted border border-edge-dim rounded px-1.5 py-0.5">
             esc
           </span>
         </div>
 
         {/* Recent micro-label */}
         <div className="px-2 pt-2">
-          <span className="px-2 text-[10px] tracking-wider text-fg-muted uppercase">
+          <span className="px-2 text-3xs tracking-wider text-fg-muted uppercase">
             Recent
           </span>
         </div>
@@ -146,7 +146,7 @@ export function ProjectSwitcher({
         {/* Project rows */}
         <div className="p-2 max-h-[50vh] overflow-y-auto flex flex-col gap-0.5">
           {filtered.length === 0 && (
-            <div className="px-3 py-4 text-[13px] text-fg-muted">
+            <div className="px-3 py-4 text-sm-tight text-fg-muted">
               No projects match “{query.trim()}”.
             </div>
           )}
@@ -177,7 +177,7 @@ export function ProjectSwitcher({
                   onClick={() => onSelect(p)}
                 >
                   {/* Avatar: first letter of the name in a rounded square. */}
-                  <span className="shrink-0 w-7 h-7 rounded-md bg-inset border border-edge-dim flex items-center justify-center text-[12px] font-semibold text-fg-2">
+                  <span className="shrink-0 w-7 h-7 rounded-md bg-inset border border-edge-dim flex items-center justify-center text-xs font-semibold text-fg-2">
                     {avatar}
                   </span>
                   {/* Name + path. */}
@@ -187,7 +187,7 @@ export function ProjectSwitcher({
                         {shown}
                       </span>
                     </span>
-                    <span className="block font-mono text-[11px] text-fg-muted truncate" title={p.path}>
+                    <span className="block font-mono text-2xs text-fg-muted truncate" title={p.path}>
                       {p.path}
                     </span>
                   </span>
@@ -206,7 +206,7 @@ export function ProjectSwitcher({
                       // squeezed the name+path column to ~140px in a 359px
                       // palette, truncating both to a few characters. The name
                       // is what identifies the project; the counts decorate.
-                      <span className="hidden sm:inline text-[11px] text-fg-muted shrink-0 whitespace-nowrap">
+                      <span className="hidden sm:inline text-2xs text-fg-muted shrink-0 whitespace-nowrap">
                         {filesLabel} file{files === 1 ? '' : 's'}
                         {typeof p.conversationCount === 'number' && (
                           <> · {p.conversationCount} chat{p.conversationCount === 1 ? '' : 's'}</>
@@ -261,7 +261,7 @@ export function ProjectSwitcher({
         {/* Footer: Add a project (opens the OS folder picker via the parent). */}
         <button
           type="button"
-          className="flex items-center gap-2 px-4 py-3 border-t border-edge-dim text-[13px] text-fg-2 hover:bg-inset hover:text-fg transition-colors rounded-b-[inherit]"
+          className="flex items-center gap-2 px-4 py-3 border-t border-edge-dim text-sm-tight text-fg-2 hover:bg-inset hover:text-fg transition-colors rounded-b-[inherit]"
           onClick={handleAdd}
         >
           <PlusIcon size={15} />

--- a/desktop/src/renderer/components/project-view/ProjectView.tsx
+++ b/desktop/src/renderer/components/project-view/ProjectView.tsx
@@ -759,7 +759,7 @@ export function ProjectView(props: ProjectViewProps) {
                       // the pill spans the screen exactly; inactive ones stay
                       // at their icon width. title= carries the label for the
                       // icon-only state (aria-label does the same for AT).
-                      className={`shrink-0 ${active ? 'max-sm:flex-1 max-sm:min-w-0' : ''} px-2.5 sm:px-3.5 py-1.5 rounded-full text-[13px] font-medium inline-flex items-center justify-center gap-1.5 sm:gap-2 transition-colors ${
+                      className={`shrink-0 ${active ? 'max-sm:flex-1 max-sm:min-w-0' : ''} px-2.5 sm:px-3.5 py-1.5 rounded-full text-sm-tight font-medium inline-flex items-center justify-center gap-1.5 sm:gap-2 transition-colors ${
                         active
                           ? 'bg-accent text-on-accent'
                           : 'text-fg-2 hover:text-fg hover:bg-inset'
@@ -774,7 +774,7 @@ export function ProjectView(props: ProjectViewProps) {
                           segment below 640px — that's what buys the room for
                           all three to fit without scrolling. */}
                       <span className={`truncate ${active ? '' : 'max-sm:hidden'}`}>{s.label}</span>
-                      <span className={`text-[11px] shrink-0 ${active ? 'opacity-80' : 'text-fg-muted max-sm:hidden'}`}>
+                      <span className={`text-2xs shrink-0 ${active ? 'opacity-80' : 'text-fg-muted max-sm:hidden'}`}>
                         {s.count}
                       </span>
                     </button>

--- a/desktop/src/renderer/components/project-view/tabs/ContextTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/ContextTab.tsx
@@ -117,7 +117,7 @@ export function ContextTab({ groups, onEditFile, onOpenInfo }: ContextTabProps) 
                 into overlapping text at ~326px. ml-auto on the button still
                 right-aligns it on the first line. */}
             <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-2 px-1">
-              <span className="text-[10px] font-medium tracking-wider uppercase text-fg-muted">
+              <span className="text-3xs font-medium tracking-wider uppercase text-fg-muted">
                 {meta.label}
               </span>
               <span className="text-[11.5px] text-fg-muted min-w-0">{meta.desc}</span>
@@ -151,16 +151,16 @@ export function ContextTab({ groups, onEditFile, onOpenInfo }: ContextTabProps) 
                       <span className="flex items-center gap-2">
                         <span className="text-[13.5px] font-medium font-mono text-fg truncate">{f.label}</span>
                         {/* Plain-text load badge — subtle pill, never a glyph. */}
-                        <span className="inline-flex items-center text-[10px] text-fg-dim bg-well border border-edge-dim rounded-full px-2 py-0.5 shrink-0">
+                        <span className="inline-flex items-center text-3xs text-fg-dim bg-well border border-edge-dim rounded-full px-2 py-0.5 shrink-0">
                           {timingLabel(f)}
                         </span>
                       </span>
                       {f.description ? (
-                        <span className="block text-[12px] text-fg-2 truncate mt-0.5">{f.description}</span>
+                        <span className="block text-xs text-fg-2 truncate mt-0.5">{f.description}</span>
                       ) : null}
                     </span>
                     {f.size ? (
-                      <span className="text-[11px] text-fg-muted font-mono shrink-0">{f.size}</span>
+                      <span className="text-2xs text-fg-muted font-mono shrink-0">{f.size}</span>
                     ) : null}
                   </button>
                 ))}

--- a/desktop/src/renderer/components/project-view/tabs/ConversationsTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/ConversationsTab.tsx
@@ -63,12 +63,12 @@ export function ConversationsTab({ conversations, onOpenPreview }: Conversations
                 <span className="min-w-0 flex-1">
                   <span className="flex items-baseline gap-2 justify-between">
                     <span className="text-[13.5px] font-medium text-fg truncate">{title}</span>
-                    <span className="text-[11px] text-fg-muted shrink-0">
+                    <span className="text-2xs text-fg-muted shrink-0">
                       {formatRelativeTime(c.lastModified)}
                     </span>
                   </span>
                   {c.preview ? (
-                    <span className="block text-[12px] text-fg-2 truncate mt-0.5">{c.preview}</span>
+                    <span className="block text-xs text-fg-2 truncate mt-0.5">{c.preview}</span>
                   ) : null}
                 </span>
               </button>

--- a/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
+++ b/desktop/src/renderer/components/project-view/tabs/FilesTab.tsx
@@ -407,13 +407,13 @@ export function FilesTab({
         />
         {isDeleted && (
           <span
-            className="absolute top-2 right-2 px-1.5 py-0.5 text-[10px] font-semibold bg-canvas/80 border border-edge rounded text-fg-2"
+            className="absolute top-2 right-2 px-1.5 py-0.5 text-3xs font-semibold bg-canvas/80 border border-edge rounded text-fg-2"
             aria-label="Deleted"
           >
             deleted
           </span>
         )}
-        <span className={`px-2.5 pt-2 pb-0.5 text-[12px] font-mono truncate w-full text-fg-2 shrink-0 ${isDeleted ? 'line-through' : ''}`}>
+        <span className={`px-2.5 pt-2 pb-0.5 text-xs font-mono truncate w-full text-fg-2 shrink-0 ${isDeleted ? 'line-through' : ''}`}>
           {filename}
         </span>
         {/* In flat mode (search / type filter) show the file's folder for
@@ -434,7 +434,7 @@ export function FilesTab({
     <div className="relative flex flex-col h-full overflow-hidden px-2 sm:px-4 pt-4 pb-4 gap-3 min-w-0 max-sm:h-auto max-sm:overflow-visible">
       {/* Breadcrumb — folder-browse mode only (search/type-filter flatten the tree). */}
       {!flat && (
-        <div className="flex items-center gap-1 text-[12px] shrink-0 flex-wrap min-w-0">
+        <div className="flex items-center gap-1 text-xs shrink-0 flex-wrap min-w-0">
           <button
             type="button"
             onClick={() => setCurrentDir('')}
@@ -470,7 +470,7 @@ export function FilesTab({
       {!loading && gated && (
         <div className="max-w-md mt-4 mx-auto text-center">
           <p className="text-sm text-fg mb-1.5">This folder is very large.</p>
-          <p className="text-[13px] text-fg-muted mb-3">
+          <p className="text-sm-tight text-fg-muted mb-3">
             It covers your whole {rootLooksLikeDrive(project.path) ? 'drive' : 'home folder'}, so
             browsing shows only a partial list and can be slow. Conversations are unaffected.
           </p>
@@ -555,9 +555,9 @@ export function FilesTab({
                               title={group.path}
                             >
                               <ChevronIcon className="w-3 h-3 shrink-0" expanded={expanded} />
-                              <span className="text-[12px] font-mono font-medium text-fg-2 shrink-0">{filename}</span>
-                              {dir && <span className="text-[11px] font-mono text-fg-faint truncate min-w-0">{dir}</span>}
-                              <span className="text-[11px] text-fg-muted shrink-0 ml-auto">
+                              <span className="text-xs font-mono font-medium text-fg-2 shrink-0">{filename}</span>
+                              {dir && <span className="text-2xs font-mono text-fg-faint truncate min-w-0">{dir}</span>}
+                              <span className="text-2xs text-fg-muted shrink-0 ml-auto">
                                 {group.hits.length} {group.hits.length === 1 ? 'match' : 'matches'}
                               </span>
                             </button>
@@ -569,7 +569,7 @@ export function FilesTab({
                                 className="w-full flex items-baseline gap-2 pl-7 pr-2.5 py-1 text-left min-w-0 hover:bg-well transition-colors"
                                 title={`${group.path}:${hit.line}`}
                               >
-                                <span className="text-[11px] font-mono text-fg-muted shrink-0 w-8 text-right">{hit.line}</span>
+                                <span className="text-2xs font-mono text-fg-muted shrink-0 w-8 text-right">{hit.line}</span>
                                 <span className="text-[11.5px] font-mono text-fg-dim truncate min-w-0 flex-1">{hit.text}</span>
                               </button>
                             ))}
@@ -631,7 +631,7 @@ export function FilesTab({
                             {previewFiles.map((s) => (
                               <div key={s.id} className="flex items-center gap-1.5 min-w-0">
                                 <span className="text-fg-muted shrink-0"><MiniTypeIcon path={s.path} /></span>
-                                <span className="text-[11px] text-fg-2 truncate">{fileNameOf(s)}</span>
+                                <span className="text-2xs text-fg-2 truncate">{fileNameOf(s)}</span>
                               </div>
                             ))}
                           </div>
@@ -648,7 +648,7 @@ export function FilesTab({
                           body above, so the whole card and the doc cards share one
                           background color. */}
                       <div className="shrink-0 border-t border-edge-dim px-2.5 py-1.5 bg-panel">
-                        <div className="text-[12px] font-mono text-fg-2 flex items-center gap-1.5">
+                        <div className="text-xs font-mono text-fg-2 flex items-center gap-1.5">
                           <span className="text-accent shrink-0"><FolderCardIcon size={13} strokeWidth={1.5} /></span>
                           <span className="truncate">{f.name}</span>
                         </div>
@@ -667,7 +667,7 @@ export function FilesTab({
       {/* Truncation note — discovery hit a cap (very large folder). Never let a
           partial list read as complete. */}
       {truncated && (
-        <p className="text-[11px] text-fg-muted shrink-0">
+        <p className="text-2xs text-fg-muted shrink-0">
           This folder is large — showing the first batch of files. Some documents deeper in the
           folder aren't listed.
         </p>

--- a/desktop/src/renderer/components/tags/NoteEditor.tsx
+++ b/desktop/src/renderer/components/tags/NoteEditor.tsx
@@ -45,7 +45,7 @@ export function NoteEditor({ value, onSave, placeholder = 'Add a note…' }: {
         rows={3}
       />
       {remaining < 500 && (
-        <span className="text-[9px] self-end text-fg-muted">{remaining} left</span>
+        <span className="text-4xs self-end text-fg-muted">{remaining} left</span>
       )}
     </div>
   );

--- a/desktop/src/renderer/components/tags/SessionTagsChip.tsx
+++ b/desktop/src/renderer/components/tags/SessionTagsChip.tsx
@@ -68,7 +68,7 @@ export function SessionTagsChip({ sessionId }: { sessionId: string | null }) {
               <div className="px-4 py-3 space-y-3 overflow-y-auto">
                 <TagPicker appliedIds={meta.tags} onToggle={meta.setTag} registry={registry} />
                 <div>
-                  <label className="text-[10px] uppercase tracking-wider text-fg-muted mb-1 block">Note</label>
+                  <label className="text-3xs uppercase tracking-wider text-fg-muted mb-1 block">Note</label>
                   <NoteEditor value={meta.note} onSave={meta.setNote} />
                 </div>
               </div>

--- a/desktop/src/renderer/components/tags/TagChip.tsx
+++ b/desktop/src/renderer/components/tags/TagChip.tsx
@@ -13,7 +13,7 @@ export function TagChip({ tag, onRemove, className = '' }: {
   const c = `var(--${tag.color})`;
   return (
     <span
-      className={`inline-flex items-center gap-1 px-1.5 py-[1px] rounded-sm text-[10px] leading-none border ${className}`}
+      className={`inline-flex items-center gap-1 px-1.5 py-[1px] rounded-sm text-3xs leading-none border ${className}`}
       style={{
         color: c,
         backgroundColor: `color-mix(in srgb, ${c} 16%, transparent)`,

--- a/desktop/src/renderer/components/tags/TagPicker.tsx
+++ b/desktop/src/renderer/components/tags/TagPicker.tsx
@@ -58,11 +58,11 @@ export function TagPicker({ appliedIds, onToggle, registry }: {
             registry={registry} />
         ))}
         {visible.length === 0 && !canCreate && (
-          <div className="px-2 py-1 text-[10px] text-fg-muted">No tags yet — type a name to create one.</div>
+          <div className="px-2 py-1 text-3xs text-fg-muted">No tags yet — type a name to create one.</div>
         )}
       </div>
       <button onClick={() => setShowArchived((v) => !v)}
-        className="self-start text-[9px] text-fg-muted hover:text-fg-2">
+        className="self-start text-4xs text-fg-muted hover:text-fg-2">
         {showArchived ? 'Hide archived' : 'Show archived'}
       </button>
     </div>
@@ -82,9 +82,9 @@ function TagRow({ tag, applied, editing, onToggle, onEdit, registry }: {
             style={{ backgroundColor: applied ? `var(--${tag.color})` : 'transparent',
                      borderColor: `var(--${tag.color})` }} />
           <TagChip tag={tag} />
-          {tag.archived && <span className="text-[9px] text-fg-muted shrink-0">archived</span>}
+          {tag.archived && <span className="text-4xs text-fg-muted shrink-0">archived</span>}
         </button>
-        <button onClick={onEdit} className="text-fg-faint hover:text-fg-muted text-[10px] shrink-0" title="Edit tag" aria-label="Edit tag">✎</button>
+        <button onClick={onEdit} className="text-fg-faint hover:text-fg-muted text-3xs shrink-0" title="Edit tag" aria-label="Edit tag">✎</button>
       </div>
       {editing && (
         <div className="ml-5 mr-1 mb-1 flex flex-col gap-1.5 p-2 rounded-sm bg-inset border border-edge-dim">
@@ -103,9 +103,9 @@ function TagRow({ tag, applied, editing, onToggle, onEdit, registry }: {
           </div>
           <div className="flex gap-3">
             <button onClick={() => registry.update(tag.id, { archived: !tag.archived })}
-              className="text-[10px] text-fg-muted hover:text-fg">{tag.archived ? 'Unarchive' : 'Archive'}</button>
+              className="text-3xs text-fg-muted hover:text-fg">{tag.archived ? 'Unarchive' : 'Archive'}</button>
             <button onClick={() => registry.remove(tag.id)}
-              className="text-[10px] text-[#DD4444] hover:brightness-125">Delete</button>
+              className="text-3xs text-[#DD4444] hover:brightness-125">Delete</button>
           </div>
         </div>
       )}

--- a/desktop/src/renderer/components/tool-views/ToolBody.tsx
+++ b/desktop/src/renderer/components/tool-views/ToolBody.tsx
@@ -57,7 +57,7 @@ function CollapsibleBlock({ children, maxLines = 20, className = '' }: { childre
       {overflow && (
         <button
           onClick={() => setOpen(o => !o)}
-          className="mt-1 text-[10px] uppercase tracking-wider text-fg-muted hover:text-fg-2"
+          className="mt-1 text-3xs uppercase tracking-wider text-fg-muted hover:text-fg-2"
         >
           {open ? 'Show less' : `Show ${lines.length - maxLines} more lines`}
         </button>
@@ -71,7 +71,7 @@ function PathHeader({ fp, extra }: { fp: string; extra?: React.ReactNode }) {
   return (
     // data-file-path carries the absolute path so the chat right-click menu can
     // offer View in folder / Copy as path (the DOM otherwise only has display labels).
-    <div className="flex items-center gap-1.5 text-[11px] font-mono" data-file-path={fp || undefined}>
+    <div className="flex items-center gap-1.5 text-2xs font-mono" data-file-path={fp || undefined}>
       {dir && <span className="text-fg-muted">{dir}/</span>}
       <span className="text-fg-2 font-medium">{basename(fp)}</span>
       {extra}
@@ -166,10 +166,10 @@ function ToolFilePreview({ fp, sessionId, chips }: { fp: string; sessionId?: str
           className="w-11 h-11 rounded-md border border-edge shrink-0"
         />
         <span className="flex-1 min-w-0">
-          <span className="block text-[13px] font-semibold text-fg truncate">{name}</span>
-          {dir && <span className="block text-[11px] font-mono text-fg-muted truncate">{dir}/</span>}
+          <span className="block text-sm-tight font-semibold text-fg truncate">{name}</span>
+          {dir && <span className="block text-2xs font-mono text-fg-muted truncate">{dir}/</span>}
         </span>
-        <span className="shrink-0 inline-flex items-center gap-1 text-[11px] font-semibold text-fg-2 border border-edge group-hover:border-fg-muted rounded-md px-2 py-1 transition-colors">
+        <span className="shrink-0 inline-flex items-center gap-1 text-2xs font-semibold text-fg-2 border border-edge group-hover:border-fg-muted rounded-md px-2 py-1 transition-colors">
           Open
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M7 7h10v10" />
@@ -195,7 +195,7 @@ function Chip({ children, tone = 'neutral' }: { children: React.ReactNode; tone?
     : tone === 'info' ? 'bg-inset text-fg-2 border-edge'
     : 'bg-inset text-fg-muted border-edge';
   return (
-    <span className={`px-1.5 py-px text-[10px] uppercase tracking-wider rounded-sm border font-medium ${toneClass}`}>
+    <span className={`px-1.5 py-px text-3xs uppercase tracking-wider rounded-sm border font-medium ${toneClass}`}>
       {children}
     </span>
   );
@@ -213,7 +213,7 @@ function CopyButton({ text }: { text: string }) {
   return (
     <button
       onClick={handle}
-      className="text-[10px] uppercase tracking-wider text-fg-muted hover:text-fg-2 px-1 rounded-sm"
+      className="text-3xs uppercase tracking-wider text-fg-muted hover:text-fg-2 px-1 rounded-sm"
       title="Copy"
     >
       {copied ? 'Copied' : 'Copy'}
@@ -224,7 +224,7 @@ function CopyButton({ text }: { text: string }) {
 function ErrorBlock({ error }: { error: string }) {
   return (
     <div>
-      <div className="text-[10px] uppercase tracking-wider text-red-500 mb-1">Error</div>
+      <div className="text-3xs uppercase tracking-wider text-red-500 mb-1">Error</div>
       <pre className="text-xs text-red-400 bg-panel rounded-sm p-2 overflow-auto max-h-48 whitespace-pre-wrap">
         {error}
       </pre>
@@ -274,7 +274,7 @@ function WriteView({ tool, sessionId }: { tool: ToolCallState; sessionId?: strin
         chips={
           <>
             <Chip tone="add">New file</Chip>
-            {lineCount > 0 && <span className="text-[10px] text-fg-muted">{lineCount} lines</span>}
+            {lineCount > 0 && <span className="text-3xs text-fg-muted">{lineCount} lines</span>}
           </>
         }
       />
@@ -329,7 +329,7 @@ function ShellView({ tool, commandField }: {
       </div>
       {response && (
         <div>
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-1">Output</div>
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-1">Output</div>
           <CollapsibleBlock maxLines={20} className="bg-canvas">{response}</CollapsibleBlock>
         </div>
       )}
@@ -406,7 +406,7 @@ function LifecyclePill({ status }: { status?: TaskStatus }) {
   }
   const currentIdx = TASK_LIFECYCLE.indexOf(status);
   return (
-    <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider">
+    <div className="flex items-center gap-1 text-3xs uppercase tracking-wider">
       {TASK_LIFECYCLE.map((s, i) => {
         const done = i < currentIdx;
         const active = i === currentIdx;
@@ -474,7 +474,7 @@ function TaskUpdateView({ tool, task }: { tool: ToolCallState; task?: TaskState 
       <LifecyclePill status={displayStatus} />
       {description && <div className="text-xs text-fg-dim whitespace-pre-wrap">{description}</div>}
       {task && task.events.length > 1 && (
-        <div className="text-[10px] text-fg-muted">
+        <div className="text-3xs text-fg-muted">
           event {task.events.findIndex(e => e.toolUseId === tool.toolUseId) + 1} of {task.events.length}
         </div>
       )}
@@ -553,7 +553,7 @@ function ReadView({ tool, sessionId }: { tool: ToolCallState; sessionId?: string
           {overflow && (
             <button
               onClick={() => setOpen(o => !o)}
-              className="text-[10px] uppercase tracking-wider text-fg-muted hover:text-fg-2"
+              className="text-3xs uppercase tracking-wider text-fg-muted hover:text-fg-2"
             >
               {open ? 'Collapse' : `Expand (${rows.length} lines)`}
             </button>
@@ -855,13 +855,13 @@ function RawFallbackView({ tool }: { tool: ToolCallState }) {
     <div className="space-y-2">
       {formatted && (
         <div>
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-1">Input</div>
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-1">Input</div>
           <CollapsibleBlock maxLines={15}>{formatted}</CollapsibleBlock>
         </div>
       )}
       {tool.response && (
         <div>
-          <div className="text-[10px] uppercase tracking-wider text-fg-muted mb-1">Response</div>
+          <div className="text-3xs uppercase tracking-wider text-fg-muted mb-1">Response</div>
           <CollapsibleBlock maxLines={20}>{tool.response}</CollapsibleBlock>
         </div>
       )}

--- a/desktop/src/renderer/components/ui/SearchFilterPill.tsx
+++ b/desktop/src/renderer/components/ui/SearchFilterPill.tsx
@@ -77,7 +77,7 @@ export const SearchFilterPill = React.forwardRef<HTMLDivElement, SearchFilterPil
             aria-label={inputAriaLabel}
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            className="bg-transparent outline-none text-[13px] text-fg w-full min-w-0 placeholder:text-fg-muted"
+            className="bg-transparent outline-none text-sm-tight text-fg w-full min-w-0 placeholder:text-fg-muted"
           />
           <button
             type="button"

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -28,8 +28,10 @@
   --scrollbar-thumb: #C0C0C0;
   --scrollbar-hover: #999999;
   /* --code is computed per-theme by theme-engine.ts from --accent / --fg-2 so community themes get a palette-matched inline-code color instead of inheriting a hardcoded yellow from :root. */
-  --link: #2563EB;
-  --link-hover: #1D4ED8;
+  /* Darkened from #2563EB/#1D4ED8 (change 36): the old pair scored 3.59:1 on
+     --inset, and --inset is the assistant bubble, where most links render. */
+  --link: #2055CA;
+  --link-hover: #1E4395;
   --hl-theme: light;
   color-scheme: light;
   --radius: 4px;

--- a/desktop/src/renderer/styles/globals.css
+++ b/desktop/src/renderer/styles/globals.css
@@ -230,6 +230,14 @@
   --text-3xs: 10px;
   --text-4xs: 9px;
 
+  /* 13px — the one real step Tailwind's scale is missing, sitting between
+     text-xs (12) and text-sm (14). Named rather than folded because all 22
+     sites are Project View body copy (ProjectHero sync rows, AddProjectModal,
+     HowContextWorksPopup, the tab pills), a screen whose type was reviewed and
+     signed off at 13px; folding to 14 would resize the whole screen for no
+     benefit. Approved 2026-07-24 as the change-35 straggler exception. */
+  --text-sm-tight: 13px;
+
   /* Label color for filled --destructive surfaces (danger buttons/toggles).
      Derived per-theme in theme-engine.ts rather than hardcoded white, because
      --destructive is community-overridable with no contrast guard — a pack can

--- a/desktop/src/renderer/themes/builtin/light.json
+++ b/desktop/src/renderer/themes/builtin/light.json
@@ -19,7 +19,7 @@
     "edge-dim": "#B3B3B380",
     "scrollbar-thumb": "#C0C0C0",
     "scrollbar-hover": "#999999",
-    "link": "#2563EB",
-    "link-hover": "#1D4ED8"
+    "link": "#2055CA",
+    "link-hover": "#1E4395"
   }
 }

--- a/desktop/src/renderer/themes/theme-engine.ts
+++ b/desktop/src/renderer/themes/theme-engine.ts
@@ -249,6 +249,40 @@ function deriveDestructiveFg(destructive: string, canvas: string, panel: string)
   return target;
 }
 
+/**
+ * Nudge a DERIVED link colour until it is actually readable.
+ *
+ * WHY: the accent-vs-fg distance guard below only asks "is this link
+ * distinguishable from body text" — never "can you read it". Measured across
+ * the 11 shipped themes, that let 4 community packs derive a link that fails
+ * AA on the surface links are mostly painted on, worst of them kuromi-dreamer
+ * at 2.90:1. Same failure shape as --destructive-fg, so same fix: mix toward
+ * white (dark themes) / black (light themes) in 2% steps until it clears 4.5:1
+ * against the WORST of canvas, panel and inset.
+ *
+ * Inset is in that set and canvas is not the tight one: the assistant bubble is
+ * `bg-inset` (AssistantTurnBubble.tsx:374) and MarkdownContent renders inside
+ * it, so the bubble — not the page — is where most links actually live. `well`
+ * is deliberately excluded; it is the command-drawer search surface and nothing
+ * renders a link on it. Including it would fail two packs with no site to fix.
+ *
+ * Only DERIVED links go through this. A pack that declares `link` has made an
+ * explicit choice, and silently overriding it would both break author intent
+ * (creme's olive #5B4A1E is deliberate) and make the audit's HARD link rules
+ * unfailable — a gate that cannot fail reports nothing.
+ */
+function deriveLink(base: string, canvas: string, panel: string, inset: string): string {
+  const worst = (c: string) =>
+    Math.min(contrastRatio(c, canvas), contrastRatio(c, panel), contrastRatio(c, inset));
+  if (worst(base) >= 4.5) return base;
+  const target = rgbLuminance(...parseHex(canvas)) < 0.5 ? '#FFFFFF' : '#000000';
+  for (let t = 0.02; t <= 1.0001; t += 0.02) {
+    const candidate = mixHex(base, target, t);
+    if (worst(candidate) >= 4.5) return candidate;
+  }
+  return target;
+}
+
 /** Computes overlay CSS custom properties from existing theme tokens.
  *  After the glassmorphism refactor, overlay surfaces consume --panels-blur /
  *  --panels-opacity directly (set globally in applyThemeToDom), so this helper
@@ -290,7 +324,17 @@ export function computeOverlayTokens(
   // themes that set accent == fg would otherwise render links invisible against
   // prose. Packs may declare `link` explicitly to opt out of the derivation.
   // Built-ins all declare their own, so this branch only runs for community packs.
-  const link = tokens.link ?? (accentFgDistance > 40 ? tokens.accent : tokens['fg-2']);
+  //
+  // The guard alone is not enough: it answers "different from body text?" but
+  // not "readable?", which is how 4 packs shipped a sub-AA link. deriveLink
+  // finishes the job — see its comment for why inset is in the surface set.
+  const link = tokens.link
+    ?? deriveLink(
+      accentFgDistance > 40 ? tokens.accent : tokens['fg-2'],
+      tokens.canvas,
+      tokens.panel,
+      tokens.inset,
+    );
   const linkHover = tokens['link-hover'] ?? `color-mix(in oklab, ${link} 85%, ${tokens.fg})`;
 
   // Label color for filled --destructive surfaces (danger buttons, danger toggles).

--- a/desktop/tests/theme-engine.test.ts
+++ b/desktop/tests/theme-engine.test.ts
@@ -171,6 +171,22 @@ describe('computeOverlayTokens — --link / --link-hover', () => {
   const derive = (tokens: typeof TOKENS) =>
     computeOverlayTokens(tokens, undefined, undefined, false);
 
+  const lum = (hex: string) => {
+    const ch = (i: number) => {
+      const c = parseInt(hex.slice(1 + i * 2, 3 + i * 2), 16) / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * ch(0) + 0.7152 * ch(1) + 0.0722 * ch(2);
+  };
+  const ratio = (a: string, b: string) => {
+    const [hi, lo] = lum(a) > lum(b) ? [lum(a), lum(b)] : [lum(b), lum(a)];
+    return (hi + 0.05) / (lo + 0.05);
+  };
+  // The three surfaces the engine's deriveLink guarantees against — canvas
+  // (prose), panel (tool cards/popups) and inset (the assistant bubble).
+  const worstOf = (c: string, t: { canvas: string; panel: string; inset: string }) =>
+    Math.min(ratio(c, t.canvas), ratio(c, t.panel), ratio(c, t.inset));
+
   it('honors a link declared by the theme instead of deriving one', () => {
     // The four built-ins declare hand-picked links; derivation must not stomp them.
     const result = derive({ ...TOKENS, link: '#2563EB', 'link-hover': '#1D4ED8' } as typeof TOKENS);
@@ -180,20 +196,54 @@ describe('computeOverlayTokens — --link / --link-hover', () => {
 
   it('derives link from accent when accent is far enough from fg', () => {
     // Community packs declare no link and used to inherit :root's #2563EB —
-    // light-blue links on every pack regardless of palette.
-    expect(derive(TOKENS)['--link']).toBe(TOKENS.accent);
+    // light-blue links on every pack regardless of palette. The derived value is
+    // accent NUDGED to AA (change 36), not accent verbatim: this fixture's
+    // #7C6AF7 only scores 3.98:1 on its own inset, so the nudge lightens it.
+    const link = derive(TOKENS)['--link'];
+    expect(link).not.toBe(TOKENS.accent);
+    expect(worstOf(link, TOKENS)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('leaves an already-readable accent alone', () => {
+    // The nudge is a floor, not a filter — a pack whose accent already reads
+    // must keep its exact colour rather than being shifted for no reason.
+    // Far enough from fg to clear the distance guard AND already 10.5:1 on the
+    // tightest surface, so nothing but a no-op is correct here.
+    const readable = { ...TOKENS, accent: '#FFD166' };
+    expect(worstOf(readable.accent, readable)).toBeGreaterThanOrEqual(4.5);
+    expect(derive(readable)['--link']).toBe(readable.accent);
+  });
+
+  it('nudges a derived link that fails AA on the assistant bubble', () => {
+    // The regression this fixes: the accent-vs-fg distance guard only asks
+    // "distinguishable from body text", so kuromi-dreamer shipped a link at
+    // 2.90:1. inset is the tight surface because it IS the assistant bubble.
+    const dim = { ...TOKENS, accent: '#3A2F70' };
+    expect(worstOf(dim.accent, dim)).toBeLessThan(4.5);
+    expect(worstOf(derive(dim)['--link'], dim)).toBeGreaterThanOrEqual(4.5);
   });
 
   it('falls back to fg-2 when accent is too close to fg to read as a link', () => {
     // Themes that set accent == fg for high-contrast buttons would otherwise
-    // render links invisible against prose. Same guard as --code.
-    const flat = { ...TOKENS, accent: TOKENS.fg };
-    expect(derive(flat)['--link']).toBe(TOKENS['fg-2']);
+    // render links invisible against prose. Same guard as --code. fg-2 is the
+    // BASE here; the nudge may still lift it, so assert the source not the hex.
+    const flat = { ...TOKENS, accent: TOKENS.fg, 'fg-2': '#B0B0E8' };
+    expect(derive(flat)['--link']).toBe('#B0B0E8');
+  });
+
+  it('does not nudge a link the theme declared itself', () => {
+    // A declared link is the author's explicit choice (creme's olive #5B4A1E is
+    // deliberate). Silently correcting it would also make the audit's HARD link
+    // rules unfailable, and a gate that cannot fail reports nothing.
+    const bad = { ...TOKENS, link: '#1A1A2E' };
+    expect(worstOf('#1A1A2E', bad)).toBeLessThan(4.5);
+    expect(derive(bad)['--link']).toBe('#1A1A2E');
   });
 
   it('derives link-hover as link mixed 85% toward fg', () => {
-    expect(derive(TOKENS)['--link-hover']).toBe(
-      `color-mix(in oklab, ${TOKENS.accent} 85%, ${TOKENS.fg})`,
+    const out = derive(TOKENS);
+    expect(out['--link-hover']).toBe(
+      `color-mix(in oklab, ${out['--link']} 85%, ${TOKENS.fg})`,
     );
   });
 
@@ -201,6 +251,29 @@ describe('computeOverlayTokens — --link / --link-hover', () => {
     // Rule 15: nothing a component consumes may fall back to :root.
     expect(derive(TOKENS)['--link']).toBeTruthy();
     expect(derive(TOKENS)['--link-hover']).toBeTruthy();
+  });
+
+  it('stays in lockstep with the vendored audit rules', async () => {
+    // Same pin as destructive-fg: feed the ENGINE's derived link to the audit.
+    // If the two derivations drift apart, the audit green-lights a link the app
+    // paints illegibly — which is exactly how these packs shipped sub-AA.
+    const { createRequire } = await import('node:module');
+    const require2 = createRequire(import.meta.url);
+    const rules = require2('../scripts/vendor/contrast-rules.js');
+    const palettes = {
+      'dim accent':   { ...TOKENS, accent: '#3A2F70' },
+      'bright accent': { ...TOKENS, accent: '#C0B4FF' },
+      'light theme':  { ...TOKENS, canvas: '#F2F2F2', panel: '#EAEAEA', inset: '#D7D7D7', fg: '#1A1A1A', accent: '#2563EB' },
+    };
+    for (const [name, tokens] of Object.entries(palettes)) {
+      const engineLink = computeOverlayTokens(tokens as typeof TOKENS, undefined, undefined, false)['--link'];
+      const audited = rules.evaluate({ ...tokens, link: engineLink });
+      for (const ruleName of ['link on canvas', 'link on panel', 'link on inset']) {
+        const rule = audited.results.HARD.find((r: { rule: string }) => r.rule === ruleName);
+        expect(rule, `${name}: ${ruleName} present`).toBeDefined();
+        expect(rule.status, `${name}: ${ruleName} for engine value ${engineLink}`).toBe('PASS');
+      }
+    }
   });
 });
 

--- a/desktop/tests/type-scale-authority.test.ts
+++ b/desktop/tests/type-scale-authority.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { describe, it, expect } from 'vitest';
+
+// Guard for tranche 6 (change 35): the renderer's type scale is enumerable.
+//
+// Before this, 572 sites across 87 files set their font size with an arbitrary
+// `text-[10px]` / `text-[11px]` / `text-[13px]` etc. Nothing listed the sizes the
+// app actually used, so "make this one step smaller" meant grepping for a pixel
+// value and hoping you found every sibling. Naming them makes the scale greppable
+// and makes a new odd size a visible decision instead of a silent one.
+//
+// Source-text assertion rather than a render test on purpose: the failure mode is
+// a future session typing `text-[10px]` into one new component, which renders
+// perfectly and only shows up as scale drift months later.
+
+const RENDERER = join(__dirname, '..', 'src', 'renderer');
+
+// The named steps. Below text-xs (12px) the ladder is 2xs/3xs/4xs; text-sm-tight
+// is the one step ABOVE xs that Tailwind's scale is missing (see globals.css).
+const NAMED_TOKENS = ['--text-2xs', '--text-3xs', '--text-4xs', '--text-sm-tight'];
+
+// Comments are allowed to quote the retired class names — several WHY comments
+// exist precisely to record what a site used to be. Strip block comments (which
+// covers JSX `{/* ... */}` too) and whole-line `//` comments before scanning, so
+// the invariant is about what SHIPS in a class list, not what prose may mention.
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//'))
+    .join('\n');
+}
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return /\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry) ? [full] : [];
+  });
+}
+
+describe('type scale authority', () => {
+  it('every step of the sub-Tailwind scale is defined in globals.css', () => {
+    const css = readFileSync(join(RENDERER, 'styles', 'globals.css'), 'utf8');
+    for (const token of NAMED_TOKENS) {
+      expect(css, `${token} must be declared in the @theme block`).toMatch(
+        new RegExp(`${token}:\\s*\\d+px`),
+      );
+    }
+  });
+
+  it('no component sets a font size with an arbitrary text-[Npx]', () => {
+    const offenders: string[] = [];
+    for (const file of walk(join(RENDERER))) {
+      const src = stripComments(readFileSync(file, 'utf8'));
+      src.split('\n').forEach((line, i) => {
+        for (const hit of line.match(/text-\[\d+px\]/g) ?? []) {
+          offenders.push(`${file.slice(RENDERER.length + 1)}:${i + 1}  ${hit}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      'Use a named step (text-4xs/3xs/2xs/xs/sm-tight/sm/base/lg). If the app '
+        + 'genuinely needs a new size, add it to the @theme block in globals.css '
+        + 'and to NAMED_TOKENS here — that is the decision this guard exists to force.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Tranche 6 of the [UI consistency ledger](https://github.com/itsdestin/youcoded-dev/blob/master/docs/active/specs/2026-07-16-ui-consistency-design-spec.md). Both changes' foundations shipped in tranche 0; this is the remaining half of each.

---

## Change 35 — name the type scale

572 sites across 87 files set their font size with an arbitrary `text-[Npx]`. Nothing enumerated the sizes the app actually used, so "make this one step smaller" meant grepping a pixel value and hoping you caught every sibling.

| From | Count | To | Visual |
|---|---|---|---|
| `text-[10px]` | 335 | `text-3xs` | none |
| `text-[11px]` | 160 | `text-2xs` | none |
| `text-[9px]` | 37 | `text-4xs` | none |
| `text-[12px]` | 11 | `text-xs` | none — Tailwind's `text-xs` **is** 12px (no root font-size override, so `0.75rem == 12px`) |
| `text-[13px]` | 22 | `text-sm-tight` | none — new token |
| `text-[15px]` | 3 | `text-base` | 15 → 16 |
| `text-[17px]` | 2 | `text-lg` | 17 → 18 |
| `text-[8px]` | 2 | `text-4xs` | 8 → 9 |

**546 of 572 are a pure no-op.** `--text-sm-tight: 13px` is added rather than folded: all 22 of those sites are Project View body copy (ProjectHero sync rows, AddProjectModal, the tab pills, HowContextWorksPopup) on a screen whose type was reviewed and signed off at 13px, and folding to `text-sm` would have resized the whole screen for no benefit. The five 15/17/8px sites fold **up**, so titles keep their step over 13px body.

Two WHY comments quote the retired class names on purpose (`globals.css:226`, `BugReportPopup.tsx:234`) and are left intact — both the rename and the guard ignore comments, because the invariant is about what ships in a class list, not what prose may mention.

**Guard:** `tests/type-scale-authority.test.ts`, mutation-verified — reintroducing a single `text-[10px]` fails it. Adding a genuinely new size now requires editing the `@theme` block *and* the guard, which is the decision this exists to force.

---

## Change 36 — make derived hyperlinks readable, and gate them

Tranche 0's link derivation picks accent when it's >40 from fg, else fg-2. That guard answers *"is this distinguishable from body text"* but never *"can you read it"*. Measured across the 11 shipped themes:

```
theme                 link      source     vsCanvas   vsPanel
light       builtin   #2563EB   declared     4.62 ok    4.30 FAIL
cotton-candy-sky      #8B47B8   derived      5.30 ok    4.38 FAIL
halftone-dimension    #E51F48   derived      4.43 FAIL  4.19 FAIL
kuromi-dreamer        #8158AD   derived      2.90 FAIL  3.29 FAIL
meadow-mist           #2F7D55   derived      4.76 ok    4.00 FAIL
strawberry-kitty      #CC4060   derived      3.53 FAIL  3.90 FAIL
```

**3 fail AA on canvas, 6 on panel.** `kuromi-dreamer` ships a link at 2.90:1.

**Fix:** `deriveLink` in `theme-engine.ts`, the same shape as the existing `deriveDestructiveFg` — mix toward white (dark themes) / black (light themes) in 2% steps until it clears 4.5:1 against the worst of **canvas, panel and inset**.

`inset` is in that set because the assistant bubble is `bg-inset` (`AssistantTurnBubble.tsx:374`) and `MarkdownContent` renders inside it — the bubble, not the page, is where most links live. `well` is excluded: it's the command-drawer search surface and renders no links, and gating on it would fail two packs over a combination that never reaches the screen.

Only **derived** links are nudged. A declared link is the author's explicit choice (creme's olive `#5B4A1E` is deliberate), and auto-correcting it would make the new HARD rules unfailable — a gate that cannot fail reports nothing.

Built-in `light` was the one declared link that failed (3.59:1 on `--inset`), so it's darkened by hand to `#2055CA` / `#1E4395`, updated in **both** sources the triple-source test diffs.

**Result:** halftone-dimension `#E51F48`→`#E93E62`, meadow-mist `#2F7D55`→`#245F41`, cotton-candy-sky `#8B47B8`→`#6F3993`, kuromi-dreamer `#8158AD`→`#5D3F7D`. All 4 built-ins and all 7 community packs pass, **zero new failures** vs. the pre-change baseline.

**Guard:** 5 new cases in `theme-engine.test.ts`, including a lockstep test that feeds the *engine's* derived link to the audit rules — if the two derivations drift, the audit green-lights a link the app paints illegibly, which is the exact failure the shared rules file exists to prevent.

---

## Cross-repo

`desktop/scripts/vendor/contrast-rules.js` is a vendored copy. Canonical source is **wecoded-marketplace#64**; **wecoded-themes#25** re-vendors the third copy. Merge order: marketplace → themes → this.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — 304 files, 3392 tests passing
- `node scripts/audit-theme-contrast.mjs` — all 4 built-ins pass
- `wecoded-themes/scripts/audit-contrast.mjs` — all 7 community packs pass, glass-composited

🤖 Generated with [Claude Code](https://claude.com/claude-code)