### PR TITLE
chore(deps): bump org.json:json from 20231013 to 20260719

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -236,7 +236,7 @@ dependencies {
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.json:json:20231013")
+    testImplementation("org.json:json:20260719")
     // Coroutines test support for runTest in SubagentWatcherTest
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
     // kotlin.test assertions (assertTrue/assertEquals/etc.) for JVM unit tests


### PR DESCRIPTION
Re-lands dependabot #221 by hand.

#221 was opened by the `/app` gradle entry in `.github/dependabot.yml`, which was **removed 2026-07-23** for duplicating the root entry. Dependabot now refuses to rebase it — *"The dependabot.yml entry that created this PR has been deleted so this PR can't be rebased"* — so it can never go green on its own, and the root entry is at its 5-open-PR cap.

One line, test-only (`testImplementation`), so nothing that ships changes. Android CI passed this exact bump on #221 before it went stale.

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)